### PR TITLE
test(constants): compile-time enum/const conformance guard (Layer 2)

### DIFF
--- a/src/constants/enumConstConformance.ts
+++ b/src/constants/enumConstConformance.ts
@@ -1,0 +1,37 @@
+/**
+ * Enum ↔ const-module conformance — COMPILE-TIME guard (Layer 2).
+ *
+ * The runtime bidirectional key+value check lives in
+ * `src/tests/constants/enumConstConformance.test.ts`. This is its compile-time twin:
+ * for each dedicated mirror, EVERY enum member must have a same-named export in its
+ * const module — a missing one is a `check-types` (tsc) failure, caught earlier than
+ * the test run. Only the KEY is asserted here (works with the current `any`-typed const
+ * values); tightening the const value types later would let a compile-time VALUE check
+ * be added too. Bucket modules use different const key names, so their coverage stays
+ * runtime-only.
+ *
+ * This module is intentionally NOT imported anywhere: it is type-only (no runtime
+ * output) and unreachable from the package entry, so it is type-checked by `tsc` but
+ * tree-shaken out of the build. The value imports below are used only in `typeof`.
+ * Only the four dedicated 1:1 mirrors are asserted here — the bucket modules use
+ * different const key names, so their coverage is enforced only by the runtime guard.
+ */
+import * as matchUpStatusConstants from './matchUpStatusConstants';
+import * as entryStatusConstants from './entryStatusConstants';
+import * as weekdayConstants from './weekdayConstants';
+import * as surfaceConstants from './surfaceConstants';
+import { MatchUpStatusEnum, EntryStatusEnum, SurfaceCategoryEnum, WeekdayEnum } from '@Types/tournamentTypes';
+
+// enum member names not present as a const export in the module (must be empty).
+type EnumMembersMissingConst<E, M> = Exclude<keyof E, keyof M>;
+// true on full coverage; on a gap, an error object that violates the `extends true`
+// constraint below so tsc reports exactly which enum member has no const.
+type Mirrored<E, M> = [EnumMembersMissingConst<E, M>] extends [never]
+  ? true
+  : { __ENUM_MEMBER_HAS_NO_CONST__: EnumMembersMissingConst<E, M> };
+type Assert<T extends true> = T;
+
+export type _AssertMatchUpStatus = Assert<Mirrored<typeof MatchUpStatusEnum, typeof matchUpStatusConstants>>;
+export type _AssertEntryStatus = Assert<Mirrored<typeof EntryStatusEnum, typeof entryStatusConstants>>;
+export type _AssertSurfaceCategory = Assert<Mirrored<typeof SurfaceCategoryEnum, typeof surfaceConstants>>;
+export type _AssertWeekday = Assert<Mirrored<typeof WeekdayEnum, typeof weekdayConstants>>;

--- a/src/tests/constants/enumConstConformance.test.ts
+++ b/src/tests/constants/enumConstConformance.test.ts
@@ -27,6 +27,9 @@ import { describe, it, expect } from 'vitest';
  * Enums with NO const twin are enum-only (a single source — nothing to guard); they
  * are listed in ENUM_ONLY so the coverage is explicit and adding a new enum forces a
  * deliberate "mirror, bucket, or enum-only?" decision here.
+ *
+ * The COMPILE-TIME twin (Layer 2) lives in `src/constants/enumConstConformance.ts`
+ * (this test file is excluded from `check-types`, so type assertions here would be dead).
  */
 
 const stringEntries = (mod: Record<string, unknown>): Record<string, string> => {


### PR DESCRIPTION
The compile-time twin of the runtime enum/const conformance guard (Layer 1, shipped in #4547). For each dedicated 1:1 mirror (matchUpStatus, entryStatus, surface, weekday) it asserts at `check-types` time that every enum member has a same-named const export — drift fails tsc with a precise message:

```
error TS2344: Type '{ __ENUM_MEMBER_HAS_NO_CONST__: "COMPLETED"; }' does not satisfy the constraint 'true'.
```

**Key discovery:** factory's `tsconfig.json` excludes `src/**/*.test.ts` from `check-types`, so compile-time assertions in a `.test.ts` are **never evaluated** (a bogus `never` error in a test file is not caught). So Layer 2 lives in a real source file, `src/constants/enumConstConformance.ts` — type-only (no runtime statements) and unreachable from the package entry, so tsc checks it while rollup tree-shakes it out (**verified absent from `dist`**).

Only the KEY is asserted (works with today's `any`-typed const values); typing the const values (the deferred **(b)**) would let a compile-time VALUE check be added too. Bucket modules keep runtime-only coverage (different const key names).

Teeth-verified both directions (add an enum member / remove a const → tsc fails naming the exact member). `test:server`, lint, check-types, full suite all green.