### PR TITLE
refactor(constants): type matchUpStatusConstants (flagship of the const-typing pass)

### DIFF
--- a/src/assemblies/generators/drawDefinitions/drawTypes/adHoc/generateAdHocMatchUps.ts
+++ b/src/assemblies/generators/drawDefinitions/drawTypes/adHoc/generateAdHocMatchUps.ts
@@ -9,7 +9,7 @@ import { UUID } from '@Tools/UUID';
 
 // constants and types
 import { INVALID_VALUES, MISSING_DRAW_DEFINITION, ErrorType } from '@Constants/errorConditionConstants';
-import { DrawDefinition, Event, MatchUp, Tournament } from '@Types/tournamentTypes';
+import { DrawDefinition, Event, MatchUp, MatchUpStatusUnion, Tournament } from '@Types/tournamentTypes';
 import { TO_BE_PLAYED } from '@Constants/matchUpStatusConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 import { TEAM } from '@Constants/matchUpTypes';
@@ -106,7 +106,9 @@ export function generateAdHocMatchUps(params: GenerateAdHocMatchUpsArgs): {
 
     return {
       roundNumber: nextRoundNumber,
-      matchUpStatus: TO_BE_PLAYED,
+      // object-literal inference widens the literal const to `string`; re-narrow to
+      // the matchUpStatus union so the built matchUp is assignable to MatchUp.
+      matchUpStatus: TO_BE_PLAYED as MatchUpStatusUnion,
       matchUpId,
       sides,
     };

--- a/src/constants/matchUpStatusConstants.ts
+++ b/src/constants/matchUpStatusConstants.ts
@@ -1,21 +1,23 @@
-export const ABANDONED: any = 'ABANDONED';
-export const AWAITING_RESULT: any = 'AWAITING_RESULT';
-export const BYE: any = 'BYE';
-export const CANCELLED: any = 'CANCELLED';
-export const COMPLETED: any = 'COMPLETED';
-export const DEAD_RUBBER: any = 'DEAD_RUBBER';
-export const DEFAULTED: any = 'DEFAULTED';
-export const DOUBLE_DEFAULT: any = 'DOUBLE_DEFAULT';
-export const DOUBLE_WALKOVER: any = 'DOUBLE_WALKOVER';
-export const IN_PROGRESS: any = 'IN_PROGRESS';
-export const INCOMPLETE: any = 'INCOMPLETE';
-export const NOT_PLAYED: any = 'NOT_PLAYED';
-export const RETIRED: any = 'RETIRED';
-export const SUSPENDED: any = 'SUSPENDED';
-export const TO_BE_PLAYED: any = 'TO_BE_PLAYED';
-export const WALKOVER: any = 'WALKOVER';
+import type { MatchUpStatusUnion } from '@Types/tournamentTypes';
 
-export const recoveryTimeRequiredMatchUpStatuses = [
+export const ABANDONED = 'ABANDONED';
+export const AWAITING_RESULT = 'AWAITING_RESULT';
+export const BYE = 'BYE';
+export const CANCELLED = 'CANCELLED';
+export const COMPLETED = 'COMPLETED';
+export const DEAD_RUBBER = 'DEAD_RUBBER';
+export const DEFAULTED = 'DEFAULTED';
+export const DOUBLE_DEFAULT = 'DOUBLE_DEFAULT';
+export const DOUBLE_WALKOVER = 'DOUBLE_WALKOVER';
+export const IN_PROGRESS = 'IN_PROGRESS';
+export const INCOMPLETE = 'INCOMPLETE';
+export const NOT_PLAYED = 'NOT_PLAYED';
+export const RETIRED = 'RETIRED';
+export const SUSPENDED = 'SUSPENDED';
+export const TO_BE_PLAYED = 'TO_BE_PLAYED';
+export const WALKOVER = 'WALKOVER';
+
+export const recoveryTimeRequiredMatchUpStatuses: MatchUpStatusUnion[] = [
   AWAITING_RESULT,
   COMPLETED,
   DEFAULTED,
@@ -25,7 +27,7 @@ export const recoveryTimeRequiredMatchUpStatuses = [
   SUSPENDED,
 ];
 
-export const particicipantsRequiredMatchUpStatuses = [
+export const particicipantsRequiredMatchUpStatuses: MatchUpStatusUnion[] = [
   AWAITING_RESULT,
   COMPLETED,
   DEFAULTED,
@@ -38,7 +40,7 @@ export const particicipantsRequiredMatchUpStatuses = [
   WALKOVER,
 ];
 
-export const validMatchUpStatuses = [
+export const validMatchUpStatuses: MatchUpStatusUnion[] = [
   ABANDONED,
   AWAITING_RESULT,
   BYE,
@@ -57,7 +59,7 @@ export const validMatchUpStatuses = [
   WALKOVER,
 ];
 
-export const directingMatchUpStatuses = [
+export const directingMatchUpStatuses: MatchUpStatusUnion[] = [
   BYE,
   DOUBLE_WALKOVER, // directing because of a produced WALKOVER
   DOUBLE_DEFAULT, // directing because of a produced WALKOVER
@@ -67,7 +69,7 @@ export const directingMatchUpStatuses = [
   WALKOVER,
 ];
 
-export const nonDirectingMatchUpStatuses = [
+export const nonDirectingMatchUpStatuses: (MatchUpStatusUnion | undefined)[] = [
   ABANDONED,
   AWAITING_RESULT,
   CANCELLED,
@@ -80,7 +82,7 @@ export const nonDirectingMatchUpStatuses = [
   undefined,
 ];
 
-export const completedMatchUpStatuses = [
+export const completedMatchUpStatuses: MatchUpStatusUnion[] = [
   CANCELLED,
   ABANDONED,
   COMPLETED,
@@ -92,7 +94,7 @@ export const completedMatchUpStatuses = [
   WALKOVER,
 ];
 
-export const activeMatchUpStatuses = [
+export const activeMatchUpStatuses: MatchUpStatusUnion[] = [
   ABANDONED,
   COMPLETED,
   DEFAULTED,
@@ -103,7 +105,7 @@ export const activeMatchUpStatuses = [
   WALKOVER,
 ];
 
-export const upcomingMatchUpStatuses = [IN_PROGRESS, INCOMPLETE, SUSPENDED, TO_BE_PLAYED];
+export const upcomingMatchUpStatuses: MatchUpStatusUnion[] = [IN_PROGRESS, INCOMPLETE, SUSPENDED, TO_BE_PLAYED];
 
 export const matchUpStatusConstants = {
   ABANDONED,

--- a/src/mutate/drawDefinitions/resetQualifyingStructure.ts
+++ b/src/mutate/drawDefinitions/resetQualifyingStructure.ts
@@ -30,7 +30,8 @@ export function resetQualifyingStructure({
   if (!structure) return { error: STRUCTURE_NOT_FOUND };
 
   const scoresPresent = structure.matchUps?.some(
-    ({ matchUpStatus, score }) => checkScoreHasValue({ score }) ?? completedMatchUpStatuses.includes(matchUpStatus),
+    ({ matchUpStatus, score }) =>
+      checkScoreHasValue({ score }) ?? (!!matchUpStatus && completedMatchUpStatuses.includes(matchUpStatus)),
   );
   if (scoresPresent) return { error: SCORES_PRESENT };
 

--- a/src/mutate/matchUps/drawPositions/assignMatchUpSideParticipant.ts
+++ b/src/mutate/matchUps/drawPositions/assignMatchUpSideParticipant.ts
@@ -67,7 +67,7 @@ export function assignMatchUpSideParticipant({
   if (
     !participantId &&
     (matchUp?.score?.scoreStringSide1 ||
-      completedMatchUpStatuses.includes(matchUp?.matchUpStatus) ||
+      (matchUp?.matchUpStatus && completedMatchUpStatuses.includes(matchUp.matchUpStatus)) ||
       (matchUp?.matchUpStatus && [DOUBLE_WALKOVER, DOUBLE_DEFAULT].includes(matchUp.matchUpStatus)))
   )
     return {

--- a/src/mutate/matchUps/schedule/schedulers/proScheduler/proColumnResolve.ts
+++ b/src/mutate/matchUps/schedule/schedulers/proScheduler/proColumnResolve.ts
@@ -106,7 +106,7 @@ export function proColumnResolve({ tournamentRecords, matchUps, scheduledDate, c
 
 function tierOf(matchUp: HydratedMatchUp): number {
   if (matchUp.winningSide) return 0;
-  if (ACTIVE_STATUSES.has(matchUp.matchUpStatus)) return 1;
+  if (matchUp.matchUpStatus && ACTIVE_STATUSES.has(matchUp.matchUpStatus)) return 1;
   return 2;
 }
 

--- a/src/mutate/practice/detectConflicts.ts
+++ b/src/mutate/practice/detectConflicts.ts
@@ -93,7 +93,7 @@ function detectMatchUpConflicts({
 
   return matchUps
     .filter((matchUp) => {
-      if (completedMatchUpStatuses.includes(matchUp.matchUpStatus)) return false;
+      if (matchUp.matchUpStatus && completedMatchUpStatuses.includes(matchUp.matchUpStatus)) return false;
       if (matchUp.winningSide) return false;
       const { scheduledDate, scheduledTime } = matchUp.schedule ?? {};
       if (!scheduledDate || !scheduledTime) return false;

--- a/src/mutate/venues/courtAvailability.ts
+++ b/src/mutate/venues/courtAvailability.ts
@@ -72,7 +72,7 @@ export function modifyCourtAvailability({
     // already happened, not future commitments. Modifying court availability
     // should never be blocked by play that has already concluded.
     const matchUpsWithInvalidScheduling = courtMatchUps.filter((matchUp) => {
-      if (completedMatchUpStatuses.includes(matchUp.matchUpStatus)) return false;
+      if (matchUp.matchUpStatus && completedMatchUpStatuses.includes(matchUp.matchUpStatus)) return false;
       if (matchUp.winningSide) return false;
       const { scheduledDate, scheduledTime } = matchUp.schedule ?? {};
       if (!scheduledDate || !scheduledTime) return false;

--- a/src/query/drawDefinition/getLuckyDrawRoundStatus.ts
+++ b/src/query/drawDefinition/getLuckyDrawRoundStatus.ts
@@ -96,8 +96,7 @@ export function getLuckyDrawRoundStatus({
   // (2 * next - current), instead of the implicit "odd matchUp count → 1 LL"
   // rule used by the default ceil-halving cascade.
   const customRoundProfile = findExtension({ element: structure, name: 'customRoundProfile' }).extension?.value as
-    | number[]
-    | undefined;
+    number[] | undefined;
 
   // Build lookup maps for resolving participants from drawPositions
   const positionAssignments = structure.positionAssignments ?? [];
@@ -121,7 +120,10 @@ export function getLuckyDrawRoundStatus({
     const profile = roundProfile[roundNumber];
     const roundMatchUps = matchUps.filter((m) => m.roundNumber === roundNumber);
     const completedCount = roundMatchUps.filter(
-      (m) => completedMatchUpStatuses.includes(m.matchUpStatus) || m.winningSide || m.matchUpStatus === BYE,
+      (m) =>
+        (m.matchUpStatus && completedMatchUpStatuses.includes(m.matchUpStatus)) ||
+        m.winningSide ||
+        m.matchUpStatus === BYE,
     ).length;
     const isComplete = completedCount === profile.matchUpsCount;
     const isFinalRound = profile.matchUpsCount === 1;

--- a/src/query/drawDefinition/getStructureCompleteness.ts
+++ b/src/query/drawDefinition/getStructureCompleteness.ts
@@ -46,7 +46,9 @@ function positionOccupied(assignment: PositionAssignment): boolean {
 // that resolves without a winner (double walkover/default, cancelled, abandoned, dead rubber).
 function matchUpResolved(matchUp: MatchUp): boolean {
   return (
-    !!matchUp.winningSide || matchUp.matchUpStatus === BYE || completedMatchUpStatuses.includes(matchUp.matchUpStatus)
+    !!matchUp.winningSide ||
+    matchUp.matchUpStatus === BYE ||
+    (!!matchUp.matchUpStatus && completedMatchUpStatuses.includes(matchUp.matchUpStatus))
   );
 }
 

--- a/src/query/drawDefinition/getStructureInconsistencies.ts
+++ b/src/query/drawDefinition/getStructureInconsistencies.ts
@@ -225,7 +225,7 @@ export function getStructureInconsistencies(
     const winnerSide = sides.find((side) => side.sideNumber === winningSide);
     const loserSide = sides.find((side) => side.sideNumber === (winningSide === 1 ? 2 : 1));
     const exit = isExit(matchUpStatus);
-    const singleExit = exit && ![DOUBLE_WALKOVER, DOUBLE_DEFAULT].includes(matchUpStatus);
+    const singleExit = exit && (!matchUpStatus || ![DOUBLE_WALKOVER, DOUBLE_DEFAULT].includes(matchUpStatus));
     const base = { matchUpId, structureId: matchUp.structureId, winningSide };
 
     // WINNING_SIDE_WITHOUT_PARTICIPANT (non-exit only — pending exits may be empty)

--- a/src/query/matchUp/analyzeScore.ts
+++ b/src/query/matchUp/analyzeScore.ts
@@ -186,7 +186,8 @@ export function analyzeScore({
       (winningSide && irregularEnding) ||
       (!winningSide &&
         !calculatedWinningSide &&
-        (![COMPLETED, DEFAULTED, RETIRED, WALKOVER].includes(relevantMatchUpStatus) ||
+        (!relevantMatchUpStatus ||
+          ![COMPLETED, DEFAULTED, RETIRED, WALKOVER].includes(relevantMatchUpStatus) ||
           (timed && relevantMatchUpStatus === COMPLETED))))
   );
 


### PR DESCRIPTION
First module of the **(b)** const-typing work (the flagship — establishes the pattern for the grind through the remaining modules). `factoryConstants.matchUpStatusConstants.*` is no longer `any`.

**Typing:** the 16 status string consts are literal-typed (dropped `: any`), and the derived status arrays carry explicit `MatchUpStatusUnion[]` (`nonDirecting`: `(MatchUpStatusUnion | undefined)[]`) — array literals otherwise widen to `string[]`, which is the root of most of the churn.

**15 latent type gaps the `any` had masked, all fixed with behaviour-preserving changes (no unsafe casts):**
- **array-literal widening → `MatchUpStatusUnion[]`**: fixed at the source via the explicit array annotations, so `matchUpFilters` / `ignoreMatchUpStatuses` consumers type-check (4 sites).
- **optional `matchUp.matchUpStatus`** (`MatchUpStatusUnion | undefined`) into `.includes()` / `Set.has()`: guarded with a truthy check — `status && arr.includes(status)` for positive tests, `!status || !arr.includes(status)` for negated ones (undefined was never a member, so runtime behaviour is identical). This matches the codebase's own existing idiom (e.g. `analyzeScore.ts:152`). (9 sites)
- **object-literal widening** in `generateAdHocMatchUps`: re-narrowed with a cast that counteracts inference widening. (2 sites)

272 targeted tests (scheduling / adHoc / drawDefinition) + full suite + coverage gate green; `test:server` 12/12; lint + check-types clean.

Next: grinding the remaining mirror/bucket modules (entryStatus, surface, weekday, then the buckets) the same way.