### PR TITLE
refactor(constants): type entryStatus + drawDefinition const modules ((b) grind)

### DIFF
--- a/src/assemblies/generators/drawDefinitions/drawTypes/adaptiveDraw.ts
+++ b/src/assemblies/generators/drawDefinitions/drawTypes/adaptiveDraw.ts
@@ -118,7 +118,7 @@ export function generateAdaptiveStructures(params: GenerateAdaptiveStructuresArg
     });
 
     if (childResult.structureId && structure.structureId) {
-      const link = {
+      const link: DrawLink = {
         linkType: LOSER,
         source: {
           roundNumber,

--- a/src/assemblies/generators/drawDefinitions/drawTypes/playoffStructures.ts
+++ b/src/assemblies/generators/drawDefinitions/drawTypes/playoffStructures.ts
@@ -174,7 +174,7 @@ export function generatePlayoffStructures(params: GeneratePlayoffStructuresArgs)
     });
 
     if (structure.structureId && targetStructureId) {
-      const link = {
+      const link: DrawLink = {
         linkType: LOSER,
         source: {
           roundNumber,

--- a/src/constants/drawDefinitionConstants.ts
+++ b/src/constants/drawDefinitionConstants.ts
@@ -46,15 +46,15 @@ export const ITEM = 'ITEM';
 export const CONTAINER = 'CONTAINER';
 
 // positioningProfile
-export const DRAW: any = 'DRAW';
-export const RANDOM: any = 'RANDOM';
-export const TOP_DOWN: any = 'TOP_DOWN';
-export const BOTTOM_UP: any = 'BOTTOM_UP';
+export const DRAW = 'DRAW';
+export const RANDOM = 'RANDOM';
+export const TOP_DOWN = 'TOP_DOWN';
+export const BOTTOM_UP = 'BOTTOM_UP';
 
 // Match and Link types
-export const POSITION: any = 'POSITION'; // participant advances based on their finishing position
-export const WINNER: any = 'WINNER'; // participant advances based on winning a matchUp
-export const LOSER: any = 'LOSER'; // partticipant advances based on losing a matchUp
+export const POSITION = 'POSITION'; // participant advances based on their finishing position
+export const WINNER = 'WINNER'; // participant advances based on winning a matchUp
+export const LOSER = 'LOSER'; // partticipant advances based on losing a matchUp
 export const FIRST_MATCHUP = 'FIRST_MATCHUP'; // condition for valididty of link
 
 // draw types

--- a/src/constants/entryStatusConstants.ts
+++ b/src/constants/entryStatusConstants.ts
@@ -1,3 +1,5 @@
+import type { EntryStatusUnion } from '@Types/tournamentTypes';
+
 export const ALTERNATE = 'ALTERNATE';
 export const CONFIRMED = 'CONFIRMED';
 export const DIRECT_ACCEPTANCE = 'DIRECT_ACCEPTANCE';
@@ -13,16 +15,16 @@ export const UNPAIRED = 'UNPAIRED';
 export const WILDCARD = 'WILDCARD';
 export const WITHDRAWN = 'WITHDRAWN';
 
-export const EQUIVALENT_ACCEPTANCE_STATUSES: any = [
+export const EQUIVALENT_ACCEPTANCE_STATUSES: EntryStatusUnion[] = [
   CONFIRMED,
   DIRECT_ACCEPTANCE,
   JUNIOR_EXEMPT,
   ORGANISER_ACCEPTANCE,
   SPECIAL_EXEMPT,
 ];
-export const DRAW_SPECIFIC_STATUSES: any = [FEED_IN, LUCKY_LOSER, QUALIFIER];
+export const DRAW_SPECIFIC_STATUSES: EntryStatusUnion[] = [FEED_IN, LUCKY_LOSER, QUALIFIER];
 
-export const DIRECT_ENTRY_STATUSES: any = [
+export const DIRECT_ENTRY_STATUSES: EntryStatusUnion[] = [
   CONFIRMED,
   DIRECT_ACCEPTANCE,
   FEED_IN,
@@ -32,7 +34,7 @@ export const DIRECT_ENTRY_STATUSES: any = [
   WILDCARD,
 ];
 
-export const STRUCTURE_SELECTED_STATUSES: any = [
+export const STRUCTURE_SELECTED_STATUSES: EntryStatusUnion[] = [
   CONFIRMED,
   DIRECT_ACCEPTANCE,
   JUNIOR_EXEMPT,
@@ -43,7 +45,7 @@ export const STRUCTURE_SELECTED_STATUSES: any = [
   WILDCARD,
 ];
 
-export const VALID_ENTRY_STATUSES: any = [
+export const VALID_ENTRY_STATUSES: EntryStatusUnion[] = [
   ALTERNATE,
   CONFIRMED,
   DIRECT_ACCEPTANCE,
@@ -60,7 +62,7 @@ export const VALID_ENTRY_STATUSES: any = [
   WITHDRAWN,
 ];
 
-export const entryStatusConstants: any = {
+export const entryStatusConstants = {
   ALTERNATE,
   CONFIRMED,
   DIRECT_ACCEPTANCE,

--- a/src/query/drawDefinitions/swiss/getSwissChart.ts
+++ b/src/query/drawDefinitions/swiss/getSwissChart.ts
@@ -44,7 +44,7 @@ export function getSwissChart({ drawDefinition, structureId }: GetSwissChartArgs
 
   const allMatchUps = structure.matchUps ?? [];
   const participantIds = (drawDefinition.entries ?? [])
-    .filter((e) => STRUCTURE_SELECTED_STATUSES.includes(e.entryStatus ?? ''))
+    .filter((e) => !!e.entryStatus && STRUCTURE_SELECTED_STATUSES.includes(e.entryStatus))
     .map(getParticipantId)
     .filter(Boolean) as string[];
 

--- a/src/query/drawDefinitions/swiss/getSwissStandings.ts
+++ b/src/query/drawDefinitions/swiss/getSwissStandings.ts
@@ -39,7 +39,7 @@ export function getSwissStandings({
 
   const matchUps = structure.matchUps ?? [];
   const participantIds = (drawDefinition.entries ?? [])
-    .filter((e) => STRUCTURE_SELECTED_STATUSES.includes(e.entryStatus ?? ''))
+    .filter((e) => !!e.entryStatus && STRUCTURE_SELECTED_STATUSES.includes(e.entryStatus))
     .map(getParticipantId)
     .filter(Boolean) as string[];
 


### PR DESCRIPTION
Continues the (b) const-typing pass after the matchUpStatus flagship (#4550). Removes the remaining `: any` from the two enum-related const modules that still had it.

**entryStatusConstants** — the 5 status arrays typed `EntryStatusUnion[]` + the barrel object (the string consts were already literal). Cascade: 2 Swiss filters used `entryStatus ?? ''` (an undefined workaround that now produces an invalid `''`) → replaced with a truthy guard, identical runtime.

**drawDefinitionConstants** — the 7 `: any` consts (`DRAW`/`RANDOM`/`TOP_DOWN`/`BOTTOM_UP`/`POSITION`/`WINNER`/`LOSER`) literal-typed. Cascade: 2 `DrawLink` builders used an intermediate `const link = {...}` that widened `linkType` to `string` → annotated `const link: DrawLink = {...}` for contextual typing (no cast).

**Already clean (0 `: any`, no changes):** surfaceConstants, weekdayConstants, participantConstants, genderConstants — so the enum-mirror/bucket modules are now all typed, and Layer 2's compile-time *value* check is unblocked for them.

583 targeted tests (swiss / generators / entries) + the enum/const conformance guard + full suite + coverage gate green; `test:server`, lint, check-types clean.