### PR TITLE
test(constants): compile-time VALUE conformance in the enum/const guard (Layer 2)

### DIFF
--- a/src/constants/enumConstConformance.ts
+++ b/src/constants/enumConstConformance.ts
@@ -3,11 +3,12 @@
  *
  * The runtime bidirectional key+value check lives in
  * `src/tests/constants/enumConstConformance.test.ts`. This is its compile-time twin:
- * for each dedicated mirror, EVERY enum member must have a same-named export in its
- * const module — a missing one is a `check-types` (tsc) failure, caught earlier than
- * the test run. Only the KEY is asserted here (works with the current `any`-typed const
- * values); tightening the const value types later would let a compile-time VALUE check
- * be added too. Bucket modules use different const key names, so their coverage stays
+ * for each dedicated mirror it asserts, at `check-types` (tsc) time:
+ *   - KEY coverage: every enum member has a same-named const export; and
+ *   - VALUE conformance: each such const's literal value equals the enum member's
+ *     value (unblocked now the const values are literal-typed — see the (b) pass).
+ * Either drift is a compile failure naming the exact member, caught earlier than the
+ * runtime test. Bucket modules use different const key names, so their coverage stays
  * runtime-only.
  *
  * This module is intentionally NOT imported anywhere: it is type-only (no runtime
@@ -22,16 +23,32 @@ import * as weekdayConstants from './weekdayConstants';
 import * as surfaceConstants from './surfaceConstants';
 import { MatchUpStatusEnum, EntryStatusEnum, SurfaceCategoryEnum, WeekdayEnum } from '@Types/tournamentTypes';
 
-// enum member names not present as a const export in the module (must be empty).
-type EnumMembersMissingConst<E, M> = Exclude<keyof E, keyof M>;
-// true on full coverage; on a gap, an error object that violates the `extends true`
-// constraint below so tsc reports exactly which enum member has no const.
-type Mirrored<E, M> = [EnumMembersMissingConst<E, M>] extends [never]
-  ? true
-  : { __ENUM_MEMBER_HAS_NO_CONST__: EnumMembersMissingConst<E, M> };
 type Assert<T extends true> = T;
 
-export type _AssertMatchUpStatus = Assert<Mirrored<typeof MatchUpStatusEnum, typeof matchUpStatusConstants>>;
-export type _AssertEntryStatus = Assert<Mirrored<typeof EntryStatusEnum, typeof entryStatusConstants>>;
-export type _AssertSurfaceCategory = Assert<Mirrored<typeof SurfaceCategoryEnum, typeof surfaceConstants>>;
-export type _AssertWeekday = Assert<Mirrored<typeof WeekdayEnum, typeof weekdayConstants>>;
+// ── KEY coverage: every enum member has a same-named const export ─────────────
+// A gap surfaces as a non-`never` type that violates the `extends true` constraint,
+// so tsc reports exactly which enum member has no const.
+type EnumMembersMissingConst<E, M> = Exclude<keyof E, keyof M>;
+type KeysMirrored<E, M> = [EnumMembersMissingConst<E, M>] extends [never]
+  ? true
+  : { __ENUM_MEMBER_HAS_NO_CONST__: EnumMembersMissingConst<E, M> };
+
+export type _KeysMatchUpStatus = Assert<KeysMirrored<typeof MatchUpStatusEnum, typeof matchUpStatusConstants>>;
+export type _KeysEntryStatus = Assert<KeysMirrored<typeof EntryStatusEnum, typeof entryStatusConstants>>;
+export type _KeysSurfaceCategory = Assert<KeysMirrored<typeof SurfaceCategoryEnum, typeof surfaceConstants>>;
+export type _KeysWeekday = Assert<KeysMirrored<typeof WeekdayEnum, typeof weekdayConstants>>;
+
+// ── VALUE conformance: each const's literal value equals the enum member's value ─
+// For enum key K, `${E[K] & string}` is the enum member's string value; the const's
+// literal type M[K] must extend it. A mismatch collects K and fails `check-types`.
+type ConstValueMismatches<E, M> = {
+  [K in keyof E]: K extends keyof M ? (M[K] extends `${E[K] & string}` ? never : K) : never;
+}[keyof E];
+type ValuesMirrored<E, M> = [ConstValueMismatches<E, M>] extends [never]
+  ? true
+  : { __CONST_VALUE_MISMATCH__: ConstValueMismatches<E, M> };
+
+export type _ValuesMatchUpStatus = Assert<ValuesMirrored<typeof MatchUpStatusEnum, typeof matchUpStatusConstants>>;
+export type _ValuesEntryStatus = Assert<ValuesMirrored<typeof EntryStatusEnum, typeof entryStatusConstants>>;
+export type _ValuesSurfaceCategory = Assert<ValuesMirrored<typeof SurfaceCategoryEnum, typeof surfaceConstants>>;
+export type _ValuesWeekday = Assert<ValuesMirrored<typeof WeekdayEnum, typeof weekdayConstants>>;


### PR DESCRIPTION
Now that the const values are literal-typed (the (b) pass), the compile-time enum/const guard checks **values**, not just keys. For each dedicated mirror (matchUpStatus, entryStatus, surface, weekday), every enum member's const literal must equal the enum member's value — a value typo fails `check-types` naming the exact member:

```
error TS2344: Type '{ __CONST_VALUE_MISMATCH__: "MON"; }' does not satisfy the constraint 'true'.
```

Teeth-verified: a wrong const value (`MON = 'MONDAY'`) and a missing const both fail tsc. Still type-only + tree-shaken from the build; runtime Layer 1 unaffected. Full suite, coverage, `test:server`, lint all green.

**Layer 3 (derive const from enum → single source): investigated, NOT recommended** — see PR discussion. Both derivations (`= Enum.MEMBER` → nominal `MatchUpStatusEnum`; `` = `${Enum.MEMBER}` as const `` → widens to the full union) cascade to ~12 errors and fight the codebase's deliberate `MatchUpStatusUnion` (string) model. The runtime Layer 1 + compile-time Layer 2 (keys + values) already make divergence impossible to merge, so the guarded-dual-source is the right terminal state; a true single source would need codegen, which is heavier tooling for no practical gain.