### PR TITLE
docs(enums): correct the curated matchUpStatus sets example

### DIFF
--- a/documentation/docs/enums.mdx
+++ b/documentation/docs/enums.mdx
@@ -53,13 +53,15 @@ Reach for **constants** when you want the curated groupings that have no enum eq
 _rule_ rather than a vocabulary:
 
 ```js
-import { matchUpStatusConstants } from 'tods-competition-factory';
+import { completedMatchUpStatuses, recoveryTimeRequiredMatchUpStatuses } from 'tods-competition-factory';
 
-const { recoveryTimeRequiredMatchUpStatuses, completedMatchUpStatuses } = matchUpStatusConstants;
+completedMatchUpStatuses; // ['CANCELLED', 'ABANDONED', 'COMPLETED', 'DEAD_RUBBER', …]
 ```
 
-Those hand-authored sets live alongside the generated members in the same constant module, so one import gets you both.
-See [Constants](./constants.mdx) for the full catalogue.
+These curated sets are **top-level named exports**, also reachable as `factoryConstants.completedMatchUpStatuses`.
+They are deliberately _not_ members of the `matchUpStatusConstants` object, which mirrors the enum members and nothing
+else — so `matchUpStatusConstants.completedMatchUpStatuses` is `undefined`. See [Constants](./constants.mdx) for the
+full catalogue.
 
 ## Values are always strings
 


### PR DESCRIPTION
The enums page sample destructured `completedMatchUpStatuses` and `recoveryTimeRequiredMatchUpStatuses` from the `matchUpStatusConstants` object. They do not exist there — that object mirrors the 16 enum members and nothing else, so both names resolved to `undefined`.

They are top-level named exports, also reachable via `factoryConstants`. Corrected the sample and called out the trap explicitly.

Verified against the unpacked published 6.17.0 tarball: the corrected import typechecks under `--strict` (exit 0), and `matchUpStatusConstants.completedMatchUpStatuses` was confirmed `undefined` at runtime. Docs build green.