### PR TITLE
fix(availability): honour disabled courts and stop mislabelling unmapped booking types

### DIFF
--- a/src/assemblies/engines/availability/AvailabilityEngine.ts
+++ b/src/assemblies/engines/availability/AvailabilityEngine.ts
@@ -45,7 +45,11 @@ import {
   type TemplateId,
 } from '@Assemblies/governors/availabilityGovernor/types';
 
+import { getDisabledStatus } from '@Query/extensions/getDisabledStatus';
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 import { extractDate } from '@Tools/dateTime';
+
+import { DISABLED } from '@Constants/extensionConstants';
 
 import {
   courtDayKey,
@@ -340,7 +344,7 @@ export class AvailabilityEngine {
    * Returns the earliest start and latest end among the given courts (or all courts).
    */
   getVisibleTimeRange(day: DayId, courtRefs?: CourtRef[]): { startTime: string; endTime: string } {
-    const courts = courtRefs && courtRefs.length > 0 ? courtRefs : this.getAllCourtsFromTournamentRecord();
+    const courts = courtRefs && courtRefs.length > 0 ? courtRefs : this.getAllCourtsFromTournamentRecord(day);
 
     let earliestStart = '23:59';
     let latestEnd = '00:00';
@@ -412,7 +416,7 @@ export class AvailabilityEngine {
    * Get complete timeline for a day (all venues, all courts)
    */
   getDayTimeline(day: DayId): VenueDayTimeline[] {
-    const courts = this.getAllCourtsFromTournamentRecord();
+    const courts = this.getAllCourtsFromTournamentRecord(day);
 
     // Group by venue
     const venuesMap = new Map<VenueId, CourtRef[]>();
@@ -1188,13 +1192,38 @@ export class AvailabilityEngine {
   /**
    * Booking type -> engine BlockType mapping
    */
+  /**
+   * `Booking.bookingType` (persisted, free-form string) → engine `BlockType`.
+   *
+   * BLOCKED and CLOSED were missing: BLOCKED is what TMX's most-used block
+   * pills write, so every generic court block was arriving here as RESERVED —
+   * a different and wrong meaning ("reserved for recreational/paying players")
+   * with a different precedence slot.
+   */
   private static readonly BOOKING_TYPE_MAP: Record<string, BlockType> = {
+    BLOCKED: BLOCK_TYPES.BLOCKED,
+    CLOSED: BLOCK_TYPES.CLOSED,
     MAINTENANCE: BLOCK_TYPES.MAINTENANCE,
     PRACTICE: BLOCK_TYPES.PRACTICE,
     RESERVED: BLOCK_TYPES.RESERVED,
     MATCH: BLOCK_TYPES.SCHEDULED,
     SCHEDULED: BLOCK_TYPES.SCHEDULED,
   };
+
+  /**
+   * Where an unrecognised `bookingType` lands.
+   *
+   * BLOCKED, deliberately: it is the generic "unavailable, reason unspecified"
+   * type, so an unknown booking still removes the court from availability.
+   * Two alternatives are wrong — RESERVED (the previous behaviour) asserts a
+   * specific meaning the data never claimed, and UNSPECIFIED is excluded from
+   * the capacity curve entirely, so an unknown booking would leave the court
+   * looking free and invite a double-booking. Fail closed.
+   *
+   * The raw string is preserved on `Block.reason`, so the original value is
+   * never lost — see `createBlockFromBooking`.
+   */
+  private static readonly UNMAPPED_BOOKING_BLOCK_TYPE: BlockType = BLOCK_TYPES.BLOCKED;
 
   /**
    * Load blocks from court dateAvailability bookings in the tournament record.
@@ -1296,7 +1325,8 @@ export class AvailabilityEngine {
     const st = booking.startTime.length === 5 ? `${booking.startTime}:00` : booking.startTime;
     const et = booking.endTime.length === 5 ? `${booking.endTime}:00` : booking.endTime;
     const blockType: BlockType =
-      AvailabilityEngine.BOOKING_TYPE_MAP[(booking.bookingType || '').toUpperCase()] || BLOCK_TYPES.RESERVED;
+      AvailabilityEngine.BOOKING_TYPE_MAP[(booking.bookingType || '').toUpperCase()] ??
+      AvailabilityEngine.UNMAPPED_BOOKING_BLOCK_TYPE;
 
     const blockId = this.generateBlockId();
     const block: Block = {
@@ -1313,18 +1343,36 @@ export class AvailabilityEngine {
   }
 
   /**
-   * Get all courts from tournament record
+   * Get all courts from tournament record.
+   *
+   * Disabled venues and courts are excluded, matching
+   * `query/venues/venuesAndCourtsGetter` — the reader the scheduler uses. Both
+   * paths delegate to `getDisabledStatus` so `disabled` has exactly ONE
+   * semantic; before this they diverged, and a disabled court was invisible to
+   * the scheduler but visible here.
+   *
+   * @param day - Optional day context. `disabled` may be date-scoped
+   * (`{ dates: [...] }`); with a day the engine honours that scoping, without
+   * one only a blanket `disabled: true` excludes — the same conservative
+   * behaviour the getter has when no dates are supplied.
    */
-  private getAllCourtsFromTournamentRecord(): CourtRef[] {
+  private getAllCourtsFromTournamentRecord(day?: DayId): CourtRef[] {
     if (!this.tournamentRecord?.venues) {
       return [];
     }
 
+    const dates = day ? [day] : [];
     const courts: CourtRef[] = [];
     for (const venue of this.tournamentRecord.venues) {
+      const venueDisabled = firstClassOrExtension({ element: venue, attribute: 'disabled', name: DISABLED });
+      if (venueDisabled) continue;
+
       const vid = resolveVenueId(venue);
       if (venue.courts) {
         for (const court of venue.courts) {
+          const disabledValue = firstClassOrExtension({ element: court, attribute: 'disabled', name: DISABLED });
+          if (getDisabledStatus({ disabledValue, dates })) continue;
+
           courts.push({
             tournamentId: this.config.tournamentId,
             venueId: vid,

--- a/src/tests/availability/availabilityEngine.test.ts
+++ b/src/tests/availability/availabilityEngine.test.ts
@@ -775,7 +775,45 @@ describe('Tournament Record Loading', () => {
     expect(engine.getAllBlocks()[0].type).toBe(BLOCK_TYPES.SCHEDULED);
   });
 
-  it('should default unknown bookingType to RESERVED', () => {
+  // BLOCKED is what TMX's generic "block N rows" pills write — by far the most
+  // common booking type in practice. It was missing from BOOKING_TYPE_MAP, so
+  // every one of those blocks silently arrived as RESERVED ("reserved for
+  // recreational/paying players"), a different meaning in a different
+  // precedence slot.
+  it('should map BLOCKED bookingType to BLOCKED BlockType', () => {
+    const record = makeBasicRecord();
+    (record.venues[0].courts[0] as any).dateAvailability = [
+      {
+        date: '2026-06-15',
+        bookings: [{ startTime: '10:00', endTime: '11:00', bookingType: 'BLOCKED' }],
+      },
+    ];
+
+    const engine = new AvailabilityEngine();
+    engine.init(record, { tournamentId: TEST_TOURNAMENT });
+
+    expect(engine.getAllBlocks()[0].type).toBe(BLOCK_TYPES.BLOCKED);
+  });
+
+  it('should map CLOSED bookingType to CLOSED BlockType', () => {
+    const record = makeBasicRecord();
+    (record.venues[0].courts[0] as any).dateAvailability = [
+      {
+        date: '2026-06-15',
+        bookings: [{ startTime: '10:00', endTime: '11:00', bookingType: 'CLOSED' }],
+      },
+    ];
+
+    const engine = new AvailabilityEngine();
+    engine.init(record, { tournamentId: TEST_TOURNAMENT });
+
+    expect(engine.getAllBlocks()[0].type).toBe(BLOCK_TYPES.CLOSED);
+  });
+
+  // Unknown types fail CLOSED, not into a meaning the data never claimed. The
+  // previous default was RESERVED; UNSPECIFIED would be worse still, since the
+  // capacity curve ignores it and the court would read as free.
+  it('should default unknown bookingType to BLOCKED and preserve the raw value', () => {
     const record = makeBasicRecord();
     (record.venues[0].courts[0] as any).dateAvailability = [
       {
@@ -787,7 +825,10 @@ describe('Tournament Record Loading', () => {
     const engine = new AvailabilityEngine();
     engine.init(record, { tournamentId: TEST_TOURNAMENT });
 
-    expect(engine.getAllBlocks()[0].type).toBe(BLOCK_TYPES.RESERVED);
+    const block = engine.getAllBlocks()[0];
+    expect(block.type).toBe(BLOCK_TYPES.BLOCKED);
+    // the original string is never lost — it survives on `reason`
+    expect(block.reason).toBe('UNKNOWN_TYPE');
   });
 
   it('should load court dateAvailability times', () => {
@@ -908,6 +949,76 @@ describe('Court Metadata', () => {
     const engine2 = new AvailabilityEngine();
     engine2.init({ tournamentId: TEST_TOURNAMENT });
     expect(engine2.listCourtMeta()).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// 8b. Disabled venues and courts
+//
+// The engine must agree with `query/venues/venuesAndCourtsGetter` — the reader
+// the scheduler uses. Previously the engine iterated `venue.courts` raw, so a
+// disabled court was invisible to the scheduler but visible here: two readers,
+// two answers, same record.
+// ============================================================================
+
+describe('Disabled venues and courts', () => {
+  const DAY = '2026-06-15';
+
+  it('should exclude a court disabled outright', () => {
+    const record = makeBasicRecord();
+    (record.venues[0].courts[0] as any).disabled = true;
+
+    const engine = new AvailabilityEngine();
+    engine.init(record, { tournamentId: TEST_TOURNAMENT });
+
+    expect(engine.listCourtMeta().map((m) => m.ref.courtId)).toEqual([COURT_2]);
+  });
+
+  it('should exclude every court of a disabled venue', () => {
+    const record = makeBasicRecord();
+    (record.venues[0] as any).disabled = true;
+
+    const engine = new AvailabilityEngine();
+    engine.init(record, { tournamentId: TEST_TOURNAMENT });
+
+    expect(engine.listCourtMeta()).toHaveLength(0);
+  });
+
+  it('should honour date-scoped disabling for the day being queried', () => {
+    const record = makeBasicRecord();
+    (record.venues[0].courts[0] as any).disabled = { dates: [DAY] };
+
+    const engine = new AvailabilityEngine();
+    engine.init(record, { tournamentId: TEST_TOURNAMENT });
+
+    // COURT_1 is disabled on DAY, so only COURT_2 appears in that day's timeline
+    const timeline = engine.getDayTimeline(DAY);
+    const courtIds = timeline.flatMap((v) => v.rails.map((r) => r.court.courtId));
+    expect(courtIds).toEqual([COURT_2]);
+  });
+
+  it('should not exclude a date-scoped disabled court on other days', () => {
+    const record = makeBasicRecord();
+    (record.venues[0].courts[0] as any).disabled = { dates: [DAY] };
+
+    const engine = new AvailabilityEngine();
+    engine.init(record, { tournamentId: TEST_TOURNAMENT });
+
+    const timeline = engine.getDayTimeline('2026-06-16');
+    const courtIds = timeline.flatMap((v) => v.rails.map((r) => r.court.courtId)).sort();
+    expect(courtIds).toEqual([COURT_1, COURT_2]);
+  });
+
+  it('should keep date-scoped disabled courts when no day context is available', () => {
+    const record = makeBasicRecord();
+    (record.venues[0].courts[0] as any).disabled = { dates: [DAY] };
+
+    const engine = new AvailabilityEngine();
+    engine.init(record, { tournamentId: TEST_TOURNAMENT });
+
+    // listCourtMeta() has no day, so only a blanket `disabled: true` excludes —
+    // matching the getter's behaviour when no dates are supplied.
+    expect(engine.listCourtMeta()).toHaveLength(2);
   });
 });
 


### PR DESCRIPTION
Two independent correctness bugs in `AvailabilityEngine`, both surfaced by the court-status survey (`Mentat/planning/COURT_STATUS_AND_PREPARATION_LOGGING.md` §1).

## 1. `disabled` was ignored — two readers, two answers

`getAllCourtsFromTournamentRecord()` iterated `venue.courts` raw with no `disabled` filter, while `query/venues/venuesAndCourtsGetter` — the reader the **scheduler** uses — honours it. A disabled court was invisible to the scheduler but visible to the availability engine, from the same record.

Both paths now delegate to `getDisabledStatus`, so `disabled` has exactly one semantic. Venue-level and court-level disabling are both honoured, matching the getter.

The day is threaded through the two callers that have one (`getVisibleTimeRange`, `getDayTimeline`), so date-scoped disabling (`{ dates: [...] }`) is honoured per day. Where no day is in scope (`listCourtMeta`) only a blanket `disabled: true` excludes — the same conservative behaviour the getter has when no dates are supplied, so this does not over-exclude.

## 2. Unmapped `bookingType` was silently relabelled

`BOOKING_TYPE_MAP` knew five types, and anything else fell through to `|| BLOCK_TYPES.RESERVED`.

**`BLOCKED` was not in the map** — and it is what TMX's generic "block N rows" pills write, so the most common block in practice was arriving as `RESERVED`: a different meaning ("reserved for recreational/paying players") sitting in a different `typePrecedence` slot.

`BLOCKED` and `CLOSED` are now mapped. The fallback is `BLOCKED` — unknown vocabulary should remove the court from availability without asserting a meaning the data never claimed. `UNSPECIFIED` would be worse than either: the capacity curve deliberately ignores it, so an unknown booking would leave the court reading as free and invite a double-booking. The raw string is preserved on `Block.reason`, so nothing is lost.

## Tests

The previous test asserted `'should default unknown bookingType to RESERVED'` — it codified the bug, and is replaced.

**Every new test was falsified**: each fix was reverted in isolation and the corresponding tests confirmed to fail (3 fail with fix 1 reverted, 3 with fix 2 reverted), then restored.

## Verification

Full gate green: **10,468 vitest tests** (coverage thresholds met), 12 jest, `verify:lint`, `check-types`.