### PR TITLE
feat(codes): add BookingTypeEnum and the DRYING court booking type

### DIFF
--- a/scripts/generateEnumConstants.mjs
+++ b/scripts/generateEnumConstants.mjs
@@ -30,6 +30,7 @@ const MIRRORS = [
   { enumName: 'EntryStatusEnum', out: 'src/constants/entryStatusValues.ts' },
   { enumName: 'SurfaceCategoryEnum', out: 'src/constants/surfaceValues.ts' },
   { enumName: 'WeekdayEnum', out: 'src/constants/weekdayValues.ts' },
+  { enumName: 'BookingTypeEnum', out: 'src/constants/bookingTypeValues.ts' },
 ];
 
 // Parse a string enum's `MEMBER = 'value'` members, in declaration order.

--- a/src/assemblies/engines/availability/AvailabilityEngine.ts
+++ b/src/assemblies/engines/availability/AvailabilityEngine.ts
@@ -49,6 +49,8 @@ import { getDisabledStatus } from '@Query/extensions/getDisabledStatus';
 import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 import { extractDate } from '@Tools/dateTime';
 
+import type { BookingTypeUnion } from '@Types/tournamentTypes';
+
 import { DISABLED } from '@Constants/extensionConstants';
 
 import {
@@ -122,6 +124,9 @@ export class AvailabilityEngine {
         BLOCK_TYPES.HARD_BLOCK,
         BLOCK_TYPES.LOCKED,
         BLOCK_TYPES.SCHEDULED,
+        // above MAINTENANCE: drying is reactive and cannot be deferred, whereas
+        // maintenance usually can — so when they overlap, drying wins.
+        BLOCK_TYPES.DRYING,
         BLOCK_TYPES.MAINTENANCE,
         BLOCK_TYPES.CLOSED,
         BLOCK_TYPES.BLOCKED,
@@ -1200,14 +1205,24 @@ export class AvailabilityEngine {
    * a different and wrong meaning ("reserved for recreational/paying players")
    * with a different precedence slot.
    */
-  private static readonly BOOKING_TYPE_MAP: Record<string, BlockType> = {
+  private static readonly BOOKING_TYPE_MAP: Record<BookingTypeUnion, BlockType> = {
     BLOCKED: BLOCK_TYPES.BLOCKED,
     CLOSED: BLOCK_TYPES.CLOSED,
+    DRYING: BLOCK_TYPES.DRYING,
     MAINTENANCE: BLOCK_TYPES.MAINTENANCE,
     PRACTICE: BLOCK_TYPES.PRACTICE,
     RESERVED: BLOCK_TYPES.RESERVED,
-    MATCH: BLOCK_TYPES.SCHEDULED,
     SCHEDULED: BLOCK_TYPES.SCHEDULED,
+  };
+
+  /**
+   * Booking types that predate `BookingTypeEnum` and still occur in stored
+   * records. Kept separate from BOOKING_TYPE_MAP so that map stays exhaustive
+   * over the enum — the exhaustiveness is what makes a new member a compile
+   * error here instead of a silent runtime fallback.
+   */
+  private static readonly LEGACY_BOOKING_TYPE_ALIASES: Record<string, BlockType> = {
+    MATCH: BLOCK_TYPES.SCHEDULED,
   };
 
   /**
@@ -1324,8 +1339,10 @@ export class AvailabilityEngine {
     if (!booking.startTime || !booking.endTime) return;
     const st = booking.startTime.length === 5 ? `${booking.startTime}:00` : booking.startTime;
     const et = booking.endTime.length === 5 ? `${booking.endTime}:00` : booking.endTime;
+    const rawType = (booking.bookingType || '').toUpperCase();
     const blockType: BlockType =
-      AvailabilityEngine.BOOKING_TYPE_MAP[(booking.bookingType || '').toUpperCase()] ??
+      AvailabilityEngine.BOOKING_TYPE_MAP[rawType as BookingTypeUnion] ??
+      AvailabilityEngine.LEGACY_BOOKING_TYPE_ALIASES[rawType] ??
       AvailabilityEngine.UNMAPPED_BOOKING_BLOCK_TYPE;
 
     const blockId = this.generateBlockId();

--- a/src/assemblies/governors/availabilityGovernor/types.ts
+++ b/src/assemblies/governors/availabilityGovernor/types.ts
@@ -31,31 +31,27 @@ export type RuleId = string;
  * - AVAILABLE is derived, not stored as blocks
  */
 export const BLOCK_TYPES = {
-  MAINTENANCE: 'MAINTENANCE',
-  PRACTICE: 'PRACTICE',
-  RESERVED: 'RESERVED',
-  BLOCKED: 'BLOCKED',
-  CLOSED: 'CLOSED',
-  SCHEDULED: 'SCHEDULED',
-  SOFT_BLOCK: 'SOFT_BLOCK',
-  HARD_BLOCK: 'HARD_BLOCK',
-  LOCKED: 'LOCKED',
-  AVAILABLE: 'AVAILABLE',
-  UNSPECIFIED: 'UNSPECIFIED',
+  DRYING: 'DRYING', // Surface drying after rain — reactive, cannot be deferred
+  MAINTENANCE: 'MAINTENANCE', // Court maintenance/cleaning — planned
+  PRACTICE: 'PRACTICE', // Practice time reserved
+  RESERVED: 'RESERVED', // Reserved for recreational/paying players
+  BLOCKED: 'BLOCKED', // Generic unavailable (miscellaneous)
+  CLOSED: 'CLOSED', // Court closed (outside open hours or explicitly closed)
+  SCHEDULED: 'SCHEDULED', // Tournament matches (read-only, created by scheduler)
+  SOFT_BLOCK: 'SOFT_BLOCK', // Can be overridden if needed (legacy)
+  HARD_BLOCK: 'HARD_BLOCK', // Cannot be overridden (legacy)
+  LOCKED: 'LOCKED', // System-locked, no user modification (legacy)
+  AVAILABLE: 'AVAILABLE', // Derived status - time without any blocks
+  UNSPECIFIED: 'UNSPECIFIED', // No explicit status (gray fog - for backwards compatibility)
 } as const;
 
-export type BlockType =
-  | 'MAINTENANCE' // Court maintenance/cleaning
-  | 'PRACTICE' // Practice time reserved
-  | 'RESERVED' // Reserved for recreational/paying players
-  | 'BLOCKED' // Generic unavailable (miscellaneous)
-  | 'CLOSED' // Court closed (outside open hours or explicitly closed)
-  | 'SCHEDULED' // Tournament matches (read-only, created by scheduler)
-  | 'SOFT_BLOCK' // Can be overridden if needed (legacy)
-  | 'HARD_BLOCK' // Cannot be overridden (legacy)
-  | 'LOCKED' // System-locked, no user modification (legacy)
-  | 'AVAILABLE' // Derived status - time without any blocks
-  | 'UNSPECIFIED'; // No explicit status (gray fog - for backwards compatibility)
+/**
+ * Derived from BLOCK_TYPES rather than hand-written.
+ *
+ * This union used to be maintained as a second, parallel list, so adding a
+ * member meant editing two places and nothing caught it if you edited one.
+ */
+export type BlockType = (typeof BLOCK_TYPES)[keyof typeof BLOCK_TYPES];
 
 export type BlockSource = 'USER' | 'TEMPLATE' | 'RULE' | 'SYSTEM';
 export type BlockHardness = 'HARD' | 'SOFT';
@@ -297,11 +293,7 @@ export interface EngineContext {
 // ============================================================================
 
 export type EngineEventType =
-  | 'STATE_CHANGED'
-  | 'BLOCKS_CHANGED'
-  | 'CONFLICTS_CHANGED'
-  | 'AVAILABILITY_CHANGED'
-  | 'PLAN_CHANGED';
+  'STATE_CHANGED' | 'BLOCKS_CHANGED' | 'CONFLICTS_CHANGED' | 'AVAILABILITY_CHANGED' | 'PLAN_CHANGED';
 
 export interface EngineEvent {
   type: EngineEventType;

--- a/src/constants/bookingTypeConstants.ts
+++ b/src/constants/bookingTypeConstants.ts
@@ -1,0 +1,16 @@
+import { BLOCKED, CLOSED, DRYING, MAINTENANCE, PRACTICE, RESERVED, SCHEDULED } from './bookingTypeValues';
+
+// primitive booking-type consts are generated from BookingTypeEnum (see bookingTypeValues.ts).
+export * from './bookingTypeValues';
+
+export const bookingTypeConstants = {
+  BLOCKED,
+  CLOSED,
+  DRYING,
+  MAINTENANCE,
+  PRACTICE,
+  RESERVED,
+  SCHEDULED,
+};
+
+export default bookingTypeConstants;

--- a/src/constants/bookingTypeValues.ts
+++ b/src/constants/bookingTypeValues.ts
@@ -1,0 +1,13 @@
+/**
+ * AUTO-GENERATED — do not edit by hand.
+ * Source: BookingTypeEnum in src/types/tournamentTypes.ts
+ * Regenerate: pnpm gen:enum-constants
+ * Drift guard:  pnpm check:enum-constants
+ */
+export const BLOCKED = 'BLOCKED';
+export const CLOSED = 'CLOSED';
+export const DRYING = 'DRYING';
+export const MAINTENANCE = 'MAINTENANCE';
+export const PRACTICE = 'PRACTICE';
+export const RESERVED = 'RESERVED';
+export const SCHEDULED = 'SCHEDULED';

--- a/src/constants/enumConstConformance.ts
+++ b/src/constants/enumConstConformance.ts
@@ -18,10 +18,17 @@
  * different const key names, so their coverage is enforced only by the runtime guard.
  */
 import * as matchUpStatusConstants from './matchUpStatusConstants';
+import * as bookingTypeConstants from './bookingTypeConstants';
 import * as entryStatusConstants from './entryStatusConstants';
 import * as weekdayConstants from './weekdayConstants';
 import * as surfaceConstants from './surfaceConstants';
-import { MatchUpStatusEnum, EntryStatusEnum, SurfaceCategoryEnum, WeekdayEnum } from '@Types/tournamentTypes';
+import {
+  MatchUpStatusEnum,
+  EntryStatusEnum,
+  SurfaceCategoryEnum,
+  WeekdayEnum,
+  BookingTypeEnum,
+} from '@Types/tournamentTypes';
 
 type Assert<T extends true> = T;
 
@@ -37,6 +44,7 @@ export type _KeysMatchUpStatus = Assert<KeysMirrored<typeof MatchUpStatusEnum, t
 export type _KeysEntryStatus = Assert<KeysMirrored<typeof EntryStatusEnum, typeof entryStatusConstants>>;
 export type _KeysSurfaceCategory = Assert<KeysMirrored<typeof SurfaceCategoryEnum, typeof surfaceConstants>>;
 export type _KeysWeekday = Assert<KeysMirrored<typeof WeekdayEnum, typeof weekdayConstants>>;
+export type _KeysBookingType = Assert<KeysMirrored<typeof BookingTypeEnum, typeof bookingTypeConstants>>;
 
 // ── VALUE conformance: each const's literal value equals the enum member's value ─
 // For enum key K, `${E[K] & string}` is the enum member's string value; the const's
@@ -52,3 +60,4 @@ export type _ValuesMatchUpStatus = Assert<ValuesMirrored<typeof MatchUpStatusEnu
 export type _ValuesEntryStatus = Assert<ValuesMirrored<typeof EntryStatusEnum, typeof entryStatusConstants>>;
 export type _ValuesSurfaceCategory = Assert<ValuesMirrored<typeof SurfaceCategoryEnum, typeof surfaceConstants>>;
 export type _ValuesWeekday = Assert<ValuesMirrored<typeof WeekdayEnum, typeof weekdayConstants>>;
+export type _ValuesBookingType = Assert<ValuesMirrored<typeof BookingTypeEnum, typeof bookingTypeConstants>>;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -25,6 +25,7 @@ export { requestConstants } from './requestConstants';
 export { availabilityConstants } from './availabilityConstants';
 export { resourceContants } from './resourceConstants';
 export { resultConstants } from './resultConstants';
+export { bookingTypeConstants } from './bookingTypeConstants';
 export { scaleConstants } from './scaleConstants';
 export { scheduleConstants } from './scheduleConstants';
 export { sortingConstants } from './sortingConstants';

--- a/src/constants/scheduleConstants.ts
+++ b/src/constants/scheduleConstants.ts
@@ -1,3 +1,5 @@
+import { BLOCKED, MAINTENANCE, PRACTICE } from './bookingTypeValues';
+
 export const DOUBLES_SINGLES = 'DOUBLES_SINGLES';
 export const SINGLES_DOUBLES = 'SINGLES_DOUBLES';
 export const TOTAL = 'total';
@@ -14,10 +16,13 @@ export const SCHEDULE_ERROR = 'ERROR';
 export const SCHEDULE_ISSUE = 'ISSUE';
 export const SCHEDULE_STATE = 'STATE';
 
-// Booking types for court grid bookings
-export const BLOCKED = 'BLOCKED';
-export const PRACTICE = 'PRACTICE';
-export const MAINTENANCE = 'MAINTENANCE';
+// Booking types for court grid bookings.
+// Re-exported from the generated BookingTypeEnum mirror rather than redefined,
+// so there is a single source. The full vocabulary (incl. CLOSED, DRYING,
+// RESERVED, SCHEDULED) lives in `bookingTypeConstants`; these three are kept
+// here as named exports because they are long-standing published surface via
+// `factoryConstants.scheduleConstants`.
+export { BLOCKED, MAINTENANCE, PRACTICE };
 
 export const scheduleConstants = {
   SINGLES_DOUBLES,

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,10 @@ export { mocksEngine } from './assemblies/engines/mock';
 
 // ENGINES - Standalone class engines -----------------------------------
 export { AvailabilityEngine } from './assemblies/engines/availability';
+// The engine-side block vocabulary. Consumers can write `Booking.bookingType`
+// (see BookingTypeEnum), so they need to be able to see what it resolves to —
+// BLOCK_TYPES is the superset that also carries derived and legacy states.
+export { BLOCK_TYPES } from './assemblies/governors/availabilityGovernor/types';
 export * as availability from './assemblies/engines/availability';
 
 // ENGINES - Scale engine -----------------------------------------------
@@ -133,6 +137,7 @@ export type * from './types';
 export {
   AddressTypeEnum,
   BallTypeEnum,
+  BookingTypeEnum,
   CountryCodeEnum,
   CourtPositionEnum,
   DrawTypeEnum,

--- a/src/tests/availability/availabilityEngine.test.ts
+++ b/src/tests/availability/availabilityEngine.test.ts
@@ -795,6 +795,48 @@ describe('Tournament Record Loading', () => {
     expect(engine.getAllBlocks()[0].type).toBe(BLOCK_TYPES.BLOCKED);
   });
 
+  it('should map DRYING bookingType to DRYING BlockType', () => {
+    const record = makeBasicRecord();
+    (record.venues[0].courts[0] as any).dateAvailability = [
+      {
+        date: '2026-06-15',
+        bookings: [{ startTime: '10:00', endTime: '11:00', bookingType: 'DRYING' }],
+      },
+    ];
+
+    const engine = new AvailabilityEngine();
+    engine.init(record, { tournamentId: TEST_TOURNAMENT });
+
+    expect(engine.getAllBlocks()[0].type).toBe(BLOCK_TYPES.DRYING);
+  });
+
+  // DRYING sits above MAINTENANCE in the default precedence: maintenance can
+  // usually be deferred, drying cannot, so drying wins an overlap.
+  it('should resolve DRYING over MAINTENANCE when they overlap', () => {
+    const engine = new AvailabilityEngine();
+    engine.init(makeBasicRecord(), { tournamentId: TEST_TOURNAMENT });
+    const precedence = engine.getConfig().typePrecedence;
+
+    expect(precedence.indexOf(BLOCK_TYPES.DRYING)).toBeLessThan(precedence.indexOf(BLOCK_TYPES.MAINTENANCE));
+  });
+
+  // MATCH predates BookingTypeEnum and is not a member; it resolves through the
+  // legacy alias table, NOT through the unmapped fallback.
+  it('should still resolve the legacy MATCH bookingType to SCHEDULED', () => {
+    const record = makeBasicRecord();
+    (record.venues[0].courts[0] as any).dateAvailability = [
+      {
+        date: '2026-06-15',
+        bookings: [{ startTime: '10:00', endTime: '11:00', bookingType: 'MATCH' }],
+      },
+    ];
+
+    const engine = new AvailabilityEngine();
+    engine.init(record, { tournamentId: TEST_TOURNAMENT });
+
+    expect(engine.getAllBlocks()[0].type).toBe(BLOCK_TYPES.SCHEDULED);
+  });
+
   it('should map CLOSED bookingType to CLOSED BlockType', () => {
     const record = makeBasicRecord();
     (record.venues[0].courts[0] as any).dateAvailability = [

--- a/src/tests/constants/enumConstConformance.test.ts
+++ b/src/tests/constants/enumConstConformance.test.ts
@@ -2,6 +2,7 @@ import * as drawDefinitionConstants from '@Constants/drawDefinitionConstants';
 import * as matchUpStatusConstants from '@Constants/matchUpStatusConstants';
 import * as participantConstants from '@Constants/participantConstants';
 import * as entryStatusConstants from '@Constants/entryStatusConstants';
+import * as bookingTypeConstants from '@Constants/bookingTypeConstants';
 import * as weekdayConstants from '@Constants/weekdayConstants';
 import * as surfaceConstants from '@Constants/surfaceConstants';
 import * as genderConstants from '@Constants/genderConstants';
@@ -46,6 +47,7 @@ const MIRRORS: { name: string; enum: Record<string, unknown>; consts: Record<str
   { name: 'EntryStatus', enum: T.EntryStatusEnum, consts: entryStatusConstants },
   { name: 'SurfaceCategory', enum: T.SurfaceCategoryEnum, consts: surfaceConstants },
   { name: 'Weekday', enum: T.WeekdayEnum, consts: weekdayConstants },
+  { name: 'BookingType', enum: T.BookingTypeEnum, consts: bookingTypeConstants },
 ];
 
 // ── Bucket coverage — every enum value backed by a const value in the bucket ──

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -1679,9 +1679,34 @@ export interface Availability {
   updatedAt?: Date | string;
 }
 
+/**
+ * What a court booking represents. Persisted on `Booking.bookingType`.
+ *
+ * DRYING is deliberately distinct from MAINTENANCE: maintenance is planned and
+ * can usually be deferred, drying is reactive and cannot — they need separate
+ * scheduling precedence, and collapsing them makes "how much court time did we
+ * lose to weather?" unanswerable after the fact.
+ *
+ * The engine-side vocabulary these map onto is `BLOCK_TYPES` (a superset —
+ * it also carries derived and legacy states that are never persisted here).
+ */
+export enum BookingTypeEnum {
+  BLOCKED = 'BLOCKED',
+  CLOSED = 'CLOSED',
+  DRYING = 'DRYING',
+  MAINTENANCE = 'MAINTENANCE',
+  PRACTICE = 'PRACTICE',
+  RESERVED = 'RESERVED',
+  SCHEDULED = 'SCHEDULED',
+}
+export type BookingTypeUnion = `${BookingTypeEnum}`;
+
 export interface Booking {
   bookingId?: string;
-  bookingType?: string;
+  // Widened with `(string & {})` so unrecognised values from external sources
+  // still type-check while known members keep autocompleting. The engine maps
+  // anything unrecognised to BLOCK_TYPES.BLOCKED — see BOOKING_TYPE_MAP.
+  bookingType?: BookingTypeUnion | (string & {});
   capacity?: number | null;
   createdAt?: Date | string;
   endTime?: string;


### PR DESCRIPTION
Implements decisions D1–D3 and D5 from `Mentat/planning/COURT_STATUS_AND_PREPARATION_LOGGING.md`, locked interactively.

## BookingTypeEnum (D2)

`Booking.bookingType` was a bare `string` — no union, no enum, no validator. Every consumer string-matched it and a typo was undetectable.

It is now `BookingTypeEnum`, generated into a constant mirror by `generateEnumConstants` and covered by both conformance guards (runtime + compile-time). The persisted field is typed `BookingTypeUnion | (string & {})` so external data still type-checks while known members autocomplete.

`scheduleConstants` re-exports `BLOCKED`/`MAINTENANCE`/`PRACTICE` **from the generated mirror** rather than redefining them, so the long-standing `factoryConstants.scheduleConstants` surface is byte-identical while the enum becomes the single source.

## DRYING (D1)

Added as both a booking type and a `BlockType`, with a precedence slot **above MAINTENANCE**: maintenance is planned and can usually be deferred, drying is reactive and cannot — so drying wins an overlap. Keeping them distinct is also what makes weather-driven court loss separable from planned maintenance in reporting.

## Exhaustive map (D2)

`BOOKING_TYPE_MAP` is now `Record<BookingTypeUnion, BlockType>`. A new enum member is a **compile error naming the missing key** instead of a silent runtime fallback — verified by removing `DRYING` and confirming `TS2741: Property 'DRYING' is missing`.

`MATCH` predates the enum and is not a member; it moves to an explicit `LEGACY_BOOKING_TYPE_ALIASES` table so the main map can stay exhaustive. A test covers that it still resolves to `SCHEDULED`.

## BlockType derived + exported (D3, D5)

`BlockType` was a hand-maintained union sitting next to the `BLOCK_TYPES` const object — adding a member meant editing two places with nothing catching a half-edit. It is now `(typeof BLOCK_TYPES)[keyof typeof BLOCK_TYPES]`, so drift is impossible by construction.

`BLOCK_TYPES` is now exported from the package. Consumers can write `bookingType`, so they need to be able to see what it resolves to.

## Verification

Full gate green: **10,473 vitest** (coverage thresholds met), 12 jest, `verify:lint`, `check-types`, `verify:generated`.

Built `dist/` and confirmed the new surface resolves at runtime: `BookingTypeEnum.DRYING`, `BLOCK_TYPES.DRYING`, all 7 `bookingTypeConstants`, and `factoryConstants.scheduleConstants.MAINTENANCE` unchanged for back-compat. Runtime enum count 30 → 31.