### PR TITLE
refactor(availability): drop the unused MATCH booking-type alias

### DIFF
--- a/src/assemblies/engines/availability/AvailabilityEngine.ts
+++ b/src/assemblies/engines/availability/AvailabilityEngine.ts
@@ -1216,16 +1216,6 @@ export class AvailabilityEngine {
   };
 
   /**
-   * Booking types that predate `BookingTypeEnum` and still occur in stored
-   * records. Kept separate from BOOKING_TYPE_MAP so that map stays exhaustive
-   * over the enum — the exhaustiveness is what makes a new member a compile
-   * error here instead of a silent runtime fallback.
-   */
-  private static readonly LEGACY_BOOKING_TYPE_ALIASES: Record<string, BlockType> = {
-    MATCH: BLOCK_TYPES.SCHEDULED,
-  };
-
-  /**
    * Where an unrecognised `bookingType` lands.
    *
    * BLOCKED, deliberately: it is the generic "unavailable, reason unspecified"
@@ -1342,7 +1332,6 @@ export class AvailabilityEngine {
     const rawType = (booking.bookingType || '').toUpperCase();
     const blockType: BlockType =
       AvailabilityEngine.BOOKING_TYPE_MAP[rawType as BookingTypeUnion] ??
-      AvailabilityEngine.LEGACY_BOOKING_TYPE_ALIASES[rawType] ??
       AvailabilityEngine.UNMAPPED_BOOKING_BLOCK_TYPE;
 
     const blockId = this.generateBlockId();

--- a/src/tests/availability/availabilityEngine.test.ts
+++ b/src/tests/availability/availabilityEngine.test.ts
@@ -760,21 +760,6 @@ describe('Tournament Record Loading', () => {
     expect(engine.getAllBlocks()[0].type).toBe(BLOCK_TYPES.PRACTICE);
   });
 
-  it('should map MATCH bookingType to SCHEDULED BlockType', () => {
-    const record = makeBasicRecord();
-    (record.venues[0].courts[0] as any).dateAvailability = [
-      {
-        date: '2026-06-15',
-        bookings: [{ startTime: '10:00', endTime: '11:00', bookingType: 'MATCH' }],
-      },
-    ];
-
-    const engine = new AvailabilityEngine();
-    engine.init(record, { tournamentId: TEST_TOURNAMENT });
-
-    expect(engine.getAllBlocks()[0].type).toBe(BLOCK_TYPES.SCHEDULED);
-  });
-
   // BLOCKED is what TMX's generic "block N rows" pills write — by far the most
   // common booking type in practice. It was missing from BOOKING_TYPE_MAP, so
   // every one of those blocks silently arrived as RESERVED ("reserved for
@@ -818,23 +803,6 @@ describe('Tournament Record Loading', () => {
     const precedence = engine.getConfig().typePrecedence;
 
     expect(precedence.indexOf(BLOCK_TYPES.DRYING)).toBeLessThan(precedence.indexOf(BLOCK_TYPES.MAINTENANCE));
-  });
-
-  // MATCH predates BookingTypeEnum and is not a member; it resolves through the
-  // legacy alias table, NOT through the unmapped fallback.
-  it('should still resolve the legacy MATCH bookingType to SCHEDULED', () => {
-    const record = makeBasicRecord();
-    (record.venues[0].courts[0] as any).dateAvailability = [
-      {
-        date: '2026-06-15',
-        bookings: [{ startTime: '10:00', endTime: '11:00', bookingType: 'MATCH' }],
-      },
-    ];
-
-    const engine = new AvailabilityEngine();
-    engine.init(record, { tournamentId: TEST_TOURNAMENT });
-
-    expect(engine.getAllBlocks()[0].type).toBe(BLOCK_TYPES.SCHEDULED);
   });
 
   it('should map CLOSED bookingType to CLOSED BlockType', () => {

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -1687,8 +1687,15 @@ export interface Availability {
  * scheduling precedence, and collapsing them makes "how much court time did we
  * lose to weather?" unanswerable after the fact.
  *
- * The engine-side vocabulary these map onto is `BLOCK_TYPES` (a superset —
- * it also carries derived and legacy states that are never persisted here).
+ * SCHEDULED is an umbrella for court time allocated to tournament play — it
+ * means the time is spoken for, whether or not a specific matchUp ends up on
+ * the court. It is NOT how scheduled matchUps reach the availability engine:
+ * those arrive through `AvailabilityEngine.importScheduledMatchUps()`, which
+ * builds SCHEDULED blocks straight from matchUps and never touches
+ * `bookingType`.
+ *
+ * The engine-side vocabulary these map onto is `BLOCK_TYPES` (a superset — it
+ * also carries derived and legacy states that are never persisted here).
  */
 export enum BookingTypeEnum {
   BLOCKED = 'BLOCKED',


### PR DESCRIPTION
`MATCH` was never migration debt, so `LEGACY_BOOKING_TYPE_ALIASES` was defending nothing. Three pieces of evidence:

1. **It was born with the engine.** `git log -S` traces `MATCH: BLOCK_TYPES.SCHEDULED` to `ee64f43de feat: :construction: first commit temporalEngine` — the engine's own first commit. It was never carried in from stored records.
2. **Nothing has ever written it.** Grepping `bookingType` across factory, TMX, courthive-components, CFS, courthive-public, epixodic, courthive-ingest, classic-converter, courthive-arena, courthive-ams, courthive-query, pdf-factory and scoringVisualizations finds no producer. The only two occurrences were the tests.
3. **It bridged a path that does not structurally exist.** Scheduled matchUps never become bookings — `importScheduledMatchUps()` builds SCHEDULED blocks directly from matchUps and never consults `bookingType`. The mapping defended a producer that could not have existed.

Removing it leaves `BOOKING_TYPE_MAP` as the single lookup, exhaustive over `BookingTypeUnion`. A stray `'MATCH'` string would now take the unmapped fallback to `BLOCKED` — fail-closed, and unreachable in practice.

Both MATCH tests are removed: the pre-existing one (which asserted the mapping) and the one added earlier this session. The generic unknown-bookingType test still covers stray values.

## Also: what SCHEDULED actually means

Documented on `BookingTypeEnum` — a SCHEDULED **booking** is an umbrella for court time allocated to tournament play, whether or not a specific matchUp lands on the court. That is distinct from the SCHEDULED **blocks** `importScheduledMatchUps` creates, and the distinction is what made the MATCH mapping look plausible in the first place.

## Verification

Full gate green: **10,471 vitest** (coverage thresholds met), 12 jest, `verify:lint`, `check-types`.