### PR TITLE
fix(score): matchUpScore carries forward non-derived score attributes

### DIFF
--- a/src/assemblies/generators/matchUps/matchUpScore.ts
+++ b/src/assemblies/generators/matchUps/matchUpScore.ts
@@ -38,5 +38,10 @@ export function matchUpScore(params) {
     scoreStringSide2 = winningSide === 2 ? winnerPerspective : loserPerspective;
   }
 
-  return { score: { sets, scoreStringSide1, scoreStringSide2 } };
+  // DECISION: carry forward every non-derived attribute of the incoming score
+  // WHY: only sets and the two score strings are derived here. Returning just those three made the
+  // returned object look like a complete score while silently dropping anything else the caller had
+  // set — e.g. score.side1PointScore on an in-progress matchUp — so a caller assigning the result
+  // over its own score lost data. Spreading keeps `score` in, `score` out. See competition-factory#4564.
+  return { score: { ...score, sets, scoreStringSide1, scoreStringSide2 } };
 }

--- a/src/mutate/matchUps/matchUpStatus/setMatchUpStatus.ts
+++ b/src/mutate/matchUps/matchUpStatus/setMatchUpStatus.ts
@@ -172,11 +172,9 @@ export function setMatchUpStatus(params: SetMatchUpStatusArgs) {
       score: { ...outcome.score, sets },
       setTBlast,
     });
-    // DECISION: merge rather than replace so non-derived score attributes survive
-    // WHY: matchUpScore returns only { sets, scoreStringSide1, scoreStringSide2 }; replacing wholesale
-    // would drop live-scoring attributes such as score.side1PointScore that callers legitimately set
-    // on an in-progress matchUp and that previously survived via the skip-generation branch
-    outcome.score = { ...outcome.score, ...scoreObject };
+    // matchUpScore carries forward every non-derived attribute of the score it was handed
+    // (score.side1PointScore and friends), so assigning its result is not lossy
+    outcome.score = scoreObject;
   }
 
   // DECISION: Delegate to setMatchUpState for core status/score setting logic


### PR DESCRIPTION
Follow-up to #4564.

`matchUpScore` returned only `{ sets, scoreStringSide1, scoreStringSide2 }` — a shape that looks like a complete score but silently drops anything else the caller set, e.g. `score.side1PointScore` on an in-progress matchUp. A caller assigning the result over its own score lost data.

This was latent while `setMatchUpStatus` skipped generation for callers supplying their own score strings. Once generation became unconditional (`277341b3d`) the loss became reachable, and was worked around at the call site with a merge. The fix belongs in `matchUpScore` so the trap is gone for any future caller: spread the incoming score, then overwrite the three derived keys.

- `generateOutcome` is unaffected — it passes `score: { sets }` only, so its result is byte-identical.
- `setMatchUpStatus` reverts to plain assignment.

Full suite green (10491 passed / 3 skipped at the time of the commit), lint + check-types clean.