### PR TITLE
feat(constants): expose action method names via actionMethodConstants

### DIFF
--- a/src/constants/actionMethodConstants.ts
+++ b/src/constants/actionMethodConstants.ts
@@ -1,0 +1,77 @@
+/**
+ * Engine method names carried on the actions returned by `positionActions()` and
+ * `matchUpActions()`.
+ *
+ * Each action a consumer receives looks like `{ type, method, payload, … }`, where
+ * `method` is the name of the engine method to invoke — `'assignDrawPosition'`,
+ * `'addPenalty'`, and so on. That makes these values part of the consumer contract,
+ * not internal detail: a client that renders available actions has to be able to
+ * recognise and dispatch them.
+ *
+ * They are grouped here rather than folded into `positionActionConstants` /
+ * `matchUpActionConstants` because they answer a different question. Those objects
+ * carry action *identities* (`ASSIGN_PARTICIPANT`); these carry the engine *method*
+ * to call for one (`ASSIGN_PARTICIPANT_METHOD`). Keeping the boundary explicit also
+ * keeps each source module's action/method pairing intact — the constants are still
+ * declared next to their actions and only aggregated here.
+ *
+ * Guarded by `src/tests/constants/actionMethodConformance.test.ts`, which fails if
+ * any identifier emitted as a `method:` field under `src/query/` is not reachable on
+ * an exported constants object.
+ */
+import {
+  ASSIGN_SIDE_METHOD,
+  ASSIGN_TEAM_POSITION_METHOD,
+  REMOVE_SIDE_METHOD,
+  REMOVE_TEAM_POSITION_METHOD,
+  REPLACE_TEAM_POSITION_METHOD,
+  SCHEDULE_METHOD,
+  SUBSTITUTION_METHOD,
+} from './matchUpActionConstants';
+import {
+  ADD_NICKNAME_METHOD,
+  ADD_PENALTY_METHOD,
+  ALTERNATE_PARTICIPANT_METHOD,
+  ASSIGN_BYE_METHOD,
+  ASSIGN_PARTICIPANT_METHOD,
+  LUCKY_PARTICIPANT_METHOD,
+  MODIFY_PAIR_ASSIGNMENT_METHOD,
+  QUALIFYING_PARTICIPANT_METHOD,
+  REMOVE_ASSIGNMENT_METHOD,
+  REMOVE_SEED_METHOD,
+  SEED_CASCADE_METHOD,
+  SEED_VALUE_METHOD,
+  SWAP_ADHOC_PARTICIPANT_METHOD,
+  SWAP_PARTICIPANT_METHOD,
+  WITHDRAW_PARTICIPANT_METHOD,
+} from './positionActionConstants';
+
+export const actionMethodConstants = {
+  // position actions
+  ADD_NICKNAME_METHOD,
+  ADD_PENALTY_METHOD,
+  ALTERNATE_PARTICIPANT_METHOD,
+  ASSIGN_BYE_METHOD,
+  ASSIGN_PARTICIPANT_METHOD,
+  LUCKY_PARTICIPANT_METHOD,
+  MODIFY_PAIR_ASSIGNMENT_METHOD,
+  QUALIFYING_PARTICIPANT_METHOD,
+  REMOVE_ASSIGNMENT_METHOD,
+  REMOVE_SEED_METHOD,
+  SEED_CASCADE_METHOD,
+  SEED_VALUE_METHOD,
+  SWAP_ADHOC_PARTICIPANT_METHOD,
+  SWAP_PARTICIPANT_METHOD,
+  WITHDRAW_PARTICIPANT_METHOD,
+
+  // matchUp actions
+  ASSIGN_SIDE_METHOD,
+  ASSIGN_TEAM_POSITION_METHOD,
+  REMOVE_SIDE_METHOD,
+  REMOVE_TEAM_POSITION_METHOD,
+  REPLACE_TEAM_POSITION_METHOD,
+  SCHEDULE_METHOD,
+  SUBSTITUTION_METHOD,
+};
+
+export default actionMethodConstants;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -25,6 +25,7 @@ export { requestConstants } from './requestConstants';
 export { availabilityConstants } from './availabilityConstants';
 export { resourceContants } from './resourceConstants';
 export { resultConstants } from './resultConstants';
+export { actionMethodConstants } from './actionMethodConstants';
 export { bookingTypeConstants } from './bookingTypeConstants';
 export { scaleConstants } from './scaleConstants';
 export { scheduleConstants } from './scheduleConstants';

--- a/src/tests/constants/actionMethodConformance.test.ts
+++ b/src/tests/constants/actionMethodConformance.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Action `method:` reachability guard.
+ *
+ * `positionActions()` and `matchUpActions()` hand consumers actions shaped like
+ * `{ type, method, payload }`, where `method` names the engine method to invoke.
+ * A consumer that cannot see the constant behind that value has to hardcode the
+ * literal — which is exactly what TMX did (`method: 'assignDrawPosition'`) for as
+ * long as the 22 `*_METHOD` constants were exported by their modules but absent
+ * from every exported object.
+ *
+ * That is the same defect class as `entryStatusConstants.REGISTERED` (a value the
+ * factory produces, unreachable on the surface consumers actually use), but it is
+ * not enum-backed, so the enum/const conformance guards cannot see it. This is its
+ * counterpart: scan what `src/query/` EMITS, and require it to be reachable.
+ *
+ * Fails when a new action is added with a `method:` constant that never makes it
+ * onto an exported constants object.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import * as factoryConstants from '@Constants/index';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '../../..');
+const QUERY_DIR = join(ROOT, 'src/query');
+
+function tsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...tsFiles(full));
+    else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts')) out.push(full);
+  }
+  return out;
+}
+
+/** CONST_CASE identifiers used as the `method:` value of an emitted action. */
+function emittedMethodIdentifiers(): string[] {
+  const found = new Set<string>();
+  for (const file of tsFiles(QUERY_DIR)) {
+    const src = readFileSync(file, 'utf8');
+    const re = /method:\s*([A-Z][A-Z0-9_]*)\b/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(src))) found.add(m[1]);
+  }
+  return [...found].sort();
+}
+
+/** Every constant NAME reachable on any exported constants object. */
+function reachableConstantNames(): Set<string> {
+  const names = new Set<string>();
+  for (const [key, value] of Object.entries(factoryConstants as Record<string, unknown>)) {
+    if (typeof value === 'string') names.add(key);
+    if (value && typeof value === 'object') {
+      for (const [innerKey, innerValue] of Object.entries(value as Record<string, unknown>)) {
+        if (typeof innerValue === 'string') names.add(innerKey);
+      }
+    }
+  }
+  return names;
+}
+
+describe('action `method:` constants are reachable by consumers', () => {
+  const emitted = emittedMethodIdentifiers();
+
+  it('finds the emitted method identifiers (guard is actually scanning)', () => {
+    // A tripwire: if the scan silently matches nothing — moved directory, changed
+    // payload shape — the reachability assertion below would vacuously pass.
+    expect(emitted.length).toBeGreaterThan(15);
+    expect(emitted).toContain('ASSIGN_PARTICIPANT_METHOD');
+  });
+
+  it('every emitted method constant is reachable on an exported constants object', () => {
+    const reachable = reachableConstantNames();
+    const unreachable = emitted.filter((name) => !reachable.has(name));
+    expect(unreachable).toEqual([]);
+  });
+
+  it('actionMethodConstants values are the engine method names, not the constant names', () => {
+    // Guards against someone "fixing" a gap by adding NAME: 'NAME' placeholders.
+    const { actionMethodConstants } = factoryConstants;
+    for (const [name, value] of Object.entries(actionMethodConstants)) {
+      expect(value, `${name} should hold an engine method name`).not.toBe(name);
+      expect(value).toMatch(/^[a-z]/);
+    }
+  });
+});


### PR DESCRIPTION
> **⚠️ CORRECTION — see #4569.** The justification below is wrong and is retained only as the historical record. It cites TMX hardcoding `method: 'assignDrawPosition'` as evidence consumers need these constants. That was a misdiagnosis: those were **direct `mutationRequest` calls** belonging to TMX's own `mutationConstants` registry, and they were fixed that way in TMX `7616c7b8` with no dependency on this object.
>
> Verified across TMX, courthive-components, courthive-public, epixodic, CFS and AMS: **no consumer branches on `action.method`** — they forward it verbatim, and branching keys off `action.type`, which `positionActionConstants` already exposed.
>
> The justification that actually holds is **internal**: this object is the only place all 22 action methods are enumerated, which makes them checkable against the generated `FactoryEngineMethod` union — so a renamed engine method becomes a compile error here instead of a "method not found" at consumer dispatch time. #4569 types the aggregate, restates the guard as a completeness check feeding that type, and adds a runtime mirror.

---

## The gap

`positionActions()` and `matchUpActions()` return actions carrying the engine method to invoke:

```js
{ type: 'ASSIGN_PARTICIPANT', method: 'assignDrawPosition', payload: { … } }
```

All **22** of those `*_METHOD` constants were exported by their modules but absent from every exported object, so consumers could not reach them. ~~TMX hardcodes `method: 'assignDrawPosition'` in `participantAssignmentMode.ts` at two sites — while importing `positionActionConstants` for `ASSIGN_PARTICIPANT` a few files away.~~ *(This inference was wrong — see the correction above.)*

Same defect class as `entryStatusConstants.REGISTERED` (#4565): a value the factory *produces*, missing from the surface consumers *use*. Not enum-backed, so the enum/const conformance guards are structurally unable to see it.

## The shape

A dedicated `actionMethodConstants` object rather than growing `positionActionConstants` / `matchUpActionConstants`. Those carry action **identities** (`ASSIGN_PARTICIPANT`); these carry the **method to call** for one (`ASSIGN_PARTICIPANT_METHOD`).

The constants stay declared next to their actions and are only aggregated here, so each source module keeps its action/method pairing intact.

## The guard

`src/tests/constants/actionMethodConformance.test.ts` scans what `src/query/` emits — every CONST_CASE identifier used as a `method:` field must be reachable on an exported constants object. *(Reframed in #4569 as a completeness check feeding the type, since consumer reachability was not the real requirement.)*

## Verification

Full gate green: **10,502 vitest** (coverage thresholds met), 12 jest, `verify:lint`, `check-types`, `verify:generated`.