### PR TITLE
fix(constants): ground actionMethodConstants in engine-method validity

### DIFF
--- a/src/constants/actionMethodConstants.ts
+++ b/src/constants/actionMethodConstants.ts
@@ -1,23 +1,31 @@
 /**
- * Engine method names carried on the actions returned by `positionActions()` and
- * `matchUpActions()`.
+ * Every engine method name carried on the actions returned by `positionActions()`
+ * and `matchUpActions()`, enumerated in one place.
  *
- * Each action a consumer receives looks like `{ type, method, payload, … }`, where
- * `method` is the name of the engine method to invoke — `'assignDrawPosition'`,
- * `'addPenalty'`, and so on. That makes these values part of the consumer contract,
- * not internal detail: a client that renders available actions has to be able to
- * recognise and dispatch them.
+ * WHY THIS EXISTS — it is an internal invariant anchor first, a public export second.
  *
- * They are grouped here rather than folded into `positionActionConstants` /
- * `matchUpActionConstants` because they answer a different question. Those objects
- * carry action *identities* (`ASSIGN_PARTICIPANT`); these carry the engine *method*
- * to call for one (`ASSIGN_PARTICIPANT_METHOD`). Keeping the boundary explicit also
- * keeps each source module's action/method pairing intact — the constants are still
- * declared next to their actions and only aggregated here.
+ * Each action looks like `{ type, method, payload, … }`, where `method` names the
+ * engine method a consumer will invoke. Nothing previously tied those strings to the
+ * engine surface: rename an engine method and the actions keep emitting the old name,
+ * with the failure surfacing at consumer dispatch time as "method not found" — in
+ * someone else's codebase. Typing this aggregate as `Record<string, FactoryEngineMethod>`
+ * against the generated method union turns that into a compile error here instead.
  *
- * Guarded by `src/tests/constants/actionMethodConformance.test.ts`, which fails if
- * any identifier emitted as a `method:` field under `src/query/` is not reachable on
- * an exported constants object.
+ * Being exported is a side benefit, NOT the justification. No consumer in the
+ * CourtHive ecosystem branches on `action.method` — they forward it verbatim
+ * (`{ method: action.method, params: action.payload }`), and code that needs to
+ * branch on an action keys off `action.type`, which `positionActionConstants` /
+ * `matchUpActionConstants` already expose. External CODES implementers may still
+ * find it useful, which is why it stays exported.
+ *
+ * Grouped here rather than folded into those two objects because they answer a
+ * different question: they carry action *identities* (`ASSIGN_PARTICIPANT`), this
+ * carries the engine *method* to call for one (`ASSIGN_PARTICIPANT_METHOD`). The
+ * constants stay declared next to their actions and are only aggregated here.
+ *
+ * `src/tests/constants/actionMethodConformance.test.ts` keeps the enumeration
+ * complete — without it, a newly added action method would simply never reach this
+ * object and the type check above would silently stop covering it.
  */
 import {
   ASSIGN_SIDE_METHOD,
@@ -46,7 +54,9 @@ import {
   WITHDRAW_PARTICIPANT_METHOD,
 } from './positionActionConstants';
 
-export const actionMethodConstants = {
+import type { FactoryEngineMethod } from '@Types/factoryEngineMethods';
+
+export const actionMethodConstants: Record<string, FactoryEngineMethod> = {
   // position actions
   ADD_NICKNAME_METHOD,
   ADD_PENALTY_METHOD,

--- a/src/tests/constants/actionMethodConformance.test.ts
+++ b/src/tests/constants/actionMethodConformance.test.ts
@@ -1,30 +1,36 @@
 /**
- * Action `method:` reachability guard.
+ * Action `method:` validity guard.
  *
  * `positionActions()` and `matchUpActions()` hand consumers actions shaped like
  * `{ type, method, payload }`, where `method` names the engine method to invoke.
- * A consumer that cannot see the constant behind that value has to hardcode the
- * literal — which is exactly what TMX did (`method: 'assignDrawPosition'`) for as
- * long as the 22 `*_METHOD` constants were exported by their modules but absent
- * from every exported object.
+ * The invariant worth protecting is that those names are REAL — rename an engine
+ * method and the actions keep emitting the old string, which fails at consumer
+ * dispatch time as "method not found", in someone else's codebase.
  *
- * That is the same defect class as `entryStatusConstants.REGISTERED` (a value the
- * factory produces, unreachable on the surface consumers actually use), but it is
- * not enum-backed, so the enum/const conformance guards cannot see it. This is its
- * counterpart: scan what `src/query/` EMITS, and require it to be reachable.
+ * `actionMethodConstants` is typed `Record<string, FactoryEngineMethod>`, so tsc
+ * catches an invalid name at the aggregation point. This file covers the two gaps
+ * that typing alone leaves:
  *
- * Fails when a new action is added with a `method:` constant that never makes it
- * onto an exported constants object.
+ *   1. COMPLETENESS — a newly added action method that never reaches
+ *      `actionMethodConstants` is simply not covered by that type. The scan of what
+ *      `src/query/` actually emits is what keeps the enumeration honest.
+ *   2. BUILT OUTPUT — the type can be bypassed (`as any`, a `.js` source). The
+ *      runtime check re-verifies values against the generated method union.
+ *
+ * Note this deliberately does NOT assert that consumers need these constants. They
+ * do not: nothing in the ecosystem branches on `action.method` — consumers forward
+ * it verbatim, and branching keys off `action.type`, which was always exported.
  */
 import { describe, expect, it } from 'vitest';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import * as factoryConstants from '@Constants/index';
+import { actionMethodConstants } from '@Constants/actionMethodConstants';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '../../..');
 const QUERY_DIR = join(ROOT, 'src/query');
+const ENGINE_METHODS_FILE = join(ROOT, 'src/types/factoryEngineMethods.ts');
 
 function tsFiles(dir: string): string[] {
   const out: string[] = [];
@@ -48,42 +54,36 @@ function emittedMethodIdentifiers(): string[] {
   return [...found].sort();
 }
 
-/** Every constant NAME reachable on any exported constants object. */
-function reachableConstantNames(): Set<string> {
-  const names = new Set<string>();
-  for (const [key, value] of Object.entries(factoryConstants as Record<string, unknown>)) {
-    if (typeof value === 'string') names.add(key);
-    if (value && typeof value === 'object') {
-      for (const [innerKey, innerValue] of Object.entries(value as Record<string, unknown>)) {
-        if (typeof innerValue === 'string') names.add(innerKey);
-      }
-    }
-  }
-  return names;
+/** The generated FactoryEngineMethod union, read as data. */
+function engineMethodNames(): Set<string> {
+  const src = readFileSync(ENGINE_METHODS_FILE, 'utf8');
+  return new Set([...src.matchAll(/\| '([^']+)'/g)].map((m) => m[1]));
 }
 
-describe('action `method:` constants are reachable by consumers', () => {
+describe('action `method:` validity', () => {
   const emitted = emittedMethodIdentifiers();
 
-  it('finds the emitted method identifiers (guard is actually scanning)', () => {
-    // A tripwire: if the scan silently matches nothing — moved directory, changed
-    // payload shape — the reachability assertion below would vacuously pass.
+  it('the scan actually finds emitted method identifiers', () => {
+    // Tripwire. If the scan silently matches nothing — directory moved, payload
+    // shape changed — the completeness assertion below would vacuously pass.
     expect(emitted.length).toBeGreaterThan(15);
     expect(emitted).toContain('ASSIGN_PARTICIPANT_METHOD');
   });
 
-  it('every emitted method constant is reachable on an exported constants object', () => {
-    const reachable = reachableConstantNames();
-    const unreachable = emitted.filter((name) => !reachable.has(name));
-    expect(unreachable).toEqual([]);
+  it('every emitted method constant is enumerated in actionMethodConstants', () => {
+    // Completeness: this is what keeps the typed aggregate covering the full set.
+    const missing = emitted.filter((name) => !(name in actionMethodConstants));
+    expect(missing).toEqual([]);
   });
 
-  it('actionMethodConstants values are the engine method names, not the constant names', () => {
-    // Guards against someone "fixing" a gap by adding NAME: 'NAME' placeholders.
-    const { actionMethodConstants } = factoryConstants;
-    for (const [name, value] of Object.entries(actionMethodConstants)) {
-      expect(value, `${name} should hold an engine method name`).not.toBe(name);
-      expect(value).toMatch(/^[a-z]/);
-    }
+  it('every enumerated method resolves to a real engine method', () => {
+    // Runtime mirror of the Record<string, FactoryEngineMethod> type, so an
+    // `as any` or a .js source cannot smuggle a dead method name through.
+    const engineMethods = engineMethodNames();
+    expect(engineMethods.size).toBeGreaterThan(500); // tripwire on the union parse
+    const dead = Object.entries(actionMethodConstants)
+      .filter(([, value]) => !engineMethods.has(value))
+      .map(([name, value]) => `${name} → ${value}`);
+    expect(dead).toEqual([]);
   });
 });


### PR DESCRIPTION
Corrects the justification for `actionMethodConstants` (#4568) and gives it a guard that earns its place.

## What #4568 got wrong

It cited TMX hardcoding `method: 'assignDrawPosition'` as evidence consumers need these constants. That was a misdiagnosis — those were **direct `mutationRequest` calls** belonging to TMX's own `mutationConstants` registry, and they were fixed that way in TMX `7616c7b8`, with no dependency on this object at all.

Checked across TMX, courthive-components, courthive-public, epixodic, CFS and AMS: **nothing branches on `action.method`.** Consumers forward it verbatim —

```ts
const methods = [{ method: action.method, params: action.payload }];
```

— and code that branches on an action keys off `action.type`, which `positionActionConstants` already exposed. The consumer-facing case was hypothetical.

## The justification that holds

Internal. This object is the **only place all 22 action methods are enumerated**, which makes them checkable against the generated `FactoryEngineMethod` union. Nothing previously tied the two together: **rename an engine method and the actions keep emitting the old string**, failing at consumer dispatch time as "method not found" — in someone else's codebase, at runtime.

All 22 are valid today, so this is preventive rather than a live fix.

## Three layers, each falsified

| Layer | Catches | Falsification |
|---|---|---|
| `Record<string, FactoryEngineMethod>` on the aggregate | invalid or renamed method name | one-char typo → `TS2820: … Did you mean "assignDrawPosition"?` |
| `src/query/` emission scan | a new action method never reaching the enumeration, silently escaping the type | removed an entry → fails naming `ASSIGN_PARTICIPANT_METHOD` |
| runtime union check | a cast bypassing the type in built output | `'noSuchEngineMethod' as FactoryEngineMethod` → fails naming it |

Plus two tripwires so neither scan can pass vacuously if a directory moves or the union fails to parse.

## Framing corrected

The module doc now states plainly that being exported is a **side benefit, not the justification**, records that no ecosystem consumer branches on `action.method`, and notes external CODES implementers as the reason it stays exported. The guard's own doc says explicitly that it does not assert consumers need these constants.

## Verification

Full gate green: **10,502 vitest** (coverage thresholds met), 12 jest, `verify:lint`, `check-types`, `verify:generated`.