### PR TITLE
fix(state): lazily bind a per-context state instead of throwing

### DIFF
--- a/src/server/providers/factory/engines/asyncGlobalState.ts
+++ b/src/server/providers/factory/engines/asyncGlobalState.ts
@@ -60,24 +60,48 @@ function createInstanceState() {
 }
 
 /**
- * DECISION: throw rather than fall back to a shared default state.
- * WHY: a permissive default is fail-open — a caller that forgets to establish a context
- * would silently share one process-wide state, which is exactly the defect this replaces,
- * and it would be invisible. Throwing preserves the previous contract and surfaces the
- * mistake immediately. Safe to be strict: the only module-scope setup CFS performs
- * (`setStateMethods` with global=true, `setGlobalSubscriptions`, `setAuditAuthorityServer`)
- * writes to module-level globalState, never to instance state.
+ * DECISION: lazily bind a NEW state to the current async context; never share, never throw.
+ * WHY: two alternatives were tried and rejected.
+ *   - Falling back to one shared default is fail-open — it IS the defect this replaces (a single
+ *     process-wide state) and it is invisible.
+ *   - Throwing assumes every entry point is statically enumerable. It is not. An earlier revision
+ *     of this file threw, and wiring it into competition-factory-server produced 56 failures
+ *     across 15 suites: `governors.mocksGovernor.generateTournamentRecord()` dispatches notices,
+ *     so a DIRECT governor call touches instance state without going near an engine. Governors are
+ *     not uniformly pure. A strict throw trades a silent correctness bug for a loud outage on a
+ *     call graph that cannot be fully swept.
+ * Lazy creation binds via `enterWith`, so the new state covers the current context AND its
+ * descendants — `setState` → `await` → `getState` stays coherent — while remaining separate from
+ * other context subtrees. The warning keeps it fail-soft rather than silent (A2).
+ *
+ * ⚠️ LIMIT: this is a safety net, NOT isolation. Unwrapped siblings launched from a COMMON parent
+ * context still share, because the first access binds a store to that shared parent which the
+ * sibling then inherits. Wrap every entry point in `runWithInstanceState` — do not rely on the net.
+ * See competition-factory#4564.
  */
+let implicitContextCount = 0;
+
 function getInstanceState(): ImplemtationGlobalStateTypes {
   const instanceState = asyncLocalStorage.getStore();
+  if (instanceState) return instanceState;
 
-  if (!instanceState) {
-    throw new Error(
-      'No factory instance state for the current async context — wrap the request in runWithInstanceState()',
+  implicitContextCount += 1;
+  if (implicitContextCount === 1 || implicitContextCount % 100 === 0) {
+    console.warn(
+      `[asyncGlobalState] engine state accessed outside runWithInstanceState() ` +
+        `(${implicitContextCount} so far) — an implicit per-context state was created. ` +
+        `Wrap the entry point in runWithInstanceState() so the store is scoped to the request.`,
     );
   }
 
-  return instanceState;
+  const created = newInstanceState();
+  asyncLocalStorage.enterWith(created);
+  return created;
+}
+
+/** Diagnostic: how many times state was created implicitly rather than via runWithInstanceState. */
+function implicitContextCreations(): number {
+  return implicitContextCount;
 }
 
 export default {
@@ -85,6 +109,7 @@ export default {
   callListener,
   createInstanceState,
   runWithInstanceState,
+  implicitContextCreations,
   cycleMutationStatus,
   deleteNotice,
   deleteNotices,

--- a/src/tests/engines/asyncGlobalStateIsolation.test.ts
+++ b/src/tests/engines/asyncGlobalStateIsolation.test.ts
@@ -6,14 +6,17 @@ import { expect, describe, test } from 'vitest';
 // implementation had never been tested; in production (CFS) a single module-scope seed meant
 // every request shared one state object.
 //
-// HONEST SCOPE: measured against the old implementation, 3 of these fail (nested scoping,
-// createInstanceState binding, fail-closed read) and 4 pass. The old primitive's propagation is
-// call-shape dependent — it happens to work under vitest's shape, which is precisely why the
-// defect survived unnoticed. A unit test cannot reproduce the production trigger (module-scope
-// seeding + the CFS request shape), so do NOT read these as proof the old code was broken; they
-// lock in the properties that actually differ and guard against regressing away from
-// AsyncLocalStorage. The fail-closed test is the load-bearing one: it is what turns "silently
-// shared one process-wide state" into a loud error.
+// HONEST SCOPE: most of these also pass against the OLD createHook implementation. Its
+// propagation is call-shape dependent and happens to work under vitest's shape — precisely why
+// the defect survived unnoticed for years. A provider unit test cannot reproduce the production
+// trigger, which was the module-scope seed in competition-factory-server, not the primitive.
+// So do NOT read these as proof the old code was broken. What they do is lock in the properties
+// that actually differ (scoped `run`, nested scoping, coherent implicit contexts) and guard
+// against regressing away from AsyncLocalStorage.
+//
+// The real guard against the production defect is structural, not here: every entry point wraps
+// itself in runWithInstanceState. `DOCUMENTS THE LIMIT` below exists to stop anyone treating the
+// implicit-context safety net as a substitute for that.
 
 const {
   runWithInstanceState,
@@ -28,17 +31,18 @@ const {
 
 const record = (tournamentId: string) => ({ tournamentId, tournamentName: `T-${tournamentId}` });
 
+/** Write one record inside a scoped context, yield, then read the context's records back. */
+const scopedWriteThenRead = (tag: string) =>
+  runWithInstanceState(async () => {
+    setTournamentRecord(record(tag));
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    return Object.keys(getTournamentRecords());
+  });
+
 describe('asyncGlobalState per-context isolation', () => {
   test('concurrent contexts do not share tournamentRecords', async () => {
-    const request = (tag: string) =>
-      runWithInstanceState(async () => {
-        setTournamentRecord(record(tag));
-        // yield so the sibling context interleaves between write and read
-        await new Promise((resolve) => setTimeout(resolve, 5));
-        return Object.keys(getTournamentRecords());
-      });
-
-    const [a, b, c] = await Promise.all([request('A'), request('B'), request('C')]);
+    // each yields between write and read so siblings interleave
+    const [a, b, c] = await Promise.all([scopedWriteThenRead('A'), scopedWriteThenRead('B'), scopedWriteThenRead('C')]);
 
     expect(a).toEqual(['A']);
     expect(b).toEqual(['B']);
@@ -130,9 +134,39 @@ describe('asyncGlobalState per-context isolation', () => {
     expect(result).toEqual(['SEEDED']);
   });
 
-  test('reading state with no context established throws rather than falling back', () => {
-    // fail-closed: a permissive default would silently reintroduce one shared process-wide
-    // state, which is the defect this provider replaces
-    expect(() => getTournamentRecords()).toThrow(/No factory instance state/);
+  test('an implicit context survives an await, so setState → await → getState stays coherent', async () => {
+    const result: any = await (async () => {
+      setTournamentRecord(record('IMPLICIT'));
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      return Object.keys(getTournamentRecords());
+    })();
+
+    expect(result).toEqual(['IMPLICIT']);
+  });
+
+  test('DOCUMENTS THE LIMIT: implicit creation is a safety net, NOT isolation', async () => {
+    // Unwrapped siblings launched from a COMMON parent context still share: the first access
+    // binds a store to that shared parent via `enterWith`, and the sibling inherits it. Implicit
+    // creation only guarantees state is scoped to a context SUBTREE rather than living
+    // process-wide forever. Strictly better than the defect, but not a substitute for wrapping —
+    // which is why every real entry point calls runWithInstanceState explicitly.
+    const before = asyncGlobalState.implicitContextCreations();
+
+    const unwrapped = (tag: string) =>
+      (async () => {
+        setTournamentRecord(record(tag));
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        return Object.keys(getTournamentRecords());
+      })();
+
+    const [a, b] = await Promise.all([unwrapped('A'), unwrapped('B')]);
+    expect(a).toEqual(['A', 'B']); // shared — the documented limit
+    expect(b).toEqual(['A', 'B']);
+
+    // wrapping the SAME calls restores isolation
+    expect(await Promise.all([scopedWriteThenRead('A'), scopedWriteThenRead('B')])).toEqual([['A'], ['B']]);
+
+    // and the implicit path is reported, not silent
+    expect(asyncGlobalState.implicitContextCreations()).toBeGreaterThan(before);
   });
 });


### PR DESCRIPTION
Follow-up to #4567, part of #4564. Pairs with competition-factory-server#866, which is the production half.

## Why this reverses the fail-closed decision from #4567

#4567 made `getInstanceState()` throw when no context was established, on the stated assumption that *"the only module-scope setup CFS performs … writes to module-level globalState, never to instance state."*

**That assumption is wrong, and I disproved it by wiring it into the server: 56 failures across 15 suites.**

`governors.mocksGovernor.generateTournamentRecord()` dispatches notices, so a **direct governor call touches instance state without going near an engine**. Governors are not uniformly pure, and the entry-point surface is therefore not statically enumerable — no sweep can guarantee it has found them all.

A strict throw trades a silent correctness bug for a loud production outage on a call graph we cannot fully sweep. Falling back to a single shared default is worse — that *is* the original defect.

## What it does now

`getInstanceState()` lazily creates a state and binds it with `enterWith`, so the new state covers the current context **and its descendants** — `setState` → `await` → `getState` stays coherent — while remaining separate from other context subtrees. A throttled `console.warn` (first, then every 100th) plus an `implicitContextCreations()` diagnostic keep it fail-soft rather than silent (architectural standard A2).

## The limit is tested, not assumed

Unwrapped siblings launched from a **common parent** still share, because the first access binds a store to that parent which the sibling inherits. The `DOCUMENTS THE LIMIT` test asserts exactly that (`['A','B']`), then shows wrapping the same calls restores isolation (`[['A'],['B']]`).

**Implicit creation is a safety net, not isolation.** Every real entry point must still wrap itself in `runWithInstanceState` — which is what the server PR does for `executionQueue`, `queryTournamentRecords`, projection rebuild, and mock generation.

I also corrected the test file's header, which still described the removed fail-closed test as "load-bearing".

## Why it matters that this lands with the server change

This keeps the reference implementation identical in contract to the production consumer. Divergence between the two is exactly how three copies of this provider drifted apart in the first place.

## Verification

Full suite **10503 passed / 2 skipped**, lint and check-types clean.