### PR TITLE
fix(types): stop constant objects widening; close the union/enum gaps

### DIFF
--- a/src/constants/auditConstants.ts
+++ b/src/constants/auditConstants.ts
@@ -6,6 +6,6 @@ export const auditConstants = {
   AUTO_SCHEDULING_AUDIT,
   DELETE_EVENTS,
   DELETE_DRAW_DEFINITIONS,
-};
+} as const;
 
 export default auditConstants;

--- a/src/constants/bookingTypeConstants.ts
+++ b/src/constants/bookingTypeConstants.ts
@@ -11,6 +11,6 @@ export const bookingTypeConstants = {
   PRACTICE,
   RESERVED,
   SCHEDULED,
-};
+} as const;
 
 export default bookingTypeConstants;

--- a/src/constants/competitionFormatConstants.ts
+++ b/src/constants/competitionFormatConstants.ts
@@ -23,6 +23,6 @@ export const competitionFormatConstants = {
   BETWEEN_GAMES,
   BETWEEN_POINTS,
   ANY,
-};
+} as const;
 
 export default competitionFormatConstants;

--- a/src/constants/dayStateConstants.ts
+++ b/src/constants/dayStateConstants.ts
@@ -19,7 +19,7 @@ export const dayStateConstants = {
   IF_NEEDED,
   UNAVAILABLE,
   NOT_SET,
-};
+} as const;
 
 /**
  * @deprecated Renamed to `dayStateConstants` — "availability" collides with court

--- a/src/constants/disciplineConstants.ts
+++ b/src/constants/disciplineConstants.ts
@@ -30,4 +30,4 @@ export const disciplineConstants = {
   PICKLEBALL,
   PADEL,
   TENNIS,
-};
+} as const;

--- a/src/constants/displayConstants.ts
+++ b/src/constants/displayConstants.ts
@@ -8,4 +8,4 @@ export const ADMIN_DISPLAY = 'ADMIN';
 export const displayConstants = {
   PUBLIC_DISPLAY,
   ADMIN_DISPLAY,
-};
+} as const;

--- a/src/constants/drawDefinitionConstants.ts
+++ b/src/constants/drawDefinitionConstants.ts
@@ -249,6 +249,6 @@ export const drawDefinitionConstants = {
   finishOrder,
   AGGREGATE_EVENT_STRUCTURES,
   FINISHING_POSITIONS,
-};
+} as const;
 
 export default drawDefinitionConstants;

--- a/src/constants/entryStatusConstants.ts
+++ b/src/constants/entryStatusConstants.ts
@@ -87,4 +87,4 @@ export const entryStatusConstants = {
   VALID_ENTRY_STATUSES,
   WILDCARD,
   WITHDRAWN,
-};
+} as const;

--- a/src/constants/errorConditionConstants.ts
+++ b/src/constants/errorConditionConstants.ts
@@ -1080,6 +1080,6 @@ export const errorConditionConstants = {
   UNRECOGNIZED_MATCHUP_STATUS,
   VALUE_UNCHANGED,
   VENUE_EXISTS,
-};
+} as const;
 
 export default errorConditionConstants;

--- a/src/constants/eventConstants.ts
+++ b/src/constants/eventConstants.ts
@@ -22,4 +22,4 @@ export const eventConstants = {
   SINGLES_EVENT,
   TEAM_EVENT,
   TEAM,
-};
+} as const;

--- a/src/constants/extensionConstants.ts
+++ b/src/constants/extensionConstants.ts
@@ -68,7 +68,7 @@ export const extensionConstants = {
   TALLY,
   TIE_FORMAT_MODIFICATIONS, // for auditing, not important when anonymized
   FACTORY, // used for capturing versioning of factory and other TODS document processors
-};
+} as const;
 
 export const internalExtensions = [
   DELEGATED_OUTCOME,

--- a/src/constants/flightConstants.ts
+++ b/src/constants/flightConstants.ts
@@ -12,4 +12,4 @@ export const flightConstants = {
   SPLIT_LEVEL_BASED,
   SPLIT_WATERFALL,
   SPLIT_SHUTTLE,
-};
+} as const;

--- a/src/constants/genderConstants.ts
+++ b/src/constants/genderConstants.ts
@@ -21,4 +21,4 @@ export const genderConstants = {
   OTHER,
   MALE,
   ANY,
-};
+} as const;

--- a/src/constants/matchUpActionConstants.ts
+++ b/src/constants/matchUpActionConstants.ts
@@ -34,6 +34,6 @@ export const matchUpActionConstants = {
   SCORE,
   START,
   END,
-};
+} as const;
 
 export default matchUpActionConstants;

--- a/src/constants/matchUpStatusConstants.ts
+++ b/src/constants/matchUpStatusConstants.ts
@@ -129,4 +129,4 @@ export const matchUpStatusConstants = {
   SUSPENDED,
   TO_BE_PLAYED,
   WALKOVER,
-};
+} as const;

--- a/src/constants/matchUpTypes.ts
+++ b/src/constants/matchUpTypes.ts
@@ -16,4 +16,4 @@ export const matchUpTypes = {
   TEAM,
   HYBRID_MATCHUP,
   HYBRID,
-};
+} as const;

--- a/src/constants/participantConstants.ts
+++ b/src/constants/participantConstants.ts
@@ -25,7 +25,7 @@ export const participantTypes = {
   GROUP,
   TEAM,
   PAIR,
-};
+} as const;
 
 export const participantConstants = {
   INDIVIDUAL,
@@ -43,4 +43,4 @@ export const participantConstants = {
   WAIVED,
   UNPAID,
   PAID,
-};
+} as const;

--- a/src/constants/participantRoles.ts
+++ b/src/constants/participantRoles.ts
@@ -53,4 +53,4 @@ export const participantRoles = {
   TRAINER,
   TRANSPORT,
   VOLUNTEER,
-};
+} as const;

--- a/src/constants/penaltyConstants.ts
+++ b/src/constants/penaltyConstants.ts
@@ -36,6 +36,6 @@ export const penaltyConstants = {
   OTHER,
   PUNCTUALITY,
   FAILUIRE_TO_SIGN_IN,
-};
+} as const;
 
 export default penaltyConstants;

--- a/src/constants/positionActionConstants.ts
+++ b/src/constants/positionActionConstants.ts
@@ -44,6 +44,6 @@ export const positionActionConstants = {
   ASSIGN_BYE,
   SEED_CASCADE,
   SEED_VALUE,
-};
+} as const;
 
 export default positionActionConstants;

--- a/src/constants/practiceConstants.ts
+++ b/src/constants/practiceConstants.ts
@@ -12,4 +12,4 @@ export const practiceConstants = {
   PRACTICE_REGISTRATION_CONFIRMED,
   PRACTICE_REGISTRATION_CANCELLED,
   practiceRegistrationStatuses,
-};
+} as const;

--- a/src/constants/rankingConstants.ts
+++ b/src/constants/rankingConstants.ts
@@ -45,4 +45,4 @@ export const rankingConstants = {
   TEAM_ONLY,
   CATEGORY_SCOPE_FIELDS,
   PROFILE_SCOPE_FIELDS,
-};
+} as const;

--- a/src/constants/ratingConstants.ts
+++ b/src/constants/ratingConstants.ts
@@ -30,6 +30,6 @@ export const ratingConstants = {
   ITTF,
   USAR,
   BWF,
-};
+} as const;
 
 export default ratingConstants;

--- a/src/constants/requestConstants.ts
+++ b/src/constants/requestConstants.ts
@@ -2,6 +2,6 @@ export const DO_NOT_SCHEDULE = 'DO_NOT_SCHEDULE';
 
 export const requestConstants = {
   DO_NOT_SCHEDULE,
-};
+} as const;
 
 export default requestConstants;

--- a/src/constants/resourceConstants.ts
+++ b/src/constants/resourceConstants.ts
@@ -8,4 +8,4 @@ export const resourceContants = {
   RESOURCE_TYPE,
   IDENTIFIER,
   NAME,
-};
+} as const;

--- a/src/constants/resultConstants.ts
+++ b/src/constants/resultConstants.ts
@@ -4,4 +4,4 @@ export const ERROR = 'error';
 export const resultConstants = {
   SUCCESS,
   ERROR,
-};
+} as const;

--- a/src/constants/scaleConstants.ts
+++ b/src/constants/scaleConstants.ts
@@ -9,4 +9,4 @@ export const scaleConstants = {
   RATING,
   SCALE,
   SEEDING,
-};
+} as const;

--- a/src/constants/scheduleConstants.ts
+++ b/src/constants/scheduleConstants.ts
@@ -44,4 +44,4 @@ export const scheduleConstants = {
   BLOCKED,
   PRACTICE,
   MAINTENANCE,
-};
+} as const;

--- a/src/constants/schemaWriteModeConstants.ts
+++ b/src/constants/schemaWriteModeConstants.ts
@@ -10,4 +10,4 @@ export const schemaWriteModeConstants = {
   NATIVE,
   LEGACY,
   DUAL,
-};
+} as const;

--- a/src/constants/surfaceConstants.ts
+++ b/src/constants/surfaceConstants.ts
@@ -9,6 +9,6 @@ export const surfaceConstants = {
   GRASS,
   CARPET,
   ARTIFICIAL,
-};
+} as const;
 
 export default surfaceConstants;

--- a/src/constants/swissConstants.ts
+++ b/src/constants/swissConstants.ts
@@ -12,4 +12,4 @@ export const swissConstants = {
   RATING_BASED,
   SCORE_GROUP,
   SONNEBORN_BERGER,
-};
+} as const;

--- a/src/constants/tallyConstants.ts
+++ b/src/constants/tallyConstants.ts
@@ -2,4 +2,4 @@ export const GEM_SCORE = 'GEMscore';
 
 export const tallyConstants = {
   GEM_SCORE,
-};
+} as const;

--- a/src/constants/tieFormatConstants.ts
+++ b/src/constants/tieFormatConstants.ts
@@ -38,6 +38,6 @@ export const tieFormatConstants = {
   USTA_TOC,
   USTA_WTT_ITT,
   USTA_ZONAL,
-};
+} as const;
 
 export default tieFormatConstants;

--- a/src/constants/timeItemConstants.ts
+++ b/src/constants/timeItemConstants.ts
@@ -94,4 +94,4 @@ export const timeItemConstants = {
   SUSPENSION,
   TIME_MODIFIERS,
   TO_BE_ANNOUNCED,
-};
+} as const;

--- a/src/constants/topicConstants.ts
+++ b/src/constants/topicConstants.ts
@@ -70,4 +70,4 @@ export const topicConstants = {
   UNPUBLISH_PARTICIPANTS,
   UNPUBLISH_TOURNAMENT,
   UPDATE_INCONTEXT_MATCHUP,
-};
+} as const;

--- a/src/constants/tournamentConstants.ts
+++ b/src/constants/tournamentConstants.ts
@@ -19,4 +19,4 @@ export const tournamentConstants = {
   CANCELLED,
   COMPLETED,
   ACTIVE,
-};
+} as const;

--- a/src/constants/venueConstants.ts
+++ b/src/constants/venueConstants.ts
@@ -14,6 +14,6 @@ export const venueConstants = {
   INDOOR,
   OUTDOOR,
   MIXED,
-};
+} as const;
 
 export default venueConstants;

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,7 +142,9 @@ export {
   CourtPositionEnum,
   DrawTypeEnum,
   EntryStatusEnum,
+  EventTypeEnum,
   FinishingPositionEnum,
+  GenderEnum,
   LengthUnitEnum,
   LinkTypeEnum,
   MatchUpStatusEnum,
@@ -164,6 +166,7 @@ export {
   SurfaceCategoryEnum,
   TournamentLevelEnum,
   WeekdayEnum,
+  WeightUnitEnum,
   WheelchairClassEnum,
   WinReasonEnum,
 } from './types/tournamentTypes';

--- a/src/tests/constants/enumConstConformance.test.ts
+++ b/src/tests/constants/enumConstConformance.test.ts
@@ -12,10 +12,12 @@ import { weekdayConstants as weekdayObject } from '@Constants/weekdayConstants';
 import { surfaceConstants as surfaceObject } from '@Constants/surfaceConstants';
 import { participantConstants as participantObject } from '@Constants/participantConstants';
 import { genderConstants as genderObject } from '@Constants/genderConstants';
+import { eventConstants as eventObject } from '@Constants/eventConstants';
 import { drawDefinitionConstants as drawDefinitionObject } from '@Constants/drawDefinitionConstants';
 import * as weekdayConstants from '@Constants/weekdayConstants';
 import * as surfaceConstants from '@Constants/surfaceConstants';
 import * as genderConstants from '@Constants/genderConstants';
+import * as eventConstants from '@Constants/eventConstants';
 import * as T from '@Types/tournamentTypes';
 import { describe, it, expect } from 'vitest';
 
@@ -83,12 +85,16 @@ const COVERAGE: {
   },
   { name: 'ParticipantType', enum: T.ParticipantTypeEnum, consts: participantConstants, object: participantObject },
   { name: 'Sex', enum: T.SexEnum, consts: genderConstants, object: genderObject },
+  { name: 'Gender', enum: T.GenderEnum, consts: genderConstants, object: genderObject },
+  { name: 'EventType', enum: T.EventTypeEnum, consts: eventConstants, object: eventObject },
 ];
 
 // Enum-only: no const-module twin (single source of truth — nothing to reconcile).
 // Listed so a newly-added enum can't silently skip the mirror/bucket decision above.
 const ENUM_ONLY = [
   'AddressTypeEnum',
+  // no const-module twin: weight units are used only on the equipment types
+  'WeightUnitEnum',
   'BallTypeEnum',
   'CountryCodeEnum',
   'CourtPositionEnum',

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -1,4 +1,3 @@
-import { DOUBLES, HYBRID, SINGLES, TEAM } from '@Constants/eventConstants';
 import { tournamentStatuses } from '@Constants/tournamentConstants';
 import { indoorOutdoorTypes } from '@Constants/venueConstants';
 import { disciplines } from '@Constants/disciplineConstants';
@@ -368,8 +367,21 @@ export interface Interleave {
   offset: number;
 }
 
-// Derived from eventConstants (drift-proof; see TournamentStatusUnion note).
-export type EventTypeUnion = typeof SINGLES | typeof DOUBLES | typeof TEAM | typeof HYBRID;
+/**
+ * The competition formats an event can take.
+ *
+ * Was previously a union of `typeof` constants with no enum behind it, which left
+ * consumers able to type against EventTypeUnion but unable to reference a member
+ * at runtime — the outlier ClubSpark reported. Now enum-backed like the other 33
+ * vocabularies, with the union derived from it.
+ */
+export enum EventTypeEnum {
+  SINGLES = 'SINGLES',
+  DOUBLES = 'DOUBLES',
+  TEAM = 'TEAM',
+  HYBRID = 'HYBRID',
+}
+export type EventTypeUnion = `${EventTypeEnum}`;
 
 /**
  * CODES first-class schedule attributes on a matchUp. Each field was
@@ -770,7 +782,20 @@ export interface CollectionValueProfile {
   notes?: string;
 }
 
-enum GenderEnum {
+/**
+ * The gender category of a COMPETITION — an event, a category, a draw.
+ *
+ * Distinct from {@link SexEnum}, which describes a PERSON. The two overlap on
+ * F / M / FEMALE / MALE and then diverge deliberately: a competition can be
+ * MIXED or ANY, a person cannot; a person can be OTHER, a competition cannot.
+ *
+ * Both vocabularies are served by the single `genderConstants` object, so
+ * `genderConstants.OTHER` is a legitimate `sex` but NOT a legitimate `gender`,
+ * and `genderConstants.MIXED` is the reverse. Prefer the enum members over the
+ * bucket when you know which dimension you are setting — the union types reject
+ * the wrong one at compile time.
+ */
+export enum GenderEnum {
   FEMALE_ABBR = 'F',
   MIXED_ABBR = 'X',
   MALE_ABBR = 'M',
@@ -1469,7 +1494,7 @@ export enum PlayingHandCodeEnum {
 }
 export type PlayingHandCodeUnion = `${PlayingHandCodeEnum}`;
 
-enum WeightUnitEnum {
+export enum WeightUnitEnum {
   GRAM = 'GRAM',
   KILOGRAM = 'KILOGRAM',
 }
@@ -1487,6 +1512,10 @@ export interface UnifiedPersonID {
   updatedAt?: Date | string;
 }
 
+/**
+ * The sex of a PERSON. Distinct from {@link GenderEnum}, which is the gender
+ * category of a competition — see the note there for how the two diverge.
+ */
 export enum SexEnum {
   FEMALE_ABBR = 'F',
   MALE_ABBR = 'M',


### PR DESCRIPTION
Two consumer-reported problems with one shared cause: **factory typed its own fields against Unions its own exported constants could not satisfy.**

## 1. Constant widening — root cause of the TMX build break

```ts
export const participantRoles = { OFFICIAL, ... };    // members widen to `string`
const { OFFICIAL } = participantRoles;
participantFilters: { participantRoles: [OFFICIAL] }  // ✗ not assignable to ParticipantRoleUnion
```

A consumer using factory's own constant could not satisfy factory's own type. Reproduced in isolation against published 6.18.0 before changing anything.

A sweep found the same widening in **37 constant objects**, not just the one that bit. `as const` applied to all of them — safe, because nothing mutates a constants object, so the whole set went green with **no readonly fallout**.

TMX was unblocked separately (commit `f9a356fc`, migrating to `ParticipantRoleEnum`); this fixes it at the source for every other consumer.

## 2. Union/enum gaps — ClubSpark feedback

> "There's StageTypeUnion provided by the factory, but there's no StageTypeEnum for it — it's kind of an outlier on how that Union is built" … "Same with EventTypeUnion"

Audited **all 40 exported `*Union` types**:

| derivation | count |
|---|---|
| enum-template | 32 |
| enum-keyof | 1 |
| array-derived | 3 |
| typeof-consts | 1 |
| hand-written | 3 |

**`StageTypeEnum` actually exists** and has been value-exported since 6.16.0 — that report predates the enum arc. The real gaps were different:

- **`GenderEnum` and `WeightUnitEnum` were declared without `export`** — their unions derived from enums no consumer could reach. Now exported.
- **`EventTypeUnion` had no enum at all** — a union of `typeof` constants. The genuine outlier. Now `EventTypeEnum`, with the union derived from it.

Runtime enums **31 → 34**. The conformance guard caught all three as unaccounted-for; each is registered deliberately — Gender and EventType as buckets (their const modules carry every value), WeightUnit as enum-only.

## 3. Gender vs Sex, documented

They share F/M/FEMALE/MALE then diverge: a competition can be MIXED or ANY, a person cannot; a person can be OTHER, a competition cannot. Both are served by **one `genderConstants` bucket**, so it offers values that are wrong for one of the two fields. Now documented at both declarations — and with literal-typed unions, the wrong one is a compile error.

## Still open for a future pass

Six unions remain without an enum, in two classes: array-derived (`DisciplineUnion`, `IndoorOutdoorUnion`, `TournamentStatusUnion` — values reachable via their exported `as const` arrays) and hand-written literals (`CategoryUnion`, `DrawStatusUnion`, `SportUnion` — no runtime source at all). The hand-written three are the likeliest next ClubSpark report.

## Verification

Full gate: **10,508 vitest** (coverage thresholds met), 12 jest, `verify:lint`, `check-types`, `verify:generated`. Built `dist/` and confirmed the new surface resolves at runtime.
