### PR TITLE
feat(types): every exported Union is now enum-backed

### DIFF
--- a/src/constants/genderConstants.ts
+++ b/src/constants/genderConstants.ts
@@ -1,14 +1,17 @@
-export const FEMALE_ABBR: string = 'F';
-export const OTHER_ABBR: string = 'O';
-export const MIXED_ABBR: string = 'X';
-export const MALE_ABBR: string = 'M';
-export const ANY_ABBR: string = 'A';
+// Values are intentionally NOT annotated `: string` — an explicit annotation widens
+// them and defeats the `as const` below, which is what previously stopped
+// genderConstants members from satisfying GenderUnion / SexUnion.
+export const FEMALE_ABBR = 'F';
+export const OTHER_ABBR = 'O';
+export const MIXED_ABBR = 'X';
+export const MALE_ABBR = 'M';
+export const ANY_ABBR = 'A';
 
-export const FEMALE: string = 'FEMALE';
-export const OTHER: string = 'OTHER';
-export const MIXED: string = 'MIXED';
-export const MALE: string = 'MALE';
-export const ANY: string = 'ANY';
+export const FEMALE = 'FEMALE';
+export const OTHER = 'OTHER';
+export const MIXED = 'MIXED';
+export const MALE = 'MALE';
+export const ANY = 'ANY';
 
 export const genderConstants = {
   FEMALE_ABBR,

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,12 +138,16 @@ export {
   AddressTypeEnum,
   BallTypeEnum,
   BookingTypeEnum,
+  CategoryEnum,
   CountryCodeEnum,
   CourtPositionEnum,
+  DisciplineEnum,
   DrawTypeEnum,
+  DrawStatusEnum,
   EntryStatusEnum,
   EventTypeEnum,
   FinishingPositionEnum,
+  IndoorOutdoorEnum,
   GenderEnum,
   LengthUnitEnum,
   LinkTypeEnum,
@@ -165,11 +169,16 @@ export {
   StructureTypeEnum,
   SurfaceCategoryEnum,
   TournamentLevelEnum,
+  TournamentStatusEnum,
   WeekdayEnum,
   WeightUnitEnum,
   WheelchairClassEnum,
   WinReasonEnum,
 } from './types/tournamentTypes';
+
+// SportEnum lives with the competition-format types rather than tournamentTypes;
+// value-exported alongside the rest so every *Union has a reachable enum.
+export { SportEnum } from './types/competitionFormat';
 
 // Statistics types (top-level convenience re-exports)
 export type { StatObject, MatchStatistics, StatCounters, StatisticsOptions } from './query/scoring/statistics/types';

--- a/src/tests/constants/enumConstConformance.test.ts
+++ b/src/tests/constants/enumConstConformance.test.ts
@@ -13,11 +13,20 @@ import { surfaceConstants as surfaceObject } from '@Constants/surfaceConstants';
 import { participantConstants as participantObject } from '@Constants/participantConstants';
 import { genderConstants as genderObject } from '@Constants/genderConstants';
 import { eventConstants as eventObject } from '@Constants/eventConstants';
+import { tournamentConstants as tournamentObject } from '@Constants/tournamentConstants';
+import { venueConstants as venueObject } from '@Constants/venueConstants';
+import { disciplineConstants as disciplineObject } from '@Constants/disciplineConstants';
 import { drawDefinitionConstants as drawDefinitionObject } from '@Constants/drawDefinitionConstants';
 import * as weekdayConstants from '@Constants/weekdayConstants';
 import * as surfaceConstants from '@Constants/surfaceConstants';
 import * as genderConstants from '@Constants/genderConstants';
 import * as eventConstants from '@Constants/eventConstants';
+import * as tournamentConstants from '@Constants/tournamentConstants';
+import * as venueConstants from '@Constants/venueConstants';
+import * as disciplineConstants from '@Constants/disciplineConstants';
+import { disciplines } from '@Constants/disciplineConstants';
+import { tournamentStatuses } from '@Constants/tournamentConstants';
+import { indoorOutdoorTypes } from '@Constants/venueConstants';
 import * as T from '@Types/tournamentTypes';
 import { describe, it, expect } from 'vitest';
 
@@ -87,6 +96,9 @@ const COVERAGE: {
   { name: 'Sex', enum: T.SexEnum, consts: genderConstants, object: genderObject },
   { name: 'Gender', enum: T.GenderEnum, consts: genderConstants, object: genderObject },
   { name: 'EventType', enum: T.EventTypeEnum, consts: eventConstants, object: eventObject },
+  { name: 'TournamentStatus', enum: T.TournamentStatusEnum, consts: tournamentConstants, object: tournamentObject },
+  { name: 'IndoorOutdoor', enum: T.IndoorOutdoorEnum, consts: venueConstants, object: venueObject },
+  { name: 'Discipline', enum: T.DisciplineEnum, consts: disciplineConstants, object: disciplineObject },
 ];
 
 // Enum-only: no const-module twin (single source of truth — nothing to reconcile).
@@ -95,6 +107,12 @@ const ENUM_ONLY = [
   'AddressTypeEnum',
   // no const-module twin: weight units are used only on the equipment types
   'WeightUnitEnum',
+  // LEVEL has no const module; AGE/BOTH live in eventConstants but the set is not covered
+  'CategoryEnum',
+  // its values are matchUp-status strings reused for a DIFFERENT concept (draw-level
+  // aggregate play state), so pinning it to matchUpStatusConstants would assert a
+  // relationship that does not exist
+  'DrawStatusEnum',
   'BallTypeEnum',
   'CountryCodeEnum',
   'CourtPositionEnum',
@@ -185,5 +203,26 @@ describe('enum ↔ exported OBJECT conformance', () => {
     const values = valuesOf(object);
     const missing = Object.values(enumEntries(e)).filter((v) => !values.has(v));
     expect(missing).toEqual([]);
+  });
+});
+
+/**
+ * Enums that mirror an exported `as const` TUPLE.
+ *
+ * These unions used to be derived from the tuple directly — `(typeof x)[number]` —
+ * so the two could not disagree. Now that the union derives from the enum, the
+ * tuple is a second source for the same vocabulary and CAN drift. Both remain
+ * public surface (courthive-facilities imports indoorOutdoorTypes), so both are
+ * pinned to each other here.
+ */
+describe('enum ↔ backing tuple parity', () => {
+  const PAIRS: { name: string; enum: Record<string, unknown>; tuple: readonly string[] }[] = [
+    { name: 'TournamentStatus', enum: T.TournamentStatusEnum, tuple: tournamentStatuses },
+    { name: 'IndoorOutdoor', enum: T.IndoorOutdoorEnum, tuple: indoorOutdoorTypes },
+    { name: 'Discipline', enum: T.DisciplineEnum, tuple: disciplines },
+  ];
+
+  it.each(PAIRS)('$name: enum values and tuple entries are the same set', ({ enum: e, tuple }) => {
+    expect(Object.values(enumEntries(e)).sort()).toEqual([...tuple].sort());
   });
 });

--- a/src/types/competitionFormat.ts
+++ b/src/types/competitionFormat.ts
@@ -39,18 +39,21 @@ export interface competitionFormat {
 // Sport Union
 // ============================================================================
 
-export type SportUnion =
-  | 'TENNIS'
-  | 'PADEL'
-  | 'PICKLEBALL'
-  | 'SQUASH'
-  | 'BADMINTON'
-  | 'TABLE_TENNIS'
-  | 'INTENNSE'
-  | 'TYPTI'
-  | 'VOLLEYBALL'
-  | 'FENCING'
-  | 'OTHER';
+/** Sports a competition format can describe. */
+export enum SportEnum {
+  TENNIS = 'TENNIS',
+  PADEL = 'PADEL',
+  PICKLEBALL = 'PICKLEBALL',
+  SQUASH = 'SQUASH',
+  BADMINTON = 'BADMINTON',
+  TABLE_TENNIS = 'TABLE_TENNIS',
+  INTENNSE = 'INTENNSE',
+  TYPTI = 'TYPTI',
+  VOLLEYBALL = 'VOLLEYBALL',
+  FENCING = 'FENCING',
+  OTHER = 'OTHER',
+}
+export type SportUnion = `${SportEnum}`;
 
 // ============================================================================
 // Timer Profile

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -1,6 +1,3 @@
-import { tournamentStatuses } from '@Constants/tournamentConstants';
-import { indoorOutdoorTypes } from '@Constants/venueConstants';
-import { disciplines } from '@Constants/disciplineConstants';
 import type { competitionFormat } from './competitionFormat';
 
 export interface Tournament {
@@ -66,7 +63,15 @@ export interface Tournament {
 // Derived from the canonical tournamentStatuses tuple so the type, the constants, and the
 // setTournamentStatus validator share one source of truth (previously the hand-written union
 // read 'ABANDONDED' and omitted IN_PROGRESS, which the validator nonetheless accepted).
-export type TournamentStatusUnion = (typeof tournamentStatuses)[number];
+/** Lifecycle status of a tournament. Values mirror the `tournamentStatuses` tuple. */
+export enum TournamentStatusEnum {
+  ACTIVE = 'ACTIVE',
+  IN_PROGRESS = 'IN_PROGRESS',
+  COMPLETED = 'COMPLETED',
+  ABANDONED = 'ABANDONED',
+  CANCELLED = 'CANCELLED',
+}
+export type TournamentStatusUnion = `${TournamentStatusEnum}`;
 
 export interface Organisation {
   onlineResources?: OnlineResource[];
@@ -199,8 +204,29 @@ export interface TimeItem {
 // `& {}` on the string arm preserves literal autocomplete for the known values (a bare
 // `| string` would collapse the union). Constrain to a whitelist via the `allowedDisciplines`
 // policy, and normalize input with `normalizeDiscipline` (@Helpers/coercedDiscipline).
-export type DisciplineUnion = (typeof disciplines)[number] | (string & {});
-export type CategoryUnion = 'AGE' | 'BOTH' | 'LEVEL';
+/**
+ * The KNOWN disciplines. The vocabulary is deliberately OPEN — see
+ * planning/DISCIPLINE_EXTENSIBILITY.md — so DisciplineUnion keeps its
+ * `| (string & {})` arm and still accepts any string. This enum names the
+ * curated set for autocomplete and normalization; it does not close the type.
+ */
+export enum DisciplineEnum {
+  TENNIS = 'TENNIS',
+  BEACH_TENNIS = 'BEACH_TENNIS',
+  WHEELCHAIR_TENNIS = 'WHEELCHAIR_TENNIS',
+  PADEL = 'PADEL',
+  PICKLEBALL = 'PICKLEBALL',
+  VOLLEYBALL = 'VOLLEYBALL',
+  BEACH_VOLLEYBALL = 'BEACH_VOLLEYBALL',
+}
+export type DisciplineUnion = `${DisciplineEnum}` | (string & {});
+/** How an event category is defined. */
+export enum CategoryEnum {
+  AGE = 'AGE',
+  BOTH = 'BOTH',
+  LEVEL = 'LEVEL',
+}
+export type CategoryUnion = `${CategoryEnum}`;
 
 export interface DrawDefinition {
   activeDates?: Date[] | string[]; // dates from startDate to endDate on which the tournament is active
@@ -245,7 +271,13 @@ export interface DrawDefinition {
   updatedAt?: Date | string;
 }
 
-export type DrawStatusUnion = 'COMPLETED' | 'IN_PROGRESS' | 'TO_BE_PLAYED';
+/** Aggregate play state of a draw. */
+export enum DrawStatusEnum {
+  COMPLETED = 'COMPLETED',
+  IN_PROGRESS = 'IN_PROGRESS',
+  TO_BE_PLAYED = 'TO_BE_PLAYED',
+}
+export type DrawStatusUnion = `${DrawStatusEnum}`;
 
 export interface Entry {
   createdAt?: Date | string;
@@ -513,7 +545,13 @@ export interface MatchUpFinishingPositionRange {
 // Derived from the canonical indoorOutdoorTypes tuple (mirrors TournamentStatusUnion / DisciplineUnion)
 // so the type and venueConstants share one source of truth and attr-audit has a value vocab to guard the
 // indoorOutdoor literals (e.g. court.indoorOutdoor === 'INDOOR') against typos.
-export type IndoorOutdoorUnion = (typeof indoorOutdoorTypes)[number];
+/** Whether a venue or court is indoors. Mirrors the `indoorOutdoorTypes` tuple. */
+export enum IndoorOutdoorEnum {
+  INDOOR = 'INDOOR',
+  OUTDOOR = 'OUTDOOR',
+  MIXED = 'MIXED',
+}
+export type IndoorOutdoorUnion = `${IndoorOutdoorEnum}`;
 
 export enum MatchUpStatusEnum {
   ABANDONED = 'ABANDONED',


### PR DESCRIPTION
Finishes the union/enum consistency arc rather than waiting for ClubSpark to file the next report.

## Before / after

| derivation | before | after |
|---|---|---|
| enum-template | 32 | 38 |
| enum-keyof | 1 | 1 |
| array-derived | 3 | 0 |
| typeof-consts | 1 | 0 |
| hand-written | 3 | 1 |
| **unions with no enum** | **9** | **0** |

Runtime enums **34 → 40**. Six added: `TournamentStatusEnum`, `DisciplineEnum`, `CategoryEnum`, `DrawStatusEnum`, `IndoorOutdoorEnum`, `SportEnum`.

Three of those unions were derived from `as const` tuples and three were hand-written string literals — a consumer could type against them but never reference a member at runtime.

## Semantics preserved

`DisciplineUnion` keeps its `| (string & {})` arm. That vocabulary is deliberately **open** (`planning/DISCIPLINE_EXTENSIBILITY.md`); the enum names the curated known set without closing the type.

## A drift risk this introduces, and its guard

Deriving those unions from enums means the backing tuples are no longer their source, so tuple and enum **can now drift where they previously could not**. Both remain public surface — `courthive-facilities` imports `indoorOutdoorTypes` — so a new guard pins each enum to its tuple as the same set.

## The last surviving widening

`genderConstants` was the one module whose members carried explicit `: string` annotations. Those widen straight through `as const`, so `GenderUnion` and `SexUnion` were still unsatisfiable by factory's own constants after the previous sweep:

```
Type 'string' is not assignable to type '"F" | "X" | "M" | "A" | "FEMALE" | …'
```

Annotations removed, with the reason recorded in the file so they are not reinstated.

## Do Gender and Sex need separate sources?

**No.** They are already independent enum declarations. What they shared was the `genderConstants` bucket — and that was only dangerous *because of the widening*. With literal types the compiler enforces the boundary:

```ts
const wrong: GenderUnion = genderConstants.OTHER;
// Type '"OTHER"' is not assignable to type '"F" | "X" | "M" | "A" | …'
```

It names the offending value instead of passing silently as `string`. Splitting the bucket would be a breaking change for no additional safety. Verified both directions against a real build.

## Verification

Full gate: **10,517 vitest** (coverage thresholds met), 12 jest, `verify:lint`, `check-types`, `verify:generated`. Audit re-run against the built package: 40 unions, 40 reachable enums, zero gaps.
