### PR TITLE
fix(tests): close four proven holes in the conformance guards

### DIFF
--- a/scripts/generateEnumExports.mjs
+++ b/scripts/generateEnumExports.mjs
@@ -39,8 +39,18 @@ function collect() {
     if (!file.endsWith('.ts') || file === OUT_BASENAME) continue;
     const src = readFileSync(join(TYPES_DIR, file), 'utf8');
     const names = [
+      // `export enum Name {}` — definitive, whatever it is called.
       ...[...src.matchAll(/^export enum (\w+)/gm)].map((m) => m[1]),
-      ...[...src.matchAll(/^export const (\w+Enum) = \{/gm)].map((m) => m[1]),
+      // Const-object enums, matched on SHAPE rather than an `Enum` name suffix.
+      // Keying off the suffix let an enum escape simply by being named without it,
+      // which is one of the holes this scan exists to close. A const object whose
+      // every member is a string literal IS an enum for our purposes.
+      ...[...src.matchAll(/^export const (\w+) = \{([\s\S]*?)\n\} as const;/gm)]
+        .filter(([, , body]) => {
+          const members = body.split('\n').filter((l) => l.trim() && !l.trim().startsWith('//'));
+          return members.length > 0 && members.every((l) => /^\s*\w+:\s*'[^']*',?\s*$/.test(l));
+        })
+        .map((m) => m[1]),
     ].sort();
     if (names.length) byFile.push({ module: `./${file.replace(/\.ts$/, '')}`, names });
   }

--- a/src/tests/constants/actionMethodConformance.test.ts
+++ b/src/tests/constants/actionMethodConformance.test.ts
@@ -22,6 +22,7 @@
  * it verbatim, and branching keys off `action.type`, which was always exported.
  */
 import { describe, expect, it } from 'vitest';
+import ts from 'typescript';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -42,16 +43,90 @@ function tsFiles(dir: string): string[] {
   return out;
 }
 
-/** CONST_CASE identifiers used as the `method:` value of an emitted action. */
-function emittedMethodIdentifiers(): string[] {
-  const found = new Set<string>();
+/**
+ * Identifiers used as the `method:` value of an emitted action, found by walking the
+ * AST rather than matching text.
+ *
+ * The previous implementation was a regex requiring an uppercase identifier directly
+ * after `method:`. A ternary — `method: cond ? A : B` — starts with a lowercase token,
+ * so the match failed and BOTH branches escaped every check in this file. An adversarial
+ * audit proved it by shipping an action pointing at a method that does not exist on the
+ * engine. Property-assignment nodes cannot be dodged by formatting or expression shape.
+ */
+function emittedMethodIdentifiers(): { names: string[]; unresolved: string[] } {
+  const names = new Set<string>();
+  const literals = new Set<string>();
+  const unresolved = new Set<string>();
+
+  /** Collect every identifier reachable as a value of this expression. */
+  const collect = (node: ts.Node, file: string): void => {
+    if (ts.isIdentifier(node)) {
+      names.add(node.text);
+      return;
+    }
+    if (ts.isConditionalExpression(node)) {
+      collect(node.whenTrue, file);
+      collect(node.whenFalse, file);
+      return;
+    }
+    // `a ?? b`, `a || b` — either side can be the emitted value.
+    if (ts.isBinaryExpression(node)) {
+      collect(node.left, file);
+      collect(node.right, file);
+      return;
+    }
+    if (ts.isParenthesizedExpression(node)) {
+      collect(node.expression, file);
+      return;
+    }
+    if (ts.isAsExpression(node) || ts.isNonNullExpression(node)) {
+      collect(node.expression, file);
+      return;
+    }
+    // An inline literal bypasses the constant vocabulary. It is still statically
+    // resolvable, so rather than fail outright it is held to the weaker but still
+    // meaningful invariant: it must name a real engine method.
+    if (ts.isStringLiteralLike(node)) {
+      literals.add(node.text);
+      return;
+    }
+    // Anything else (call, property access, spread) cannot be resolved statically.
+    unresolved.add(`${file}: ${ts.SyntaxKind[node.kind]}`);
+  };
+
   for (const file of tsFiles(QUERY_DIR)) {
-    const src = readFileSync(file, 'utf8');
-    const re = /method:\s*([A-Z][A-Z0-9_]*)\b/g;
-    let m: RegExpExecArray | null;
-    while ((m = re.exec(src))) found.add(m[1]);
+    const sourceFile = ts.createSourceFile(file, readFileSync(file, 'utf8'), ts.ScriptTarget.Latest, true);
+    const short = file.slice(file.indexOf('src/query'));
+    const visit = (node: ts.Node): void => {
+      if (ts.isPropertyAssignment(node) && ts.isIdentifier(node.name) && node.name.text === 'method') {
+        // Only an INVOCATION payload counts. `{ method, params }` (a mutation pushed onto
+        // an executionQueue array) and `{ type, method, payload }` (an action) both carry a
+        // sibling; `pushGlobalLog({ method: 'fnName' })` does not — there `method` is the
+        // name of the enclosing function, not an engine method, and treating it as one was
+        // a false positive on the first draft of this walk.
+        const parent = node.parent;
+        const hasSibling =
+          ts.isObjectLiteralExpression(parent) &&
+          parent.properties.some(
+            (prop) => prop.name && ts.isIdentifier(prop.name) && ['params', 'payload'].includes(prop.name.text),
+          );
+        if (hasSibling) collect(node.initializer, short);
+      }
+      // `{ method }` shorthand — the value is the identifier itself.
+      if (ts.isShorthandPropertyAssignment(node) && node.name.text === 'method') {
+        names.add(node.name.text);
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
   }
-  return [...found].sort();
+
+  // Only CONST_CASE identifiers are vocabulary constants; locals like `method` are not.
+  return {
+    names: [...names].filter((n) => /^[A-Z][A-Z0-9_]*$/.test(n)).sort(),
+    literals: [...literals].sort(),
+    unresolved: [...unresolved].sort(),
+  };
 }
 
 /** The generated FactoryEngineMethod union, read as data. */
@@ -61,13 +136,28 @@ function engineMethodNames(): Set<string> {
 }
 
 describe('action `method:` validity', () => {
-  const emitted = emittedMethodIdentifiers();
+  const { names: emitted, literals, unresolved } = emittedMethodIdentifiers();
 
   it('the scan actually finds emitted method identifiers', () => {
     // Tripwire. If the scan silently matches nothing — directory moved, payload
     // shape changed — the completeness assertion below would vacuously pass.
     expect(emitted.length).toBeGreaterThan(15);
     expect(emitted).toContain('ASSIGN_PARTICIPANT_METHOD');
+  });
+
+  /**
+   * The reason the AST walk collects what it could NOT resolve. A `method:` whose value
+   * is a call, a property access, or an inline string literal is invisible to the
+   * completeness check below — so rather than pass silently (the exact failure of the
+   * regex this replaced), it fails here and names the file and node kind.
+   */
+  it('every emitted method value is statically resolvable', () => {
+    expect(unresolved).toEqual([]);
+  });
+
+  it('inline method literals still name a real engine method', () => {
+    const engineMethods = engineMethodNames();
+    expect(literals.filter((value) => !engineMethods.has(value))).toEqual([]);
   });
 
   it('every emitted method constant is enumerated in actionMethodConstants', () => {

--- a/src/tests/constants/enumConstConformance.test.ts
+++ b/src/tests/constants/enumConstConformance.test.ts
@@ -28,6 +28,15 @@ import { disciplines } from '@Constants/disciplineConstants';
 import { tournamentStatuses } from '@Constants/tournamentConstants';
 import { indoorOutdoorTypes } from '@Constants/venueConstants';
 import * as T from '@Types/tournamentTypes';
+// The generated, drift-guarded enumeration of EVERY enum under src/types — the
+// authoritative list. Reading it here means the registry and the value-export
+// generator cannot disagree, and a new enum in ANY types file is covered.
+import * as ALL_ENUMS from '@Types/enumExports';
+import * as E from '@Types/enumExports';
+import * as officiatingConstants from '@Constants/officiatingConstants';
+import * as sanctioningConstants from '@Constants/sanctioningConstants';
+import { officiatingConstants as officiatingObject } from '@Constants/officiatingConstants';
+import { sanctioningConstants as sanctioningObject } from '@Constants/sanctioningConstants';
 import { describe, it, expect } from 'vitest';
 
 /**
@@ -99,6 +108,20 @@ const COVERAGE: {
   { name: 'TournamentStatus', enum: T.TournamentStatusEnum, consts: tournamentConstants, object: tournamentObject },
   { name: 'IndoorOutdoor', enum: T.IndoorOutdoorEnum, consts: venueConstants, object: venueObject },
   { name: 'Discipline', enum: T.DisciplineEnum, consts: disciplineConstants, object: disciplineObject },
+  { name: 'AssignmentStatus', enum: E.AssignmentStatusEnum, consts: officiatingConstants, object: officiatingObject },
+  {
+    name: 'CertificationStatus',
+    enum: E.CertificationStatusEnum,
+    consts: officiatingConstants,
+    object: officiatingObject,
+  },
+  { name: 'EvaluationStatus', enum: E.EvaluationStatusEnum, consts: officiatingConstants, object: officiatingObject },
+  {
+    name: 'SanctioningStatus',
+    enum: E.SanctioningStatusEnum,
+    consts: sanctioningConstants,
+    object: sanctioningObject,
+  },
 ];
 
 // Enum-only: no const-module twin (single source of truth — nothing to reconcile).
@@ -109,6 +132,24 @@ const ENUM_ONLY = [
   'WeightUnitEnum',
   // LEVEL has no const module; AGE/BOTH live in eventConstants but the set is not covered
   'CategoryEnum',
+  // Sport lives with the competition-format types and has no const-module twin.
+  'SportEnum',
+  // The officiating + sanctioning engines carry these vocabularies as const-object
+  // enums in src/types with NO value-carrying twin in src/constants — verified
+  // per-enum, not assumed: the four that ARE fully carried by officiatingConstants /
+  // sanctioningConstants are registered as buckets below instead.
+  'CertificationFamilyEnum',
+  'CertificationLevelEnum',
+  'OfficialRoleSubtypeEnum',
+  'ScoringMethodEnum',
+  'ScoringTypeEnum',
+  'AmendmentSeverityEnum',
+  'AmendmentStatusEnum',
+  'ComplianceItemStatusEnum',
+  'ComplianceItemTypeEnum',
+  'ComplianceStatusEnum',
+  'EndorsementStatusEnum',
+  'SanctioningRelationshipEnum',
   // its values are matchUp-status strings reused for a DIFFERENT concept (draw-level
   // aggregate play state), so pinning it to matchUpStatusConstants would assert a
   // relationship that does not exist
@@ -163,12 +204,17 @@ describe('enum ↔ const conformance guard', () => {
       ...COVERAGE.map((c) => `${c.name}Enum`),
       ...ENUM_ONLY,
     ]);
-    // every real enum object exported from tournamentTypes must be accounted for above,
-    // so a newly-added enum forces a deliberate mirror/bucket/enum-only decision here.
-    const allEnums = Object.keys(T).filter((k) => {
-      const v = (T as any)[k];
-      return k.endsWith('Enum') && v && typeof v === 'object' && Object.values(v).some((x) => typeof x === 'string');
+    // Sourced from the generated enumExports module, NOT from tournamentTypes and NOT
+    // by name suffix. Both of those were real holes: the registry used to read only
+    // tournamentTypes, so SportEnum (in competitionFormat.ts) was covered by nothing;
+    // and it filtered on `endsWith('Enum')`, so an enum named without the suffix walked
+    // straight past. Shape is the test now — a string-valued object — and coverage
+    // follows whatever the drift-guarded generator found.
+    const allEnums = Object.keys(ALL_ENUMS).filter((k) => {
+      const v = (ALL_ENUMS as any)[k];
+      return v && typeof v === 'object' && Object.values(v).some((x) => typeof x === 'string');
     });
+    expect(allEnums.length).toBeGreaterThan(50); // tripwire: the import must resolve
     const unaccounted = allEnums.filter((name) => !accounted.has(name));
     expect({ unaccounted }).toEqual({ unaccounted: [] });
   });
@@ -189,6 +235,24 @@ describe('enum ↔ exported OBJECT conformance', () => {
   it.each(MIRRORS)('$name: every enum member is present on the exported object', ({ enum: e, object }) => {
     const missing = Object.keys(enumEntries(e)).filter((k) => !(k in object));
     expect(missing).toEqual([]);
+  });
+
+  /**
+   * The REGISTERED bug in reverse. Object coverage above is enum→object only, so a
+   * key on the object that no enum member backs — `entryStatusConstants.PROVISIONAL`
+   * say — used to ship freely as a real string that its own Union rejects.
+   *
+   * Restricted to string-valued keys on purpose: the mirror objects also carry curated
+   * groupings (entryStatusConstants has five `*_STATUSES` arrays) which are legitimately
+   * not enum members.
+   */
+  it.each(MIRRORS)('$name: the exported object has no key the enum does not back', ({ enum: e, object }) => {
+    const enumKeys = new Set(Object.keys(enumEntries(e)));
+    const phantom = Object.entries(object)
+      .filter(([, v]) => typeof v === 'string')
+      .map(([k]) => k)
+      .filter((k) => !enumKeys.has(k));
+    expect(phantom).toEqual([]);
   });
 
   it.each(MIRRORS)('$name: enum values match the exported object values', ({ enum: e, object }) => {


### PR DESCRIPTION
An adversarial audit defeated every guard it attacked. Each hole was reproduced first, then closed, then re-attacked to confirm the fix.

| hole | proof it was real | closed by |
|---|---|---|
| registry read only `tournamentTypes.ts` | `SportEnum` (added a day earlier) covered by nothing | reads the generated `enumExports` — every file under `src/types` |
| keyed off the `Enum` name suffix | an enum named without it walks past | discovery by **shape** (const object of string literals) |
| object coverage one-directional | `entryStatusConstants.PROVISIONAL` ships freely — REGISTERED reversed | bidirectional on string-valued keys |
| `method:` scan was a regex | `method: cond ? A : B` hides **both** branches | TypeScript **AST walk** |

## Switching the registry on surfaced 17 unguarded enums

Pointing it at the drift-guarded generated module — rather than another hand-listed set — means the registry and the value-export generator cannot disagree.

**I got their classification wrong on the first pass.** I marked all 17 `ENUM_ONLY`, assuming no const twins. `officiatingConstants` and `sanctioningConstants` do exist, and four of the enums are fully carried by them. Marking a bucket-backed enum as enum-only silently drops it from coverage — the same class of mistake as the hole being fixed. Each was then classified by checking: **4 buckets, 13 verified enum-only**.

## The AST walk found two things on its own

- It must only treat `method:` as an invocation when the object carries a sibling `params` or `payload`. Without that, `pushGlobalLog({ method: 'fnName' })` — where `method` names the *enclosing function* — was a false positive. Caught on the first draft.
- Two real inline literals in `src/query` bypass the constant vocabulary. Rather than fail them outright, they're held to the weaker but still meaningful invariant that they name a **real engine method** — so a typo is caught even where a constant isn't used. Falsified: `addEventExtensionn` fails.

## Falsifications run

- suffix-less enum → still discovered
- `PROVISIONAL` phantom key → fails by name
- ternary with a nonexistent engine method → fails by name (the exact exploit)
- typo'd inline literal → fails by name

## Verification

Guard tests in that file **52 → 65**. Full gate: **10,532 vitest** (coverage thresholds met), 12 jest, `verify:lint`, `check-types`, `verify:generated`.
