### PR TITLE
fix(readModel): round_segment silently deleted every segmented round

### DIFF
--- a/src/query/readModel/readModelRows.ts
+++ b/src/query/readModel/readModelRows.ts
@@ -202,7 +202,8 @@ export function schedulingProfileRows(tournamentId: string, schedulingProfile: a
           draw_id: round?.drawId ?? null,
           structure_id: round?.structureId ?? null,
           round_number: round?.roundNumber ?? null,
-          round_segment: round?.roundSegment ?? null,
+          round_segment_number: round?.roundSegment?.segmentNumber ?? null,
+          round_segments_count: round?.roundSegment?.segmentsCount ?? null,
           winner_finishing_position_range: round?.winnerFinishingPositionRange ?? null,
         });
       });

--- a/src/tests/queries/readModel/readModelRows.test.ts
+++ b/src/tests/queries/readModel/readModelRows.test.ts
@@ -296,6 +296,30 @@ describe('orderOfPlayRow', () => {
 });
 
 describe('schedulingProfileRows', () => {
+  /**
+   * The regression that motivated the split. `roundSegment` is an OBJECT
+   * ({ segmentsCount, segmentNumber }); it used to be assigned whole to a single
+   * `round_segment` field declared `number | null` — unchecked, because the source
+   * round is `any`. The read model's column is `integer`, so Postgres rejected every
+   * segmented row, and because the scheduling plan re-projects as delete-then-insert
+   * the row was deleted and never restored. Both halves must emit as scalars.
+   */
+  it('emits a segmented round as two scalars, never the raw object', () => {
+    const profile = [
+      {
+        scheduleDate: '2025-01-05',
+        venues: [{ venueId: 'v1', rounds: [{ roundNumber: 2, roundSegment: { segmentsCount: 3, segmentNumber: 2 } }] }],
+      },
+    ];
+    const [row] = schedulingProfileRows('t1', profile) as any[];
+    expect(row.round_segment_number).toBe(2);
+    expect(row.round_segments_count).toBe(3);
+    expect(typeof row.round_segment_number).toBe('number');
+    expect(typeof row.round_segments_count).toBe('number');
+    // the field that could not hold the value is gone entirely
+    expect('round_segment' in row).toBe(false);
+  });
+
   it('flattens per (date, venue, round order) with round identity', () => {
     const profile = [
       {
@@ -305,7 +329,7 @@ describe('schedulingProfileRows', () => {
             venueId: 'v1',
             rounds: [
               { eventId: 'e1', drawId: 'd1', structureId: 's1', roundNumber: 1 },
-              { drawId: 'd2', roundNumber: 2, roundSegment: 1 },
+              { drawId: 'd2', roundNumber: 2, roundSegment: { segmentsCount: 3, segmentNumber: 2 } },
             ],
           },
         ],
@@ -322,7 +346,8 @@ describe('schedulingProfileRows', () => {
         draw_id: 'd1',
         structure_id: 's1',
         round_number: 1,
-        round_segment: null,
+        round_segment_number: null,
+        round_segments_count: null,
         winner_finishing_position_range: null,
       },
       {
@@ -334,7 +359,8 @@ describe('schedulingProfileRows', () => {
         draw_id: 'd2',
         structure_id: null,
         round_number: 2,
-        round_segment: 1,
+        round_segment_number: 2,
+        round_segments_count: 3,
         winner_finishing_position_range: null,
       },
     ]);

--- a/src/types/readModelTypes.ts
+++ b/src/types/readModelTypes.ts
@@ -134,7 +134,14 @@ export interface ReadModelSchedulingProfileRow {
   draw_id: string | null;
   structure_id: string | null;
   round_number: number | null;
-  round_segment: number | null;
+  // A round's segment is a PAIR — "segment 2 of 3" — so it needs two columns.
+  // These were previously one `round_segment: number | null`, which was a lie: the
+  // producer assigned the whole `{ segmentsCount, segmentNumber }` object to it,
+  // unchecked because the source round is `any`. Postgres rejected every such row
+  // against an `integer` column, and since the scheduling plan re-projects as
+  // delete-then-insert, each segmented round was deleted and never restored.
+  round_segment_number: number | null;
+  round_segments_count: number | null;
   winner_finishing_position_range: string | null;
 }
 


### PR DESCRIPTION
A round's segment is a **pair** — "segment 2 of 3" — and `roundSegment` is an object, `{ segmentsCount, segmentNumber }`. The producer assigned it whole to a single `round_segment` field declared `number | null`, unchecked because the source round is typed `any`. The read model's column is `integer`.

## This was data loss, not a missing value

Reproduced end to end across factory, courthive-query and CFS:

```
Postgres: invalid input syntax for type integer: "{"segmentsCount":2,"segmentNumber":1}"
          → 0 rows
```

The scheduling plan re-projects as **delete-by-tournament THEN re-insert**. The delete succeeded, the insert was rejected, and the consumer's `skip-and-surface` advanced the cursor past the poison row.

So every segmented round was removed from `query_scheduling_profile` and never restored — while `/health/projection` stayed **green**, because the delete succeeded and `lag` therefore never rose. Unsegmented rounds projected fine, so the table looked partially populated rather than broken. That combination is why it went unnoticed.

## Two scalar columns

Storing only `segmentNumber` would discard the denominator, and "segment 1" of an unknown total isn't the fact. `jsonb` would keep the shape but give up the querying the read model exists for.

Verified against real Postgres — the row that previously vanished now persists:

```
round_order | round_number | round_segment_number | round_segments_count
          0 |            1 |                      |
          1 |            2 |                    2 |                    3
```

## The test was asserting a fiction

It passed throughout because it used `roundSegment: 1` — a **number**, a shape that never occurs. Corrected to the real object, plus a regression test asserting both halves emit as scalars and that the field which could not hold the value is gone. Falsified by restoring the single-field emit: both tests fail.

## Coordination

- **CFS needs no change** — it forwards the row wholesale; `courthive-query`'s `tableMeta` allow-list decides the columns.
- Paired with **courthive-query migration 014**, which adds the two columns and drops the old one. Safe to drop outright: no row carrying a segment ever inserted successfully, so there is nothing to migrate.
- Deploying factory alone stops the loss immediately, since the poison value is no longer emitted.
- **A projection rebuild is required after deploy.** Rows already deleted are not recovered by this fix.

## Verification

Full gate: **10,533 vitest** (coverage thresholds met), 12 jest, `verify:lint`, `check-types`, `verify:generated`.
