### PR TITLE
feat(venues): add addVenueOtherId mutation for UnifiedVenueID capture

### DIFF
--- a/src/assemblies/governors/venueGovernor/mutate.ts
+++ b/src/assemblies/governors/venueGovernor/mutate.ts
@@ -8,4 +8,5 @@ export { enableCourts } from '@Mutate/venues/enableCourts';
 export { enableVenues } from '@Mutate/venues/enableVenues';
 export { modifyCourt } from '@Mutate/venues/modifyCourt';
 export { modifyVenue } from '@Mutate/venues/modifyVenue';
+export { addVenueOtherId } from '@Mutate/venues/addVenueOtherId';
 export { addVenue } from '@Mutate/venues/addVenue';

--- a/src/constants/mutationLockScopeMap.ts
+++ b/src/constants/mutationLockScopeMap.ts
@@ -230,6 +230,7 @@ export const methodScopeMap: Record<string, MutationLockScope> = {
   deleteCourts: 'VENUES',
   modifyCourt: 'VENUES',
   modifyVenue: 'VENUES',
+  addVenueOtherId: 'VENUES',
   addVenue: 'VENUES',
 
   // PUBLISHING — publishingGovernor/mutate

--- a/src/mutate/venues/addVenueOtherId.ts
+++ b/src/mutate/venues/addVenueOtherId.ts
@@ -1,0 +1,114 @@
+import { resolveTournamentRecords } from '@Helpers/parameters/resolveTournamentRecords';
+import { requireParams } from '@Helpers/parameters/requireParams';
+import { addNotice } from '@Global/state/globalState';
+import { findVenue } from '@Query/venues/findVenue';
+
+// constants and types
+import { ErrorType, MISSING_VALUE, VENUE_NOT_FOUND } from '@Constants/errorConditionConstants';
+import { MODIFY_VENUE } from '@Constants/topicConstants';
+import { SUCCESS } from '@Constants/resultConstants';
+
+/**
+ * Upsert a `UnifiedVenueID` entry into a venue's `venueOtherIds[]` array — the
+ * CODES mechanism for recording that the same physical venue is known by a
+ * different id at another organisation (a federation, a canonical facility
+ * registry, an upstream league site).
+ *
+ * Mirrors {@link addPersonOtherId}. `organisationId` is the upsert key: if the
+ * venue already has an entry with the given `organisationId`, that entry's
+ * `venueId` (and optional `uniqueOrganisationName`) is replaced. Otherwise a
+ * new entry is appended with a `createdAt` timestamp.
+ *
+ * Note the two distinct ids: `venueId` locates the venue WITHIN this
+ * tournamentRecord, while `otherVenueId` is the value stored into the
+ * `UnifiedVenueID.venueId` field — the id in the OTHER organisation's
+ * namespace (e.g. an ALTA facility number, an ITA institution slug, a
+ * courthive-facilities `facilityId`).
+ *
+ * Idempotent: re-applying the same `(organisationId, otherVenueId)` is a no-op.
+ *
+ * Factory is deliberately neutral on what `organisationId` represents — the
+ * caller chooses (federation id, canonical-registry id from a downstream
+ * service, anything). The factory neither validates nor interprets it.
+ */
+export function addVenueOtherId(params: {
+  tournamentRecords?: { [key: string]: any };
+  tournamentRecord?: any;
+  uniqueOrganisationName?: string;
+  organisationId: string;
+  otherVenueId: string;
+  venueId: string;
+}) {
+  const { uniqueOrganisationName, organisationId, otherVenueId, venueId } = params;
+
+  const tournamentRecords = resolveTournamentRecords(params);
+  const paramsCheck = requireParams({ venueId }, ['venueId']);
+  if (paramsCheck.error) return paramsCheck;
+
+  if (!organisationId) return { error: MISSING_VALUE, info: 'Missing organisationId' };
+  if (!otherVenueId) return { error: MISSING_VALUE, info: 'Missing otherVenueId' };
+
+  let success;
+  let error;
+
+  for (const tournamentRecord of Object.values(tournamentRecords)) {
+    const result = venueOtherIdAdd({
+      uniqueOrganisationName,
+      organisationId,
+      otherVenueId,
+      tournamentRecord,
+      venueId,
+    });
+    if (result.success) success = true;
+    if (result.error) error = result.error;
+    // suppress VENUE_NOT_FOUND across records — a venue lives in one — but surface anything else
+    if (result.error && result.error !== VENUE_NOT_FOUND) return result;
+  }
+
+  return success ? { ...SUCCESS } : { error: error ?? VENUE_NOT_FOUND };
+}
+
+function venueOtherIdAdd({
+  uniqueOrganisationName,
+  organisationId,
+  otherVenueId,
+  tournamentRecord,
+  venueId,
+}: {
+  uniqueOrganisationName?: string;
+  organisationId: string;
+  otherVenueId: string;
+  tournamentRecord: any;
+  venueId: string;
+}): { success?: boolean; error?: ErrorType } {
+  const { venue } = findVenue({ tournamentRecord, venueId });
+  if (!venue) return { error: VENUE_NOT_FOUND };
+
+  venue.venueOtherIds ??= [];
+  const existing = venue.venueOtherIds.find((entry: any) => entry?.organisationId === organisationId);
+
+  if (existing) {
+    if (existing.venueId === otherVenueId && existing.uniqueOrganisationName === uniqueOrganisationName) {
+      // Idempotent no-op: same (organisationId, otherVenueId, name) already stamped.
+      return { ...SUCCESS };
+    }
+    existing.venueId = otherVenueId;
+    if (uniqueOrganisationName !== undefined) existing.uniqueOrganisationName = uniqueOrganisationName;
+    existing.updatedAt = new Date().toISOString();
+  } else {
+    venue.venueOtherIds.push({
+      ...(uniqueOrganisationName !== undefined ? { uniqueOrganisationName } : {}),
+      organisationId,
+      venueId: otherVenueId,
+      createdAt: new Date().toISOString(),
+    });
+  }
+
+  addNotice({
+    payload: { venue, tournamentId: tournamentRecord.tournamentId },
+    topic: MODIFY_VENUE,
+    key: venue.venueId,
+  });
+
+  return { ...SUCCESS };
+}

--- a/src/tests/mutations/venues/addVenueOtherId.test.ts
+++ b/src/tests/mutations/venues/addVenueOtherId.test.ts
@@ -1,0 +1,99 @@
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+import { MISSING_VALUE, VENUE_NOT_FOUND } from '@Constants/errorConditionConstants';
+
+function setup() {
+  mocksEngine.generateTournamentRecord({ setState: true });
+  const result: any = tournamentEngine.addVenue({ venue: { venueName: 'Center Courts' } });
+  expect(result.success).toEqual(true);
+  return { venueId: result.venue.venueId };
+}
+
+describe('addVenueOtherId — append', () => {
+  it('appends a new (organisationId, otherVenueId) to an empty array', () => {
+    const { venueId } = setup();
+    const result: any = tournamentEngine.addVenueOtherId({
+      venueId,
+      organisationId: 'ALTA',
+      otherVenueId: '999',
+      uniqueOrganisationName: 'Atlanta Lawn Tennis Association',
+    });
+    expect(result.success).toEqual(true);
+
+    const otherIds = tournamentEngine.findVenue({ venueId }).venue.venueOtherIds;
+    expect(otherIds).toHaveLength(1);
+    expect(otherIds[0].organisationId).toEqual('ALTA');
+    expect(otherIds[0].venueId).toEqual('999');
+    expect(otherIds[0].uniqueOrganisationName).toEqual('Atlanta Lawn Tennis Association');
+    expect(otherIds[0].createdAt).toBeDefined();
+  });
+
+  it('appends a second entry under a different organisationId', () => {
+    const { venueId } = setup();
+    tournamentEngine.addVenueOtherId({ venueId, organisationId: 'ALTA', otherVenueId: '999' });
+    tournamentEngine.addVenueOtherId({ venueId, organisationId: 'ITA', otherVenueId: 'STANFORD' });
+    const otherIds = tournamentEngine.findVenue({ venueId }).venue.venueOtherIds;
+    expect(otherIds).toHaveLength(2);
+    expect(otherIds.map((o: any) => o.organisationId).sort()).toEqual(['ALTA', 'ITA']);
+  });
+});
+
+describe('addVenueOtherId — upsert by organisationId', () => {
+  it('replaces otherVenueId when organisationId already exists', () => {
+    const { venueId } = setup();
+    tournamentEngine.addVenueOtherId({ venueId, organisationId: 'ALTA', otherVenueId: 'OLD' });
+    const result: any = tournamentEngine.addVenueOtherId({ venueId, organisationId: 'ALTA', otherVenueId: 'NEW' });
+    expect(result.success).toEqual(true);
+
+    const otherIds = tournamentEngine.findVenue({ venueId }).venue.venueOtherIds;
+    expect(otherIds).toHaveLength(1);
+    expect(otherIds[0].venueId).toEqual('NEW');
+    expect(otherIds[0].updatedAt).toBeDefined();
+  });
+
+  it('does not duplicate when the same (organisationId, otherVenueId) is re-applied', () => {
+    const { venueId } = setup();
+    tournamentEngine.addVenueOtherId({ venueId, organisationId: 'ITA', otherVenueId: 'STANFORD' });
+    tournamentEngine.addVenueOtherId({ venueId, organisationId: 'ITA', otherVenueId: 'STANFORD' });
+    const otherIds = tournamentEngine.findVenue({ venueId }).venue.venueOtherIds;
+    expect(otherIds).toHaveLength(1);
+  });
+});
+
+describe('addVenueOtherId — error paths', () => {
+  it('returns VENUE_NOT_FOUND when venueId is unknown', () => {
+    setup();
+    const result: any = tournamentEngine.addVenueOtherId({
+      venueId: 'no-such-venue',
+      organisationId: 'ALTA',
+      otherVenueId: '999',
+    });
+    expect(result.error).toEqual(VENUE_NOT_FOUND);
+  });
+
+  it('returns MISSING_VALUE when organisationId is empty', () => {
+    const { venueId } = setup();
+    const result: any = tournamentEngine.addVenueOtherId({ venueId, organisationId: '', otherVenueId: '999' });
+    expect(result.error).toEqual(MISSING_VALUE);
+  });
+
+  it('returns MISSING_VALUE when otherVenueId is empty', () => {
+    const { venueId } = setup();
+    const result: any = tournamentEngine.addVenueOtherId({ venueId, organisationId: 'ALTA', otherVenueId: '' });
+    expect(result.error).toEqual(MISSING_VALUE);
+  });
+});
+
+describe('addVenueOtherId — mixed organisations', () => {
+  it('preserves existing entries from other organisations', () => {
+    const { venueId } = setup();
+    tournamentEngine.addVenueOtherId({ venueId, organisationId: 'ALTA', otherVenueId: 'KEEP' });
+    tournamentEngine.addVenueOtherId({ venueId, organisationId: 'ITA', otherVenueId: 'NEW' });
+    const otherIds = tournamentEngine.findVenue({ venueId }).venue.venueOtherIds;
+    expect(otherIds).toHaveLength(2);
+    const keep = otherIds.find((o: any) => o.organisationId === 'ALTA');
+    expect(keep?.venueId).toEqual('KEEP');
+  });
+});

--- a/src/types/factoryEngineMethods.ts
+++ b/src/types/factoryEngineMethods.ts
@@ -63,6 +63,7 @@ export type FactoryEngineMethod =
   | 'addTournamentExtension'
   | 'addTournamentTimeItem'
   | 'addVenue'
+  | 'addVenueOtherId'
   | 'addVoluntaryConsolationStructure'
   | 'adHocPositionSwap'
   | 'aggregateTieFormats'
@@ -714,6 +715,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'addTournamentExtension',
   'addTournamentTimeItem',
   'addVenue',
+  'addVenueOtherId',
   'addVoluntaryConsolationStructure',
   'adHocPositionSwap',
   'aggregateTieFormats',

--- a/src/types/methodSignatures.ts
+++ b/src/types/methodSignatures.ts
@@ -495,6 +495,7 @@ import type { publishEvent } from '@Mutate/publishing/publishEvent';
 import type { publishEventSeeding, unPublishEventSeeding } from '@Mutate/publishing/eventSeeding';
 import type { resetScorecard } from '@Mutate/matchUps/resetScorecard';
 import type { addOnlineResource } from '@Mutate/base/addOnlineResource';
+import type { addVenueOtherId } from '@Mutate/venues/addVenueOtherId';
 import type { publicFindParticipant } from '@Acquire/publicFindParticipant';
 import type { getMatchUpsMap } from '@Query/matchUps/getMatchUpsMap';
 import type { setEventDisplay } from '@Mutate/events/setEventDisplay';
@@ -646,6 +647,7 @@ export interface MethodSignatures {
   addTournamentExtension: EngineMethod<typeof addTournamentExtension>;
   addTournamentTimeItem: EngineMethod<typeof addTournamentTimeItem>;
   addVenue: EngineMethod<typeof addVenue>;
+  addVenueOtherId: EngineMethod<typeof addVenueOtherId>;
   addVoluntaryConsolationStructure: EngineMethod<typeof addVoluntaryConsolationStructure>;
   adHocPositionSwap: EngineMethod<typeof adHocPositionSwap>;
   aggregateTieFormats: EngineMethod<typeof aggregateTieFormats>;


### PR DESCRIPTION
Adds the venue equivalent of addPersonOtherId — upsert keyed by organisationId, idempotent, emits MODIFY_VENUE. Registered across venueGovernor, methodSignatures, factoryEngineMethods, mutationLockScopeMap (VENUES scope). 8 unit tests. Closes the CODES venueOtherIds mutation gap.