### PR TITLE
fix(tieFormat): mint collectionIds so published fixtures are usable

### DIFF
--- a/documentation/docs/governors/tie-format-governor.md
+++ b/documentation/docs/governors/tie-format-governor.md
@@ -102,6 +102,29 @@ Not every format is a bare majority: `USTA_OZAKI_CUP` (23 of 36) and `USTA_SECTI
 deliberately set a higher bar, and `TEAM_DOUBLES_3_AGGREGATION`, `USTA_TOC` and `USTA_WTT_ITT` use
 `aggregateValue` instead of a goal.
 
+### Collection identity
+
+The published fixtures carry **no `collectionId`** — and cannot. A `collectionId` identifies a collection
+_instance_ within a record, and matchUps reference it; a shared fixture holding one would hand every record
+that used it the same collection identities.
+
+The factory therefore **mints collectionIds when a tieFormat is attached** — on a copy, so the object you
+passed (often the shared fixture itself) is never stamped. Consuming a fixture directly is safe:
+
+```js
+const { event } = engine.addEvent({
+  event: { eventName: 'Dual', eventType: TEAM, tieFormat: fixtures.tieFormats.USTA_COLLEGE },
+});
+// event.tieFormat.collectionDefinitions each carry a freshly minted collectionId
+```
+
+Two records built from the same fixture get **distinct** collection identities, which is the point.
+
+> Before 2026-08-09 this minting did not happen on that path: `addEvent` minted for a `tieFormatName` but
+> only validated a supplied tieFormat object. Lines were then generated with `collectionId: null`, could not
+> be attributed to their collection, and the tie never scored — a completed 4-3 dual stayed `TO_BE_PLAYED`.
+> `validateTieFormat` still reports such a tieFormat valid unless called with `checkCollectionIds: true`.
+
 ### Centralised Storage with `tieFormatId`
 
 Rather than duplicating identical tieFormat objects on every draw, structure, and matchUp, the factory supports **centralised storage**:

--- a/src/assemblies/generators/drawDefinitions/generateDrawDefinition/checkFormatScopeEquivalence.ts
+++ b/src/assemblies/generators/drawDefinitions/generateDrawDefinition/checkFormatScopeEquivalence.ts
@@ -1,5 +1,6 @@
 import { setMatchUpMatchUpFormat } from '@Mutate/matchUps/matchUpFormat/setMatchUpMatchUpFormat';
 import { checkTieFormat } from '@Mutate/tieFormat/checkTieFormat';
+import { makeDeepCopy } from '@Tools/makeDeepCopy';
 
 export function checkFormatScopeEquivalence({
   existingQualifyingStructures,
@@ -21,7 +22,10 @@ export function checkFormatScopeEquivalence({
     // there is no need to attach to the drawDefinition
     if (!equivalentInScope) {
       if (tieFormat) {
-        const result = checkTieFormat({ tieFormat });
+        // on a COPY: checkTieFormat mints missing collectionIds IN PLACE, and `tieFormat` here is the
+        // caller's object — which is the shared `fixtures.tieFormats.*` object when a published fixture
+        // was passed. Stamping ids onto it would give every later record the same collection identities.
+        const result = checkTieFormat({ tieFormat: makeDeepCopy(tieFormat, false, true) });
         if (result.error) return result;
 
         const existingQualifyingTieFormats = existingQualifyingStructures?.every((structure) => structure.tieFormat);

--- a/src/assemblies/generators/drawDefinitions/generateDrawDefinition/setUpDrawGeneration.ts
+++ b/src/assemblies/generators/drawDefinitions/generateDrawDefinition/setUpDrawGeneration.ts
@@ -1,4 +1,6 @@
 import { newDrawDefinition } from '@Generators/drawDefinitions/newDrawDefinition';
+import { checkTieFormat } from '@Mutate/tieFormat/checkTieFormat';
+import { makeDeepCopy } from '@Tools/makeDeepCopy';
 import { checkFormatScopeEquivalence } from './checkFormatScopeEquivalence';
 import { decorateResult } from '@Functions/global/decorateResult';
 import { policyAttachment } from './drawDefinitionPolicyAttachment';
@@ -14,17 +16,9 @@ export function setUpDrawGeneration(params): ResultType & {
   drawDefinition?: DrawDefinition;
   structureId?: string;
 } {
-  const {
-    tournamentRecord,
-    policyDefinitions,
-    appliedPolicies,
-    matchUpFormat,
-    matchUpType,
-    tieFormat,
-    drawType,
-    stack,
-    event,
-  } = params;
+  const { tournamentRecord, policyDefinitions, appliedPolicies, matchUpFormat, matchUpType, drawType, stack, event } =
+    params;
+  let { tieFormat } = params;
 
   const existingDrawDefinition = params.drawId
     ? (event?.drawDefinitions?.find((d) => d.drawId === params.drawId) as DrawDefinition)
@@ -44,7 +38,11 @@ export function setUpDrawGeneration(params): ResultType & {
     existingQualifyingStructures[0].structureId;
 
   // Only overwrite drawType when not just adding qualifying to an existing draw
-  if (existingDrawDefinition && drawType !== existingDrawDefinition.drawType && !existingQualifyingPlaceholderStructureId)
+  if (
+    existingDrawDefinition &&
+    drawType !== existingDrawDefinition.drawType &&
+    !existingQualifyingPlaceholderStructureId
+  )
     existingDrawDefinition.drawType = drawType as DrawTypeUnion;
 
   const drawDefinition: any =
@@ -54,6 +52,19 @@ export function setUpDrawGeneration(params): ResultType & {
       drawId: params.drawId,
       drawType,
     });
+
+  // Normalize the incoming tieFormat ONCE, before anything consumes it: mint any missing collectionIds
+  // on a copy, then put that copy back on params so every downstream step — the scope-equivalence
+  // attachment here and the tie matchUp generation in generateDrawTypeAndModifyDrawDefinition — works
+  // from the SAME identities. Minting independently in each step gave the drawDefinition one set of
+  // collectionIds and the generated lines another, so the lines could not be attributed to their
+  // collection and a completed dual stalled at IN_PROGRESS.
+  if (tieFormat) {
+    const collectionIdResult = checkTieFormat({ tieFormat: makeDeepCopy(tieFormat, false, true) });
+    if (collectionIdResult.error) return decorateResult({ result: collectionIdResult, stack });
+    tieFormat = collectionIdResult.tieFormat;
+    params.tieFormat = tieFormat;
+  }
 
   const equivalenceResult = checkFormatScopeEquivalence({
     existingQualifyingStructures,

--- a/src/assemblies/generators/drawDefinitions/generateDrawTypeAndModifyDrawDefinition.ts
+++ b/src/assemblies/generators/drawDefinitions/generateDrawTypeAndModifyDrawDefinition.ts
@@ -1,5 +1,6 @@
 import { getStageDrawPositionsCount } from '@Query/drawDefinition/getStageDrawPositions';
 import { resolveTieFormat } from '@Query/hierarchical/tieFormats/resolveTieFormat';
+import { checkTieFormat } from '@Mutate/tieFormat/checkTieFormat';
 import { generateDrawStructuresAndLinks } from './generateDrawStructuresAndLinks';
 import { copyTieFormat } from '@Query/hierarchical/tieFormats/copyTieFormat';
 import { modifyDrawNotice } from '@Mutate/notifications/drawNotifications';
@@ -81,6 +82,15 @@ export function generateDrawTypeAndModifyDrawDefinition(params: GenerateDrawType
   }
 
   tieFormat = copyTieFormat(tieFormat ?? resolveTieFormat({ drawDefinition })?.tieFormat);
+
+  // mint any missing collectionIds. A published `fixtures.tieFormats.*` object carries none — it cannot,
+  // since a collectionId identifies a collection INSTANCE within a record — and without them every
+  // generated line carries `collectionId: null`, cannot be attributed to its collection, and the tie
+  // never scores. Safe to mint in place: `copyTieFormat` above already detached this from the caller.
+  if (tieFormat) {
+    const collectionIdResult = checkTieFormat({ tieFormat });
+    if (collectionIdResult.error) return collectionIdResult;
+  }
   matchUpType = matchUpType ?? (drawDefinition.matchUpType || SINGLES);
   params.tieFormat = tieFormat;
   params.matchUpType = matchUpType;

--- a/src/mutate/events/addEvent.ts
+++ b/src/mutate/events/addEvent.ts
@@ -1,8 +1,9 @@
 import { addDrawNotice, addMatchUpsNotice } from '../notifications/drawNotifications';
 import tieFormatDefaults from '@Assemblies/generators/templates/tieFormatDefaults';
+import { checkTieFormat } from '@Mutate/tieFormat/checkTieFormat';
+import { makeDeepCopy } from '@Tools/makeDeepCopy';
 import { addEventNotice } from '@Mutate/notifications/eventNotifications';
 import { allEventMatchUps } from '@Query/matchUps/getAllEventMatchUps';
-import { validateTieFormat } from '@Validators/validateTieFormat';
 import { requireParams } from '@Helpers/parameters/requireParams';
 import { normalizeDiscipline } from '@Helpers/coercedDiscipline';
 import { definedAttributes } from '@Tools/definedAttributes';
@@ -70,8 +71,18 @@ export function addEvent({ suppressNotifications, tournamentRecord, internalUse,
 
   if (event.eventType === TEAM_EVENT) {
     if (event.tieFormat) {
-      const result = validateTieFormat({ tieFormat: event.tieFormat });
+      // A supplied tieFormat may carry no collectionIds — the published `fixtures.tieFormats` cannot
+      // hold them, since a collectionId identifies a collection INSTANCE within a record and a shared
+      // fixture would hand every record the same identities. Mint them here so the stored tieFormat is
+      // usable: without ids the generated lines all carry `collectionId: null`, cannot be attributed to
+      // their collection, and the tie never scores.
+      //
+      // On a COPY: `eventRecord` is a shallow spread of `event`, so mutating `event.tieFormat` in place
+      // would stamp ids onto the caller's object — and onto the shared fixture when that is what was
+      // passed.
+      const result = checkTieFormat({ tieFormat: makeDeepCopy(event.tieFormat, false, true) });
       if (result.error) return result;
+      eventRecord.tieFormat = result.tieFormat;
     } else if (event.tieFormatName) {
       if (!tieFormats[event.tieFormatName]) {
         return {

--- a/src/tests/mutations/participants/team/publishedTieFormatUsable.test.ts
+++ b/src/tests/mutations/participants/team/publishedTieFormatUsable.test.ts
@@ -1,0 +1,135 @@
+import { mocksEngine } from '@Assemblies/engines/mock';
+import { tieFormats } from '@Fixtures/scoring/tieFormats';
+import tournamentEngine from '@Engines/syncEngine';
+import { expect, it, describe } from 'vitest';
+
+// constants
+import { SINGLE_ELIMINATION } from '@Constants/drawDefinitionConstants';
+import { DIRECT_ACCEPTANCE } from '@Constants/entryStatusConstants';
+import { POLICY_TYPE_SCORING } from '@Constants/policyConstants';
+import { COMPLETED } from '@Constants/matchUpStatusConstants';
+import { TEAM as TEAM_EVENT } from '@Constants/eventConstants';
+import { TEAM as TEAM_PARTICIPANT } from '@Constants/participantConstants';
+import { COMPETITOR } from '@Constants/participantRoles';
+import { DOUBLES } from '@Constants/matchUpTypes';
+
+/**
+ * `fixtures.tieFormats.*` is a published surface whose whole purpose is to be consumed directly. The
+ * fixtures cannot carry collectionIds — a collectionId identifies a collection INSTANCE within a record,
+ * and a shared module-level fixture would hand every record that used it the same identities — so the
+ * factory must mint them when the tieFormat is attached.
+ *
+ * Until 2026-08-09 it did not, on this path: `addEvent` minted ids for a `tieFormatName` but merely
+ * VALIDATED a supplied tieFormat object, and `validateTieFormat` does not check collectionIds by default.
+ * Every generated line then carried `collectionId: null`, could not be attributed to its collection, and
+ * the tie never scored — a completed 4-3 dual stayed TO_BE_PLAYED with no winner.
+ */
+function buildDual(tieFormat: any) {
+  tournamentEngine.reset();
+  tournamentEngine.newTournamentRecord({ tournamentId: 'tournamentId' });
+  tournamentEngine.attachPolicies({
+    policyDefinitions: { [POLICY_TYPE_SCORING]: { requireParticipantsForScoring: false } },
+  });
+  tournamentEngine.addParticipants({
+    participants: ['A', 'B'].map((participantName) => ({
+      participantType: TEAM_PARTICIPANT,
+      participantId: participantName,
+      participantRole: COMPETITOR,
+      participantName,
+    })),
+  });
+  tournamentEngine.addEvent({
+    event: { eventId: 'eventId', eventName: 'Dual', eventType: TEAM_EVENT, tieFormat },
+  });
+  tournamentEngine.addEventEntries({
+    entryStatus: DIRECT_ACCEPTANCE,
+    participantIds: ['A', 'B'],
+    eventId: 'eventId',
+  });
+
+  let result: any = tournamentEngine.generateDrawDefinition({
+    drawType: SINGLE_ELIMINATION,
+    eventId: 'eventId',
+    drawSize: 2,
+    tieFormat,
+  });
+  const drawId = result.drawDefinition.drawId;
+  tournamentEngine.addDrawDefinition({ eventId: 'eventId', drawDefinition: result.drawDefinition });
+  return { drawId };
+}
+
+function scoreDual(drawId: string, side1Wins: number) {
+  const tie: any = tournamentEngine
+    .allDrawMatchUps({ drawId })
+    .matchUps.find(({ matchUpType }) => matchUpType === TEAM_EVENT);
+
+  const doubles = tie.tieMatchUps.filter(({ matchUpType }) => matchUpType === DOUBLES);
+  const singles = tie.tieMatchUps.filter(({ matchUpType }) => matchUpType !== DOUBLES);
+  const winners = new Set([...doubles.slice(0, 2), ...singles.slice(0, side1Wins - 1)].map((l: any) => l.matchUpId));
+
+  for (const line of tie.tieMatchUps) {
+    const { outcome } = mocksEngine.generateOutcomeFromScoreString({
+      winningSide: winners.has(line.matchUpId) ? 1 : 2,
+      matchUpStatus: COMPLETED,
+      scoreString: '6-1 6-1',
+    });
+    tournamentEngine.setMatchUpStatus({ matchUpId: line.matchUpId, drawId, outcome });
+  }
+
+  return tournamentEngine.allDrawMatchUps({ drawId }).matchUps.find(({ matchUpType }) => matchUpType === TEAM_EVENT);
+}
+
+describe('published tieFormat fixtures are usable directly', () => {
+  it('mints collectionIds onto the stored tieFormat', () => {
+    buildDual(tieFormats.USTA_COLLEGE);
+
+    const { event }: any = tournamentEngine.getEvent({ eventId: 'eventId' });
+    const collectionIds = event.tieFormat.collectionDefinitions.map(({ collectionId }) => collectionId);
+
+    expect(collectionIds.every((id) => typeof id === 'string' && id.length)).toEqual(true);
+    expect(new Set(collectionIds).size).toEqual(collectionIds.length);
+  });
+
+  it('attributes every generated line to a collection', () => {
+    const { drawId } = buildDual(tieFormats.USTA_COLLEGE);
+    const tie: any = tournamentEngine
+      .allDrawMatchUps({ drawId })
+      .matchUps.find(({ matchUpType }) => matchUpType === TEAM_EVENT);
+
+    expect(tie.tieMatchUps.length).toEqual(9);
+    expect(tie.tieMatchUps.every(({ collectionId }) => !!collectionId)).toEqual(true);
+  });
+
+  // the user-visible defect: a completed 4-3 dual produced no score and no winner
+  it('scores a dual built from a published fixture', () => {
+    const { drawId } = buildDual(tieFormats.USTA_COLLEGE);
+    const tie: any = scoreDual(drawId, 4);
+
+    expect(tie.matchUpStatus).toEqual(COMPLETED);
+    expect(tie.winningSide).toEqual(1);
+    expect(tie.score.scoreStringSide1).toEqual('4-3');
+  });
+
+  // the reason fixtures cannot carry ids in the first place: they are shared module-level objects
+  it('never stamps ids onto the shared fixture', () => {
+    const before = tieFormats.USTA_COLLEGE.collectionDefinitions.map(({ collectionId }: any) => collectionId);
+    expect(before.every((id) => id === undefined)).toEqual(true);
+
+    buildDual(tieFormats.USTA_COLLEGE);
+
+    const after = tieFormats.USTA_COLLEGE.collectionDefinitions.map(({ collectionId }: any) => collectionId);
+    expect(after).toEqual(before);
+  });
+
+  it('gives two records built from the same fixture distinct collection identities', () => {
+    buildDual(tieFormats.USTA_COLLEGE);
+    const first: any = tournamentEngine.getEvent({ eventId: 'eventId' }).event;
+    const firstIds = first.tieFormat.collectionDefinitions.map(({ collectionId }) => collectionId);
+
+    buildDual(tieFormats.USTA_COLLEGE);
+    const second: any = tournamentEngine.getEvent({ eventId: 'eventId' }).event;
+    const secondIds = second.tieFormat.collectionDefinitions.map(({ collectionId }) => collectionId);
+
+    expect(firstIds).not.toEqual(secondIds);
+  });
+});


### PR DESCRIPTION
## The defect

`fixtures.tieFormats.*` is a published surface meant to be consumed directly — and the fixtures **cannot** carry `collectionId`s. A `collectionId` identifies a collection *instance* within a record, so a shared module-level fixture holding one would hand every record that used it the same collection identities.

The factory did not mint them on the plain engine path. `addEvent` minted ids for a `tieFormatName` but merely **validated** a supplied tieFormat object, and `validateTieFormat` does not check collectionIds by default. Every generated line then carried `collectionId: null`, could not be attributed to its collection, and **the tie never scored**:

| tieFormat | result of a completed 4–3 college dual |
| --- | --- |
| raw `fixtures.tieFormats.USTA_COLLEGE` | `TO_BE_PLAYED` — no score, no winningSide |
| same, ids minted | `4-3`, winningSide 1, `COMPLETED` |

**Why the suite never caught it:** `mocksEngine` and the `tieFormatName` path both hydrate ids, and every existing test reaches tieFormats through one of those two doors. Only a consumer using the *published fixture object* — which is what `fixtures.tieFormats` is for — hits it.

## The fix

Mint missing collectionIds **on a copy** at each entry point, so the caller's object (often the shared fixture) is never stamped:

- `addEvent` — copies a supplied tieFormat, mints, stores the copy. `eventRecord` is a shallow spread of `event`, so minting in place would have contaminated the fixture process-wide.
- `setUpDrawGeneration` — normalizes **once** and writes the copy back to `params.tieFormat`.
- `generateDrawTypeAndModifyDrawDefinition` / `checkFormatScopeEquivalence` — defensive, since each is reachable independently.

The single-normalization point matters: minting independently per step gave the drawDefinition one set of collectionIds and the generated lines another, which scored the singles, silently dropped the doubles collection point, and stalled a completed dual at `IN_PROGRESS`.

## Tests

Five regression tests. The one asserting the shared fixture is never mutated **caught a second in-place mutation** of the caller's object in the draw path that the first fix had missed.

- ids minted onto the stored tieFormat
- every generated line attributed to a collection
- a dual built from a published fixture scores `4-3` / `COMPLETED`
- the shared fixture is never stamped
- two records from the same fixture get **distinct** collection identities

## Verification

Full suite **1040 files / 10,676 tests, 0 failures**; lint, check-types and the docs build clean. Documented under "Collection identity" in the tieFormat governor.

## Still open (not in this PR)

`validateTieFormat` reports an id-less tieFormat **valid** by default — `checkCollectionIds` is opt-in. Minting makes that unreachable through the engine, but a consumer validating directly still gets a false all-clear. Flipping the default could reject tieFormats that consumers validate mid-construction, so it needs its own call.
