### PR TITLE
feat(sanctioning): materialize venues when activating a sanctioned tournament

### DIFF
--- a/documentation/docs/governors/sanctioning-governor.md
+++ b/documentation/docs/governors/sanctioning-governor.md
@@ -199,8 +199,21 @@ Opens (or adjusts) public registration on a proposal **before** a `tournamentRec
 Generates a `tournamentRecord` from an `APPROVED` sanctioning record and transitions to `ACTIVE`. Reuses the `tournamentId` and per-event `eventId`s already assigned by [`openProposalRegistration`](#openproposalregistration) — so registrations collected before activation remain valid — otherwise mints new ids.
 
 ```ts
-{ sanctioningRecord; sanctioningPolicy?: SanctioningPolicy }
+{ sanctioningRecord; sanctioningPolicy?: SanctioningPolicy; venues?: Venue[] }
 ```
+
+**Venues.** Pass `venues` to materialize canonical venues onto the generated `tournamentRecord` —
+typically pulled by the caller from a facility registry for the facility the sanctioning record was
+attached to. They are **supplied, not resolved**: the factory has no runtime dependencies and no
+service awareness, so resolution belongs to the caller and materialization to the engine. A canonical
+venue carries `facilityId` and typed `courts`, so the activated tournament inherits one
+cross-tournament identity for the place it is played at instead of a re-entered venue.
+
+When no `venues` are supplied, `proposal.venues` (`VenueProposal[]`) is materialized instead. That is
+a fallback: a proposal venue is what an applicant typed, so it has no canonical identity — its
+`facilityId` defaults to its own `venueId` — and `numberOfCourts` is deliberately **not** expanded
+into placeholder courts, which would fabricate identities to be reconciled against a registry later.
+Supplied `venues` always win over the proposal description.
 
 **Returns:** `{ success, tournamentRecord }`
 

--- a/src/mutate/sanctioning/activateFromSanctioning.ts
+++ b/src/mutate/sanctioning/activateFromSanctioning.ts
@@ -7,15 +7,78 @@ import { INVALID_VALUES } from '@Constants/errorConditionConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 
 // types
-import type { SanctioningRecord, SanctioningPolicy, ComplianceRecord, ComplianceItem } from '@Types/sanctioningTypes';
-import type { Tournament, Event } from '@Types/tournamentTypes';
+import type {
+  SanctioningRecord,
+  SanctioningPolicy,
+  ComplianceRecord,
+  ComplianceItem,
+  VenueProposal,
+} from '@Types/sanctioningTypes';
+import type { Tournament, Event, Venue } from '@Types/tournamentTypes';
 
 type ActivateFromSanctioningArgs = {
   sanctioningRecord: SanctioningRecord;
   sanctioningPolicy?: SanctioningPolicy;
+  /**
+   * Canonical venues, already resolved by the caller — typically pulled from the facility registry
+   * for the facility the sanctioning record was attached to. Supplied rather than fetched because
+   * the factory has no runtime dependencies and no service awareness; resolution is the caller's
+   * job, materialization is ours.
+   *
+   * These carry `facilityId` and typed `courts`, so the activated tournament inherits one
+   * cross-tournament identity for the place it is played at instead of a re-entered venue.
+   */
+  venues?: Venue[];
 };
 
-export function activateFromSanctioning({ sanctioningRecord, sanctioningPolicy }: ActivateFromSanctioningArgs) {
+/**
+ * A proposal's own venue description, used only when no canonical venue was supplied.
+ *
+ * This is strictly a fallback: a VenueProposal is what an applicant typed at proposal time, so it
+ * has no canonical identity and no real courts. It is still better than dropping the venue
+ * entirely, which is what happened before — `venues: []` was hardcoded while
+ * `proposal.venues` was declared and read nowhere.
+ *
+ * `numberOfCourts` is deliberately NOT expanded into placeholder courts: inventing "Court 1..n"
+ * would fabricate identities that later have to be reconciled against the registry's real ones.
+ */
+function venueFromProposal(vp: VenueProposal): Venue {
+  const venueId = vp.venueId ?? UUID();
+  const address =
+    vp.address || vp.city || vp.state || vp.countryCode || vp.coordinates
+      ? [
+          {
+            ...(vp.address ? { addressLine1: vp.address } : {}),
+            ...(vp.city ? { city: vp.city } : {}),
+            ...(vp.state ? { state: vp.state } : {}),
+            ...(vp.countryCode ? { countryCode: vp.countryCode } : {}),
+            // TODS Address stores coordinates as strings while VenueProposal.coordinates are
+            // numbers — coerce rather than widen Address, which many other call sites depend on.
+            ...(vp.coordinates
+              ? { latitude: String(vp.coordinates.latitude), longitude: String(vp.coordinates.longitude) }
+              : {}),
+          },
+        ]
+      : undefined;
+
+  return {
+    venueId,
+    // A venue is its own facility until something dedupes it onto a canonical one.
+    facilityId: venueId,
+    venueName: vp.venueName,
+    ...(address ? { addresses: address } : {}),
+    ...(vp.extensions ? { extensions: vp.extensions } : {}),
+    courts: [],
+  };
+}
+
+/** Caller-resolved canonical venues win; the proposal's description is the fallback. */
+function resolveVenues(venues: Venue[] | undefined, proposalVenues: VenueProposal[] | undefined): Venue[] {
+  if (venues?.length) return venues;
+  return (proposalVenues ?? []).map(venueFromProposal);
+}
+
+export function activateFromSanctioning({ sanctioningRecord, sanctioningPolicy, venues }: ActivateFromSanctioningArgs) {
   if (!sanctioningRecord) return { error: MISSING_SANCTIONING_RECORD };
   if (sanctioningRecord.status !== 'APPROVED') {
     return {
@@ -94,7 +157,7 @@ export function activateFromSanctioning({ sanctioningRecord, sanctioningPolicy }
         : []),
     ],
 
-    venues: [],
+    venues: resolveVenues(venues, proposal.venues),
     participants: [],
     timeItems: [],
   };

--- a/src/tests/sanctioning/activationVenues.test.ts
+++ b/src/tests/sanctioning/activationVenues.test.ts
@@ -1,0 +1,136 @@
+import { activateFromSanctioning } from '@Mutate/sanctioning/activateFromSanctioning';
+import { expect, it, describe } from 'vitest';
+
+// constants
+import { APPROVED } from '@Constants/sanctioningConstants';
+
+/**
+ * Venue materialization at activation.
+ *
+ * `venues: []` was hardcoded while `proposal.venues` was declared and read nowhere, so a sanctioned
+ * tournament was born with no venue even when the proposal named one — and the canonical facility a
+ * sanctioning record had been attached to never reached the tournamentRecord at all.
+ *
+ * The factory does not resolve venues: it has no runtime dependencies and no service awareness, so
+ * the caller supplies canonical venues (pulled from the facility registry) and the factory
+ * materializes them. The proposal's own description is the fallback.
+ */
+
+const baseRecord = (venues?: any) =>
+  ({
+    sanctioningId: 's-1',
+    status: APPROVED,
+    governingBodyId: 'gb-1',
+    proposal: {
+      tournamentName: 'Peachtree Summer Open',
+      proposedStartDate: '2026-09-01',
+      proposedEndDate: '2026-09-05',
+      events: [{ eventName: 'Mens Singles', eventType: 'SINGLES' }],
+      ...(venues ? { venues } : {}),
+    },
+    statusHistory: [],
+  }) as any;
+
+const CANONICAL = {
+  venueId: 'fac-1',
+  facilityId: 'fac-1',
+  venueName: 'Life Time Peachtree Corners',
+  addresses: [{ city: 'Norcross', countryCode: 'USA', latitude: '33.9695', longitude: '-84.2216' }],
+  courts: [
+    { courtId: 'c1', courtName: 'Court 1', surfaceCategory: 'HARD', indoorOutdoor: 'OUTDOOR', courtOrder: 1 },
+    { courtId: 'c2', courtName: 'Court 2', surfaceCategory: 'HARD', indoorOutdoor: 'OUTDOOR', courtOrder: 2 },
+  ],
+};
+
+describe('activateFromSanctioning venue materialization', () => {
+  it('carries a caller-resolved canonical venue onto the tournamentRecord', () => {
+    let result: any = activateFromSanctioning({ sanctioningRecord: baseRecord(), venues: [CANONICAL] as any });
+
+    expect(result.success).toEqual(true);
+    expect(result.tournamentRecord.venues).toHaveLength(1);
+    expect(result.tournamentRecord.venues[0]).toEqual(CANONICAL);
+  });
+
+  /**
+   * facilityId is the whole point: cast() reads it into query_venues.facility_id, so "which
+   * tournaments are at this facility" becomes a SQL join instead of a post-hoc dedupe.
+   */
+  it('preserves facilityId and typed courts rather than flattening them', () => {
+    let result: any = activateFromSanctioning({ sanctioningRecord: baseRecord(), venues: [CANONICAL] as any });
+    const venue = result.tournamentRecord.venues[0];
+
+    expect(venue.facilityId).toEqual('fac-1');
+    expect(venue.courts).toHaveLength(2);
+    expect(venue.courts[0].courtOrder).toEqual(1);
+    expect(venue.courts[0].surfaceCategory).toEqual('HARD');
+  });
+
+  it('falls back to the proposal venue when the caller resolved none', () => {
+    const proposalVenue = {
+      venueName: 'Community Park',
+      city: 'Cary',
+      countryCode: 'USA',
+      coordinates: { latitude: 35.79, longitude: -78.78 },
+    };
+    let result: any = activateFromSanctioning({ sanctioningRecord: baseRecord([proposalVenue]) });
+
+    expect(result.tournamentRecord.venues).toHaveLength(1);
+    const venue = result.tournamentRecord.venues[0];
+    expect(venue.venueName).toEqual('Community Park');
+    expect(venue.addresses[0].city).toEqual('Cary');
+    // TODS Address stores coordinates as strings; VenueProposal supplies numbers
+    expect(venue.addresses[0].latitude).toEqual('35.79');
+  });
+
+  it('gives a fallback venue an identity, defaulting facilityId to its own venueId', () => {
+    let result: any = activateFromSanctioning({ sanctioningRecord: baseRecord([{ venueName: 'Community Park' }]) });
+    const venue = result.tournamentRecord.venues[0];
+
+    expect(venue.venueId).toBeDefined();
+    expect(venue.facilityId).toEqual(venue.venueId);
+  });
+
+  it('honours a venueId the proposal already carried', () => {
+    let result: any = activateFromSanctioning({
+      sanctioningRecord: baseRecord([{ venueName: 'Community Park', venueId: 'v-known' }]),
+    });
+    expect(result.tournamentRecord.venues[0].venueId).toEqual('v-known');
+  });
+
+  /**
+   * numberOfCourts is a count, not an inventory. Expanding it into "Court 1..n" would fabricate
+   * court identities that later have to be reconciled against the registry's real ones.
+   */
+  it('does not invent courts from a proposal court count', () => {
+    let result: any = activateFromSanctioning({
+      sanctioningRecord: baseRecord([{ venueName: 'Community Park', numberOfCourts: 8 }]),
+    });
+    expect(result.tournamentRecord.venues[0].courts).toEqual([]);
+  });
+
+  it('prefers the canonical venue over the proposal description when both exist', () => {
+    let result: any = activateFromSanctioning({
+      sanctioningRecord: baseRecord([{ venueName: 'Stale Proposal Name' }]),
+      venues: [CANONICAL] as any,
+    });
+
+    expect(result.tournamentRecord.venues).toHaveLength(1);
+    expect(result.tournamentRecord.venues[0].venueName).toEqual('Life Time Peachtree Corners');
+  });
+
+  it('still activates with no venue information at all', () => {
+    let result: any = activateFromSanctioning({ sanctioningRecord: baseRecord() });
+
+    expect(result.success).toEqual(true);
+    expect(result.tournamentRecord.venues).toEqual([]);
+  });
+
+  it('carries every venue when several are supplied', () => {
+    const second = { ...CANONICAL, venueId: 'fac-2', facilityId: 'fac-2', venueName: 'Second Site' };
+    let result: any = activateFromSanctioning({
+      sanctioningRecord: baseRecord(),
+      venues: [CANONICAL, second] as any,
+    });
+    expect(result.tournamentRecord.venues.map((v: any) => v.facilityId)).toEqual(['fac-1', 'fac-2']);
+  });
+});


### PR DESCRIPTION
`activateFromSanctioning` hardcoded `venues: []` while `SanctioningProposal.venues` was declared and read nowhere — so a sanctioned tournament was born with no venue even when the proposal named one, and the canonical facility a record had been attached to never reached the `tournamentRecord`.

**Venues are supplied, not resolved.** The factory has no runtime dependencies and no service awareness, so pulling a venue from the facility registry belongs to the caller; materializing it belongs here. A canonical venue carries `facilityId` and typed `courts`, so the activated tournament inherits one cross-tournament identity for the place it is played at — which is what lets `cast()` populate `query_venues.facility_id` instead of leaving a post-hoc dedupe.

`proposal.venues` is the fallback when the caller resolved none, and explicitly lesser: a `VenueProposal` is what an applicant typed, so its `facilityId` defaults to its own `venueId`, and `numberOfCourts` is **not** expanded into placeholder courts — inventing "Court 1..n" would fabricate identities to reconcile against the registry's real ones later. Supplied venues always win.

One shape mismatch surfaced: TODS `Address` stores coordinates as strings while `VenueProposal.coordinates` are numbers. Coerced at the boundary rather than widening `Address`, which many other call sites depend on.

Completes the WS3 loop: a facility is searched, picked and attached in the AMS console (`courthive-facilities@880f14e`, `courthive-ams@8f90321`), and now survives activation into the tournamentRecord.

**Verification:** 9 new tests, confirmed to fail when the behaviour is removed (restoring `venues: []` fails 8; letting the proposal win over the canonical venue fails 1). Full suite **10,685 passing**, `check-types` and `lint` clean, build passes. Governor docs updated.