### PR TITLE
fix(fixtures): resolve alpha-3 and IOC codes before building a country flag

### DIFF
--- a/src/fixtures/countryData.ts
+++ b/src/fixtures/countryData.ts
@@ -1,9 +1,29 @@
 // ISO- 3166-1 alpha-2
 
+/**
+ * A country's flag emoji.
+ *
+ * A flag is two Unicode regional indicator symbols, one per letter of the ISO 3166-1
+ * **alpha-2** code. This maps letter -> indicator, so the argument must resolve to alpha-2
+ * before mapping: given a three-letter code it would otherwise emit THREE indicators, which
+ * renders as the flag followed by a stray letter ("🇺🇸🇦" for 'USA').
+ *
+ * That is not a hypothetical — `countries[].iso` is alpha-**3**, so it is what most callers
+ * hold and pass, and `flagIOC` below fed alpha-3 in for every country. Accepting alpha-3 and
+ * IOC codes here fixes each caller in place rather than requiring every one of them to reach
+ * for `iso2` (and makes the defensive `.slice(0, 4)` some consumers apply a no-op).
+ *
+ * Anything that resolves to no known country is returned unchanged — better a visible code
+ * than a garbage glyph.
+ */
 export function countryToFlag(isoCode: string): string {
-  return isoCode && typeof String.fromCodePoint !== 'undefined'
-    ? isoCode.toUpperCase().replace(/./g, (char) => String.fromCodePoint(char.charCodeAt(0) + 127397))
-    : isoCode;
+  if (!isoCode || typeof String.fromCodePoint === 'undefined') return isoCode;
+
+  const code = isoCode.toUpperCase();
+  const alpha2 = code.length === 2 ? code : countries.find((c) => c.iso === code || c.ioc === code)?.iso2;
+  if (alpha2?.length !== 2) return isoCode;
+
+  return alpha2.replace(/./g, (char) => String.fromCodePoint(char.charCodeAt(0) + 127397));
 }
 
 export function flagIOC(ioc: string): string {

--- a/src/tests/fixtures/countryFlag.test.ts
+++ b/src/tests/fixtures/countryFlag.test.ts
@@ -1,0 +1,73 @@
+import { countries, countryToFlag, flagIOC } from '@Fixtures/countryData';
+import { expect, it, describe } from 'vitest';
+
+/**
+ * A flag emoji is exactly two Unicode regional indicator symbols. Counting code points is the
+ * whole assertion: `countryToFlag` maps letter -> indicator, so a three-letter code silently
+ * produced three of them and rendered as the flag plus a stray letter ("🇺🇸🇦"). Nothing threw,
+ * nothing was undefined — it just looked wrong, which is why it survived in four consumers.
+ */
+const REGIONAL_INDICATOR = /^[\u{1F1E6}-\u{1F1FF}]+$/u;
+
+function indicatorCount(flag: string): number {
+  return [...flag].length;
+}
+
+describe('countryToFlag', () => {
+  it('maps a two-letter alpha-2 code to a two-indicator flag', () => {
+    expect(indicatorCount(countryToFlag('US'))).toBe(2);
+    expect(REGIONAL_INDICATOR.test(countryToFlag('US'))).toBe(true);
+  });
+
+  it('maps a three-letter alpha-3 code to the SAME flag, not three indicators', () => {
+    expect(countryToFlag('USA')).toEqual(countryToFlag('US'));
+    expect(indicatorCount(countryToFlag('USA'))).toBe(2);
+  });
+
+  it('accepts an IOC code that differs from the alpha-3 code', () => {
+    // GER (IOC) vs DEU (ISO alpha-3) — both must resolve to the German flag.
+    expect(countryToFlag('GER')).toEqual(countryToFlag('DE'));
+  });
+
+  it('is case-insensitive', () => {
+    expect(countryToFlag('usa')).toEqual(countryToFlag('USA'));
+    expect(countryToFlag('us')).toEqual(countryToFlag('US'));
+  });
+
+  it('never emits three or more indicators for any country in the fixture', () => {
+    // The regression in aggregate: every alpha-3 code in the table must round-trip to a
+    // two-indicator flag. A single stray letter anywhere fails this.
+    const offenders = countries
+      .filter((country) => country.iso && country.iso2)
+      .map((country) => ({ iso: country.iso, flag: countryToFlag(country.iso) }))
+      .filter((entry) => indicatorCount(entry.flag) !== 2);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('returns an unrecognised code unchanged rather than a garbage glyph', () => {
+    expect(countryToFlag('ZZZ')).toEqual('ZZZ');
+  });
+
+  it('returns falsy input unchanged', () => {
+    expect(countryToFlag('')).toEqual('');
+  });
+});
+
+describe('flagIOC', () => {
+  it('resolves an IOC code to a two-indicator flag', () => {
+    // flagIOC maps ioc -> `c.iso`, which is alpha-3 — so it produced three indicators for
+    // every country until countryToFlag learned to normalise.
+    expect(indicatorCount(flagIOC('USA'))).toBe(2);
+    expect(flagIOC('USA')).toEqual(countryToFlag('US'));
+  });
+
+  it('resolves every IOC code in the fixture to a two-indicator flag', () => {
+    const offenders = countries
+      .filter((country) => country.ioc && country.iso2)
+      .map((country) => ({ ioc: country.ioc, flag: flagIOC(country.ioc) }))
+      .filter((entry) => indicatorCount(entry.flag) !== 2);
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
A flag emoji is two Unicode regional indicator symbols, one per letter of the ISO 3166-1
**alpha-2** code. `countryToFlag` mapped every character of its argument with no length
guard, so a three-letter code produced THREE indicators and rendered as the flag followed
by a stray letter — `🇺🇸🇦 United States`.

That is the common case, not an edge case: `countries[].iso` is alpha-**3**, so it is what
callers hold and pass.

### Affected in the ecosystem today

- TMX `venuesTab/addVenue.ts`, `venuesTab/editVenue.ts`, `modals/selectIdiom.ts` (×2),
  `participantTab/editIndividualParticipant.ts` — all visibly wrong
- this module's own `flagIOC`, which maps ioc → `c.iso` (alpha-3) and fed it straight back
  in, so every IOC lookup was wrong
- TMX `modals/participantProfileModal.ts` and courthive-components `renderFlag.ts` masked it
  with `.slice(0, 4)` — a correct flag is exactly 4 UTF-16 units, so the workaround
  truncated the stray indicator

### Approach

Normalising inside `countryToFlag` fixes every caller in place rather than asking each to
reach for `iso2`, and turns those `.slice(0, 4)` workarounds into no-ops. IOC codes are
accepted too, since consumers pass nationality codes that may be either. An unrecognised
code is returned unchanged — a visible code beats a garbage glyph.

### Tests

Tests assert the indicator **count**, which is the only thing that catches this: nothing
threw and nothing was undefined, it just looked wrong, which is why it survived in four
consumers. Includes aggregate cases over every alpha-3 and IOC code in the fixture.
Verified to fail (6 of 9) against the pre-fix behaviour.

### Verification

`pnpm test` 10694 passed / 1 skipped · `pnpm lint` 0 · `pnpm check-types` 0.
