### PR TITLE
fix(participants): let an empty string clear birthDate and nationalityCode

### DIFF
--- a/src/mutate/participants/modifyParticipant.ts
+++ b/src/mutate/participants/modifyParticipant.ts
@@ -163,8 +163,17 @@ function generatePairParticipantName({ individualParticipants, newValues }) {
   return participantName;
 }
 
+// An explicit empty string means "clear this field". `undefined` must keep meaning "leave
+// untouched" — consumers send the whole person object on every save, so a field they do not
+// manage has to survive. Clearing DELETES the key rather than storing '', so readers see an
+// absent field instead of a falsy one each of them would have to special-case.
+function isClearRequest(value) {
+  return value === '';
+}
+
 function updatePerson({ updateParticipantName, existingParticipant, newValues, person }) {
   const newPersonValues: any = {};
+  const clearedKeys: string[] = [];
   const { standardFamilyName, standardGivenName, nationalityCode, personId, birthDate, tennisId, sex } = person;
   const canonicalSex = coercedSex(sex);
   if (canonicalSex) newPersonValues.sex = canonicalSex;
@@ -172,11 +181,9 @@ function updatePerson({ updateParticipantName, existingParticipant, newValues, p
   let personNameModified;
   if (isString(personId)) newPersonValues.personId = personId;
 
-  if (
-    nationalityCode &&
-    isString(nationalityCode) &&
-    (validNationalityCode(nationalityCode) || nationalityCode === '') // empty string to remove value
-  ) {
+  if (isClearRequest(nationalityCode)) {
+    clearedKeys.push('nationalityCode');
+  } else if (nationalityCode && isString(nationalityCode) && validNationalityCode(nationalityCode)) {
     newPersonValues.nationalityCode = nationalityCode;
   }
 
@@ -202,7 +209,9 @@ function updatePerson({ updateParticipantName, existingParticipant, newValues, p
     }
   }
 
-  if (birthDate) {
+  if (isClearRequest(birthDate)) {
+    clearedKeys.push('birthDate');
+  } else if (birthDate) {
     if (!isValidDateString(birthDate)) return { error: INVALID_DATE };
     const birthYear = new Date(birthDate).getFullYear();
     if (new Date(birthDate) > new Date() || birthYear < 1900) {
@@ -216,6 +225,7 @@ function updatePerson({ updateParticipantName, existingParticipant, newValues, p
   }
 
   Object.assign(existingParticipant.person, newPersonValues);
+  for (const key of clearedKeys) delete existingParticipant.person[key];
   return undefined;
 }
 

--- a/src/tests/mutations/participants/clearPersonFields.test.ts
+++ b/src/tests/mutations/participants/clearPersonFields.test.ts
@@ -1,0 +1,115 @@
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { expect, it, describe } from 'vitest';
+
+/**
+ * `updatePerson` could set a person field but never unset one.
+ *
+ * - `birthDate` was gated on `if (birthDate)`, so an emptied field was a silent no-op: a
+ *   wrong date of birth could be corrected but never removed.
+ * - `nationalityCode` *looked* clearable — its condition carried `|| nationalityCode === ''`
+ *   with the comment "empty string to remove value" — but the leading `nationalityCode &&`
+ *   in the same expression short-circuits on `''` first, so the clear branch was unreachable.
+ *
+ * An explicit empty string now means "clear", and clearing DELETES the key rather than
+ * storing `''`, so consumers reading `person.birthDate` / `person.nationalityCode` see an
+ * absent field instead of a falsy one they would each have to special-case.
+ *
+ * `undefined` must keep meaning "leave untouched": consumers such as TMX send the whole
+ * person object on every save, so a field they do not manage must survive.
+ */
+
+function seedParticipantWithPerson() {
+  mocksEngine.generateTournamentRecord({
+    participantsProfile: { participantsCount: 4 },
+    setState: true,
+  });
+
+  const participant = tournamentEngine.getParticipants().participants[0];
+  const result: any = tournamentEngine.modifyParticipant({
+    participant: {
+      ...participant,
+      person: { ...participant.person, nationalityCode: 'FRA', birthDate: '1990-03-04' },
+    },
+  });
+  expect(result.success).toEqual(true);
+
+  const seeded = tournamentEngine.findParticipant({ participantId: participant.participantId }).participant;
+  expect(seeded.person.birthDate).toEqual('1990-03-04');
+  expect(seeded.person.nationalityCode).toEqual('FRA');
+
+  return seeded;
+}
+
+function personAfterModify(participant: any, person: any) {
+  const result: any = tournamentEngine.modifyParticipant({ participant: { ...participant, person } });
+  expect(result.success).toEqual(true);
+  return tournamentEngine.findParticipant({ participantId: participant.participantId }).participant.person;
+}
+
+describe('clearing person fields via modifyParticipant', () => {
+  it('an empty birthDate removes the stored value', () => {
+    const participant = seedParticipantWithPerson();
+    const person = personAfterModify(participant, { ...participant.person, birthDate: '' });
+
+    expect(person.birthDate).toBeUndefined();
+    // clearing one field must not disturb its neighbours
+    expect(person.nationalityCode).toEqual('FRA');
+    expect(person.standardGivenName).toEqual(participant.person.standardGivenName);
+  });
+
+  it('an empty nationalityCode removes the stored value', () => {
+    const participant = seedParticipantWithPerson();
+    const person = personAfterModify(participant, { ...participant.person, nationalityCode: '' });
+
+    expect(person.nationalityCode).toBeUndefined();
+    expect(person.birthDate).toEqual('1990-03-04');
+  });
+
+  it('clears both at once', () => {
+    const participant = seedParticipantWithPerson();
+    const person = personAfterModify(participant, { ...participant.person, nationalityCode: '', birthDate: '' });
+
+    expect(person.birthDate).toBeUndefined();
+    expect(person.nationalityCode).toBeUndefined();
+  });
+
+  it('omitting a field leaves it untouched — undefined is not a clear', () => {
+    const participant = seedParticipantWithPerson();
+    const { birthDate: _birthDate, nationalityCode: _nationalityCode, ...personWithoutThem } = participant.person;
+    const person = personAfterModify(participant, personWithoutThem);
+
+    expect(person.birthDate).toEqual('1990-03-04');
+    expect(person.nationalityCode).toEqual('FRA');
+  });
+
+  it('an explicit undefined also leaves the field untouched', () => {
+    const participant = seedParticipantWithPerson();
+    const person = personAfterModify(participant, {
+      ...participant.person,
+      nationalityCode: undefined,
+      birthDate: undefined,
+    });
+
+    expect(person.birthDate).toEqual('1990-03-04');
+    expect(person.nationalityCode).toEqual('FRA');
+  });
+
+  it('still rejects an invalid birthDate rather than treating it as a clear', () => {
+    const participant = seedParticipantWithPerson();
+    const result: any = tournamentEngine.modifyParticipant({
+      participant: { ...participant, person: { ...participant.person, birthDate: 'garbage' } },
+    });
+
+    expect(result.error).not.toBeUndefined();
+    const person = tournamentEngine.findParticipant({ participantId: participant.participantId }).participant.person;
+    expect(person.birthDate).toEqual('1990-03-04');
+  });
+
+  it('still ignores an unrecognised nationalityCode rather than clearing it', () => {
+    const participant = seedParticipantWithPerson();
+    const person = personAfterModify(participant, { ...participant.person, nationalityCode: 'ZZZ' });
+
+    expect(person.nationalityCode).toEqual('FRA');
+  });
+});


### PR DESCRIPTION
`updatePerson` could set a person field but never unset one.

birthDate was gated on `if (birthDate)`, so an emptied field was a silent no-op:
a wrong date of birth could be corrected but never removed.

nationalityCode looked clearable — the condition carried `|| nationalityCode === ''`
with the comment "empty string to remove value" — but the leading `nationalityCode &&`
in the same expression short-circuits on '' first, so the clear branch was
unreachable. Dead code documenting a capability that had never worked, which is why
no test covered it.

An explicit empty string now means clear, and clearing deletes the key rather than
storing '', so readers see an absent field instead of a falsy one each would have to
special-case. `undefined` keeps meaning "leave untouched" — consumers such as TMX
send the whole person object on every save, so a field they do not manage must
survive.

Both fields are fixed together because they are the same defect three lines apart;
fixing birthDate alone would have left a comment next to it claiming behaviour that
does not exist.

Existing validation is unchanged: an invalid or future birthDate still errors rather
than being treated as a clear, and an unrecognised nationalityCode is still ignored.

Tests cover clear-one, clear-both, omitted-field, explicit-undefined, and both
rejection paths. Verified to fail 3 of 7 against the pre-fix behaviour — the four
that already passed pin the semantics this change must not alter.