### PR TITLE
fix(query): zonePct margin was 100x too large

### DIFF
--- a/src/query/matchUps/getPredictiveAccuracy.ts
+++ b/src/query/matchUps/getPredictiveAccuracy.ts
@@ -66,9 +66,12 @@ export function getPredictiveAccuracy(params: getPredictiveAccuracyArgs) {
     ? Math.abs(scaleProfile.range[0] - scaleProfile.range[1])
     : 0;
 
+  // `zonePct` is a PERCENT of the scale's range. The parentheses here were previously misplaced —
+  // `(zonePct ?? 0 / 100)` parses as `zonePct ?? (0 / 100)` because `/` binds tighter than `??`, so the
+  // division never applied and the margin came out 100x too large (zonePct: 20 on WTN gave 780, not 7.8).
   const zoneMargin =
     isConvertableInteger(zonePct) && ratingsRangeDifference
-      ? (zonePct ?? 0 / 100) * ratingsRangeDifference
+      ? ((zonePct ?? 0) / 100) * ratingsRangeDifference
       : (params.zoneMargin ?? ratingsRangeDifference);
 
   const contextProfile = { withScaleValues: true, withCompetitiveness: true };
@@ -176,6 +179,7 @@ export function getPredictiveAccuracy(params: getPredictiveAccuracyArgs) {
     ...SUCCESS,
     relevantMatchUps,
     zoneDistribution,
+    zoneMargin, // returned so callers (and tests) can assert the resolved margin, not just infer it
     zoneData,
     accuracy,
     nonZone,

--- a/src/tests/query/predictiveAccuracyBranches.test.ts
+++ b/src/tests/query/predictiveAccuracyBranches.test.ts
@@ -228,12 +228,27 @@ test('getPredictiveAccuracy with zonePct', () => {
     setState: true,
   });
 
+  // zonePct is a PERCENT of the scale range: WTN spans |40 - 1| = 39, so 20% === a margin of 7.8.
+  // Asserting the resolved margin (and the equivalence with the explicit form) rather than only
+  // `success`: the previous version passed both before and after a 100x precedence bug, because it
+  // never looked at a value.
   const result = tournamentEngine.getPredictiveAccuracy({
     matchUpType: SINGLES,
     scaleName: 'WTN',
     zonePct: 20,
   });
   expect(result.success).toBe(true);
+  expect(result.zoneMargin).toBeCloseTo(7.8, 6);
+
+  const explicit = tournamentEngine.getPredictiveAccuracy({
+    matchUpType: SINGLES,
+    scaleName: 'WTN',
+    zoneMargin: 7.8,
+  });
+  expect(explicit.zoneMargin).toBeCloseTo(7.8, 6);
+  // the percent form and the equivalent absolute form must select the same matchUps
+  expect(result.zoneData?.length).toEqual(explicit.zoneData?.length);
+  expect(result.nonZone).toEqual(explicit.nonZone);
 });
 
 test('getPredictiveAccuracy with exclusionRule', () => {


### PR DESCRIPTION
`(zonePct ?? 0 / 100)` parses as `zonePct ?? (0 / 100)` because `/` binds tighter than `??`, so the division never applied. `zonePct: 20` against WTN (range `|40 - 1|` = 39) produced a margin of **780 instead of 7.8**.

## Latent — nobody's results were wrong

- No caller inside the factory passes `zonePct`; the only reference was the test below.
- No ecosystem consumer passes it either — grepped TMX, competition-factory-server, courthive-public, courthive-ams, courthive-query: zero hits.

## Why it survived

It was unobservable and unasserted. `zoneMargin` was not returned, so the single test passed `zonePct: 20` and asserted only `result.success`. It passed identically before and after the defect.

`zoneMargin` is now returned (purely additive) and the test asserts the resolved value, plus equivalence between the percent form and the explicit `zoneMargin` form.

## Verification

Reintroduced the bug and confirmed the test fails with `expected 780 to be close to 7.8`, then restored and confirmed it passes. Full query suite: 159 files / 1288 tests passing. Types and lint clean.

Found while grounding the design note for policy-shaped delta bands (`Mentat/planning/COMPETITIVE_FINGERPRINT.md` §8A.3.4), which proposes a percent-of-scale-range boundary form and was about to follow this expression as precedent.