### PR TITLE
feat(query): policy-shaped delta bands — a signed competitive-exposure axis

### DIFF
--- a/documentation/docs/policies/competitiveBands.md
+++ b/documentation/docs/policies/competitiveBands.md
@@ -6,6 +6,15 @@ The **Competitive Bands Policy** (`POLICY_TYPE_COMPETITIVE_BANDS`) defines thres
 
 **Policy Type:** `competitiveBands`
 
+The policy carries **two independent axes**. Keeping them straight is the difference between reading these numbers correctly and misreading them:
+
+| Axis                         | Policy block   | Scalar       | Domain            | Bands                    | Answers                                          |
+| ---------------------------- | -------------- | ------------ | ----------------- | ------------------------ | ------------------------------------------------ |
+| **Realized** competitiveness | `profileBands` | score spread | unsigned, 0–100   | exactly 3, named in code | "how close was the match that was played?"       |
+| **Signed exposure**          | `deltaBands`   | rating delta | signed, unbounded | N, named in policy       | "did this player play up, or down, and how far?" |
+
+They are orthogonal. `deltaBands` is **not** a widening of the three realized bands: adding it moves no Competitive Ratio and changes no existing output. See [Signed Exposure](#signed-exposure--deltabands) below.
+
 **When to Use:**
 
 - Analyzing match competitiveness patterns
@@ -27,6 +36,11 @@ The **Competitive Bands Policy** (`POLICY_TYPE_COMPETITIVE_BANDS`) defines thres
       ROUTINE: number;             // Threshold for routine matches (%)
       // Matches above ROUTINE threshold are considered COMPETITIVE
     };
+    deltaBands?: Array<{           // Optional — the SIGNED EXPOSURE axis
+      key: string;                 // Band name; policy-defined, not a factory enum
+      max?: number;                // Upper bound in rating units, XOR maxPct
+      maxPct?: number;             // Upper bound as a percent of the scale's range
+    }>;                            // Ordered; the FINAL entry omits its bound
     predictionModel?: {            // Optional — used by predictMatchUpCompetitiveBands
       competitiveAnchors: Array<{ delta: number; probability: number }>;
       decisiveAnchors: Array<{ delta: number; probability: number }>;
@@ -45,19 +59,27 @@ The **Competitive Bands Policy** (`POLICY_TYPE_COMPETITIVE_BANDS`) defines thres
 
 ## Default Policy
 
-The factory provides `POLICY_COMPETITIVE_BANDS_DEFAULT`:
+The factory provides `POLICY_COMPETITIVE_BANDS_DEFAULT` on the `fixtures.policies` catalog:
 
 ```js
-import { POLICY_COMPETITIVE_BANDS_DEFAULT } from 'tods-competition-factory';
+import { fixtures } from 'tods-competition-factory';
 
-// Default thresholds:
+const { POLICY_COMPETITIVE_BANDS_DEFAULT } = fixtures.policies;
+
 // {
 //   competitiveBands: {
 //     policyName: 'Competitive Bands Default',
 //     profileBands: {
 //       DECISIVE: 20,     // Score spread ≤ 20% = decisive win
 //       ROUTINE: 50       // Score spread ≤ 50% = routine match
-//     }
+//     },
+//     deltaBands: [       // the signed exposure axis — see below
+//       { key: 'ANCHOR',  maxPct: -10.3 },
+//       { key: 'DOWN',    maxPct: -1.3 },
+//       { key: 'EVEN',    maxPct: 1.3 },
+//       { key: 'UP',      maxPct: 10.3 },
+//       { key: 'STRETCH' },
+//     ],
 //   }
 // }
 ```
@@ -97,8 +119,9 @@ import { POLICY_COMPETITIVE_BANDS_DEFAULT } from 'tods-competition-factory';
 ### Attach Default Policy
 
 ```js
-import { tournamentEngine } from 'tods-competition-factory';
-import { POLICY_COMPETITIVE_BANDS_DEFAULT } from 'tods-competition-factory';
+import { tournamentEngine, fixtures } from 'tods-competition-factory';
+
+const { POLICY_COMPETITIVE_BANDS_DEFAULT } = fixtures.policies;
 
 tournamentEngine.setState(tournamentRecord);
 
@@ -413,6 +436,182 @@ const juniorPolicy = {
 
 ---
 
+## Signed Exposure — `deltaBands`
+
+`profileBands` answers "how close was the match?". `deltaBands` answers a different question: **"did this player play up, or down, and how far?"** That question needs a _signed_ scalar — a rating delta oriented against a perspective — where realized competitiveness is deliberately unsigned (a four-point gap is equally uncompetitive whichever side it favours).
+
+Adding `deltaBands` to a policy changes nothing about the three realized bands. No existing caller's output moves.
+
+### An ordered boundary list
+
+`deltaBands` is a list, not a fixed shape. **N entries produce N bands**, and the final entry omits its bound to catch the remainder:
+
+```js
+import { POLICY_TYPE_COMPETITIVE_BANDS } from 'tods-competition-factory';
+
+const policy = {
+  [POLICY_TYPE_COMPETITIVE_BANDS]: {
+    profileBands: { DECISIVE: 20, ROUTINE: 50 },
+    deltaBands: [
+      { key: 'ANCHOR', max: -4 },
+      { key: 'DOWN', max: -0.5 },
+      { key: 'EVEN', max: 0.5 },
+      { key: 'UP', max: 4 },
+      { key: 'STRETCH' }, // open upper bound — catches the remainder
+    ],
+  },
+};
+```
+
+Resolution walks the list in order and returns the first band whose `max` the signed delta **does not exceed** (the upper edge is inclusive, matching `profileBands`). A federation wanting three signed bands, or nine, or an asymmetric split, expresses that entirely in policy — no factory change.
+
+Band **keys are policy-defined strings**. The default set (`ANCHOR` / `DOWN` / `EVEN` / `UP` / `STRETCH`) is exported as plain constants for convenience, but nothing in the resolver knows those names, and a custom vocabulary is a first-class case.
+
+### Boundary units — `max` XOR `maxPct`
+
+A boundary is expressed one of two ways, never both:
+
+| Form     | Meaning                                | Use when                                                            |
+| -------- | -------------------------------------- | ------------------------------------------------------------------- |
+| `max`    | absolute rating units                  | the federation means a specific number of rating points             |
+| `maxPct` | percent of the scale's range magnitude | the policy should behave sensibly across scales (the portable form) |
+
+`maxPct` resolves to `(maxPct / 100) * Math.abs(range[1] - range[0])` using the scale's `range` from `ratingsParameters`. The same policy therefore adapts:
+
+| Scale | `range`     | Magnitude | `maxPct: 10` resolves to |
+| ----- | ----------- | --------- | ------------------------ |
+| WTN   | `[40, 1]`   | 39        | 3.9                      |
+| UTR   | `[1, 16]`   | 15        | 1.5                      |
+| ELO   | `[0, 3000]` | 3000      | 300                      |
+
+Three things are **validation errors**, not tolerated shapes — each would otherwise produce plausible-looking but wrong bands:
+
+- declaring both `max` and `maxPct` on one entry (`INVALID_POLICY_DEFINITION`)
+- a `maxPct` boundary against a scale with no `range`, or with no `scaleName` supplied — there is no silent fallback to absolute units
+- boundaries that do not ascend, or a final entry that carries a bound (which would leave deltas past it with no band)
+
+### Orientation lives in the factory
+
+Sign orientation is derived from `ratingsParameters[scaleName].ascending`, so callers never hand-roll it:
+
+```text
+signedDelta = ascending ? (ownRating - oppRating) : (oppRating - ownRating)
+```
+
+`ascending: true` means a **lower** value is stronger (WTN, BWF ranking). The result is always oriented so that **positive means the tougher opponent**:
+
+```js
+import { tools } from 'tods-competition-factory';
+
+tools.signedRatingDelta({ ownRating: 10, oppRating: 12, scaleName: 'WTN' }); // → { signedDelta: -2 }  playing down
+tools.signedRatingDelta({ ownRating: 10, oppRating: 12, scaleName: 'UTR' }); // → { signedDelta: 2 }   playing up
+```
+
+A scale absent from `ratingsParameters` **errors** unless an explicit `ascending` is passed. Guessing the direction would invert the meaning of every band, so it is refused rather than assumed.
+
+### Reading it per matchUp
+
+The signed axis engages on `getMatchUpCompetitiveProfile` only when a `scaleName` is supplied — which is exactly why existing callers see no change:
+
+```js
+const result = tournamentEngine.getMatchUpCompetitiveProfile({
+  policyDefinitions: POLICY_COMPETITIVE_BANDS_DEFAULT,
+  participantId, // perspective; defaults to side 1
+  scaleName: 'WTN',
+  matchUp,
+});
+// → {
+//     success: true,
+//     competitiveness: 'COMPETITIVE',  // realized — unchanged
+//     pctSpread: 58,                   // realized — unchanged
+//     perspectiveSideNumber: 1,
+//     signedDelta: -5,
+//     deltaBand: 'ANCHOR',
+//   }
+```
+
+`predictMatchUpCompetitiveBands` gains the same two fields additively. Its `delta` remains the **absolute** delta it has always returned:
+
+```js
+tournamentEngine.predictMatchUpCompetitiveBands({
+  policyDefinitions: POLICY_COMPETITIVE_BANDS_DEFAULT,
+  side1Rating: 4.5,
+  side2Rating: 5,
+  scaleName: 'UTR',
+});
+// → { competitive: …, decisive: …, routine: …, delta: 0.5, signedDelta: 0.5, deltaBand: 'UP' }
+```
+
+### Reading it per participant — `getCompetitiveProfile`
+
+`getCompetitiveProfile` aggregates **both axes** over a matchUp array. It is **pure**: no storage access, no tournamentRecord, no engine state. TMX runs it offline against IndexedDB state to draw an in-card fingerprint bar; a server runs the identical function over a whole corpus. One implementation, so the two cannot drift.
+
+```js
+const profile = tournamentEngine.getCompetitiveProfile({
+  policyDefinitions: POLICY_COMPETITIVE_BANDS_DEFAULT,
+  scaleName: 'WTN',
+  participantId,
+  matchUps, // the caller decides what is in scope
+});
+// → {
+//     success: true,
+//     participantId,
+//     matchUpsCount: 6,
+//     realized: {
+//       counts: { DECISIVE: 2, ROUTINE: 2, COMPETITIVE: 1 },
+//       ratios: { DECISIVE: 40, ROUTINE: 40, COMPETITIVE: 20 },
+//       completed: 5,
+//     },
+//     exposure: {
+//       counts: { ANCHOR: 1, DOWN: 1, EVEN: 1, UP: 1, STRETCH: 1 },
+//       ratios: { ANCHOR: 20, DOWN: 20, EVEN: 20, UP: 20, STRETCH: 20 },
+//       meanSignedDelta: 0,
+//       deltaBandsApplied: true,
+//       unrated: 1,
+//       rated: 5,
+//     },
+//   }
+```
+
+Behaviour worth knowing:
+
+- **Realized counts only completed matchUps** — a score spread needs a result. `realized.completed` reports how many that was.
+- **Exposure counts every matchUp with ratings on both sides**, result or not: who you were drawn against is known before the match is played.
+- **`rated` / `unrated` are reported** so a bar rendered from `ratios` can never quietly imply coverage it does not have. A missing rating is missing data, not an error.
+- **`exposure.counts` is zero-filled** for every band the policy declares, so a five-segment bar has five segments even for a participant who has never played up.
+- **A pair is the MEAN of its individual ratings**, not the sum — the boundaries are in single-player units, so a summed pair delta would be systematically ~2× and land in the wrong band.
+- Pass `singlesForDoubles: true` to read individuals' SINGLES ratings in a doubles matchUp.
+
+### No `deltaBands` means no bands
+
+If the resolved policy declares no `deltaBands`, the signed APIs return the **delta with no band** — never a guessed default. This is deliberately asymmetric with `profileBands`, which does fall back to the shipped 20/50 thresholds:
+
+- the realized thresholds are long-standing and load-bearing for existing consumers;
+- the default delta boundaries are an **explicitly arbitrary** cut (see below), so stamping band labels derived from them onto everyone's data would assert something that has not been established.
+
+Opting in is one import: `fixtures.policies.POLICY_COMPETITIVE_BANDS_DEFAULT`.
+
+### About the shipped default
+
+The default is **symmetric as a convenience, not as a claim.** Playing up two levels and playing down two levels are unlikely to be developmentally equivalent, and the ordered list expresses asymmetry freely (`+2` / `-4`) — but there is no evidence for any particular asymmetry, and shipping an invented one would put an unevidenced judgement into everyone's numbers. Asymmetry is a federation policy choice.
+
+`10.3%` of WTN's 39-point range is ≈ ±4 WTN, the cut used in the ITA college-tennis corpus analysis, where it sat near the 90th percentile of observed `|delta|`. That is an arbitrary cut, restated here so it is not mistaken for a finding.
+
+### Using the resolver directly
+
+For code that already holds a signed delta (an ingest pipeline, a projection job), the resolver is exported on `tools`:
+
+```js
+import { tools } from 'tods-competition-factory';
+
+tools.resolveDeltaBand(-5, deltaBands, 'WTN'); // → { band: 'ANCHOR' }
+tools.resolveDeltaBoundaries(deltaBands, 'WTN'); // → { boundaries: [{ key: 'ANCHOR', max: -4.017 }, …] }
+```
+
+`resolveDeltaBoundaries` validates and converts **once**; prefer it when walking many matchUps rather than re-resolving per row.
+
+---
+
 ## Notes
 
 - **Default thresholds** (20%, 50%) are based on typical tennis match distributions
@@ -421,6 +620,7 @@ const juniorPolicy = {
 - **Tiebreaks** are included in spread calculations (fractional games)
 - Thresholds are percentages (0-100 scale)
 - Policy affects analytics only - does not impact match progression
-- Used by `getMatchUpCompetitiveProfile`, `getMatchUpsStats`, `getParticipantStats`
+- Used by `getMatchUpCompetitiveProfile`, `getMatchUpsStats`, `getParticipantStats`, `getCompetitiveProfile`
 - Can be attached at tournament, event, or draw level
 - More decisive matches (lower spread) suggest better seeding or skill gaps
+- `deltaBands` is a **second axis**, not a widening of the three realized bands; enabling it moves no Competitive Ratio

--- a/src/assemblies/governors/matchUpGovernor/query.ts
+++ b/src/assemblies/governors/matchUpGovernor/query.ts
@@ -9,6 +9,8 @@ export { participantScheduledMatchUps } from '@Query/matchUps/participantSchedul
 export { getMatchUpDailyLimitsUpdate } from '@Query/extensions/getMatchUpDailyLimitsUpdate';
 export { competitionScheduleMatchUps } from '@Query/matchUps/competitionScheduleMatchUps';
 export { getMatchUpCompetitiveProfile } from '@Query/matchUp/getMatchUpCompetitiveProfile';
+export { getMatchUpRatingDelta } from '@Query/matchUp/getMatchUpRatingDelta';
+export { getCompetitiveProfile } from '@Query/matchUps/getCompetitiveProfile';
 export { getCheckedInParticipantIds } from '@Query/matchUp/getCheckedInParticipantIds';
 export { getMatchUpScheduleDetails } from '@Query/matchUp/getMatchUpScheduleDetails';
 export { matchUpActions } from '@Query/drawDefinition/matchUpActions/matchUpActions';

--- a/src/assemblies/tools/index.ts
+++ b/src/assemblies/tools/index.ts
@@ -4,7 +4,17 @@ export { visualizeScheduledMatchUps } from '../../tests/testHarness/testUtilitie
 // than from a governor because they take POSITIONAL arguments — a governor
 // export becomes an engine method, and the engine wrapper hands every method a
 // single params object, which would silently arrive as `signedDelta`.
-export { resolveDeltaBand, resolveDeltaBoundaries, signedRatingDelta } from '@Query/matchUp/resolveDeltaBand';
+//
+// `resolveDeltaBand` validates on every call, which is right for one-off use.
+// A corpus walk pairs `resolveDeltaBoundaries` (validate + convert ONCE) with
+// `bandFromBoundaries` (walk per row); exporting only the former would leave
+// the boundaries it returns as inert data.
+export {
+  resolveDeltaBoundaries,
+  bandFromBoundaries,
+  signedRatingDelta,
+  resolveDeltaBand,
+} from '@Query/matchUp/resolveDeltaBand';
 export { hasAttributeValues, createMap, generateHashCode, undefinedToNull } from '@Tools/objects';
 export { generateDateRange, dateTime, isValidEmbargoDate } from '@Tools/dateTime';
 export { matchUpChronologicalSort } from '@Functions/sorters/matchUpChronologicalSort';

--- a/src/assemblies/tools/index.ts
+++ b/src/assemblies/tools/index.ts
@@ -1,5 +1,10 @@
 export { nearestPowerOf2, nextPowerOf2, isPowerOf2, isOdd, isConvertableInteger, isNumeric } from '@Tools/math';
 export { visualizeScheduledMatchUps } from '../../tests/testHarness/testUtilities/visualizeScheduledMatchUps';
+// Pure helpers for the signed competitive-exposure axis. Exported here rather
+// than from a governor because they take POSITIONAL arguments — a governor
+// export becomes an engine method, and the engine wrapper hands every method a
+// single params object, which would silently arrive as `signedDelta`.
+export { resolveDeltaBand, resolveDeltaBoundaries, signedRatingDelta } from '@Query/matchUp/resolveDeltaBand';
 export { hasAttributeValues, createMap, generateHashCode, undefinedToNull } from '@Tools/objects';
 export { generateDateRange, dateTime, isValidEmbargoDate } from '@Tools/dateTime';
 export { matchUpChronologicalSort } from '@Functions/sorters/matchUpChronologicalSort';

--- a/src/constants/statsConstants.ts
+++ b/src/constants/statsConstants.ts
@@ -4,3 +4,21 @@ export const COMPETITIVE = 'COMPETITIVE';
 export const ROUTINE = 'ROUTINE';
 export const DECISIVE = 'DECISIVE';
 export const WIN_RATIO = 'winRatio';
+
+// Default keys for the SIGNED EXPOSURE axis — `deltaBands` on
+// POLICY_TYPE_COMPETITIVE_BANDS. Orthogonal to the three keys above, which
+// band REALIZED competitiveness (unsigned score spread, 0-100). Exposure bands
+// a signed rating delta, oriented so that positive means "tougher opponent":
+// ANCHOR is playing well down, STRETCH is playing well up.
+//
+// These name the DEFAULT band set only. Nothing in `resolveDeltaBand` knows
+// them — band count and names come entirely from policy. Plain consts rather
+// than an enum, matching the keys above, which carry no enum-guard obligation
+// (statsConstants has zero references in enumConstConformance.test.ts) and
+// because a policy's `key` types as `string` so a federation can ship its own
+// vocabulary.
+export const ANCHOR = 'ANCHOR';
+export const DOWN = 'DOWN';
+export const EVEN = 'EVEN';
+export const UP = 'UP';
+export const STRETCH = 'STRETCH';

--- a/src/fixtures/policies/POLICY_COMPETITIVE_BANDS_DEFAULT.ts
+++ b/src/fixtures/policies/POLICY_COMPETITIVE_BANDS_DEFAULT.ts
@@ -1,6 +1,5 @@
+import { ANCHOR, DECISIVE, DOWN, EVEN, ROUTINE, STRETCH, UP } from '@Constants/statsConstants';
 import { POLICY_TYPE_COMPETITIVE_BANDS } from '@Constants/policyConstants';
-
-import { DECISIVE, ROUTINE } from '@Constants/statsConstants';
 
 // Default prediction-model anchors are calibrated from Dave Fish's
 // "Need For a Rating System" (2011) data: ~25% competitive ratio at
@@ -15,6 +14,35 @@ export const POLICY_COMPETITIVE_BANDS_DEFAULT = {
       [DECISIVE]: 20,
       [ROUTINE]: 50,
     },
+    // SIGNED EXPOSURE axis — a second, orthogonal axis, NOT a widening of
+    // `profileBands`. An ordered boundary list: N entries produce N bands and
+    // the final entry omits its bound to catch the remainder. A boundary is
+    // `max` (absolute rating units) XOR `maxPct` (percent of the scale's
+    // range); declaring both is a validation error.
+    //
+    // `maxPct` is the portable form, which is why the shipped default uses it:
+    // one policy behaves sensibly across WTN / UTR / NTRP / ELO, whose ranges
+    // differ by orders of magnitude.
+    //
+    // This default is SYMMETRIC as a convenience, not as a claim. Playing up
+    // two levels and playing down two levels are unlikely to be
+    // developmentally equivalent, and the ordered list expresses asymmetry
+    // freely (+2 / -4) — but we have no evidence supporting any particular
+    // asymmetry, and shipping an invented one would put an unevidenced
+    // developmental judgement into everyone's numbers. Asymmetry is a
+    // federation policy choice.
+    //
+    // 10.3% of the WTN range (39 points) is ~±4 WTN, the cut used in the ITA
+    // college corpus analysis. It sat near the 90th percentile of observed
+    // |delta| there — an explicitly arbitrary cut, restated so it is not
+    // mistaken for a finding.
+    deltaBands: [
+      { key: ANCHOR, maxPct: -10.3 },
+      { key: DOWN, maxPct: -1.3 },
+      { key: EVEN, maxPct: 1.3 },
+      { key: UP, maxPct: 10.3 },
+      { key: STRETCH },
+    ],
     predictionModel: {
       competitiveAnchors: [
         { delta: 0, probability: 0.7 },

--- a/src/fixtures/policies/index.ts
+++ b/src/fixtures/policies/index.ts
@@ -1,5 +1,7 @@
 import { POLICY_AVOIDANCE_COUNTRY } from './POLICY_AVOIDANCE_COUNTRY';
 
+import { POLICY_COMPETITIVE_BANDS_DEFAULT } from './POLICY_COMPETITIVE_BANDS_DEFAULT';
+
 import { POLICY_COMPETITION_STANDARD } from './POLICY_COMPETITION_STANDARD';
 import { POLICY_COMPETITION_PRESSURE } from './POLICY_COMPETITION_PRESSURE';
 import { POLICY_COMPETITION_SWISS } from './POLICY_COMPETITION_SWISS';
@@ -38,6 +40,10 @@ import { POLICY_PRINT_DEFAULT } from './POLICY_PRINT_DEFAULT';
 
 export const policies = {
   POLICY_AVOIDANCE_COUNTRY,
+
+  // The only way for a consumer to obtain the default `deltaBands`, which the
+  // signed-exposure APIs deliberately do NOT fall back to on their own.
+  POLICY_COMPETITIVE_BANDS_DEFAULT,
 
   POLICY_COMPETITION_STANDARD,
   POLICY_COMPETITION_PRESSURE,

--- a/src/query/matchUp/getMatchUpCompetitiveProfile.ts
+++ b/src/query/matchUp/getMatchUpCompetitiveProfile.ts
@@ -1,37 +1,97 @@
+import { resolveCompetitiveBands, resolveDeltaBands } from './resolveCompetitiveBands';
 import { getBand, getScoreComponents, pctSpread } from './scoreComponents';
-import { resolveCompetitiveBands } from './resolveCompetitiveBands';
+import { DeltaBand, resolveDeltaBand } from './resolveDeltaBand';
+import { getMatchUpRatingDelta } from './getMatchUpRatingDelta';
 
-import { MatchUp, Tournament } from '@Types/tournamentTypes';
-import { SUCCESS } from '@Constants/resultConstants';
+// constants and types
 import { ErrorType, INVALID_VALUES, MISSING_MATCHUP } from '@Constants/errorConditionConstants';
+import { MatchUp, Tournament } from '@Types/tournamentTypes';
+import { PolicyDefinitions } from '@Types/factoryTypes';
+import { SUCCESS } from '@Constants/resultConstants';
 
 type GetMatchUpCompetitivenessArgs = {
+  policyDefinitions?: PolicyDefinitions;
+  singlesForDoubles?: boolean;
   tournamentRecord?: Tournament;
+  deltaBands?: DeltaBand[];
+  scaleAccessor?: string;
+  participantId?: string;
+  sideNumber?: number;
+  ascending?: boolean;
+  scaleName?: string;
   profileBands?: any;
   matchUp: MatchUp;
 };
 
+/**
+ * Bands a completed matchUp on both competitive axes.
+ *
+ * REALIZED (always): `competitiveness` + `pctSpread` from the score spread —
+ * unsigned, 0-100, three policy thresholds.
+ *
+ * SIGNED EXPOSURE (opt-in): `signedDelta` + `deltaBand` from the two sides'
+ * rating delta — signed, unbounded, N policy boundaries. Engages ONLY when
+ * `scaleName` is supplied, which is also what makes this change invisible to
+ * every existing caller: without it the returned object is unchanged.
+ */
 export function getMatchUpCompetitiveProfile({
+  singlesForDoubles,
+  policyDefinitions,
   tournamentRecord,
+  scaleAccessor,
+  participantId,
   profileBands,
+  deltaBands,
+  sideNumber,
+  ascending,
+  scaleName,
   matchUp,
 }: GetMatchUpCompetitivenessArgs): {
+  perspectiveSideNumber?: number;
   competitiveness?: any;
+  signedDelta?: number;
+  deltaBand?: string;
   pctSpread?: number;
   success?: boolean;
   error?: ErrorType;
+  info?: string;
 } {
   if (!matchUp) return { error: MISSING_MATCHUP };
   const { score, winningSide } = matchUp;
 
   if (!winningSide) return { error: INVALID_VALUES };
 
-  const bandProfiles = profileBands || resolveCompetitiveBands({ tournamentRecord });
+  const bandProfiles = profileBands || resolveCompetitiveBands({ policyDefinitions, tournamentRecord });
 
   const scoreComponents = getScoreComponents({ score });
   const spread = pctSpread([scoreComponents]);
   const competitiveness = getBand(spread, bandProfiles);
   const pctSpreadValue = Array.isArray(spread) ? spread[0] : spread;
 
-  return { ...SUCCESS, competitiveness, pctSpread: pctSpreadValue };
+  const realized = { ...SUCCESS, competitiveness, pctSpread: pctSpreadValue };
+
+  if (!scaleName) return realized;
+
+  const { perspectiveSideNumber, signedDelta, error, info } = getMatchUpRatingDelta({
+    singlesForDoubles,
+    scaleAccessor,
+    participantId,
+    sideNumber,
+    ascending,
+    scaleName,
+    matchUp,
+  });
+  // An unresolvable orientation is a caller configuration error, surfaced
+  // rather than folded into a partial result.
+  if (error) return { error, info };
+  if (signedDelta === undefined) return { ...realized, perspectiveSideNumber };
+
+  const bands = deltaBands ?? resolveDeltaBands({ policyDefinitions, tournamentRecord });
+  // No deltaBands in policy: the delta, and no band. Never a guessed default.
+  if (!bands) return { ...realized, perspectiveSideNumber, signedDelta };
+
+  const bandResult = resolveDeltaBand(signedDelta, bands, scaleName);
+  if (bandResult.error) return { error: bandResult.error, info: bandResult.info };
+
+  return { ...realized, perspectiveSideNumber, signedDelta, deltaBand: bandResult.band };
 }

--- a/src/query/matchUp/getMatchUpRatingDelta.ts
+++ b/src/query/matchUp/getMatchUpRatingDelta.ts
@@ -1,0 +1,147 @@
+import { signedRatingDelta } from './resolveDeltaBand';
+import ratingsParameters from '@Fixtures/ratings/ratingsParameters';
+
+// constants and types
+import { ErrorType } from '@Constants/errorConditionConstants';
+import { SINGLES } from '@Constants/matchUpTypes';
+
+export type MatchUpRatingDelta = {
+  perspectiveSideNumber?: number;
+  signedDelta?: number;
+  ownRating?: number;
+  oppRating?: number;
+  error?: ErrorType;
+  info?: string;
+};
+
+type GetMatchUpRatingDeltaArgs = {
+  singlesForDoubles?: boolean;
+  scaleAccessor?: string;
+  participantId?: string;
+  sideNumber?: number;
+  ascending?: boolean;
+  scaleName?: string;
+  matchUp: any;
+};
+
+function participantIds(participant: any): string[] {
+  if (!participant) return [];
+  const individualIds = (participant.individualParticipants ?? [])
+    .map((individual: any) => individual?.participantId)
+    .filter(Boolean);
+  return participant.participantId ? [participant.participantId, ...individualIds] : individualIds;
+}
+
+function scaleValueForParticipant({
+  valueAccessor,
+  participant,
+  scaleName,
+  type,
+}: {
+  valueAccessor?: string;
+  participant: any;
+  scaleName?: string;
+  type: string;
+}): number | undefined {
+  // Mirrors getPredictiveAccuracy's resolution order: a rating wins over a
+  // ranking of the same scaleName.
+  const rating = participant?.ratings?.[type]?.find((entry: any) => entry.scaleName === scaleName);
+  const ranking = participant?.rankings?.[type]?.find((entry: any) => entry.scaleName === scaleName);
+  const scaleValue = (rating ?? ranking)?.scaleValue;
+  const value = valueAccessor ? scaleValue?.[valueAccessor] : scaleValue;
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * A side's rating on `scaleName`.
+ *
+ * For a pair, the MEAN of the individual ratings — not the sum. The delta these
+ * feed is banded against boundaries expressed in single-player rating units (or
+ * a percentage of the scale's range), so a summed pair delta would be
+ * systematically ~2x and land in the wrong band. (`getPredictiveAccuracy` sums
+ * and compensates with `zoneDoubling`; that only works because its margin is a
+ * single scalar rather than a band ladder.) A pair with any unrated individual
+ * is unrated: averaging over the rated subset would understate the delta.
+ */
+function sideRating({
+  valueAccessor,
+  scaleName,
+  side,
+  type,
+}: {
+  valueAccessor?: string;
+  scaleName?: string;
+  side: any;
+  type: string;
+}): number | undefined {
+  const participant = side?.participant;
+  const individuals = participant?.individualParticipants;
+
+  if (Array.isArray(individuals) && individuals.length) {
+    const values = individuals.map((individual: any) =>
+      scaleValueForParticipant({ participant: individual, valueAccessor, scaleName, type }),
+    );
+    if (values.some((value) => value === undefined)) return undefined;
+    return (values as number[]).reduce((total, value) => total + value, 0) / values.length;
+  }
+
+  return scaleValueForParticipant({ participant, valueAccessor, scaleName, type });
+}
+
+function perspectiveIndex({
+  participantId,
+  sideNumber,
+  sides,
+}: {
+  participantId?: string;
+  sideNumber?: number;
+  sides: any[];
+}): number | undefined {
+  if (sideNumber === 1 || sideNumber === 2) return sideNumber - 1;
+  if (participantId) {
+    const index = sides.findIndex((side) => participantIds(side?.participant).includes(participantId));
+    return index === -1 ? undefined : index;
+  }
+  // No perspective given: side 1, reported back as `perspectiveSideNumber` so
+  // the caller can see which way the sign points.
+  return 0;
+}
+
+/**
+ * The signed rating delta of a matchUp from one side's perspective — positive
+ * means the opponent was stronger (playing up).
+ *
+ * A matchUp whose sides are not hydrated with participants, or where either
+ * side has no value on `scaleName`, yields no `signedDelta` and NO error: an
+ * absent rating is missing data, not a caller mistake. A caller that asked for
+ * the signed axis against a scale of unknown orientation DOES get an error.
+ */
+export function getMatchUpRatingDelta({
+  singlesForDoubles,
+  scaleAccessor,
+  participantId,
+  sideNumber,
+  ascending,
+  scaleName,
+  matchUp,
+}: GetMatchUpRatingDeltaArgs): MatchUpRatingDelta {
+  const sides = matchUp?.sides;
+  if (!Array.isArray(sides) || sides.length !== 2) return {};
+
+  const index = perspectiveIndex({ participantId, sideNumber, sides });
+  if (index === undefined) return {};
+
+  const type = singlesForDoubles ? SINGLES : (matchUp.matchUpType ?? SINGLES);
+  const valueAccessor = scaleAccessor ?? (scaleName ? ratingsParameters[scaleName]?.accessor : undefined);
+
+  const ownRating = sideRating({ side: sides[index], valueAccessor, scaleName, type });
+  const oppRating = sideRating({ side: sides[1 - index], valueAccessor, scaleName, type });
+  const perspectiveSideNumber = index + 1;
+
+  if (ownRating === undefined || oppRating === undefined) return { perspectiveSideNumber };
+
+  const { signedDelta, error, info } = signedRatingDelta({ ownRating, oppRating, ascending, scaleName });
+  if (error) return { error, info };
+
+  return { perspectiveSideNumber, signedDelta, ownRating, oppRating };
+}

--- a/src/query/matchUp/predictMatchUpCompetitiveBands.ts
+++ b/src/query/matchUp/predictMatchUpCompetitiveBands.ts
@@ -1,19 +1,26 @@
 import { predictBandsFromDelta, BandPrediction, PredictionModel } from './competitiveBandsPrediction';
+import { DeltaBand, resolveDeltaBand, signedRatingDelta } from './resolveDeltaBand';
+import { resolveDeltaBands } from './resolveCompetitiveBands';
 import { findPolicy } from '@Acquire/findPolicy';
 
 // constants and types
 import { ErrorType, INVALID_VALUES } from '@Constants/errorConditionConstants';
 import { POLICY_TYPE_COMPETITIVE_BANDS } from '@Constants/policyConstants';
+import { PolicyDefinitions } from '@Types/factoryTypes';
 import { Tournament } from '@Types/tournamentTypes';
 
 // Fixtures
 import POLICY_COMPETITIVE_BANDS_DEFAULT from '@Fixtures/policies/POLICY_COMPETITIVE_BANDS_DEFAULT';
 
 type PredictMatchUpCompetitiveBandsArgs = {
+  policyDefinitions?: PolicyDefinitions;
   predictionModel?: PredictionModel;
   tournamentRecord?: Tournament;
+  deltaBands?: DeltaBand[];
   side1Rating?: number;
   side2Rating?: number;
+  ascending?: boolean;
+  scaleName?: string;
 };
 
 const DEFAULT_PREDICTION_MODEL: PredictionModel =
@@ -40,14 +47,27 @@ function resolvePredictionModel(
 // single (projected) matchUp from the rating delta of the two sides.
 // The shape of the curve is policy-controlled — see the predictionModel
 // block on POLICY_COMPETITIVE_BANDS. Singles only (one rating per side).
+//
+// `delta` is the ABSOLUTE delta, unchanged: competitiveness is symmetric, so a
+// 4-point gap is equally uncompetitive whichever side it favours. The signed
+// exposure axis is a separate question — "who did side 1 play up against?" —
+// and is returned ADDITIVELY as `signedDelta` (+ `deltaBand`) when a
+// `scaleName` or explicit `ascending` establishes which direction is stronger.
 export function predictMatchUpCompetitiveBands({
+  policyDefinitions,
   tournamentRecord,
   predictionModel,
   side1Rating,
   side2Rating,
+  deltaBands,
+  ascending,
+  scaleName,
 }: PredictMatchUpCompetitiveBandsArgs): BandPrediction & {
-  delta?: number;
+  signedDelta?: number;
+  deltaBand?: string;
   error?: ErrorType;
+  delta?: number;
+  info?: string;
 } {
   if (typeof side1Rating !== 'number' || typeof side2Rating !== 'number') {
     return { competitive: 0, decisive: 0, routine: 0, error: INVALID_VALUES };
@@ -57,5 +77,22 @@ export function predictMatchUpCompetitiveBands({
   const delta = Math.abs(side1Rating - side2Rating);
   const bands = predictBandsFromDelta(delta, model);
 
-  return { ...bands, delta };
+  const orientationRequested = scaleName !== undefined || typeof ascending === 'boolean';
+  if (!orientationRequested) return { ...bands, delta };
+
+  // Side 1's perspective: positive means side 2 was the stronger side.
+  const signed = signedRatingDelta({ ownRating: side1Rating, oppRating: side2Rating, ascending, scaleName });
+  if (signed.error) return { competitive: 0, decisive: 0, routine: 0, error: signed.error, info: signed.info };
+
+  const signedDelta = signed.signedDelta as number;
+  const resolvedBands = deltaBands ?? resolveDeltaBands({ policyDefinitions, tournamentRecord });
+  // No deltaBands in policy: the delta, and no band. Never a guessed default.
+  if (!resolvedBands) return { ...bands, delta, signedDelta };
+
+  const bandResult = resolveDeltaBand(signedDelta, resolvedBands, scaleName);
+  if (bandResult.error) {
+    return { competitive: 0, decisive: 0, routine: 0, error: bandResult.error, info: bandResult.info };
+  }
+
+  return { ...bands, delta, signedDelta, deltaBand: bandResult.band };
 }

--- a/src/query/matchUp/resolveCompetitiveBands.ts
+++ b/src/query/matchUp/resolveCompetitiveBands.ts
@@ -3,6 +3,7 @@ import { getAppliedPolicies } from '@Query/extensions/getAppliedPolicies';
 import POLICY_COMPETITIVE_BANDS_DEFAULT from '@Fixtures/policies/POLICY_COMPETITIVE_BANDS_DEFAULT';
 import { POLICY_TYPE_COMPETITIVE_BANDS } from '@Constants/policyConstants';
 import { PolicyDefinitions } from '@Types/factoryTypes';
+import { DeltaBand } from './resolveDeltaBand';
 import { DrawDefinition, Event, Structure, Tournament } from '@Types/tournamentTypes';
 
 type ResolveCompetitiveBandsArgs = {
@@ -35,4 +36,42 @@ export function resolveCompetitiveBands({
   }
 
   return POLICY_COMPETITIVE_BANDS_DEFAULT[POLICY_TYPE_COMPETITIVE_BANDS].profileBands;
+}
+
+/**
+ * The SIGNED exposure axis's `deltaBands`, resolved explicit-argument first,
+ * then from applied policies (event -> draw -> tournament scope).
+ *
+ * Deliberately asymmetric with `resolveCompetitiveBands` above: there is NO
+ * fixture fallback. A caller that has not opted into `deltaBands` gets no
+ * bands, and the signed APIs then return the delta with no band rather than a
+ * guessed default. The realized thresholds (20/50) are long-standing and
+ * load-bearing for existing consumers; the default delta boundaries are an
+ * explicitly arbitrary cut taken from one corpus, so stamping band labels
+ * derived from them onto everybody's data would be asserting something we have
+ * not established. Opting in is one import:
+ * `POLICY_COMPETITIVE_BANDS_DEFAULT`, via `fixtures.policies`.
+ */
+export function resolveDeltaBands({
+  policyDefinitions,
+  tournamentRecord,
+  drawDefinition,
+  structure,
+  event,
+}: ResolveCompetitiveBandsArgs): DeltaBand[] | undefined {
+  const explicit = policyDefinitions?.[POLICY_TYPE_COMPETITIVE_BANDS];
+  if (explicit?.deltaBands) return explicit.deltaBands;
+
+  if (tournamentRecord) {
+    const { appliedPolicies } = getAppliedPolicies({
+      tournamentRecord,
+      drawDefinition,
+      structure,
+      event,
+    });
+    const applied = appliedPolicies?.[POLICY_TYPE_COMPETITIVE_BANDS];
+    if (applied?.deltaBands) return applied.deltaBands;
+  }
+
+  return undefined;
 }

--- a/src/query/matchUp/resolveDeltaBand.ts
+++ b/src/query/matchUp/resolveDeltaBand.ts
@@ -1,0 +1,213 @@
+import ratingsParameters from '@Fixtures/ratings/ratingsParameters';
+
+// constants and types
+import {
+  ErrorType,
+  INVALID_POLICY_DEFINITION,
+  INVALID_VALUES,
+  MISSING_VALUE,
+} from '@Constants/errorConditionConstants';
+
+/**
+ * One entry in a `deltaBands` ordered boundary list.
+ *
+ * A boundary is `max` (absolute rating units) XOR `maxPct` (percent of the
+ * scale's range). Both on one entry is a validation error, not a precedence
+ * rule. The FINAL entry omits both and catches the remainder, so N entries
+ * always produce exactly N bands.
+ */
+export type DeltaBand = {
+  maxPct?: number;
+  max?: number;
+  key: string;
+};
+
+export type ResolvedDeltaBoundary = {
+  max?: number;
+  key: string;
+};
+
+type BoundaryResult = { max?: number; error?: ErrorType; info?: string };
+
+type OrientationResult = { ascending?: boolean; error?: ErrorType; info?: string };
+
+type OrientationArgs = {
+  ascending?: boolean;
+  scaleName?: string;
+};
+
+type SignedRatingDeltaArgs = OrientationArgs & {
+  oppRating?: number;
+  ownRating?: number;
+};
+
+const invalidPolicy = (info: string) => ({ error: INVALID_POLICY_DEFINITION, info });
+
+function scaleRangeMagnitude(scaleName?: string): number | undefined {
+  const range = scaleName ? ratingsParameters[scaleName]?.range : undefined;
+  return Array.isArray(range) && range.length === 2 ? Math.abs(range[1] - range[0]) : undefined;
+}
+
+function resolveBoundary({
+  rangeMagnitude,
+  scaleName,
+  isFinal,
+  index,
+  band,
+}: {
+  rangeMagnitude?: number;
+  scaleName?: string;
+  isFinal: boolean;
+  band: DeltaBand;
+  index: number;
+}): BoundaryResult {
+  if (typeof band?.key !== 'string' || !band.key.length) return invalidPolicy(`deltaBands[${index}].key is required`);
+
+  const hasMaxPct = band.maxPct !== undefined;
+  const hasMax = band.max !== undefined;
+
+  if (hasMax && hasMaxPct) {
+    return invalidPolicy(`deltaBands[${index}] declares both max and maxPct; a boundary is one or the other`);
+  }
+
+  if (isFinal) {
+    // N entries produce N bands: the final entry is the open-ended catch-all.
+    // A bound here would leave deltas beyond it with no band at all.
+    if (hasMax || hasMaxPct) {
+      return invalidPolicy(`deltaBands[${index}] is the final entry and must omit max/maxPct to catch the remainder`);
+    }
+    return {};
+  }
+
+  if (!hasMax && !hasMaxPct) return invalidPolicy(`deltaBands[${index}] requires max or maxPct`);
+
+  const declared = hasMax ? band.max : band.maxPct;
+  if (typeof declared !== 'number' || !Number.isFinite(declared)) {
+    return invalidPolicy(`deltaBands[${index}] ${hasMax ? 'max' : 'maxPct'} must be a finite number`);
+  }
+
+  if (hasMax) return { max: declared };
+
+  // A percentage of an unknown range is unknowable. Never fall back to
+  // treating it as absolute units — that would silently rescale every band.
+  if (rangeMagnitude === undefined) {
+    return invalidPolicy(
+      `deltaBands[${index}].maxPct requires a scaleName with a defined range in ratingsParameters; received: ${scaleName ?? 'undefined'}`,
+    );
+  }
+
+  return { max: (declared / 100) * rangeMagnitude };
+}
+
+/**
+ * Validates a `deltaBands` policy list and resolves every boundary to absolute
+ * rating units. Exposed separately from `resolveDeltaBand` so a caller walking
+ * thousands of matchUps validates and converts once rather than per matchUp.
+ */
+export function resolveDeltaBoundaries(
+  deltaBands?: DeltaBand[],
+  scaleName?: string,
+): { boundaries?: ResolvedDeltaBoundary[]; error?: ErrorType; info?: string } {
+  if (!Array.isArray(deltaBands) || !deltaBands.length) {
+    return { error: MISSING_VALUE, info: 'deltaBands must be a non-empty array' };
+  }
+
+  const rangeMagnitude = scaleRangeMagnitude(scaleName);
+  const boundaries: ResolvedDeltaBoundary[] = [];
+
+  for (let index = 0; index < deltaBands.length; index++) {
+    const isFinal = index === deltaBands.length - 1;
+    const { max, error, info } = resolveBoundary({
+      band: deltaBands[index],
+      rangeMagnitude,
+      scaleName,
+      isFinal,
+      index,
+    });
+    if (error) return { error, info };
+
+    const previous = boundaries.at(-1)?.max;
+    if (max !== undefined && previous !== undefined && max <= previous) {
+      return invalidPolicy(
+        `deltaBands[${index}] resolves to ${max}, which does not exceed deltaBands[${index - 1}] (${previous}); boundaries must ascend`,
+      );
+    }
+
+    boundaries.push(max === undefined ? { key: deltaBands[index].key } : { key: deltaBands[index].key, max });
+  }
+
+  return { boundaries };
+}
+
+/**
+ * Ordered walk: the first band whose `max` the signed delta does not exceed.
+ * The final boundary carries no `max`, so a match is guaranteed.
+ */
+export function bandFromBoundaries(signedDelta: number, boundaries: ResolvedDeltaBoundary[]): string | undefined {
+  const matched = boundaries.find(({ max }) => max === undefined || signedDelta <= max) ?? boundaries.at(-1);
+  return matched?.key;
+}
+
+/**
+ * Resolves a signed rating delta to a policy-defined band.
+ *
+ * Generic by construction — band count and names come from `deltaBands`, in
+ * contrast with `getBand` (the realized/unsigned axis), which hardcodes
+ * exactly three.
+ */
+export function resolveDeltaBand(
+  signedDelta: number,
+  deltaBands?: DeltaBand[],
+  scaleName?: string,
+): { band?: string; error?: ErrorType; info?: string } {
+  if (typeof signedDelta !== 'number' || !Number.isFinite(signedDelta)) {
+    return { error: INVALID_VALUES, info: 'signedDelta must be a finite number' };
+  }
+
+  const { boundaries, error, info } = resolveDeltaBoundaries(deltaBands, scaleName);
+  if (error) return { error, info };
+
+  return { band: bandFromBoundaries(signedDelta, boundaries as ResolvedDeltaBoundary[]) };
+}
+
+/**
+ * Scale orientation, which decides which way the sign points.
+ *
+ * `ascending: true` means a LOWER value is stronger (WTN, BWF rank). Resolved
+ * from `ratingsParameters` so callers never hand-roll it — the ITA analysis
+ * scripts each carrying their own copy of this is the divergence this exists to
+ * remove. An unknown scale with no explicit `ascending` is an error rather than
+ * an assumed orientation: guessing inverts the meaning of every band.
+ */
+export function resolveScaleOrientation({ ascending, scaleName }: OrientationArgs): OrientationResult {
+  if (typeof ascending === 'boolean') return { ascending };
+
+  const scaleAscending = scaleName ? ratingsParameters[scaleName]?.ascending : undefined;
+  if (typeof scaleAscending === 'boolean') return { ascending: scaleAscending };
+
+  return {
+    error: MISSING_VALUE,
+    info: `scale orientation unknown: pass { ascending } or a scaleName present in ratingsParameters; received: ${scaleName ?? 'undefined'}`,
+  };
+}
+
+/**
+ * Signed rating delta from one side's perspective, oriented so that POSITIVE
+ * means a tougher opponent (playing up) and negative means playing down.
+ */
+export function signedRatingDelta({ ownRating, oppRating, ascending, scaleName }: SignedRatingDeltaArgs): {
+  signedDelta?: number;
+  error?: ErrorType;
+  info?: string;
+} {
+  const rated = [ownRating, oppRating].every((value) => typeof value === 'number' && Number.isFinite(value));
+  if (!rated) return { error: INVALID_VALUES, info: 'ownRating and oppRating must be finite numbers' };
+
+  const orientation = resolveScaleOrientation({ ascending, scaleName });
+  if (orientation.error) return { error: orientation.error, info: orientation.info };
+
+  const own = ownRating as number;
+  const opp = oppRating as number;
+
+  return { signedDelta: orientation.ascending ? own - opp : opp - own };
+}

--- a/src/query/matchUps/getCompetitiveProfile.ts
+++ b/src/query/matchUps/getCompetitiveProfile.ts
@@ -1,0 +1,183 @@
+import {
+  bandFromBoundaries,
+  DeltaBand,
+  ResolvedDeltaBoundary,
+  resolveDeltaBoundaries,
+} from '@Query/matchUp/resolveDeltaBand';
+import { resolveCompetitiveBands, resolveDeltaBands } from '@Query/matchUp/resolveCompetitiveBands';
+import { getBand, getScoreComponents, pctSpread } from '@Query/matchUp/scoreComponents';
+import { getMatchUpRatingDelta } from '@Query/matchUp/getMatchUpRatingDelta';
+
+// constants and types
+import { ErrorType, INVALID_VALUES } from '@Constants/errorConditionConstants';
+import { COMPETITIVE, DECISIVE, ROUTINE } from '@Constants/statsConstants';
+import { PolicyDefinitions } from '@Types/factoryTypes';
+import { SUCCESS } from '@Constants/resultConstants';
+
+type Counts = { [key: string]: number };
+
+type CompetitiveAxis = {
+  ratios: Counts;
+  counts: Counts;
+};
+
+export type CompetitiveProfile = {
+  realized: CompetitiveAxis & { completed: number };
+  exposure: CompetitiveAxis & {
+    meanSignedDelta?: number;
+    deltaBandsApplied: boolean;
+    unrated: number;
+    rated: number;
+  };
+  matchUpsCount: number;
+  participantId?: string;
+  success?: boolean;
+};
+
+type GetCompetitiveProfileArgs = {
+  policyDefinitions?: PolicyDefinitions;
+  singlesForDoubles?: boolean;
+  deltaBands?: DeltaBand[];
+  scaleAccessor?: string;
+  participantId?: string;
+  ascending?: boolean;
+  profileBands?: any;
+  scaleName?: string;
+  matchUps: any[];
+};
+
+const percent = (part: number, whole: number): number => (whole ? Math.round((10000 * part) / whole) / 100 : 0);
+
+function ratiosFrom(counts: Counts, whole: number): Counts {
+  return Object.assign({}, ...Object.keys(counts).map((key) => ({ [key]: percent(counts[key], whole) })));
+}
+
+function participantIds(participant: any): string[] {
+  if (!participant) return [];
+  const individualIds = (participant.individualParticipants ?? [])
+    .map((individual: any) => individual?.participantId)
+    .filter(Boolean);
+  return participant.participantId ? [participant.participantId, ...individualIds] : individualIds;
+}
+
+function includesParticipant(matchUp: any, participantId: string): boolean {
+  return (matchUp?.sides ?? []).some((side: any) => participantIds(side?.participant).includes(participantId));
+}
+
+/**
+ * Both competitive axes for one participant (or for a whole matchUp array),
+ * aggregated.
+ *
+ * PURE over the `matchUps` array it is given — no storage access, no engine
+ * state, no tournamentRecord required. That is deliberate: TMX computes this
+ * offline from IndexedDB state for an in-card fingerprint bar, and the server
+ * runs the identical code over a corpus. One implementation, so the two cannot
+ * drift.
+ *
+ * The caller decides which matchUps are in scope (completed only, one season,
+ * one division). Within them:
+ *
+ * - REALIZED counts only matchUps with a `winningSide` — a score spread needs a
+ *   result. `realized.completed` reports how many that was.
+ * - EXPOSURE counts every matchUp with a resolvable rating on both sides,
+ *   result or not: who you were drawn against is known before the match is
+ *   played. `exposure.rated` / `unrated` report the split, so a bar rendered
+ *   from `ratios` can never quietly imply coverage it does not have.
+ *
+ * `exposure.counts` is zero-filled for every band the policy declares, so a
+ * five-segment bar has five segments even when a participant has never played
+ * up. With no `deltaBands` in policy, `deltaBandsApplied` is false and the
+ * exposure counts are empty — never a guessed default.
+ */
+export function getCompetitiveProfile({
+  singlesForDoubles,
+  policyDefinitions,
+  scaleAccessor,
+  participantId,
+  profileBands,
+  deltaBands,
+  ascending,
+  scaleName,
+  matchUps,
+}: GetCompetitiveProfileArgs): CompetitiveProfile | { error: ErrorType; info?: string } {
+  if (!Array.isArray(matchUps)) return { error: INVALID_VALUES, info: 'matchUps must be an array' };
+
+  const scoped = participantId ? matchUps.filter((matchUp) => includesParticipant(matchUp, participantId)) : matchUps;
+
+  const bandProfiles = profileBands || resolveCompetitiveBands({ policyDefinitions });
+
+  // The exposure axis engages only when a scale is identified — same rule as
+  // getMatchUpCompetitiveProfile. A caller that wants the realized axis alone
+  // is not made to care that the policy it passed carries `deltaBands`.
+  const exposureRequested = scaleName !== undefined || ascending !== undefined;
+  const resolvedDeltaBands = exposureRequested ? (deltaBands ?? resolveDeltaBands({ policyDefinitions })) : undefined;
+
+  let boundaries: ResolvedDeltaBoundary[] | undefined;
+  if (resolvedDeltaBands) {
+    // Validated and converted ONCE rather than per matchUp.
+    const resolution = resolveDeltaBoundaries(resolvedDeltaBands, scaleName);
+    if (resolution.error) return { error: resolution.error, info: resolution.info };
+    boundaries = resolution.boundaries;
+  }
+
+  const realizedCounts: Counts = { [DECISIVE]: 0, [ROUTINE]: 0, [COMPETITIVE]: 0 };
+  const exposureCounts: Counts = Object.assign({}, ...(boundaries ?? []).map(({ key }) => ({ [key]: 0 })));
+
+  let deltaTotal = 0;
+  let completed = 0;
+  let unrated = 0;
+  let rated = 0;
+
+  for (const matchUp of scoped) {
+    if (matchUp?.winningSide) {
+      completed += 1;
+      const spread = pctSpread([getScoreComponents({ score: matchUp.score })]);
+      const band = getBand(spread, bandProfiles);
+      realizedCounts[band] = (realizedCounts[band] ?? 0) + 1;
+    }
+
+    if (!exposureRequested) continue;
+
+    const { signedDelta, error, info } = getMatchUpRatingDelta({
+      singlesForDoubles,
+      scaleAccessor,
+      participantId,
+      ascending,
+      scaleName,
+      matchUp,
+    });
+    if (error) return { error, info };
+    if (signedDelta === undefined) {
+      // Missing ratings, not a caller mistake — counted so the ratios below can
+      // never be read as coverage they do not have.
+      unrated += 1;
+      continue;
+    }
+
+    rated += 1;
+    deltaTotal += signedDelta;
+    if (boundaries) {
+      const band = bandFromBoundaries(signedDelta, boundaries);
+      if (band) exposureCounts[band] = (exposureCounts[band] ?? 0) + 1;
+    }
+  }
+
+  return {
+    ...SUCCESS,
+    participantId,
+    matchUpsCount: scoped.length,
+    realized: {
+      counts: realizedCounts,
+      ratios: ratiosFrom(realizedCounts, completed),
+      completed,
+    },
+    exposure: {
+      counts: exposureCounts,
+      ratios: ratiosFrom(exposureCounts, rated),
+      meanSignedDelta: rated ? Math.round(10000 * (deltaTotal / rated)) / 10000 : undefined,
+      deltaBandsApplied: Boolean(boundaries),
+      unrated,
+      rated,
+    },
+  };
+}

--- a/src/tests/queries/matchUps/competitiveProfileEngineAgreement.test.ts
+++ b/src/tests/queries/matchUps/competitiveProfileEngineAgreement.test.ts
@@ -1,0 +1,116 @@
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+// constants and fixtures
+import POLICY_COMPETITIVE_BANDS_DEFAULT from '@Fixtures/policies/POLICY_COMPETITIVE_BANDS_DEFAULT';
+import { COMPETITIVE, DECISIVE, RETIRED, ROUTINE, WALKOVER } from '@Constants/statsConstants';
+import { POLICY_TYPE_COMPETITIVE_BANDS } from '@Constants/policyConstants';
+import { WTN } from '@Constants/ratingConstants';
+
+const CONTEXT_PROFILE = { withCompetitiveness: true, withScaleValues: true };
+
+function seededMatchUps() {
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ drawSize: 16, category: { ratingType: WTN } }],
+    completeAllMatchUps: true,
+    setState: true,
+  });
+
+  const { matchUps } = tournamentEngine.allTournamentMatchUps({ contextProfile: CONTEXT_PROFILE, inContext: true });
+  return matchUps ?? [];
+}
+
+describe('getCompetitiveProfile agrees with the existing realized-band surfaces', () => {
+  it('reproduces the per-matchUp bands that allTournamentMatchUps already attaches', () => {
+    const matchUps = seededMatchUps();
+
+    // The pre-existing path: competitiveProfile attached during enrichment.
+    const attachedTally: any = { [DECISIVE]: 0, [ROUTINE]: 0, [COMPETITIVE]: 0 };
+    for (const matchUp of matchUps) {
+      if (!matchUp.winningSide) continue;
+      const band = matchUp.competitiveProfile?.competitiveness;
+      attachedTally[band] = (attachedTally[band] ?? 0) + 1;
+    }
+
+    // Tripwire: a vacuous comparison (all zeros, or every matchUp in one band)
+    // would let a broken aggregate pass.
+    const nonZeroBands = Object.values(attachedTally).filter((count: any) => count > 0).length;
+    expect(nonZeroBands).toBeGreaterThan(1);
+
+    const profile: any = tournamentEngine.getCompetitiveProfile({ matchUps });
+
+    expect(profile.realized.counts).toEqual(attachedTally);
+    expect(profile.realized.completed).toEqual(matchUps.filter(({ winningSide }) => winningSide).length);
+  });
+
+  it('reproduces getMatchUpsStats percentages', () => {
+    const matchUps = seededMatchUps();
+
+    const stats: any = tournamentEngine.getMatchUpsStats({ matchUps });
+    // The comparison is only apples-to-apples with no walkovers/retirements,
+    // which getMatchUpsStats counts on a different denominator basis.
+    expect(stats.competitiveBands[WALKOVER]).toEqual(0);
+    expect(stats.competitiveBands[RETIRED]).toEqual(0);
+
+    const profile: any = tournamentEngine.getCompetitiveProfile({ matchUps });
+
+    for (const band of [DECISIVE, ROUTINE, COMPETITIVE]) {
+      expect(profile.realized.ratios[band]).toBeCloseTo(stats.competitiveBands[band], 1);
+    }
+  });
+});
+
+describe('the signed exposure axis resolves through the engine and hydrated participants', () => {
+  it('bands every rated matchUp for a participant', () => {
+    const matchUps = seededMatchUps();
+
+    const participantId = matchUps.find(({ sides }) => sides?.[0]?.participant?.participantId)?.sides?.[0]?.participant
+      ?.participantId;
+    expect(participantId).toBeDefined();
+
+    const profile: any = tournamentEngine.getCompetitiveProfile({
+      policyDefinitions: POLICY_COMPETITIVE_BANDS_DEFAULT,
+      scaleName: WTN,
+      participantId,
+      matchUps,
+    });
+
+    expect(profile.matchUpsCount).toBeGreaterThan(0);
+    // WTN ratings were seeded, so the mock participants resolve on this scale.
+    expect(profile.exposure.rated).toBeGreaterThan(0);
+    expect(profile.exposure.deltaBandsApplied).toEqual(true);
+
+    // Every rated matchUp landed in exactly one band, and the default policy's
+    // five keys are all present (zero-filled when unused).
+    const counted: number = Object.values(profile.exposure.counts).reduce((a: any, b: any) => a + b, 0);
+    expect(counted).toEqual(profile.exposure.rated);
+    expect(Object.keys(profile.exposure.counts)).toHaveLength(5);
+
+    // Ratios are percentages of the rated subset.
+    const ratioTotal: number = Object.values(profile.exposure.ratios).reduce((a: any, b: any) => a + b, 0);
+    expect(ratioTotal).toBeCloseTo(100, 1);
+  });
+
+  it('exposes the signed delta on a single matchUp through the engine', () => {
+    const matchUps = seededMatchUps();
+    const matchUp = matchUps.find(({ winningSide, sides }) => winningSide && sides?.length === 2);
+
+    const withoutScale: any = tournamentEngine.getMatchUpCompetitiveProfile({ matchUp });
+    const withScale: any = tournamentEngine.getMatchUpCompetitiveProfile({
+      policyDefinitions: POLICY_COMPETITIVE_BANDS_DEFAULT,
+      scaleName: WTN,
+      matchUp,
+    });
+
+    // Realized output is unchanged by the presence of the signed axis.
+    expect(withScale.competitiveness).toEqual(withoutScale.competitiveness);
+    expect(withScale.pctSpread).toEqual(withoutScale.pctSpread);
+    expect(withoutScale.signedDelta).toBeUndefined();
+
+    expect(typeof withScale.signedDelta).toEqual('number');
+
+    const bandKeys = POLICY_COMPETITIVE_BANDS_DEFAULT[POLICY_TYPE_COMPETITIVE_BANDS].deltaBands.map(({ key }) => key);
+    expect(bandKeys).toContain(withScale.deltaBand);
+  });
+});

--- a/src/tests/queries/matchUps/competitiveSignedExposure.test.ts
+++ b/src/tests/queries/matchUps/competitiveSignedExposure.test.ts
@@ -1,0 +1,521 @@
+import { predictMatchUpCompetitiveBands } from '@Query/matchUp/predictMatchUpCompetitiveBands';
+import { getMatchUpCompetitiveProfile } from '@Query/matchUp/getMatchUpCompetitiveProfile';
+import { getCompetitiveProfile } from '@Query/matchUps/getCompetitiveProfile';
+import { describe, expect, it } from 'vitest';
+
+// constants and fixtures
+import { ANCHOR, COMPETITIVE, DECISIVE, DOWN, EVEN, ROUTINE, STRETCH, UP } from '@Constants/statsConstants';
+import { INVALID_POLICY_DEFINITION, MISSING_VALUE } from '@Constants/errorConditionConstants';
+import { POLICY_TYPE_COMPETITIVE_BANDS } from '@Constants/policyConstants';
+import { DOUBLES, SINGLES } from '@Constants/matchUpTypes';
+import { UTR, WTN } from '@Constants/ratingConstants';
+import POLICY_COMPETITIVE_BANDS_DEFAULT from '@Fixtures/policies/POLICY_COMPETITIVE_BANDS_DEFAULT';
+
+const DEFAULT_POLICY = POLICY_COMPETITIVE_BANDS_DEFAULT;
+const REALIZED_ONLY_POLICY = {
+  [POLICY_TYPE_COMPETITIVE_BANDS]: { profileBands: { [DECISIVE]: 20, [ROUTINE]: 50 } },
+};
+
+const wtnParticipant = (participantId: string, wtnRating?: number) => ({
+  participantId,
+  ...(wtnRating === undefined ? {} : { ratings: { [SINGLES]: [{ scaleName: WTN, scaleValue: { wtnRating } }] } }),
+});
+
+// 6-4 6-3 => 12 games to 7 => 58% spread => COMPETITIVE under the default 20/50 thresholds.
+const COMPETITIVE_SETS = [
+  { side1Score: 6, side2Score: 4 },
+  { side1Score: 6, side2Score: 3 },
+];
+
+const singlesMatchUp = ({
+  ownRating,
+  oppRating,
+  winningSide,
+  sets = COMPETITIVE_SETS,
+  ownId = 'p1',
+  oppId = 'opp',
+}: any) => ({
+  matchUpType: SINGLES,
+  ...(winningSide ? { winningSide } : {}),
+  score: { sets },
+  sides: [
+    { sideNumber: 1, participant: wtnParticipant(ownId, ownRating) },
+    { sideNumber: 2, participant: wtnParticipant(oppId, oppRating) },
+  ],
+});
+
+describe('getMatchUpCompetitiveProfile — the realized axis is untouched', () => {
+  it('returns exactly what it returned before when no scaleName is given', () => {
+    const matchUp: any = singlesMatchUp({ ownRating: 20, oppRating: 25, winningSide: 1 });
+
+    // Byte-identical: same keys, same values. The signed axis engages ONLY on
+    // `scaleName`, which is what makes this change invisible to existing callers.
+    expect(getMatchUpCompetitiveProfile({ matchUp })).toEqual({
+      competitiveness: COMPETITIVE,
+      pctSpread: 58,
+      success: true,
+    });
+  });
+
+  it('realized output is identical with the signed axis engaged', () => {
+    const matchUp: any = singlesMatchUp({ ownRating: 20, oppRating: 25, winningSide: 1 });
+
+    const realized: any = getMatchUpCompetitiveProfile({ matchUp });
+    const withSigned: any = getMatchUpCompetitiveProfile({
+      policyDefinitions: DEFAULT_POLICY,
+      scaleName: WTN,
+      matchUp,
+    });
+
+    expect(withSigned.competitiveness).toEqual(realized.competitiveness);
+    expect(withSigned.pctSpread).toEqual(realized.pctSpread);
+  });
+});
+
+describe('getMatchUpCompetitiveProfile — signed exposure axis', () => {
+  it('adds signedDelta and deltaBand from the perspective of side 1 by default', () => {
+    const matchUp: any = singlesMatchUp({ ownRating: 20, oppRating: 25, winningSide: 1 });
+
+    // WTN: own 20 vs opp 25 — the opponent's higher WTN is WEAKER, so this is
+    // playing down by 5, past the -4.017 (10.3% of 39) ANCHOR boundary.
+    expect(getMatchUpCompetitiveProfile({ policyDefinitions: DEFAULT_POLICY, scaleName: WTN, matchUp })).toEqual({
+      competitiveness: COMPETITIVE,
+      perspectiveSideNumber: 1,
+      deltaBand: ANCHOR,
+      signedDelta: -5,
+      pctSpread: 58,
+      success: true,
+    });
+  });
+
+  it('inverts for the other participant — same matchUp, opposite exposure', () => {
+    const matchUp: any = singlesMatchUp({ ownRating: 20, oppRating: 25, winningSide: 1 });
+
+    const result: any = getMatchUpCompetitiveProfile({
+      policyDefinitions: DEFAULT_POLICY,
+      participantId: 'opp',
+      scaleName: WTN,
+      matchUp,
+    });
+
+    expect(result.signedDelta).toEqual(5);
+    expect(result.deltaBand).toEqual(STRETCH);
+    expect(result.perspectiveSideNumber).toEqual(2);
+  });
+
+  it('honours an explicit sideNumber', () => {
+    const matchUp: any = singlesMatchUp({ ownRating: 20, oppRating: 25, winningSide: 1 });
+    const result: any = getMatchUpCompetitiveProfile({
+      policyDefinitions: DEFAULT_POLICY,
+      scaleName: WTN,
+      sideNumber: 2,
+      matchUp,
+    });
+    expect(result.signedDelta).toEqual(5);
+    expect(result.perspectiveSideNumber).toEqual(2);
+  });
+
+  it('returns the delta and NO band when policy declares no deltaBands', () => {
+    const matchUp: any = singlesMatchUp({ ownRating: 20, oppRating: 25, winningSide: 1 });
+
+    const result: any = getMatchUpCompetitiveProfile({
+      policyDefinitions: REALIZED_ONLY_POLICY,
+      scaleName: WTN,
+      matchUp,
+    });
+
+    expect(result.signedDelta).toEqual(-5);
+    expect(result.deltaBand).toBeUndefined();
+    expect('deltaBand' in result).toEqual(false);
+  });
+
+  it('returns no signedDelta when either side is unrated, and no error', () => {
+    const matchUp: any = singlesMatchUp({ ownRating: 20, oppRating: undefined, winningSide: 1 });
+
+    const result: any = getMatchUpCompetitiveProfile({
+      policyDefinitions: DEFAULT_POLICY,
+      scaleName: WTN,
+      matchUp,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.signedDelta).toBeUndefined();
+    expect(result.competitiveness).toEqual(COMPETITIVE);
+  });
+
+  it('surfaces an unresolvable scale orientation as an error', () => {
+    const matchUp: any = {
+      ...singlesMatchUp({ ownRating: 20, oppRating: 25, winningSide: 1 }),
+      sides: [
+        {
+          sideNumber: 1,
+          participant: {
+            participantId: 'p1',
+            ratings: { [SINGLES]: [{ scaleName: 'HOUSE_LADDER', scaleValue: 10 }] },
+          },
+        },
+        {
+          sideNumber: 2,
+          participant: {
+            participantId: 'opp',
+            ratings: { [SINGLES]: [{ scaleName: 'HOUSE_LADDER', scaleValue: 14 }] },
+          },
+        },
+      ],
+    };
+
+    const result: any = getMatchUpCompetitiveProfile({
+      policyDefinitions: DEFAULT_POLICY,
+      scaleName: 'HOUSE_LADDER',
+      matchUp,
+    });
+    expect(result.error).toEqual(MISSING_VALUE);
+
+    // ...and an explicit orientation makes the same data resolvable. `maxPct`
+    // still cannot apply to a range-less scale, so bands come in absolute units.
+    const oriented: any = getMatchUpCompetitiveProfile({
+      deltaBands: [{ key: DOWN, max: -1 }, { key: EVEN, max: 1 }, { key: UP }],
+      scaleName: 'HOUSE_LADDER',
+      ascending: false,
+      matchUp,
+    });
+    expect(oriented.signedDelta).toEqual(4);
+    expect(oriented.deltaBand).toEqual(UP);
+  });
+
+  it('surfaces an invalid deltaBands policy rather than dropping the band', () => {
+    const matchUp: any = singlesMatchUp({ ownRating: 20, oppRating: 25, winningSide: 1 });
+    const result: any = getMatchUpCompetitiveProfile({
+      deltaBands: [{ key: UP, max: 4, maxPct: 10 }, { key: STRETCH }],
+      scaleName: WTN,
+      matchUp,
+    });
+    expect(result.error).toEqual(INVALID_POLICY_DEFINITION);
+    expect(result.competitiveness).toBeUndefined();
+  });
+
+  it('averages a doubles pair rather than summing it', () => {
+    const pair = (participantId: string, ratings: number[]) => ({
+      participantId,
+      individualParticipants: ratings.map((wtnRating, index) => ({
+        participantId: `${participantId}-${index}`,
+        ratings: { [DOUBLES]: [{ scaleName: WTN, scaleValue: { wtnRating } }] },
+      })),
+    });
+
+    const matchUp: any = {
+      matchUpType: DOUBLES,
+      winningSide: 1,
+      score: { sets: COMPETITIVE_SETS },
+      sides: [
+        { sideNumber: 1, participant: pair('pair1', [20, 22]) },
+        { sideNumber: 2, participant: pair('pair2', [24, 26]) },
+      ],
+    };
+
+    const result: any = getMatchUpCompetitiveProfile({
+      policyDefinitions: DEFAULT_POLICY,
+      scaleName: WTN,
+      matchUp,
+    });
+
+    // Means are 21 and 25 => -4, which is DOWN. Summing would give 42 vs 50 =>
+    // -8 => ANCHOR, so this assertion discriminates the two implementations.
+    expect(result.signedDelta).toEqual(-4);
+    expect(result.deltaBand).toEqual(DOWN);
+  });
+
+  it('an individual with no rating makes the whole pair unrated', () => {
+    const matchUp: any = {
+      matchUpType: DOUBLES,
+      winningSide: 1,
+      score: { sets: COMPETITIVE_SETS },
+      sides: [
+        {
+          sideNumber: 1,
+          participant: {
+            participantId: 'pair1',
+            individualParticipants: [
+              { participantId: 'a', ratings: { [DOUBLES]: [{ scaleName: WTN, scaleValue: { wtnRating: 20 } }] } },
+              { participantId: 'b' },
+            ],
+          },
+        },
+        {
+          sideNumber: 2,
+          participant: {
+            participantId: 'pair2',
+            individualParticipants: [
+              { participantId: 'c', ratings: { [DOUBLES]: [{ scaleName: WTN, scaleValue: { wtnRating: 24 } }] } },
+              { participantId: 'd', ratings: { [DOUBLES]: [{ scaleName: WTN, scaleValue: { wtnRating: 26 } }] } },
+            ],
+          },
+        },
+      ],
+    };
+
+    const result: any = getMatchUpCompetitiveProfile({
+      policyDefinitions: DEFAULT_POLICY,
+      scaleName: WTN,
+      matchUp,
+    });
+    expect(result.signedDelta).toBeUndefined();
+    expect(result.error).toBeUndefined();
+  });
+});
+
+describe('predictMatchUpCompetitiveBands — signed delta is additive', () => {
+  it('returns exactly the pre-existing shape when no orientation is requested', () => {
+    const result: any = predictMatchUpCompetitiveBands({ side1Rating: 4.5, side2Rating: 5 });
+
+    expect(Object.keys(result).toSorted((a, b) => a.localeCompare(b))).toEqual([
+      'competitive',
+      'decisive',
+      'delta',
+      'routine',
+    ]);
+    expect(result.delta).toEqual(0.5);
+    expect(result.signedDelta).toBeUndefined();
+  });
+
+  it('keeps delta ABSOLUTE while adding the signed value', () => {
+    const utr: any = predictMatchUpCompetitiveBands({
+      policyDefinitions: DEFAULT_POLICY,
+      side1Rating: 4.5,
+      side2Rating: 5,
+      scaleName: UTR,
+    });
+
+    expect(utr.delta).toEqual(0.5); // unchanged: |4.5 - 5|
+    expect(utr.signedDelta).toEqual(0.5); // UTR: higher is stronger, so side 2 was tougher
+    // 10.3% of UTR's 15-point range is 1.545, and 1.3% is 0.195 => UP.
+    expect(utr.deltaBand).toEqual(UP);
+
+    const wtn: any = predictMatchUpCompetitiveBands({
+      policyDefinitions: DEFAULT_POLICY,
+      side1Rating: 4.5,
+      side2Rating: 5,
+      scaleName: WTN,
+    });
+
+    expect(wtn.delta).toEqual(0.5);
+    expect(wtn.signedDelta).toEqual(-0.5); // WTN: lower is stronger — playing down
+    // 1.3% of WTN's 39-point range is 0.507, so -0.5 is inside EVEN.
+    expect(wtn.deltaBand).toEqual(EVEN);
+
+    // Same ratings, same prediction — only the exposure reading differs.
+    expect(wtn.competitive).toEqual(utr.competitive);
+  });
+
+  it('returns the signed delta with no band when policy declares no deltaBands', () => {
+    const result: any = predictMatchUpCompetitiveBands({
+      policyDefinitions: REALIZED_ONLY_POLICY,
+      side1Rating: 4.5,
+      side2Rating: 5,
+      scaleName: UTR,
+    });
+    expect(result.signedDelta).toEqual(0.5);
+    expect(result.deltaBand).toBeUndefined();
+  });
+
+  it('errors when an orientation was requested but cannot be established', () => {
+    const result: any = predictMatchUpCompetitiveBands({
+      side1Rating: 4.5,
+      side2Rating: 5,
+      scaleName: 'HOUSE_LADDER',
+    });
+    expect(result.error).toEqual(MISSING_VALUE);
+    expect(result.competitive).toEqual(0);
+  });
+
+  it('accepts an explicit ascending with absolute-unit bands and no scaleName', () => {
+    const result: any = predictMatchUpCompetitiveBands({
+      deltaBands: [{ key: DOWN, max: -0.25 }, { key: EVEN, max: 0.25 }, { key: UP }],
+      side1Rating: 4.5,
+      side2Rating: 5,
+      ascending: false,
+    });
+    expect(result.signedDelta).toEqual(0.5);
+    expect(result.deltaBand).toEqual(UP);
+    expect(result.delta).toEqual(0.5);
+  });
+});
+
+describe('getCompetitiveProfile — pure aggregate over a matchUp array', () => {
+  // Six matchUps for p1 (WTN 20) plus one it is not in. Deltas: -5 ANCHOR,
+  // -4 DOWN, 0 EVEN, +4 UP, +5 STRETCH, and one unrated opponent.
+  const matchUps: any[] = [
+    singlesMatchUp({
+      ownRating: 20,
+      oppRating: 25,
+      winningSide: 1,
+      sets: [
+        { side1Score: 6, side2Score: 0 },
+        { side1Score: 6, side2Score: 0 },
+      ],
+    }),
+    singlesMatchUp({
+      ownRating: 20,
+      oppRating: 24,
+      winningSide: 1,
+      sets: [
+        { side1Score: 6, side2Score: 2 },
+        { side1Score: 6, side2Score: 2 },
+      ],
+    }),
+    singlesMatchUp({
+      ownRating: 20,
+      oppRating: 20,
+      winningSide: 2,
+      sets: [
+        { side1Score: 4, side2Score: 6 },
+        { side1Score: 3, side2Score: 6 },
+      ],
+    }),
+    singlesMatchUp({
+      ownRating: 20,
+      oppRating: 16,
+      winningSide: 2,
+      sets: [
+        { side1Score: 2, side2Score: 6 },
+        { side1Score: 2, side2Score: 6 },
+      ],
+    }),
+    // Not yet played: exposure is known, realized is not.
+    singlesMatchUp({ ownRating: 20, oppRating: 15 }),
+    singlesMatchUp({
+      ownRating: 20,
+      oppRating: undefined,
+      winningSide: 1,
+      sets: [
+        { side1Score: 6, side2Score: 1 },
+        { side1Score: 6, side2Score: 1 },
+      ],
+    }),
+    singlesMatchUp({ ownId: 'q1', oppId: 'q2', ownRating: 30, oppRating: 31, winningSide: 1 }),
+  ];
+
+  it('counts both axes, with exact counts and ratios', () => {
+    const profile: any = getCompetitiveProfile({
+      policyDefinitions: DEFAULT_POLICY,
+      participantId: 'p1',
+      scaleName: WTN,
+      matchUps,
+    });
+
+    expect(profile.matchUpsCount).toEqual(6); // the q1-vs-q2 matchUp is filtered out
+    expect(profile.participantId).toEqual('p1');
+
+    // Realized: only matchUps with a winningSide. 0% and 17% are DECISIVE,
+    // 33% twice is ROUTINE, 58% is COMPETITIVE.
+    expect(profile.realized.completed).toEqual(5);
+    expect(profile.realized.counts).toEqual({ [DECISIVE]: 2, [ROUTINE]: 2, [COMPETITIVE]: 1 });
+    expect(profile.realized.ratios).toEqual({ [DECISIVE]: 40, [ROUTINE]: 40, [COMPETITIVE]: 20 });
+
+    // Exposure: the unplayed matchUp counts, the unrated one does not.
+    expect(profile.exposure.rated).toEqual(5);
+    expect(profile.exposure.unrated).toEqual(1);
+    expect(profile.exposure.counts).toEqual({
+      [ANCHOR]: 1,
+      [DOWN]: 1,
+      [EVEN]: 1,
+      [UP]: 1,
+      [STRETCH]: 1,
+    });
+    expect(profile.exposure.ratios).toEqual({
+      [ANCHOR]: 20,
+      [DOWN]: 20,
+      [EVEN]: 20,
+      [UP]: 20,
+      [STRETCH]: 20,
+    });
+    expect(profile.exposure.meanSignedDelta).toEqual(0); // (-5 - 4 + 0 + 4 + 5) / 5
+    expect(profile.exposure.deltaBandsApplied).toEqual(true);
+  });
+
+  it('zero-fills every band the policy declares, so a bar always has N segments', () => {
+    const profile: any = getCompetitiveProfile({
+      policyDefinitions: DEFAULT_POLICY,
+      matchUps: [singlesMatchUp({ ownRating: 20, oppRating: 20, winningSide: 1 })],
+      participantId: 'p1',
+      scaleName: WTN,
+    });
+
+    expect(profile.exposure.counts).toEqual({
+      [ANCHOR]: 0,
+      [DOWN]: 0,
+      [EVEN]: 1,
+      [UP]: 0,
+      [STRETCH]: 0,
+    });
+  });
+
+  it('reports deltas with no bands when policy declares no deltaBands', () => {
+    const profile: any = getCompetitiveProfile({
+      policyDefinitions: REALIZED_ONLY_POLICY,
+      participantId: 'p1',
+      scaleName: WTN,
+      matchUps,
+    });
+
+    expect(profile.exposure.deltaBandsApplied).toEqual(false);
+    expect(profile.exposure.counts).toEqual({});
+    expect(profile.exposure.ratios).toEqual({});
+    // The delta axis itself still resolved — only the labelling was withheld.
+    expect(profile.exposure.rated).toEqual(5);
+    expect(profile.exposure.meanSignedDelta).toEqual(0);
+    expect(profile.realized.counts).toEqual({ [DECISIVE]: 2, [ROUTINE]: 2, [COMPETITIVE]: 1 });
+  });
+
+  it('leaves the exposure axis idle when no scale is given', () => {
+    const profile: any = getCompetitiveProfile({ policyDefinitions: DEFAULT_POLICY, participantId: 'p1', matchUps });
+
+    expect(profile.exposure.rated).toEqual(0);
+    expect(profile.exposure.unrated).toEqual(0);
+    expect(profile.exposure.meanSignedDelta).toBeUndefined();
+    expect(profile.realized.counts).toEqual({ [DECISIVE]: 2, [ROUTINE]: 2, [COMPETITIVE]: 1 });
+  });
+
+  it('takes side 1 as the perspective when no participantId is given', () => {
+    const profile: any = getCompetitiveProfile({
+      policyDefinitions: DEFAULT_POLICY,
+      scaleName: WTN,
+      matchUps,
+    });
+
+    expect(profile.matchUpsCount).toEqual(7); // no participant filter
+    expect(profile.participantId).toBeUndefined();
+    // Side 1 of the extra matchUp is WTN 30 against 31 => -1 => DOWN.
+    expect(profile.exposure.counts[DOWN]).toEqual(2);
+    expect(profile.exposure.rated).toEqual(6);
+  });
+
+  it('surfaces an invalid deltaBands policy once, not per matchUp', () => {
+    const profile: any = getCompetitiveProfile({
+      deltaBands: [{ key: DOWN, max: 1 }, { key: UP, max: 1 }, { key: STRETCH }],
+      participantId: 'p1',
+      scaleName: WTN,
+      matchUps,
+    });
+    expect(profile.error).toEqual(INVALID_POLICY_DEFINITION);
+    expect(profile.realized).toBeUndefined();
+  });
+
+  it('rejects a non-array matchUps argument', () => {
+    expect(getCompetitiveProfile({ matchUps: undefined as any }).error).toBeDefined();
+  });
+
+  it('returns empty counts for a participant with no matchUps', () => {
+    const profile: any = getCompetitiveProfile({
+      policyDefinitions: DEFAULT_POLICY,
+      participantId: 'nobody',
+      scaleName: WTN,
+      matchUps,
+    });
+
+    expect(profile.matchUpsCount).toEqual(0);
+    expect(profile.realized.counts).toEqual({ [DECISIVE]: 0, [ROUTINE]: 0, [COMPETITIVE]: 0 });
+    expect(profile.realized.ratios).toEqual({ [DECISIVE]: 0, [ROUTINE]: 0, [COMPETITIVE]: 0 });
+    expect(profile.exposure.meanSignedDelta).toBeUndefined();
+  });
+});

--- a/src/tests/queries/matchUps/deltaBandResolution.test.ts
+++ b/src/tests/queries/matchUps/deltaBandResolution.test.ts
@@ -1,9 +1,11 @@
 import {
   resolveDeltaBoundaries,
   resolveScaleOrientation,
+  bandFromBoundaries,
   signedRatingDelta,
   resolveDeltaBand,
 } from '@Query/matchUp/resolveDeltaBand';
+import * as tools from '@Assemblies/tools';
 import { describe, expect, it } from 'vitest';
 
 // constants and fixtures
@@ -78,6 +80,37 @@ describe('resolveDeltaBand — band count and names come from policy', () => {
     const bands = [{ key: 'ALL' }];
     expect(resolveDeltaBand(-99, bands).band).toEqual('ALL');
     expect(resolveDeltaBand(99, bands).band).toEqual('ALL');
+  });
+});
+
+describe('the corpus path — validate once, then walk', () => {
+  it('agrees with resolveDeltaBand on every delta', () => {
+    const bands = [
+      { key: ANCHOR, maxPct: -10.3 },
+      { key: DOWN, maxPct: -1.3 },
+      { key: EVEN, maxPct: 1.3 },
+      { key: UP, maxPct: 10.3 },
+      { key: STRETCH },
+    ];
+    const { boundaries } = resolveDeltaBoundaries(bands, WTN);
+    expect(boundaries).toHaveLength(5);
+
+    // The per-row walk must not drift from the validating single call — that
+    // divergence is the whole failure mode this module exists to remove.
+    const deltas = [-20, -4.017, -4.016, -0.507, -0.506, 0, 0.507, 4.017, 4.018, 20];
+    const walked = deltas.map((delta) => bandFromBoundaries(delta, boundaries as any));
+    const resolved = deltas.map((delta) => resolveDeltaBand(delta, bands, WTN).band);
+    expect(walked).toEqual(resolved);
+    expect(walked).toEqual([ANCHOR, ANCHOR, DOWN, DOWN, EVEN, EVEN, EVEN, UP, STRETCH, STRETCH]);
+  });
+
+  it('is reachable on the public tools surface', () => {
+    // Guards the barrel specifically: the assertions above import the module
+    // directly and would still pass if the public export were dropped.
+    for (const name of ['resolveDeltaBand', 'resolveDeltaBoundaries', 'bandFromBoundaries', 'signedRatingDelta']) {
+      expect(typeof tools[name]).toEqual('function');
+    }
+    expect(tools.resolveDeltaBand(-5, FIVE_BANDS).band).toEqual(ANCHOR);
   });
 });
 

--- a/src/tests/queries/matchUps/deltaBandResolution.test.ts
+++ b/src/tests/queries/matchUps/deltaBandResolution.test.ts
@@ -1,0 +1,240 @@
+import {
+  resolveDeltaBoundaries,
+  resolveScaleOrientation,
+  signedRatingDelta,
+  resolveDeltaBand,
+} from '@Query/matchUp/resolveDeltaBand';
+import { describe, expect, it } from 'vitest';
+
+// constants and fixtures
+import { INVALID_POLICY_DEFINITION, INVALID_VALUES, MISSING_VALUE } from '@Constants/errorConditionConstants';
+import { ANCHOR, DOWN, EVEN, STRETCH, UP } from '@Constants/statsConstants';
+import { ELO, UTR, WTN } from '@Constants/ratingConstants';
+
+// WTN range is [40, 1] => magnitude 39, and `ascending: true` (lower is stronger).
+// UTR range is [1, 16] => magnitude 15, and `ascending: false`.
+const WTN_RANGE_MAGNITUDE = 39;
+
+// Absolute-unit bands need no scale at all — nothing to convert.
+const FIVE_BANDS = [
+  { key: ANCHOR, max: -4 },
+  { key: DOWN, max: -0.5 },
+  { key: EVEN, max: 0.5 },
+  { key: UP, max: 4 },
+  { key: STRETCH },
+];
+
+describe('resolveDeltaBand — band count and names come from policy', () => {
+  it('resolves 2 bands', () => {
+    const bands = [{ key: 'LOWER', max: 0 }, { key: 'UPPER' }];
+    expect(resolveDeltaBand(-1, bands).band).toEqual('LOWER');
+    expect(resolveDeltaBand(0, bands).band).toEqual('LOWER'); // boundary is inclusive
+    expect(resolveDeltaBand(0.1, bands).band).toEqual('UPPER');
+  });
+
+  it('resolves 3 bands', () => {
+    const bands = [{ key: 'A', max: -1 }, { key: 'B', max: 1 }, { key: 'C' }];
+    const resolved = [-2, -1, 0, 1, 1.5].map((delta) => resolveDeltaBand(delta, bands).band);
+    expect(resolved).toEqual(['A', 'A', 'B', 'B', 'C']);
+  });
+
+  it('resolves 5 bands, boundaries inclusive on the upper edge', () => {
+    const deltas = [-4, -3.99, -0.5, -0.49, 0.5, 0.51, 4, 4.01];
+    const resolved = deltas.map((delta) => resolveDeltaBand(delta, FIVE_BANDS).band);
+    expect(resolved).toEqual([ANCHOR, DOWN, DOWN, EVEN, EVEN, UP, UP, STRETCH]);
+  });
+
+  it('resolves 9 bands', () => {
+    const bands: any[] = [-4, -3, -2, -1, 0, 1, 2, 3].map((max, index) => ({ key: `B${index}`, max }));
+    bands.push({ key: 'B8' });
+
+    expect(resolveDeltaBoundaries(bands).boundaries).toHaveLength(9);
+
+    const resolved = [-5, -4, -3.5, 0, 0.5, 3, 3.5].map((delta) => resolveDeltaBand(delta, bands).band);
+    expect(resolved).toEqual(['B0', 'B0', 'B1', 'B4', 'B5', 'B7', 'B8']);
+  });
+
+  it('supports asymmetric boundaries — +2 up against -4 down', () => {
+    const asymmetric = [
+      { key: ANCHOR, max: -4 },
+      { key: DOWN, max: -0.5 },
+      { key: EVEN, max: 0.5 },
+      { key: UP, max: 2 },
+      { key: STRETCH },
+    ];
+    // -3 is DOWN here but +3 is already STRETCH: the same magnitude lands in
+    // different bands, which is the whole point of the ordered list.
+    expect(resolveDeltaBand(-3, asymmetric).band).toEqual(DOWN);
+    expect(resolveDeltaBand(3, asymmetric).band).toEqual(STRETCH);
+    expect(resolveDeltaBand(2, asymmetric).band).toEqual(UP);
+  });
+
+  it('the first entry is open-ended below and the last open-ended above', () => {
+    expect(resolveDeltaBand(-1_000_000, FIVE_BANDS).band).toEqual(ANCHOR);
+    expect(resolveDeltaBand(1_000_000, FIVE_BANDS).band).toEqual(STRETCH);
+  });
+
+  it('a single-entry list is a valid (degenerate) policy — one band catches everything', () => {
+    const bands = [{ key: 'ALL' }];
+    expect(resolveDeltaBand(-99, bands).band).toEqual('ALL');
+    expect(resolveDeltaBand(99, bands).band).toEqual('ALL');
+  });
+});
+
+describe('resolveDeltaBand — maxPct is a percentage of the scale range', () => {
+  it('converts maxPct against the scale range magnitude', () => {
+    const { boundaries } = resolveDeltaBoundaries([{ key: UP, maxPct: 10.3 }, { key: STRETCH }], WTN);
+    expect(boundaries?.[0].max).toBeCloseTo((10.3 / 100) * WTN_RANGE_MAGNITUDE, 10);
+    expect(boundaries?.[0].max).toBeCloseTo(4.017, 10);
+    expect(boundaries?.[1].max).toBeUndefined();
+  });
+
+  it('maxPct and the equivalent max resolve identically', () => {
+    const asPct = [{ key: UP, maxPct: 10.3 }, { key: STRETCH }];
+    const asUnits = [{ key: UP, max: 4.017 }, { key: STRETCH }];
+
+    for (const delta of [-10, 0, 4, 4.016, 4.018, 10]) {
+      expect(resolveDeltaBand(delta, asPct, WTN).band).toEqual(resolveDeltaBand(delta, asUnits, WTN).band);
+    }
+    expect(resolveDeltaBand(4, asPct, WTN).band).toEqual(UP);
+    expect(resolveDeltaBand(4.018, asPct, WTN).band).toEqual(STRETCH);
+  });
+
+  it('the SAME maxPct policy yields different absolute boundaries per scale', () => {
+    const bands = [{ key: UP, maxPct: 10 }, { key: STRETCH }];
+    // 10% of WTN's 39-point range is 3.9; of UTR's 15-point range, 1.5; of
+    // ELO's 3000-point range, 300. This portability is why the shipped default
+    // uses maxPct.
+    expect(resolveDeltaBoundaries(bands, WTN).boundaries?.[0].max).toBeCloseTo(3.9, 10);
+    expect(resolveDeltaBoundaries(bands, UTR).boundaries?.[0].max).toBeCloseTo(1.5, 10);
+    expect(resolveDeltaBoundaries(bands, ELO).boundaries?.[0].max).toBeCloseTo(300, 10);
+  });
+
+  it('errors on maxPct against a scale with no range — never a silent fallback to absolute units', () => {
+    const bands = [{ key: UP, maxPct: 10.3 }, { key: STRETCH }];
+
+    const unknownScale: any = resolveDeltaBand(4, bands, 'NOT_A_REGISTERED_SCALE');
+    expect(unknownScale.error).toEqual(INVALID_POLICY_DEFINITION);
+    expect(unknownScale.info).toContain('maxPct');
+    expect(unknownScale.band).toBeUndefined();
+
+    const noScale: any = resolveDeltaBand(4, bands);
+    expect(noScale.error).toEqual(INVALID_POLICY_DEFINITION);
+    expect(noScale.band).toBeUndefined();
+
+    // Falsification: the same shape in absolute units is accepted with no
+    // scaleName, so the rejection above is about maxPct, not about the list.
+    expect(resolveDeltaBand(4, [{ key: UP, max: 4.017 }, { key: STRETCH }]).band).toEqual(UP);
+  });
+});
+
+describe('resolveDeltaBand — policy validation', () => {
+  it('rejects an entry declaring both max and maxPct', () => {
+    const result: any = resolveDeltaBand(0, [{ key: UP, max: 4, maxPct: 10 }, { key: STRETCH }], WTN);
+    expect(result.error).toEqual(INVALID_POLICY_DEFINITION);
+    expect(result.info).toContain('both max and maxPct');
+  });
+
+  it('rejects a bounded final entry — it must catch the remainder', () => {
+    const result: any = resolveDeltaBand(
+      0,
+      [
+        { key: DOWN, max: -1 },
+        { key: UP, max: 1 },
+      ],
+      WTN,
+    );
+    expect(result.error).toEqual(INVALID_POLICY_DEFINITION);
+    expect(result.info).toContain('final entry');
+  });
+
+  it('rejects a non-final entry with no bound', () => {
+    const result: any = resolveDeltaBand(0, [{ key: DOWN }, { key: UP, max: 1 }, { key: STRETCH }], WTN);
+    expect(result.error).toEqual(INVALID_POLICY_DEFINITION);
+    expect(result.info).toContain('requires max or maxPct');
+  });
+
+  it('rejects boundaries that do not ascend — an out-of-order band is unreachable', () => {
+    const result: any = resolveDeltaBand(0, [{ key: UP, max: 4 }, { key: DOWN, max: -4 }, { key: STRETCH }]);
+    expect(result.error).toEqual(INVALID_POLICY_DEFINITION);
+    expect(result.info).toContain('ascend');
+  });
+
+  it('rejects duplicate boundaries (equal is not ascending)', () => {
+    const result: any = resolveDeltaBand(0, [{ key: 'A', max: 1 }, { key: 'B', max: 1 }, { key: 'C' }]);
+    expect(result.error).toEqual(INVALID_POLICY_DEFINITION);
+  });
+
+  it('rejects a non-finite bound', () => {
+    const result: any = resolveDeltaBand(0, [{ key: 'A', max: Number.NaN }, { key: 'B' }]);
+    expect(result.error).toEqual(INVALID_POLICY_DEFINITION);
+    expect(result.info).toContain('finite');
+  });
+
+  it('rejects an entry with no key', () => {
+    const result: any = resolveDeltaBand(0, [{ max: 1 } as any, { key: 'B' }]);
+    expect(result.error).toEqual(INVALID_POLICY_DEFINITION);
+    expect(result.info).toContain('key');
+  });
+
+  it('rejects a missing or empty deltaBands list', () => {
+    expect(resolveDeltaBand(0).error).toEqual(MISSING_VALUE);
+    expect(resolveDeltaBand(0, []).error).toEqual(MISSING_VALUE);
+    expect(resolveDeltaBoundaries(undefined, WTN).error).toEqual(MISSING_VALUE);
+  });
+
+  it('rejects a non-finite signedDelta', () => {
+    for (const delta of [Number.NaN, Number.POSITIVE_INFINITY, undefined as any, '2' as any]) {
+      const result: any = resolveDeltaBand(delta, FIVE_BANDS);
+      expect(result.error).toEqual(INVALID_VALUES);
+      expect(result.band).toBeUndefined();
+    }
+  });
+});
+
+describe('sign orientation is resolved inside the factory', () => {
+  it('flips with ratingsParameters.ascending', () => {
+    // WTN ascending: true (lower is stronger) — a HIGHER own value means the
+    // opponent was stronger, so own - opp.
+    expect(signedRatingDelta({ ownRating: 10, oppRating: 12, scaleName: WTN }).signedDelta).toEqual(-2);
+    // UTR ascending: false (higher is stronger) — opp - own.
+    expect(signedRatingDelta({ ownRating: 10, oppRating: 12, scaleName: UTR }).signedDelta).toEqual(2);
+  });
+
+  it('is oriented so positive always means the tougher opponent', () => {
+    // WTN 20 vs a stronger (lower) 15 => playing up.
+    expect(signedRatingDelta({ ownRating: 20, oppRating: 15, scaleName: WTN }).signedDelta).toEqual(5);
+    // UTR 5 vs a stronger (higher) 10 => playing up.
+    expect(signedRatingDelta({ ownRating: 5, oppRating: 10, scaleName: UTR }).signedDelta).toEqual(5);
+  });
+
+  it('an explicit ascending overrides the scale', () => {
+    expect(signedRatingDelta({ ownRating: 10, oppRating: 12, scaleName: WTN, ascending: false }).signedDelta).toEqual(
+      2,
+    );
+    expect(resolveScaleOrientation({ scaleName: WTN, ascending: false }).ascending).toEqual(false);
+  });
+
+  it('errors when orientation cannot be established — never assumes a direction', () => {
+    const unknown: any = signedRatingDelta({ ownRating: 10, oppRating: 12, scaleName: 'HOUSE_LADDER' });
+    expect(unknown.error).toEqual(MISSING_VALUE);
+    expect(unknown.signedDelta).toBeUndefined();
+
+    expect(resolveScaleOrientation({}).error).toEqual(MISSING_VALUE);
+
+    // ...but an explicit orientation makes the same custom scale usable.
+    const explicit = signedRatingDelta({ ownRating: 10, oppRating: 12, scaleName: 'HOUSE_LADDER', ascending: true });
+    expect(explicit.signedDelta).toEqual(-2);
+  });
+
+  it('errors on non-numeric ratings', () => {
+    expect(signedRatingDelta({ ownRating: 10, scaleName: WTN }).error).toEqual(INVALID_VALUES);
+    expect(signedRatingDelta({ ownRating: Number.NaN, oppRating: 3, scaleName: WTN }).error).toEqual(INVALID_VALUES);
+  });
+
+  it('resolves scale orientation for every scale it is asked about', () => {
+    expect(resolveScaleOrientation({ scaleName: WTN }).ascending).toEqual(true);
+    expect(resolveScaleOrientation({ scaleName: UTR }).ascending).toEqual(false);
+    expect(resolveScaleOrientation({ scaleName: ELO }).ascending).toEqual(false);
+  });
+});

--- a/src/types/factoryEngineMethods.ts
+++ b/src/types/factoryEngineMethods.ts
@@ -254,6 +254,7 @@ export type FactoryEngineMethod =
   | 'getCompetitionPolicy'
   | 'getCompetitionState'
   | 'getCompetitionVenues'
+  | 'getCompetitiveProfile'
   | 'getCourtInfo'
   | 'getCourts'
   | 'getDevContext'
@@ -297,6 +298,7 @@ export type FactoryEngineMethod =
   | 'getMatchUpFormatTiming'
   | 'getMatchUpFormatTimingUpdate'
   | 'getMatchUpFormatVariance'
+  | 'getMatchUpRatingDelta'
   | 'getMatchUpScheduleDetails'
   | 'getMatchUpsMap'
   | 'getMatchUpsStats'
@@ -907,6 +909,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'getCompetitionPolicy',
   'getCompetitionState',
   'getCompetitionVenues',
+  'getCompetitiveProfile',
   'getCourtInfo',
   'getCourts',
   'getDevContext',
@@ -950,6 +953,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'getMatchUpFormatTiming',
   'getMatchUpFormatTimingUpdate',
   'getMatchUpFormatVariance',
+  'getMatchUpRatingDelta',
   'getMatchUpScheduleDetails',
   'getMatchUpsMap',
   'getMatchUpsStats',

--- a/src/types/methodSignatures.ts
+++ b/src/types/methodSignatures.ts
@@ -368,6 +368,7 @@ import type { applyLineUps } from '@Mutate/matchUps/lineUps/applyLineUps';
 import type { calculateMatchUpMargin } from '@Query/matchUp/calculateMatchUpMargin';
 import type { checkMatchUpIsComplete } from '@Query/matchUp/checkMatchUpIsComplete';
 import type { getAggregateTeamResults } from '@Query/scales/getAggregateTeamResults';
+import type { getCompetitiveProfile } from '@Query/matchUps/getCompetitiveProfile';
 import type { getPredictiveAccuracy } from '@Query/matchUps/getPredictiveAccuracy';
 import type { getSchedulingProfile, setSchedulingProfile } from '@Mutate/tournaments/schedulingProfile';
 import type { publishParticipants } from '@Mutate/timeItems/publishParticipants';
@@ -393,6 +394,7 @@ import type { deleteDrawDefinitions } from '@Mutate/events/deleteDrawDefinitions
 import type { getAppliedPolicies, getPolicyDefinitions } from '@Query/extensions/getAppliedPolicies';
 import type { getEventInconsistencies } from '@Query/event/getEventInconsistencies';
 import type { getMatchUpFormat } from '@Query/hierarchical/getMatchUpFormat';
+import type { getMatchUpRatingDelta } from '@Query/matchUp/getMatchUpRatingDelta';
 import type { getRounds } from '@Query/matchUps/scheduling/getRounds';
 import type { getTournamentInfo } from '@Query/tournaments/getTournamentInfo';
 import type { hydrateTournamentRecord } from '@Mutate/base/hydrateTournamentRecord';
@@ -811,6 +813,7 @@ export interface MethodSignatures {
   getCompetitionPolicy: EngineMethod<typeof getCompetitionPolicy>;
   getCompetitionState: EngineMethod<typeof getCompetitionState>;
   getCompetitionVenues: EngineMethod<typeof getCompetitionVenues>;
+  getCompetitiveProfile: EngineMethod<typeof getCompetitiveProfile>;
   getCourtInfo: EngineMethod<typeof getCourtInfo>;
   getCourts: EngineMethod<typeof getCourts>;
   getDraftState: EngineMethod<typeof getDraftState>;
@@ -852,6 +855,7 @@ export interface MethodSignatures {
   getMatchUpFormatTiming: EngineMethod<typeof getMatchUpFormatTiming>;
   getMatchUpFormatTimingUpdate: EngineMethod<typeof getMatchUpFormatTimingUpdate>;
   getMatchUpFormatVariance: EngineMethod<typeof getMatchUpFormatVariance>;
+  getMatchUpRatingDelta: EngineMethod<typeof getMatchUpRatingDelta>;
   getMatchUpScheduleDetails: EngineMethod<typeof getMatchUpScheduleDetails>;
   getMatchUpsMap: EngineMethod<typeof getMatchUpsMap>;
   getMatchUpsStats: EngineMethod<typeof getMatchUpsStats>;


### PR DESCRIPTION
Implements **§8A** of `Mentat/planning/COMPETITIVE_FINGERPRINT.md` — a *signed exposure* axis alongside the existing *realized competitiveness* axis.

## What this is

| Axis | Policy block | Scalar | Domain | Bands |
|---|---|---|---|---|
| **Realized** competitiveness | `profileBands` | score spread | unsigned, 0–100 | exactly 3, named in code |
| **Signed exposure** (new) | `deltaBands` | rating delta | signed, unbounded | N, named in policy |

These are orthogonal. This is **not** a widening of the three unsigned bands: `profileBands` / DECISIVE / ROUTINE / COMPETITIVE behave exactly as before and **no Competitive Ratio figure moves**.

## Why now

Analysis scripts in `courthive-ingest` each carry their own copy of the threshold and sign-orientation logic. Until this lands, the pipeline and TMX numbers can diverge silently — the mock-divergence class architectural standard A5 exists to prevent. It is also the prerequisite for the TMX in-card fingerprint bar, which must compute locally from IndexedDB state.

## What ships

1. **`deltaBands`** on `POLICY_TYPE_COMPETITIVE_BANDS` + a default in the fixture. An ordered boundary list: N entries produce N bands, the final entry omits its bound and catches the remainder. Band count and names come from policy — contrast `getBand`, which hardcodes exactly three.
2. **`max` XOR `maxPct`.** Absolute rating units, or percent of the scale's range (`(maxPct / 100) * Math.abs(range[1] - range[0])`). Both on one entry is a **validation error**, not a precedence rule. `maxPct` against a scale with no `range` is an **error**, never a silent fallback to absolute units. Non-ascending boundaries and a bounded final entry also error — each would otherwise leave a band unreachable or a delta unbanded.
3. **`resolveDeltaBand(signedDelta, deltaBands, scaleName)`** — generic ordered walk. Plus `resolveDeltaBoundaries` so a caller walking a corpus validates and converts once rather than per row.
4. **Sign orientation inside the factory**, from `ratingsParameters[scale].ascending`, oriented so **positive always means the tougher opponent**. An unknown scale with no explicit `ascending` errors rather than assuming a direction — guessing inverts the meaning of every band.
5. **Additive output** on `getMatchUpCompetitiveProfile` and `predictMatchUpCompetitiveBands` (`signedDelta`, `deltaBand`). The signed axis engages **only** on `scaleName`, so existing callers get byte-identical results; `predict` keeps returning today's absolute `delta` unchanged.
6. **`getCompetitiveProfile({ matchUps, participantId, scaleName, scaleAccessor, policyDefinitions })`** — **pure** over a matchUp array, no storage assumptions. TMX runs it offline against IndexedDB; a server runs the identical code over a corpus.
7. **Default band keys as plain consts** in `statsConstants.ts`, matching the existing three. No enum, no `src/types` registration — `statsConstants` has zero references in `enumConstConformance.test.ts`, so there was never an enum to fall off.
8. **Docusaurus page** — `documentation/docs/policies/competitiveBands.md` gains a full "Signed Exposure" section.

## Two decisions worth review

**No fixture fallback for `deltaBands`.** If policy declares none, the signed APIs return the delta and **no band** — never a guessed default. Deliberately asymmetric with `profileBands`, which does fall back to 20/50: those thresholds are long-standing and load-bearing for existing consumers, whereas the default delta boundaries are an explicitly arbitrary cut (≈90th percentile of observed `|delta|` in one corpus) and the symmetry is a convenience, not a claim. Stamping band labels derived from that onto everyone's data would assert something not established.

**`POLICY_COMPETITIVE_BANDS_DEFAULT` added to `fixtures.policies`.** The docs page claimed it was importable from the package; it was not exported anywhere public. Since the point above makes opting in explicit, a consumer needs a way to obtain the default — this is it. Surface addition only; `verify:surface` reports no removals.

A pair's rating is the **mean** of its individuals, not the sum: the boundaries are in single-player units, so a summed pair delta would be systematically ~2× and land in the wrong band. (`getPredictiveAccuracy` sums and compensates with `zoneDoubling`; that only works because its margin is a single scalar rather than a band ladder.)

## Verification

| Gate | Result |
|---|---|
| `pnpm test --run` | **10755 passed** / 1 skipped (baseline 10701 — **+54 new**, 0 regressions) |
| `pnpm test:server` (jest) | 12 passed |
| `pnpm lint` | clean, 0 warnings |
| `pnpm check-types` | clean |
| `pnpm verify:generated` | enum-constants / enum-exports / engine-methods / method-signatures all in sync |
| `pnpm build` | succeeds |
| `pnpm verify:surface` | no exports removed |
| `markdownlint` + `prettier` on touched files | clean |

Tests **assert values, not `success`** — the `zonePct` bug in #4601 survived precisely because its only test asserted `result.success`. Coverage: N-band resolution for N = 1, 2, 3, 5, 9; asymmetric boundaries (`+2` / `-4`); open-ended first and last entries; `max`/`maxPct` equivalence and per-scale portability (WTN 3.9 / UTR 1.5 / ELO 300 for the same `maxPct: 10`); every validation error with its `info`; orientation flipping with `ascending`; a doubles assertion that discriminates mean-of-pair from sum-of-pair; and agreement between the new aggregate and **both** existing realized-band surfaces (`competitiveProfile` enrichment and `getMatchUpsStats`) on seeded data, with a tripwire so that comparison cannot pass vacuously.

The realized-axis assertions were **mutation-tested**: flipping the sign orientation, making the upper boundary exclusive, and removing the range check each produced failures (4, 5, and 1 respectively), so the suite is shown to report "dirty", not just "clean".

