### PR TITLE
test(query): seed the inferredGender DOUBLES mock — it sat on a probabilistic floor

### DIFF
--- a/src/tests/queries/matchUps/inferredGender.test.ts
+++ b/src/tests/queries/matchUps/inferredGender.test.ts
@@ -39,6 +39,14 @@ test('contextProfile can specify inferGender - works with SINGLES', () => {
   expect(igMatchUps.length).toBeGreaterThanOrEqual(1);
 });
 
+// `nonRandom: 1` seeds participant sexes and draw positioning. Without it this
+// test sat on a probabilistic floor: inferredGender requires BOTH pairs to be
+// single-sex AND to agree, so P is 1/2 x 1/2 x 1/2 = 12.5% per matchUp. Measured
+// over 240 unseeded generations of exactly this scenario the mean was ~7.9 of 63
+// matchUps (as predicted) but the tail reached 1, and the 63 matchUps are
+// correlated because the same pairs recur through the rounds — so `>= 1` failed
+// on CI run 31758113547. Seeded, it lands on 12. The SINGLES case above needs no
+// seed: side gender is the individual's own sex, so P is 1/2 per matchUp.
 test('contextProfile can specify inferGender - works with DOUBLES', () => {
   const {
     tournamentRecord,
@@ -46,6 +54,7 @@ test('contextProfile can specify inferGender - works with DOUBLES', () => {
   } = mocksEngine.generateTournamentRecord({
     drawProfiles: [{ drawSize: 64, eventType: DOUBLES }],
     completeAllMatchUps: true,
+    nonRandom: 1,
   });
 
   tournamentEngine.setState(tournamentRecord);


### PR DESCRIPTION
Fixes the flake that failed [CI run 31758113547](https://github.com/CourtHive/competition-factory/actions/runs/31758113547/job/94638307009):

```text
contextProfile can specify inferGender - works with DOUBLES
AssertionError: expected 0 to be greater than or equal to 1
```

**Not infrastructure.** The mock data is unseeded and the assertion sits just above where the distribution actually reaches.

## Why it fails

`inferMatchUpGender` (`src/query/matchUps/addMatchUpContext.ts:622`) sets `inferredGender` only when **both** sides resolve to a single sex **and** the two agree. For DOUBLES that is ½ (side 1 pair same-sex) × ½ (side 2 pair same-sex) × ½ (the two agree) = **12.5% per matchUp**, against a `>= 1` assertion over 63 matchUps.

Measured over **240 unseeded generations** of exactly this scenario (two independent 120-run batches):

| | mean of 63 | min | max | lowest ten |
|---|---|---|---|---|
| batch 1 | 8.00 | 1 | 16 | 1, 2, 2, 3, 3, 3, 3, 4, 4, 4 |
| batch 2 | 7.70 | 1 | 16 | 1, 1, 2, 3, 3, 3, 3, 3, 4, 4 |

Mean ≈ 7.85 against a predicted 63 × 0.125 = 7.9 — the model holds. Naive independence puts P(all 63 miss) at 0.875⁶³ ≈ 2×10⁻⁴, but the 63 matchUps are **correlated** (the same 64 pair participants recur through the rounds), so the real tail is fatter — three generations scored **1** within those 240 samples.

## The fix

`nonRandom: 1` on the DOUBLES mock, which seeds participant sexes and draw positioning. The count then lands on **12**, stable across repeated runs in separate processes.

Two things verified rather than assumed:

- **The seed does not make the assertion vacuous.** Breaking the pair-agreement branch in `inferMatchUpGender` still fails the seeded DOUBLES test — and only that one.
- **The SINGLES case above is left alone.** Its side gender is the individual's own `sex`, so P is ½ per matchUp (measured ≈ 31 of 63) and P(zero) ≈ 0.5⁶³. It needs no seed, and `completeAllMatchUps` outcomes are not fully inside the seeded stream, so `nonRandom: 1` should not be read as making this file bit-deterministic.

For the same reason the assertion stays `>= 1` rather than pinning the exact 12: later-round pairings still depend on unseeded outcomes, so an exact count would risk reintroducing the flake through a different door.

## Provenance

Diagnosed by the `jest-worktree-triage-2026-08-14` session, which handed it over as a note rather than a commit because the path falls inside another session's claimed surface. Independently reproduced (the 240 generations above are this session's own measurements) before applying.

Split out from #4602 deliberately: that PR's title describes a feature, and an unrelated test fix riding inside it is the mixing that architectural standard A8 was written about.
