### PR TITLE
chore(jest): exclude .claude worktrees from test discovery

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -18,5 +18,12 @@ module.exports = {
   collectCoverageFrom: ['**/*.(t|j)s'],
   coverageDirectory: '../coverage',
   testRegex: '.*\\.spec\\.ts$',
+  // `rootDir` is the repo root, so a git worktree checked out under `.claude/worktrees/`
+  // would otherwise be globbed as a second copy of every spec. Those copies resolve
+  // incoherently — aliases map back to `<rootDir>/src` while relative imports hit the
+  // worktree's own (unbuilt) tree — so exclude them from test discovery and from the
+  // haste map (the latter also silences duplicate-package-name collision warnings).
+  testPathIgnorePatterns: ['/node_modules/', '<rootDir>/.claude/'],
+  modulePathIgnorePatterns: ['<rootDir>/.claude/'],
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, { prefix: '<rootDir>/' }),
 };


### PR DESCRIPTION
## Problem

`pnpm test:server` fails for anyone with a git worktree checked out under `.claude/` — 2 failed / 16 passed,
plus three `jest-haste-map: Haste module naming collision` warnings:

```
TypeError: engineAsync.importMethods is not a function
  at getMutationEngine (src/server/providers/factory/engines/mutationEngine.ts:12:17)
```

No source change is involved. `jest.config.cjs` sets `rootDir: '.'` with `testRegex: '.*\.spec\.ts$'` and no
`testPathIgnorePatterns`, so jest discovers every server spec twice — `npx jest --listTests` returns 18 suites
where there should be 9, in exact duplicate pairs.

The duplicate copies then resolve incoherently:

- A worktree has no `dist/` (it was never built), so `import { asyncEngine, globalState } from '../../../..'`
  in `src/server/providers/factory/engines/mutationEngine.ts:1` cannot reach `main: dist/index.js`. Jest falls
  through to the worktree's own `src/index.ts`.
- Meanwhile `moduleNameMapper` is built with `prefix: '<rootDir>/'`, so `@Assemblies/*` and every other alias
  in those same files resolves back to the **main** checkout's `src/`.
- Result: two copies of the global-state module in one graph. `setStateProvider` lands on one, `asyncEngine()`
  reads the other and returns `{"error":{"code":"ERR_MISSING_ASYNC_STATE_PROVIDER"}}` — an error object with
  no `importMethods`. Hence the TypeError, and the 500 in the e2e spec downstream of it.

## Change

Two ignore patterns in `jest.config.cjs`, with a comment recording why so they are not tidied away later.
`modulePathIgnorePatterns` is what removes the haste-map collisions.

## Verification

```
$ pnpm test:server
Test Suites: 9 passed, 9 total
Tests:       12 passed, 12 total
```

No haste-collision warnings. `npx prettier --check jest.config.cjs` clean.

`vitest.config.mts` was never exposed — its `include: ['src/**/*.test.…']` cannot reach `.claude/`, so
`pnpm test` is unaffected by this PR.
