### PR TITLE
feat(sanctioning): retire the redundant sanctioningTier extension

### DIFF
--- a/documentation/docs/engines/sanctioning-engine.md
+++ b/documentation/docs/engines/sanctioning-engine.md
@@ -283,9 +283,9 @@ Because the tier lands on the native `tournamentTier` field, ranking policies re
 sanctioned tournament through the usual `tierToLevel[system][value]` path, with no translation step.
 
 :::note
-A `sanctioningTier` **extension** carrying the tier's value is still written alongside
-`tournamentTier`, for one release, so anything already reading it keeps working. Read
-`tournamentTier`; the extension is scheduled for removal.
+`sanctioningId` is the only extension activation writes. A redundant `sanctioningTier` extension was
+written alongside `tournamentTier` for one release (6.24.0) and was removed in 6.25.0 — read
+`tournamentTier`.
 :::
 
 ```js

--- a/src/mutate/sanctioning/activateFromSanctioning.ts
+++ b/src/mutate/sanctioning/activateFromSanctioning.ts
@@ -153,18 +153,18 @@ export function activateFromSanctioning({ sanctioningRecord, sanctioningPolicy, 
 
     // Store sanctioning reference.
     //
-    // The `sanctioningTier` extension is now REDUNDANT with native `tournamentTier` above, and is
-    // written for one release only so that anything already reading it does not break. It keeps its
-    // original string shape (the tier's value) for exactly that reason. Scheduled for removal in
-    // phase 4 of planning/SANCTIONING_TIER_VOCABULARY.md, one release after this one.
+    // `sanctioningId` is the only extension written here. The tier's home is the native
+    // `tournamentTier` field set above — a canonical value with a native home should not also
+    // arrive as a CODES name/value extension, which is the escape hatch for values that have none.
+    //
+    // A redundant `sanctioningTier` extension was written alongside it for one release (6.24.0) so
+    // that anything already reading it would not break. Nothing did: no reader existed anywhere in
+    // the ecosystem, and no tournament in production ever carried it.
     extensions: [
       {
         name: 'sanctioningId',
         value: sanctioningRecord.sanctioningId,
       },
-      ...(sanctioningRecord.sanctioningTier
-        ? [{ name: 'sanctioningTier', value: sanctioningRecord.sanctioningTier.value }]
-        : []),
     ],
 
     venues: resolveVenues(venues, proposal.venues),

--- a/src/tests/sanctioning/sanctioningActivation.test.ts
+++ b/src/tests/sanctioning/sanctioningActivation.test.ts
@@ -121,14 +121,27 @@ describe('Activation — Tournament Generation', () => {
     const sanctioningExt = tr.extensions.find((e: any) => e.name === 'sanctioningId');
     expect(sanctioningExt).toBeDefined();
     expect(sanctioningExt.value).toBeDefined();
+  });
 
-    const tierExt = tr.extensions.find((e: any) => e.name === 'sanctioningTier');
-    expect(tierExt).toBeDefined();
-    expect(tierExt.value).toEqual('Level 2');
+  // Inverted in phase 4. 6.24.0 wrote a `sanctioningTier` extension alongside the native
+  // `tournamentTier` for exactly one release, so anything reading it had a transition window.
+  // Nothing was: no reader existed in the ecosystem and no production tournament carried it.
+  // The tier's only home is now the native field — a canonical value with a native home must not
+  // also arrive as a CODES escape-hatch extension.
+  it('no longer writes a redundant sanctioningTier extension', () => {
+    createApprovedRecord();
+    let result: any = sanctioningEngine.activateFromSanctioning({ sanctioningPolicy: testPolicy });
+    const tr = result.tournamentRecord;
+
+    expect(tr.extensions.find((e: any) => e.name === 'sanctioningTier')).toBeUndefined();
+    // ...while the tier itself is still present, natively
+    expect(tr.tournamentTier).toEqual({ system: 'GENERIC', value: 'Level 2' });
+    // sanctioningId is the ONLY extension activation writes
+    expect(tr.extensions.map((e: any) => e.name)).toEqual(['sanctioningId']);
   });
 
   // The regression this suite previously had no coverage for: the sanctioned tier used to reach the
-  // tournament ONLY as the name/value extension asserted above, so a tournament born from sanctioning
+  // tournament ONLY as a name/value extension, so a tournament born from sanctioning
   // had no `tournamentTier` and `getEventRankingPoints` resolved no level for it — even when the
   // applicant had explicitly chosen a tier.
   it('sets NATIVE tournamentTier from the sanctioning record', () => {

--- a/src/tests/sanctioning/sanctioningMutations.test.ts
+++ b/src/tests/sanctioning/sanctioningMutations.test.ts
@@ -1023,7 +1023,7 @@ describe('activateFromSanctioning — guard paths', () => {
     expect(record.compliance).toBeUndefined();
   });
 
-  it('generates tournament without sanctioningTier extension or tournamentTier when tier not set', () => {
+  it('generates tournament without a tier extension or tournamentTier when tier not set', () => {
     const record = makeRecord({ status: 'APPROVED' });
     delete (record as any).sanctioningTier;
     let result: any = activateFromSanctioning({ sanctioningRecord: record });


### PR DESCRIPTION
**Phase 4** of [`planning/SANCTIONING_TIER_VOCABULARY.md`](https://github.com/CourtHive/Mentat), one release after the unification landed in **6.24.0**.

## What it removes

`activateFromSanctioning` wrote the sanctioned tier **twice**: natively as `tournamentTier`, and again as a CODES `name`/`value` extension. The extension was kept deliberately for one release so anything already reading it had a transition window rather than a break.

`sanctioningId` is now the only extension activation writes.

## The test is inverted, not deleted

`stores sanctioning reference as extension` previously asserted the tier extension was present. Rather than dropping that coverage, a sibling test now pins the **absence**, and additionally asserts:

- the tier is still there **natively** (`tournamentTier` equals `{ system, value }`), so the removal cannot be mistaken for losing the tier
- `sanctioningId` is the **sole** extension, so a future reintroduction of any redundant extension fails loudly

Verified by restoring the extension write and confirming the new assertion fails — it is not vacuous.

## Verification

- vitest **10768 passed** / 1 skipped (1046 files) — +1 vs the 10767 baseline
- jest 12 passed, lint 0 warnings, `check-types` clean, `verify:generated` in sync
- coverage gate passed — statements 95.08 / branches 86.79 / functions 97.99 / lines 97.60