### PR TITLE
fix(officiating): expose conflict-of-interest methods on officiatingEngine

### DIFF
--- a/documentation/docs/engines/officiating-engine.md
+++ b/documentation/docs/engines/officiating-engine.md
@@ -357,11 +357,23 @@ officiatingEngine.getOfficialConflicts({
 Rules absent from the policy, or present with `enabled: false`, are not evaluated at all — a policy is
 an allow-list of checks, never a silent partial application.
 
-:::note `getMatchUpOfficialConflicts` is not an engine method
+:::note `getMatchUpOfficialConflicts` lives on `tournamentEngine`, not here
 The per-matchUp variant needs a `tournamentRecord` + `drawDefinition`, which officiating-engine state
-does not hold — this engine is an `OfficialRecord` aggregate. Consumers that hold a tournament (the
-server, TMX) import it from the officiating **governor** instead. A regression test asserts this
-omission is deliberate, so it cannot be silently "fixed".
+does not hold — this engine is an `OfficialRecord` aggregate. It is exposed on **`tournamentEngine`**,
+which resolves both from its own state:
+
+```js
+tournamentEngine.getMatchUpOfficialConflicts({
+  drawId, // tournamentRecord + drawDefinition resolved from engine state
+  matchUpId,
+  officialRecord, // optional registry record
+  policyDefinitions,
+});
+// → { success, conflicts, blocked, checkedParticipants }
+```
+
+Regression tests assert both halves: that it is absent here, and that it is present and state-resolving
+on `tournamentEngine`.
 :::
 
 ### Evaluation Policies

--- a/documentation/docs/engines/officiating-engine.md
+++ b/documentation/docs/engines/officiating-engine.md
@@ -320,6 +320,50 @@ officiatingEngine.addCertificationRequirement({
 
 ---
 
+### Conflict of Interest
+
+Declared relationships that make an official unsuitable for an assignment. Self-declaration is how
+federations administer this — the factory cannot infer that an official coaches a player.
+
+#### addConflictDeclaration / removeConflictDeclaration
+
+```js
+// At least one of personId / participantId / organisationId is REQUIRED — a declaration that
+// identifies nobody can never match a participant.
+officiatingEngine.addConflictDeclaration({
+  officialRecordId,
+  personId: 'person-042',
+  relationship: 'COACH',
+});
+// → { success: true, declaration }
+
+officiatingEngine.removeConflictDeclaration({ officialRecordId, declarationId });
+```
+
+#### getOfficialConflicts
+
+Evaluates the official against a supplied participant list.
+
+```js
+officiatingEngine.getOfficialConflicts({
+  officialRecordId,
+  participants, // the participants to check against
+  nationalityCode, // optional — required for the NATIONALITY rule
+  policyDefinitions, // POLICY_OFFICIATING_CONFLICT_OF_INTEREST or a variant
+});
+// → { success: true, conflicts, blocked }
+```
+
+Rules absent from the policy, or present with `enabled: false`, are not evaluated at all — a policy is
+an allow-list of checks, never a silent partial application.
+
+:::note `getMatchUpOfficialConflicts` is not an engine method
+The per-matchUp variant needs a `tournamentRecord` + `drawDefinition`, which officiating-engine state
+does not hold — this engine is an `OfficialRecord` aggregate. Consumers that hold a tournament (the
+server, TMX) import it from the officiating **governor** instead. A regression test asserts this
+omission is deliberate, so it cannot be silently "fixed".
+:::
+
 ### Evaluation Policies
 
 #### addEvaluationPolicy

--- a/src/assemblies/engines/officiating/index.ts
+++ b/src/assemblies/engines/officiating/index.ts
@@ -176,10 +176,10 @@ export const officiatingEngine = (() => {
     },
 
     // --- Conflict of Interest ---
-    // NOTE: `getMatchUpOfficialConflicts` is deliberately NOT exposed here. It needs a
-    // tournamentRecord + drawDefinition, which officiating-engine state does not hold — this engine
-    // is an OfficialRecord aggregate. It stays a governor/direct import for consumers that hold a
-    // tournament (CFS, TMX). Do not "complete the set" by adding it.
+    // NOTE: `getMatchUpOfficialConflicts` is deliberately NOT exposed here — it belongs on
+    // `tournamentEngine`, where it already is. It needs a tournamentRecord + drawDefinition, which
+    // this engine's state does not hold (this is an OfficialRecord aggregate); tournamentEngine
+    // resolves both from its own state given a drawId. Do not "complete the set" by adding it here.
     addConflictDeclaration: (params: any) => {
       const officialRecord = params.officialRecord ?? resolveRecord(params.officialRecordId);
       return addConflictDeclaration({ ...params, officialRecord });

--- a/src/assemblies/engines/officiating/index.ts
+++ b/src/assemblies/engines/officiating/index.ts
@@ -2,7 +2,10 @@ import { transitionCertificationStatus } from '@Mutate/officiating/transitionCer
 import { transitionEvaluationStatus } from '@Mutate/officiating/transitionEvaluationStatus';
 import { transitionAssignmentStatus } from '@Mutate/officiating/transitionAssignmentStatus';
 import { addCertificationRequirement } from '@Mutate/officiating/addCertificationRequirement';
+import { removeConflictDeclaration } from '@Mutate/officiating/removeConflictDeclaration';
 import { removeOfficialAssignment } from '@Mutate/officiating/removeOfficialAssignment';
+import { addConflictDeclaration } from '@Mutate/officiating/addConflictDeclaration';
+import { getOfficialConflicts } from '@Query/officiating/getOfficialConflicts';
 import { getOfficialCertifications } from '@Query/officiating/getOfficialCertifications';
 import { validateCertification } from '@Validators/officiating/validateCertification';
 import { getOfficialAssignments } from '@Query/officiating/getOfficialAssignments';
@@ -170,6 +173,26 @@ export const officiatingEngine = (() => {
     removeSuspension: (params: any) => {
       const officialRecord = params.officialRecord ?? resolveRecord(params.officialRecordId);
       return removeSuspension({ ...params, officialRecord });
+    },
+
+    // --- Conflict of Interest ---
+    // NOTE: `getMatchUpOfficialConflicts` is deliberately NOT exposed here. It needs a
+    // tournamentRecord + drawDefinition, which officiating-engine state does not hold — this engine
+    // is an OfficialRecord aggregate. It stays a governor/direct import for consumers that hold a
+    // tournament (CFS, TMX). Do not "complete the set" by adding it.
+    addConflictDeclaration: (params: any) => {
+      const officialRecord = params.officialRecord ?? resolveRecord(params.officialRecordId);
+      return addConflictDeclaration({ ...params, officialRecord });
+    },
+
+    removeConflictDeclaration: (params: any) => {
+      const officialRecord = params.officialRecord ?? resolveRecord(params.officialRecordId);
+      return removeConflictDeclaration({ ...params, officialRecord });
+    },
+
+    getOfficialConflicts: (params: any) => {
+      const officialRecord = params?.officialRecord ?? resolveRecord(params?.officialRecordId);
+      return getOfficialConflicts({ ...params, officialRecord: officialRecord as OfficialRecord });
     },
 
     // --- Evaluation Policies ---

--- a/src/tests/officiating/matchUpOfficialConflicts.test.ts
+++ b/src/tests/officiating/matchUpOfficialConflicts.test.ts
@@ -260,6 +260,34 @@ describe('getMatchUpOfficialConflicts', () => {
   });
 });
 
+describe('getMatchUpOfficialConflicts is exposed on tournamentEngine', () => {
+  // It is deliberately absent from `officiatingEngine` (an OfficialRecord aggregate with no tournament
+  // state) — but it must be present on the engine that DOES hold a tournament, and must resolve
+  // tournamentRecord + drawDefinition from engine state rather than requiring the caller to assemble
+  // them. Asserted rather than assumed: the officiating engine's exclusion list points here.
+  it('is a function on tournamentEngine', () => {
+    expect((tournamentEngine as any).getMatchUpOfficialConflicts).toBeTypeOf('function');
+  });
+
+  it('resolves tournamentRecord and drawDefinition from engine state given only drawId', () => {
+    const { matchUpId, drawId, sides } = setup();
+
+    const result: any = (tournamentEngine as any).getMatchUpOfficialConflicts({
+      policyDefinitions: POLICY_OFFICIATING_CONFLICT_OF_INTEREST,
+      officialRecord: makeOfficialRecord({
+        conflictDeclarations: [{ declarationId: 'dec-1', participantId: sides[0].participantId }],
+      }),
+      matchUpId,
+      drawId,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.checkedParticipants).toHaveLength(2);
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.blocked).toBe(true);
+  });
+});
+
 describe('addMatchUpOfficial conflict gate', () => {
   it('assigns unchanged when no conflict policy is supplied', () => {
     const { tournamentId, matchUpId, drawId, officialParticipantId } = setup();

--- a/src/tests/officiating/officiatingEngine.test.ts
+++ b/src/tests/officiating/officiatingEngine.test.ts
@@ -905,9 +905,11 @@ describe('Officiating Engine — Methods Registration', () => {
  * a decision on the record rather than an oversight.
  */
 const NOT_ON_ENGINE: Record<string, string> = {
-  // Needs a tournamentRecord + drawDefinition, which officiating-engine state does not hold. Stays a
-  // governor/direct import for consumers that hold a tournament (CFS, TMX).
-  getMatchUpOfficialConflicts: 'requires tournamentRecord + drawDefinition, not OfficialRecord state',
+  // Belongs on `tournamentEngine`, NOT here — it needs a tournamentRecord + drawDefinition, which this
+  // engine's state does not hold (this is an OfficialRecord aggregate). It IS already exposed on
+  // tournamentEngine, which resolves both from engine state given a drawId, so this is a placement
+  // decision rather than an absence. Verified empirically, not assumed.
+  getMatchUpOfficialConflicts: 'lives on tournamentEngine — needs tournament state, not OfficialRecord state',
   // Pure status-transition validator, consumed directly rather than as an engine operation.
   // (`validateCertification` IS on the engine — this guard caught that on its first run.)
   validateOfficiatingStatusTransition: 'pure validator, consumed directly',

--- a/src/tests/officiating/officiatingEngine.test.ts
+++ b/src/tests/officiating/officiatingEngine.test.ts
@@ -1,4 +1,5 @@
 import { getOfficiatingMethods, setOfficiatingMethods } from '@Assemblies/engines/officiating/officiatingState';
+import * as officiatingGovernor from '@Assemblies/governors/officiatingGovernor';
 import { officiatingEngine } from '@Assemblies/engines/officiating';
 import { beforeEach, describe, expect, it } from 'vitest';
 
@@ -888,5 +889,93 @@ describe('Officiating Engine — Methods Registration', () => {
     expect(methods.myMethod()).toBe('custom');
     // Non-function values should not be registered
     expect(methods.notAFunction).toBeUndefined();
+  });
+});
+
+/**
+ * Governor ↔ engine exposure guard.
+ *
+ * The officiating engine is a HAND-AUTHORED object literal, so adding a method to the governor does
+ * NOT expose it on the engine. That split has already bitten once: factory 6.25.0 shipped the
+ * conflict-of-interest methods on the governor (which CFS imports) but not on the engine — and
+ * courthive-ams drives every officiating operation through a generic `engine[method]` passthrough, so
+ * the whole feature was unreachable while every existing test stayed green.
+ *
+ * Anything deliberately NOT exposed must be listed in NOT_ON_ENGINE with a reason, so the omission is
+ * a decision on the record rather than an oversight.
+ */
+const NOT_ON_ENGINE: Record<string, string> = {
+  // Needs a tournamentRecord + drawDefinition, which officiating-engine state does not hold. Stays a
+  // governor/direct import for consumers that hold a tournament (CFS, TMX).
+  getMatchUpOfficialConflicts: 'requires tournamentRecord + drawDefinition, not OfficialRecord state',
+  // Pure status-transition validator, consumed directly rather than as an engine operation.
+  // (`validateCertification` IS on the engine — this guard caught that on its first run.)
+  validateOfficiatingStatusTransition: 'pure validator, consumed directly',
+  // Engine exposes this as `queryOfficialRecord`'s underlying getter via getState/resolveRecord.
+  queryOfficialRecord: 'engine exposes record access via getState / resolveRecord',
+};
+
+describe('Officiating governor ↔ engine exposure', () => {
+  const governorMethods = Object.entries(officiatingGovernor as Record<string, unknown>)
+    .filter(([, value]) => typeof value === 'function')
+    .map(([name]) => name);
+
+  it('finds governor methods to check', () => {
+    expect(governorMethods.length).toBeGreaterThan(10);
+  });
+
+  it('every governor method is on the engine, or explicitly excluded with a reason', () => {
+    const missing = governorMethods.filter(
+      (name) => typeof (officiatingEngine as any)[name] !== 'function' && !NOT_ON_ENGINE[name],
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it('the exclusion list has no stale entries', () => {
+    // An excluded name that IS on the engine means the list is lying about the surface.
+    const contradictory = Object.keys(NOT_ON_ENGINE).filter(
+      (name) => typeof (officiatingEngine as any)[name] === 'function',
+    );
+    expect(contradictory).toEqual([]);
+  });
+});
+
+describe('Officiating Engine — Conflict of Interest', () => {
+  beforeEach(() => {
+    officiatingEngine.reset();
+  });
+
+  it('adds, evaluates and removes a conflict declaration through the engine', () => {
+    // This is the path courthive-ams uses: engine[method] against the active record.
+    const created: any = createTestRecord();
+    const officialRecordId = created.officialRecord.officialRecordId;
+
+    let result: any = officiatingEngine.addConflictDeclaration({
+      officialRecordId,
+      personId: 'person-042',
+      relationship: 'COACH',
+    });
+    expect(result.success).toBe(true);
+    const declarationId = result.declaration.declarationId;
+
+    // Evaluate against a participant matching the declaration.
+    result = officiatingEngine.getOfficialConflicts({
+      officialRecordId,
+      participants: [{ participantId: 'par-1', person: { personId: 'person-042' } }],
+      policyDefinitions: {
+        officiatingConflict: {
+          conflictRules: { DECLARED_RELATIONSHIP: { enabled: true, severity: 'BLOCK' } },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.blocked).toBe(true);
+
+    result = officiatingEngine.removeConflictDeclaration({ officialRecordId, declarationId });
+    expect(result.success).toBe(true);
+
+    const state: any = officiatingEngine.getState();
+    expect(state.officialRecords[officialRecordId].conflictDeclarations).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Follow-up to #4609. The conflict-of-interest feature shipped in **6.25.0 is currently unreachable**.

## The gap

#4609 exposed the COI methods via the officiating **governor** — which is what competition-factory-server imports. The officiating **engine** is a *separate, hand-authored object literal* with an explicit import list, and it was not updated. So `officiatingEngine.addConflictDeclaration` is `undefined`.

That matters because **courthive-ams drives every officiating operation through a generic passthrough** (`officiating.service.ts`: `engine[method]` after `setState` + `setActiveOfficialRecordId`). AMS already pins factory 6.25.0 and needs no new endpoint — but nothing it dispatches can reach these methods. The whole feature is inert for its only consumer.

Every existing suite stayed green throughout, because none of them call the engine for these methods.

## What's here

Exposes on the engine, following its existing `params.officialRecord ?? resolveRecord(params.officialRecordId)` pattern:

- `addConflictDeclaration`, `removeConflictDeclaration`
- `getOfficialConflicts`

**`getMatchUpOfficialConflicts` is deliberately NOT exposed here — because it already lives on `tournamentEngine`.** It needs a `tournamentRecord` + `drawDefinition`, which officiating-engine state does not hold (this engine is an `OfficialRecord` aggregate). `tournamentEngine` resolves both from its own state:

```js
tournamentEngine.getMatchUpOfficialConflicts({ drawId, matchUpId, officialRecord, policyDefinitions });
// → { success, conflicts, blocked, checkedParticipants }
```

Verified empirically against the real syncEngine, not assumed. Tests assert **both** halves — absent from the officiating engine, present and state-resolving on `tournamentEngine` — so the placement is guarded in both directions.

**This narrows the blocker's scope, and the second commit corrects the first one's wording:** TMX was never blocked, because TMX uses `tournamentEngine`. **courthive-ams** was blocked, because it drives `officiatingEngine`.

## The part that prevents recurrence

A **governor↔engine exposure guard**: every governor method must either be on the engine, or listed in `NOT_ON_ENGINE` with a stated reason. A second assertion fails on *stale* entries — an excluded name that IS on the engine means the list is lying about the surface.

This is the second exposure gap in recent memory. `entryStatusConstants.REGISTERED` shipped as `undefined` in 6.16.0/6.17.0 while every guard stayed green, for the same structural reason: two surfaces, one of them hand-maintained, and no test comparing them.

The guard proved itself immediately — **on its first run it failed**, because I had wrongly listed `validateCertification` as not-exposed when it is.

## Verification

- lint 0 warnings, `check-types` clean, `verify:generated` in sync (enum-constants, enum-exports 60, engine-methods 657, method-signatures).
- **10820 tests passed / 1 skipped** (+10), 0 regressions.
- Coverage **95.09 / 86.82 / 97.99 / 97.62** against the 95/95/85/95 gate.
- Falsified both ways: deleting `addConflictDeclaration` from the engine (reproducing the exact 6.25.0 bug) fails 2 tests; exposing the excluded `getMatchUpOfficialConflicts` fails 1. Both restored green.
- New engine-level test exercises the real AMS path — add declaration → evaluate → remove — through `engine[method]` against the active record, rather than importing the functions directly.

## Follow-up (not in this PR)

Design for the operator-facing surface is in `Mentat/planning/OFFICIATING_CONFLICT_TMX_SURFACE.md`. Notably, conflict declarations are moving toward being expressible **inside the tournamentRecord** via `GROUP` participants (a coach GROUPed with players is a relationship), which removes the dependency on a maintained external registry for the common case.

