### PR TITLE
feat(officiating): tournament-scoped conflict declarations via GROUP participants

### DIFF
--- a/documentation/docs/governors/officiating-governor.md
+++ b/documentation/docs/governors/officiating-governor.md
@@ -279,6 +279,43 @@ so the query makes no assumption about where the tournament record lives.
 `nationalityCode` must be supplied by the caller: an `OfficialRecord` carries no person detail, so the
 official's own nationality cannot be derived from it.
 
+#### Two declaration sources — either is sufficient
+
+`officialRecord` is **optional**. A conflict declaration can come from either:
+
+| source                   | scope                      | supplied as                                   |
+| ------------------------ | -------------------------- | --------------------------------------------- |
+| registry (courthive-ams) | durable, cross-tournament  | `officialRecord.conflictDeclarations`         |
+| tournamentRecord         | transient, this event only | `officialParticipantId` + `groupParticipants` |
+
+Supplying **neither** is an error (`MISSING_CONFLICT_SOURCE`).
+
+The tournament-scoped source exists because expecting officials to keep a global registry current is
+unrealistic — and an empty registry would otherwise make every check return "no conflicts", which is
+indistinguishable from a check that passed. A tournament assignment is the natural moment to capture a
+relationship, so the declaration lives where it is created.
+
+A `GROUP` participant containing the official and one or more competitors **is** the declaration. Create
+it with `createGroupParticipant({ groupName, individualParticipantIds, participantRole })`.
+
+#### `participantRole` marks an authored relationship
+
+`SHARED_GROUPING` defaults to `WARN`, because `GROUP` is a general primitive — squads and
+attribute-derived groupings are legitimate and would otherwise false-positive. The GROUP's own
+`participantRole` distinguishes an authored relationship from an incidental one, and `ConflictRule.roleSeverity`
+escalates per role:
+
+```ts
+[CONFLICT_SHARED_GROUPING]: {
+  enabled: true,
+  severity: CONFLICT_WARN,                       // incidental groupings
+  roleSeverity: { COACH: 'BLOCK', MEDICAL: 'BLOCK', PHYSIO: 'BLOCK', TRAINER: 'BLOCK' },
+}
+```
+
+`createGroupParticipant` defaults `participantRole` to `OTHER`, so an unspecified grouping carries `OTHER`,
+is absent from `roleSeverity`, and falls through to the base severity.
+
 A rule that is absent from the policy, or present with `enabled: false`, is **not evaluated at all** — a
 policy is an allow-list of checks, never a silent partial application.
 

--- a/src/constants/officiatingConstants.ts
+++ b/src/constants/officiatingConstants.ts
@@ -75,6 +75,7 @@ export const CONFLICT_SAME_PERSON = 'SAME_PERSON';
 export const CONFLICT_DECLARED_RELATIONSHIP = 'DECLARED_RELATIONSHIP';
 export const CONFLICT_NATIONALITY = 'NATIONALITY';
 export const CONFLICT_ORGANISATION = 'ORGANISATION';
+export const CONFLICT_SHARED_GROUPING = 'SHARED_GROUPING';
 
 export const CONFLICT_BLOCK = 'BLOCK';
 export const CONFLICT_WARN = 'WARN';
@@ -175,6 +176,12 @@ export const CONFLICT_DECLARATION_NOT_FOUND: ErrorType = {
   code: 'ERR_NOT_FOUND_CONFLICT_DECLARATION',
 };
 
+export const MISSING_CONFLICT_SOURCE: ErrorType = {
+  message:
+    'Missing conflict source — supply an officialRecord and/or the official participant plus tournament groupings',
+  code: 'ERR_MISSING_CONFLICT_SOURCE',
+};
+
 export const MISSING_CONFLICT_PARTICIPANTS: ErrorType = {
   message: 'Missing participants — a conflict-of-interest policy was supplied but there is nothing to check against',
   code: 'ERR_MISSING_CONFLICT_PARTICIPANTS',
@@ -229,6 +236,7 @@ export const officiatingConstants = {
   CONFLICT_DECLARED_RELATIONSHIP,
   CONFLICT_NATIONALITY,
   CONFLICT_ORGANISATION,
+  CONFLICT_SHARED_GROUPING,
   CONFLICT_BLOCK,
   CONFLICT_WARN,
 } as const;

--- a/src/fixtures/policies/POLICY_OFFICIATING_CONFLICT_OF_INTEREST.ts
+++ b/src/fixtures/policies/POLICY_OFFICIATING_CONFLICT_OF_INTEREST.ts
@@ -1,12 +1,26 @@
 import { POLICY_TYPE_OFFICIATING_CONFLICT } from '@Constants/policyConstants';
 import {
   CONFLICT_DECLARED_RELATIONSHIP,
+  CONFLICT_SHARED_GROUPING,
   CONFLICT_ORGANISATION,
   CONFLICT_NATIONALITY,
   CONFLICT_SAME_PERSON,
   CONFLICT_BLOCK,
   CONFLICT_WARN,
 } from '@Constants/officiatingConstants';
+import { COACH, MEDICAL, PHYSIO, TRAINER } from '@Constants/participantRoles';
+
+/**
+ * GROUP participantRoles that represent a relationship close enough to disqualify an official.
+ * A GROUP carrying one of these was authored to express that relationship; a GROUP with no role
+ * (a squad, an attribute-derived grouping) is incidental and only warns.
+ */
+const DISQUALIFYING_GROUP_ROLES = {
+  [COACH]: CONFLICT_BLOCK,
+  [MEDICAL]: CONFLICT_BLOCK,
+  [PHYSIO]: CONFLICT_BLOCK,
+  [TRAINER]: CONFLICT_BLOCK,
+};
 
 /**
  * Default conflict-of-interest policy for official assignment.
@@ -30,6 +44,15 @@ export const POLICY_OFFICIATING_CONFLICT_OF_INTEREST = {
       [CONFLICT_DECLARED_RELATIONSHIP]: { enabled: true, severity: CONFLICT_BLOCK },
       [CONFLICT_ORGANISATION]: { enabled: true, severity: CONFLICT_WARN },
       [CONFLICT_NATIONALITY]: { enabled: false, severity: CONFLICT_WARN },
+      // Tournament-scoped relationships expressed as GROUP membership. WARN by default because
+      // GROUP is a general primitive — squads and attribute-derived groupings are legitimate and
+      // would otherwise false-positive. `roleSeverity` escalates the groups that were authored to
+      // express a relationship.
+      [CONFLICT_SHARED_GROUPING]: {
+        enabled: true,
+        severity: CONFLICT_WARN,
+        roleSeverity: DISQUALIFYING_GROUP_ROLES,
+      },
     },
   },
 };
@@ -46,6 +69,11 @@ export const POLICY_OFFICIATING_CONFLICT_OF_INTEREST_ITF = {
       [CONFLICT_DECLARED_RELATIONSHIP]: { enabled: true, severity: CONFLICT_BLOCK },
       [CONFLICT_ORGANISATION]: { enabled: true, severity: CONFLICT_BLOCK },
       [CONFLICT_NATIONALITY]: { enabled: true, severity: CONFLICT_BLOCK },
+      [CONFLICT_SHARED_GROUPING]: {
+        enabled: true,
+        severity: CONFLICT_BLOCK,
+        roleSeverity: DISQUALIFYING_GROUP_ROLES,
+      },
     },
   },
 };

--- a/src/mutate/matchUps/schedule/scheduleItems/scheduleItems.ts
+++ b/src/mutate/matchUps/schedule/scheduleItems/scheduleItems.ts
@@ -44,7 +44,7 @@ import { DrawDefinition, Event } from '@Types/tournamentTypes';
 import { OBJECT, OF_TYPE } from '@Constants/attributeConstants';
 import { AddScheduleAttributeArgs } from '@Types/factoryTypes';
 import { INDIVIDUAL } from '@Constants/participantConstants';
-import { MISSING_OFFICIAL_RECORD, OFFICIAL_CONFLICT_OF_INTEREST } from '@Constants/officiatingConstants';
+import { OFFICIAL_CONFLICT_OF_INTEREST } from '@Constants/officiatingConstants';
 import { POLICY_TYPE_OFFICIATING_CONFLICT } from '@Constants/policyConstants';
 import { OFFICIAL } from '@Constants/participantRoles';
 import { SUCCESS } from '@Constants/resultConstants';
@@ -626,18 +626,17 @@ export function addMatchUpOfficial({
     if (!participant) return { error: PARTICIPANT_NOT_FOUND };
   }
 
-  // Conflict-of-interest gate — opt-in, and scoped to THIS matchUp's sides
-  // rather than the whole field. Requires both a policy and the official's
-  // record; supplying a policy without the record is an error rather than a
-  // silent pass, for the same reason `assignOfficial` fails closed.
-  // The two guards below also narrow the optional params for the call that
-  // follows; `getMatchUpOfficialConflicts` enforces the same preconditions
-  // independently, so neither is load-bearing on its own.
+  // Conflict-of-interest gate — opt-in, and scoped to THIS matchUp's sides rather than the whole
+  // field. An `officialRecord` is NOT required: the official's own participantId is a sufficient
+  // declaration source via tournament GROUP membership, so the gate works with nothing but the
+  // tournamentRecord. A registry record, when supplied, adds durable cross-tournament declarations.
   if (policyDefinitions?.[POLICY_TYPE_OFFICIATING_CONFLICT]) {
     if (!tournamentRecord) return { error: MISSING_TOURNAMENT_RECORD };
-    if (!officialRecord) return { error: MISSING_OFFICIAL_RECORD };
 
     const conflictResult = getMatchUpOfficialConflicts({
+      // The official being assigned IS the subject of the check — their participantId unlocks the
+      // tournament-scoped SHARED_GROUPING rule with no registry record required.
+      officialParticipantId: participantId,
       policyDefinitions,
       tournamentRecord,
       organisationIds,

--- a/src/query/officiating/getMatchUpOfficialConflicts.ts
+++ b/src/query/officiating/getMatchUpOfficialConflicts.ts
@@ -4,7 +4,8 @@ import { findDrawMatchUp } from '@Acquire/findDrawMatchUp';
 
 // Constants
 import { MISSING_TOURNAMENT_RECORD, MISSING_MATCHUP_ID } from '@Constants/errorConditionConstants';
-import { MISSING_OFFICIAL_RECORD } from '@Constants/officiatingConstants';
+import { MISSING_CONFLICT_SOURCE } from '@Constants/officiatingConstants';
+import { GROUP } from '@Constants/participantConstants';
 import { POLICY_TYPE_OFFICIATING_CONFLICT } from '@Constants/policyConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 
@@ -14,7 +15,10 @@ import type { OfficialConflict, OfficialRecord } from '@Types/officiatingTypes';
 
 type GetMatchUpOfficialConflictsArgs = {
   policyDefinitions?: { [key: string]: any };
-  officialRecord: OfficialRecord;
+  /** Durable registry declarations. OPTIONAL when `officialParticipantId` is supplied. */
+  officialRecord?: OfficialRecord;
+  /** The official's participantId in this tournament — enables the SHARED_GROUPING rule. */
+  officialParticipantId?: string;
   drawDefinition: DrawDefinition;
   tournamentRecord: Tournament;
   organisationIds?: string[];
@@ -49,6 +53,7 @@ type GetMatchUpOfficialConflictsResult = {
  * every possible opponent as a conflict would block most early-round assignments.
  */
 export function getMatchUpOfficialConflicts({
+  officialParticipantId,
   policyDefinitions,
   tournamentRecord,
   organisationIds,
@@ -60,7 +65,9 @@ export function getMatchUpOfficialConflicts({
 }: GetMatchUpOfficialConflictsArgs): GetMatchUpOfficialConflictsResult {
   if (!tournamentRecord) return { error: MISSING_TOURNAMENT_RECORD };
   if (!matchUpId) return { error: MISSING_MATCHUP_ID };
-  if (!officialRecord) return { error: MISSING_OFFICIAL_RECORD };
+  // Either declaration source is sufficient: a registry record, or the official's participantId
+  // (which unlocks tournament-scoped GROUP relationships).
+  if (!officialRecord && !officialParticipantId) return { error: MISSING_CONFLICT_SOURCE };
 
   // No conflict policy ⇒ nothing to evaluate; skip resolving participants.
   if (!policyDefinitions?.[POLICY_TYPE_OFFICIATING_CONFLICT]) {
@@ -101,8 +108,14 @@ export function getMatchUpOfficialConflicts({
   };
   for (const participantId of sideParticipantIds) include(participantId);
 
+  // GROUP participants are the tournament-scoped declaration source: a GROUP containing the official
+  // and a competitor IS the relationship. Passed whole; the query resolves the official's memberships.
+  const groupParticipants = tournamentParticipants.filter((participant) => participant.participantType === GROUP);
+
   const conflictResult = getOfficialConflicts({
     participants: checkedParticipants,
+    officialParticipantId,
+    groupParticipants,
     policyDefinitions,
     organisationIds,
     nationalityCode,

--- a/src/query/officiating/getOfficialConflicts.ts
+++ b/src/query/officiating/getOfficialConflicts.ts
@@ -2,8 +2,9 @@
 import {
   CONFLICT_DECLARED_RELATIONSHIP,
   MISSING_CONFLICT_PARTICIPANTS,
+  CONFLICT_SHARED_GROUPING,
+  MISSING_CONFLICT_SOURCE,
   CONFLICT_ORGANISATION,
-  MISSING_OFFICIAL_RECORD,
   CONFLICT_NATIONALITY,
   CONFLICT_SAME_PERSON,
   CONFLICT_BLOCK,
@@ -16,6 +17,7 @@ import type {
   OfficialConflictDeclaration,
   ConflictOfInterestPolicy,
   ConflictSeverity,
+  ConflictRule,
   OfficialConflict,
   OfficialRecord,
   ConflictType,
@@ -23,8 +25,13 @@ import type {
 import type { Participant } from '@Types/tournamentTypes';
 
 type GetOfficialConflictsArgs = {
-  officialRecord: OfficialRecord;
+  /** Durable registry declarations. OPTIONAL — a tournament-scoped check needs no registry record. */
+  officialRecord?: OfficialRecord;
   participants?: Participant[];
+  /** The official's participantId in THIS tournament — required for the SHARED_GROUPING rule. */
+  officialParticipantId?: string;
+  /** GROUP participants of the tournament, used to detect a shared grouping. */
+  groupParticipants?: Participant[];
   /** The official's own nationality — required for the NATIONALITY rule, which
    *  cannot be derived from the OfficialRecord (it carries no person detail). */
   nationalityCode?: string;
@@ -53,8 +60,12 @@ type ParticipantContext = {
 type RuleContext = ParticipantContext & {
   declarations: OfficialConflictDeclaration[];
   declaredOrganisationIds: Set<string>;
-  officialPersonId: string;
+  /** GROUP participants containing the official, keyed for membership lookup. */
+  officialGroupings: Participant[];
+  officialParticipantId?: string;
+  officialPersonId?: string;
   nationalityCode?: string;
+  rule?: ConflictRule;
 };
 
 function participantContext(participant: Participant): ParticipantContext {
@@ -145,6 +156,34 @@ function organisationConflicts(severity: ConflictSeverity, context: RuleContext)
   ];
 }
 
+function sharedGroupingConflicts(severity: ConflictSeverity, context: RuleContext): OfficialConflict[] {
+  const { participantPersonId, participantName, participantId, officialGroupings, rule } = context;
+  if (!participantId) return [];
+
+  return officialGroupings
+    .filter((group) => (group.individualParticipantIds ?? []).includes(participantId))
+    .map((group) => {
+      // A GROUP carrying a `participantRole` is an explicitly-authored relationship (e.g. a coaching
+      // group); one without is an incidental grouping. Per-role escalation lets policy block the
+      // former while merely warning on the latter.
+      const groupRole = group.participantRole;
+      const escalated = groupRole ? rule?.roleSeverity?.[groupRole] : undefined;
+      return {
+        conflictType: CONFLICT_SHARED_GROUPING,
+        severity: escalated ?? severity,
+        personId: participantPersonId,
+        participantId,
+        participantName,
+        groupParticipantId: group.participantId,
+        groupName: group.participantName,
+        groupRole,
+        reason: groupRole
+          ? `Official shares a ${groupRole} grouping (${group.participantName ?? group.participantId}) with this participant`
+          : `Official shares a grouping (${group.participantName ?? group.participantId}) with this participant`,
+      };
+    });
+}
+
 const CONFLICT_EVALUATORS: Record<
   ConflictType,
   (severity: ConflictSeverity, context: RuleContext) => OfficialConflict[]
@@ -153,15 +192,16 @@ const CONFLICT_EVALUATORS: Record<
   [CONFLICT_DECLARED_RELATIONSHIP]: declaredRelationshipConflicts,
   [CONFLICT_NATIONALITY]: nationalityConflicts,
   [CONFLICT_ORGANISATION]: organisationConflicts,
+  [CONFLICT_SHARED_GROUPING]: sharedGroupingConflicts,
 };
 
 /** Rules absent from the policy, or present with `enabled: false`, are not
  *  evaluated at all — a policy is an allow-list of checks, never a silent
  *  partial application. */
-function enabledRules(policy: ConflictOfInterestPolicy): [ConflictType, ConflictSeverity][] {
+function enabledRules(policy: ConflictOfInterestPolicy): [ConflictType, ConflictRule][] {
   return Object.entries(policy.conflictRules ?? {})
     .filter(([conflictType, rule]) => rule?.enabled && conflictType in CONFLICT_EVALUATORS)
-    .map(([conflictType, rule]) => [conflictType as ConflictType, rule!.severity]);
+    .map(([conflictType, rule]) => [conflictType as ConflictType, rule as ConflictRule]);
 }
 
 /**
@@ -171,24 +211,37 @@ function enabledRules(policy: ConflictOfInterestPolicy): [ConflictType, Conflict
  * Pure and side-effect free: the caller supplies the participants, so this makes
  * no assumption about where the tournament record lives.
  *
+ * **Two independent declaration sources, either of which is sufficient:**
+ * - `officialRecord.conflictDeclarations` — durable, registry-owned (courthive-ams)
+ * - `groupParticipants` + `officialParticipantId` — transient, expressed inside the
+ *   tournamentRecord as GROUP membership (a coach GROUPed with players IS the declaration)
+ *
+ * The tournament-scoped source exists because expecting officials to keep a global registry
+ * current is unrealistic, and an empty registry would otherwise make this return "no conflicts"
+ * for everyone — indistinguishable from a check that passed.
+ *
  * Returns an error rather than an empty result when a policy is supplied with no
  * participants to check: "no conflicts" and "nothing was checked" must not look
  * the same to a caller that is about to make an assignment decision.
  */
 export function getOfficialConflicts({
-  officialRecord,
-  participants,
+  officialParticipantId,
+  groupParticipants,
+  policyDefinitions,
   nationalityCode,
   organisationIds,
-  policyDefinitions,
+  officialRecord,
+  participants,
 }: GetOfficialConflictsArgs): GetOfficialConflictsResult {
-  if (!officialRecord) return { error: MISSING_OFFICIAL_RECORD };
+  const hasRegistrySource = Boolean(officialRecord);
+  const hasTournamentSource = Boolean(officialParticipantId);
+  if (!hasRegistrySource && !hasTournamentSource) return { error: MISSING_CONFLICT_SOURCE };
 
   const policy: ConflictOfInterestPolicy | undefined = policyDefinitions?.[POLICY_TYPE_OFFICIATING_CONFLICT];
   if (!policy) return { ...SUCCESS, conflicts: [], blocked: false };
   if (!Array.isArray(participants)) return { error: MISSING_CONFLICT_PARTICIPANTS };
 
-  const declarations = officialRecord.conflictDeclarations ?? [];
+  const declarations = officialRecord?.conflictDeclarations ?? [];
   const declaredOrganisationIds = new Set(
     [...declarations.map((declaration) => declaration.organisationId), ...(organisationIds ?? [])].filter(
       (organisationId): organisationId is string => Boolean(organisationId),
@@ -197,15 +250,27 @@ export function getOfficialConflicts({
 
   const rules = enabledRules(policy);
 
+  // GROUP participants the official belongs to. Resolved once — membership is the same for every
+  // participant being checked.
+  const officialGroupings = officialParticipantId
+    ? (groupParticipants ?? []).filter((group) =>
+        (group.individualParticipantIds ?? []).includes(officialParticipantId),
+      )
+    : [];
+
   const conflicts = participants.flatMap((participant) => {
     const context: RuleContext = {
       ...participantContext(participant),
-      officialPersonId: officialRecord.personId,
+      officialPersonId: officialRecord?.personId,
       declaredOrganisationIds,
+      officialParticipantId,
+      officialGroupings,
       nationalityCode,
       declarations,
     };
-    return rules.flatMap(([conflictType, severity]) => CONFLICT_EVALUATORS[conflictType](severity, context));
+    return rules.flatMap(([conflictType, rule]) =>
+      CONFLICT_EVALUATORS[conflictType](rule.severity, { ...context, rule }),
+    );
   });
 
   const blocked = conflicts.some((conflict) => conflict.severity === CONFLICT_BLOCK);

--- a/src/tests/officiating/matchUpOfficialConflicts.test.ts
+++ b/src/tests/officiating/matchUpOfficialConflicts.test.ts
@@ -9,13 +9,15 @@ import { MISSING_TOURNAMENT_RECORD, MISSING_MATCHUP_ID } from '@Constants/errorC
 import {
   OFFICIAL_CONFLICT_OF_INTEREST,
   CONFLICT_DECLARED_RELATIONSHIP,
-  MISSING_OFFICIAL_RECORD,
+  MISSING_CONFLICT_SOURCE,
+  CONFLICT_SHARED_GROUPING,
   CONFLICT_NATIONALITY,
+  CONFLICT_BLOCK,
   CONFLICT_WARN,
 } from '@Constants/officiatingConstants';
 import { POLICY_TYPE_OFFICIATING_CONFLICT } from '@Constants/policyConstants';
 import { INDIVIDUAL, PAIR } from '@Constants/participantConstants';
-import { OFFICIAL } from '@Constants/participantRoles';
+import { COACH, OFFICIAL, OTHER } from '@Constants/participantRoles';
 import { DOUBLES } from '@Constants/matchUpTypes';
 
 import type { OfficialRecord } from '@Types/officiatingTypes';
@@ -167,13 +169,14 @@ describe('getMatchUpOfficialConflicts', () => {
     });
     expect(result.error).toEqual(MISSING_MATCHUP_ID);
 
+    // Neither a registry record NOR an official participantId — nothing to evaluate against.
     result = getMatchUpOfficialConflicts({
       tournamentRecord: {} as any,
       drawDefinition: {} as any,
       officialRecord: undefined as any,
       matchUpId: 'x',
     });
-    expect(result.error).toEqual(MISSING_OFFICIAL_RECORD);
+    expect(result.error).toEqual(MISSING_CONFLICT_SOURCE);
   });
 
   it('is inert with no conflict policy and does not resolve participants', () => {
@@ -257,6 +260,89 @@ describe('getMatchUpOfficialConflicts', () => {
     });
     expect(result.conflicts).toEqual([]);
     expect(result.blocked).toBe(false);
+  });
+});
+
+describe('SHARED_GROUPING — tournament-scoped relationships, no registry record', () => {
+  /**
+   * One tournament; GROUP the official together with the given competitors.
+   * `participantRole` on the GROUP is what marks it as an authored relationship.
+   */
+  function setupGrouped(competitorFrom: 'matchUp' | 'elsewhere', participantRole?: string) {
+    const ctx = setup();
+    const { tournamentId, officialParticipantId, sides, tournamentRecord, drawId } = ctx;
+
+    const memberId =
+      competitorFrom === 'matchUp'
+        ? sides[0].participantId
+        : // someone NOT in this matchUp
+          tournamentRecord.participants.find(
+            (p: any) =>
+              p.participantType === INDIVIDUAL &&
+              p.participantId !== officialParticipantId &&
+              !sides.some((side: any) => side.participantId === p.participantId),
+          )?.participantId;
+
+    const result: any = tournamentEngine.createGroupParticipant({
+      individualParticipantIds: [officialParticipantId, memberId],
+      groupName: 'Team Alpha',
+      participantRole,
+      tournamentId,
+    });
+    expect(result.success).toEqual(true);
+
+    // re-read: the engine holds the authoritative record after the mutation
+    const updated = tournamentEngine.getTournament().tournamentRecord;
+    const drawDefinition = updated.events[0].drawDefinitions.find((d: any) => d.drawId === drawId);
+    return { ...ctx, tournamentRecord: updated, drawDefinition };
+  }
+
+  function evaluate(ctx: any, extra: any = {}) {
+    return getMatchUpOfficialConflicts({
+      policyDefinitions: POLICY_OFFICIATING_CONFLICT_OF_INTEREST,
+      officialParticipantId: ctx.officialParticipantId,
+      tournamentRecord: ctx.tournamentRecord,
+      drawDefinition: ctx.drawDefinition,
+      matchUpId: ctx.matchUpId,
+      ...extra,
+    }) as any;
+  }
+
+  it('flags a shared grouping with NO officialRecord at all', () => {
+    // The point of the whole design: an empty external registry must not mean "no conflicts".
+    const result = evaluate(setupGrouped('matchUp'));
+    expect(result.error).toBeUndefined();
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0].conflictType).toEqual(CONFLICT_SHARED_GROUPING);
+    expect(result.conflicts[0].groupName).toEqual('Team Alpha');
+  });
+
+  it('an unspecified grouping warns — OTHER is not in the escalation map', () => {
+    // createGroupParticipant defaults participantRole to OTHER, so every GROUP carries a role.
+    // OTHER is the incidental marker: it falls through to the rule's base severity.
+    const result = evaluate(setupGrouped('matchUp'));
+    expect(result.conflicts[0].severity).toEqual(CONFLICT_WARN);
+    expect(result.conflicts[0].groupRole).toEqual(OTHER);
+    expect(result.blocked).toBe(false);
+  });
+
+  it('a COACH grouping blocks — participantRole is what escalates it', () => {
+    const result = evaluate(setupGrouped('matchUp', COACH));
+    expect(result.conflicts[0].severity).toEqual(CONFLICT_BLOCK);
+    expect(result.conflicts[0].groupRole).toEqual(COACH);
+    expect(result.blocked).toBe(true);
+  });
+
+  it('does not flag a grouping whose members are not in this matchUp', () => {
+    const result = evaluate(setupGrouped('elsewhere', COACH));
+    expect(result.conflicts).toEqual([]);
+    expect(result.blocked).toBe(false);
+  });
+
+  it('errors when neither declaration source is supplied', () => {
+    const ctx = setupGrouped('matchUp');
+    const result = evaluate({ ...ctx, officialParticipantId: undefined });
+    expect(result.error).toEqual(MISSING_CONFLICT_SOURCE);
   });
 });
 
@@ -358,12 +444,10 @@ describe('addMatchUpOfficial conflict gate', () => {
     expect(matchUp.schedule?.official).toEqual(officialParticipantId);
   });
 
-  // End-to-end assertion that the mutation writes nothing when the check cannot
-  // run. Note this is enforced in TWO places — the outer guard here (which also
-  // narrows the optional type) and `getMatchUpOfficialConflicts` itself — so
-  // removing either one alone leaves this green. The query-level guard is
-  // isolated directly in the getMatchUpOfficialConflicts block above.
-  it('writes nothing when a policy is supplied without an officialRecord', () => {
+  // CONTRACT CHANGE (SHARED_GROUPING): supplying a policy without an officialRecord no longer fails.
+  // The official being assigned supplies their own participantId, which is a sufficient declaration
+  // source via tournament GROUP membership — so the gate runs against the tournamentRecord alone.
+  it('runs the gate without an officialRecord, using the assigned official as the subject', () => {
     const { tournamentId, matchUpId, drawId, officialParticipantId } = setup();
     const result: any = tournamentEngine.addMatchUpOfficial({
       policyDefinitions: POLICY_OFFICIATING_CONFLICT_OF_INTEREST,
@@ -372,10 +456,12 @@ describe('addMatchUpOfficial conflict gate', () => {
       matchUpId,
       drawId,
     });
-    expect(result.error).toEqual(MISSING_OFFICIAL_RECORD);
+    // No groupings exist for this official, so there is nothing to flag — and crucially no error.
+    expect(result.error).toBeUndefined();
+    expect(result.success).toEqual(true);
 
     const { matchUps } = tournamentEngine.allTournamentMatchUps();
     const matchUp = matchUps.find((m: any) => m.matchUpId === matchUpId);
-    expect(matchUp.schedule?.official).toBeUndefined();
+    expect(matchUp.schedule?.official).toEqual(officialParticipantId);
   });
 });

--- a/src/tests/officiating/officiatingConflicts.test.ts
+++ b/src/tests/officiating/officiatingConflicts.test.ts
@@ -14,6 +14,7 @@ import {
   OFFICIAL_CONFLICT_OF_INTEREST,
   MISSING_CONFLICT_PARTICIPANTS,
   CONFLICT_DECLARED_RELATIONSHIP,
+  MISSING_CONFLICT_SOURCE,
   MISSING_OFFICIAL_RECORD,
   CONFLICT_ORGANISATION,
   CONFLICT_NATIONALITY,
@@ -72,9 +73,22 @@ const ALL_RULES_BLOCK = {
 // getOfficialConflicts
 // ---------------------------------------------------------------------------
 describe('getOfficialConflicts', () => {
-  it('returns error when officialRecord is missing', () => {
+  it('returns error when NEITHER declaration source is supplied', () => {
+    // officialRecord is optional since SHARED_GROUPING: an officialParticipantId (tournament GROUP
+    // membership) is an equally valid source. Supplying neither is still an error.
     let result: any = getOfficialConflicts({ officialRecord: undefined as any });
-    expect(result.error).toEqual(MISSING_OFFICIAL_RECORD);
+    expect(result.error).toEqual(MISSING_CONFLICT_SOURCE);
+  });
+
+  it('accepts an officialParticipantId with NO officialRecord', () => {
+    let result: any = getOfficialConflicts({
+      officialParticipantId: 'par-official',
+      participants: [makeParticipant()],
+      policyDefinitions: POLICY_OFFICIATING_CONFLICT_OF_INTEREST,
+      groupParticipants: [],
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
   });
 
   it('is inert when no conflict policy is supplied', () => {

--- a/src/types/officiatingTypes.ts
+++ b/src/types/officiatingTypes.ts
@@ -91,6 +91,17 @@ export const ConflictTypeEnum = {
   NATIONALITY: 'NATIONALITY',
   /** The official has declared an affiliation with an entered participant's organisation. */
   ORGANISATION: 'ORGANISATION',
+  /**
+   * The official shares a GROUP participant with an entered participant — a relationship expressed
+   * inside the tournamentRecord rather than in an external registry. A GROUP containing a coach and
+   * the players they coach IS the declaration, and it is scoped to the tournament where it applies.
+   *
+   * GROUP is a general grouping primitive (squads, attribute-derived groupings), so a bare shared
+   * grouping is an inferred association, not a declared one — hence the default severity is WARN.
+   * A GROUP carrying a `participantRole` is an explicitly-authored relationship and can be escalated
+   * per-role via `ConflictRule.roleSeverity`.
+   */
+  SHARED_GROUPING: 'SHARED_GROUPING',
 } as const;
 
 export type ConflictType = (typeof ConflictTypeEnum)[keyof typeof ConflictTypeEnum];
@@ -141,6 +152,11 @@ export interface OfficialConflict {
   relationship?: string;
   nationalityCode?: string;
   declarationId?: string;
+  /** SHARED_GROUPING only — the GROUP participant that links official and participant. */
+  groupParticipantId?: string;
+  groupName?: string;
+  /** The GROUP's own `participantRole`, when it carries one. */
+  groupRole?: string;
   reason: string;
 }
 
@@ -148,6 +164,15 @@ export interface OfficialConflict {
 export interface ConflictRule {
   enabled: boolean;
   severity: ConflictSeverity;
+  /**
+   * SHARED_GROUPING only: severity override keyed by the GROUP participant's own `participantRole`.
+   * A grouping with no role, or a role absent from this map, falls back to `severity`.
+   *
+   * This is what separates an explicitly-authored relationship group (`participantRole: 'COACH'`)
+   * from an incidental one — e.g. `{ COACH: 'BLOCK' }` blocks coach groupings while other shared
+   * groupings merely warn.
+   */
+  roleSeverity?: Record<string, ConflictSeverity>;
 }
 
 export interface ConflictOfInterestPolicy {


### PR DESCRIPTION
> **Stacked on #4611** — base is `fix/officiating-engine-exposure`, not `master`, so the diff shows only this change. **#4611 must merge first.**

A conflict declaration no longer requires an external registry record. **A `GROUP` participant containing the official and a competitor IS the declaration**, scoped to the tournament where it applies.

## Why

The original design treated declarations as durable, registry-owned facts (courthive-ams). That made the whole feature depend on officials keeping a global registry current — unrealistic — and it failed badly where the registry is empty: every check returned "no conflicts", which is **indistinguishable from a check that passed**.

Most relationships are transient (an umpire coaching a player *at this event*), and a tournament assignment is the natural moment to capture one. So the declaration should live where it is created.

The model already supported this with no schema change: `createGroupParticipant` accepts `participantRole`, `addIndividualParticipantIds` adds individuals to a `GROUP`, and the official is already an INDIVIDUAL participant with `participantRole: OFFICIAL` because `addMatchUpOfficial` requires exactly that.

## What changed

`getOfficialConflicts` takes **two independent sources and requires only one**:

| source | scope | supplied as |
|---|---|---|
| registry | durable, cross-tournament | `officialRecord.conflictDeclarations` |
| tournamentRecord | transient, this event | `officialParticipantId` + `groupParticipants` |

Supplying neither is `MISSING_CONFLICT_SOURCE`. `officialRecord` is now **optional** throughout — including `getMatchUpOfficialConflicts` and the `addMatchUpOfficial` gate, which passes **the official being assigned** as the subject, so the gate runs against the tournamentRecord alone with no cross-service call.

### New `SHARED_GROUPING` rule — default `WARN`

`GROUP` is a general primitive (`createTeamsFromAttributes` builds them from arbitrary attributes; squads are legitimate), so a bare shared grouping is an *inferred* association, not a declared one. Blocking on it would false-positive on data created for unrelated reasons.

**`participantRole` on the GROUP is what marks an authored relationship**, escalated via `ConflictRule.roleSeverity`:

```ts
[CONFLICT_SHARED_GROUPING]: {
  enabled: true,
  severity: CONFLICT_WARN,                       // incidental groupings
  roleSeverity: { COACH: 'BLOCK', MEDICAL: 'BLOCK', PHYSIO: 'BLOCK', TRAINER: 'BLOCK' },
}
```

Discovered rather than assumed: `createGroupParticipant` defaults `participantRole` to `OTHER`, so there is **no unroled GROUP**. That works in our favour — `OTHER` is the incidental marker, absent from `roleSeverity`, falling through to the base severity. Asserted by test.

## Contract change — three existing tests rewritten

Three tests encoded the old required-`officialRecord` behaviour (two asserting `MISSING_OFFICIAL_RECORD`, one asserting the gate *refuses* without a record). They are rewritten **with the change stated in place** rather than deleted, so a later reader doesn't assume the old invariant still holds.

## Verification

- lint 0, `check-types` clean, `verify:generated` in sync (engine-methods 657).
- **10826 tests passed / 1 skipped** (+6), 0 regressions.
- Coverage **95.08 / 86.80 / 97.99 / 97.61** against the 95/95/85/95 gate. `getOfficialConflicts` 98.14/83.33/100/100; `getMatchUpOfficialConflicts` 91.66/80.76/100/100.
- **Falsified four ways**, each red then restored: removing the GROUP source (3 failures), ignoring `roleSeverity` so COACH stops blocking (1), matching groupings regardless of membership (2), dropping the rule from the default policy (3).

## Open question

`roleSeverity` currently blocks on `COACH` / `MEDICAL` / `PHYSIO` / `TRAINER`. **`CAPTAIN` is the obvious omission** — a team role that may or may not imply disqualifying closeness. It is policy rather than stored data, so changing it later is migration-free.
