### PR TITLE
feat(query): survey matchUpFormats across an event, project competitionFormat

### DIFF
--- a/documentation/docs/governors/query-governor.md
+++ b/documentation/docs/governors/query-governor.md
@@ -2171,6 +2171,31 @@ const {
 } = tournamentInfo;
 ```
 
+`tournamentInfo.eventInfo` carries one projection per event (filtered to published events when
+`usePublishState` is set). Alongside the event's own attributes it includes two format fields:
+
+```js
+const [event] = tournamentInfo.eventInfo;
+
+event.matchUpFormat; // the event's OWN declared code, or undefined
+event.competitionFormat; // the event's OWN competitionFormat, or undefined
+event.matchUpFormats; // every distinct code declared anywhere in the event
+```
+
+`matchUpFormats` is a **survey, not a resolution.** It collects distinct codes from the event, each of its
+drawDefinitions, and their structures (depth-first, recursing because round-robin item structures nest),
+in encounter order. Nothing about the order implies precedence — `competitionFormat` documents the
+effective-format hierarchy as `matchUp > structure > drawDefinition > event`, where specificity flows
+downward, so a caller must not read `matchUpFormats[0]` as "the" format for the event. When draws disagree
+the survey keeps every code, precisely so a caller can tell the event is not uniform. It is omitted when
+nothing declares a format.
+
+The survey exists because a scoring code identifies the **sport** being played, and the sport is a property
+of the whole event however deep the code happens to be stored. In practice codes are declared at
+drawDefinition level far more often than on the event: a live tournament surveyed when this was added
+declared nothing on the event and `SET3-S:6/TB7` on its drawDefinition, so an event-level read alone
+reported no format at all.
+
 ---
 
 ## getTournamentPersons

--- a/src/query/event/extractEventInfo.ts
+++ b/src/query/event/extractEventInfo.ts
@@ -1,5 +1,51 @@
+import type { DrawDefinition, Event, Structure } from '@Types/tournamentTypes';
+
+/**
+ * Walk a structure tree collecting declared matchUpFormat codes.
+ *
+ * Round-robin item structures nest under `structure.structures`, so this
+ * recurses rather than reading one level.
+ */
+function collectStructureMatchUpFormats(structures: Structure[] | undefined, collected: Set<string>): void {
+  for (const structure of structures ?? []) {
+    if (structure?.matchUpFormat) collected.add(structure.matchUpFormat);
+    collectStructureMatchUpFormats(structure?.structures, collected);
+  }
+}
+
+/**
+ * Every distinct matchUpFormat code declared anywhere in an event — on the
+ * event itself, on any of its drawDefinitions, or on any of their structures
+ * (depth-first, in encounter order).
+ *
+ * This is a **survey, not a resolution**. `competitionFormat` documents the
+ * effective-format hierarchy as `matchUp > structure > drawDefinition > event`,
+ * where specificity flows downward; nothing here implies precedence, and a
+ * caller must not read the first entry as "the" format for the event. It exists
+ * because a scoring code identifies the SPORT being played, and the sport is a
+ * property of the whole event however deep the code happens to be stored.
+ *
+ * In practice codes are usually declared at drawDefinition level: a live
+ * tournament surveyed while this was written declared nothing on the event and
+ * `SET3-S:6/TB7` on its drawDefinition.
+ */
+export function getEventMatchUpFormats(event?: Event): string[] {
+  const collected = new Set<string>();
+
+  if (event?.matchUpFormat) collected.add(event.matchUpFormat);
+
+  const drawDefinitions: DrawDefinition[] = event?.drawDefinitions ?? [];
+  for (const drawDefinition of drawDefinitions) {
+    if (drawDefinition?.matchUpFormat) collected.add(drawDefinition.matchUpFormat);
+    collectStructureMatchUpFormats(drawDefinition?.structures, collected);
+  }
+
+  return [...collected];
+}
+
 export function extractEventInfo({ event }) {
   const {
+    competitionFormat,
     surfaceCategory,
     onlineResources,
     matchUpFormat,
@@ -18,8 +64,15 @@ export function extractEventInfo({ event }) {
 
   const entriesCount = event.entries?.length ?? 0;
 
+  // Distinct codes from anywhere in the event. Omitted when empty so events
+  // that declare no format keep their existing payload shape, matching the
+  // undefined-valued fields alongside.
+  const matchUpFormats = getEventMatchUpFormats(event);
+
   const eventInfo = {
     drawDefinitionCount: event.drawDefinitions?.length,
+    matchUpFormats: matchUpFormats.length ? matchUpFormats : undefined,
+    competitionFormat,
     entriesCount,
     surfaceCategory,
     onlineResources,

--- a/src/tests/queries/events/extractEventInfo.test.ts
+++ b/src/tests/queries/events/extractEventInfo.test.ts
@@ -1,0 +1,128 @@
+import { extractEventInfo, getEventMatchUpFormats } from '@Query/event/extractEventInfo';
+import tournamentEngine from '@Engines/syncEngine';
+import { mocksEngine } from '@Assemblies/engines/mock';
+import { expect, it, describe } from 'vitest';
+
+// A live tournament surveyed while this was written declared no format on the
+// event and this code on its drawDefinition — the shape the survey exists for.
+const DRAW_FORMAT = 'SET3-S:6/TB7';
+const STRUCTURE_FORMAT = 'SET3-S:6/TB7-F:TB10';
+const EVENT_FORMAT = 'SET5-S:6/TB7';
+// Pickleball: a rally-scored code, which is how a scoring code identifies sport.
+const RALLY_FORMAT = 'SET3-S:11@RALLY';
+
+describe('getEventMatchUpFormats', () => {
+  it('surveys the event, its drawDefinitions, and their structures', () => {
+    const event: any = {
+      matchUpFormat: EVENT_FORMAT,
+      drawDefinitions: [{ matchUpFormat: DRAW_FORMAT, structures: [{ matchUpFormat: STRUCTURE_FORMAT }] }],
+    };
+    expect(getEventMatchUpFormats(event)).toEqual([EVENT_FORMAT, DRAW_FORMAT, STRUCTURE_FORMAT]);
+  });
+
+  it('finds a drawDefinition format when the event declares none', () => {
+    const event: any = { drawDefinitions: [{ matchUpFormat: DRAW_FORMAT }] };
+    expect(getEventMatchUpFormats(event)).toEqual([DRAW_FORMAT]);
+  });
+
+  it('recurses into nested structures, as round-robin item structures nest', () => {
+    const event: any = {
+      drawDefinitions: [{ structures: [{ structures: [{ matchUpFormat: STRUCTURE_FORMAT }] }] }],
+    };
+    expect(getEventMatchUpFormats(event)).toEqual([STRUCTURE_FORMAT]);
+  });
+
+  it('deduplicates codes repeated across draws and structures', () => {
+    const event: any = {
+      matchUpFormat: DRAW_FORMAT,
+      drawDefinitions: [
+        { matchUpFormat: DRAW_FORMAT, structures: [{ matchUpFormat: DRAW_FORMAT }] },
+        { matchUpFormat: DRAW_FORMAT },
+      ],
+    };
+    expect(getEventMatchUpFormats(event)).toEqual([DRAW_FORMAT]);
+  });
+
+  it('preserves every distinct code when draws disagree', () => {
+    // Deliberate: the survey must not collapse a mixed-format event to one
+    // code, because a caller cannot then tell the event is not uniform.
+    const event: any = {
+      drawDefinitions: [{ matchUpFormat: DRAW_FORMAT }, { matchUpFormat: RALLY_FORMAT }],
+    };
+    expect(getEventMatchUpFormats(event)).toEqual([DRAW_FORMAT, RALLY_FORMAT]);
+  });
+
+  it('returns an empty array when nothing declares a format', () => {
+    expect(getEventMatchUpFormats({ drawDefinitions: [{ structures: [{}] }] } as any)).toEqual([]);
+    expect(getEventMatchUpFormats({} as any)).toEqual([]);
+    expect(getEventMatchUpFormats(undefined)).toEqual([]);
+  });
+});
+
+describe('extractEventInfo', () => {
+  it('projects matchUpFormats without disturbing the event-level matchUpFormat', () => {
+    const event: any = {
+      eventId: 'e1',
+      eventName: 'Mens Open Singles',
+      drawDefinitions: [{ matchUpFormat: DRAW_FORMAT }],
+    };
+    const { eventInfo }: any = extractEventInfo({ event });
+
+    // The event declares none, so the existing field keeps its exact meaning...
+    expect(eventInfo.matchUpFormat).toBeUndefined();
+    // ...while the survey exposes what the draws declare.
+    expect(eventInfo.matchUpFormats).toEqual([DRAW_FORMAT]);
+  });
+
+  it('omits matchUpFormats entirely when no format is declared anywhere', () => {
+    const { eventInfo }: any = extractEventInfo({ event: { eventId: 'e1' } });
+    expect(eventInfo.matchUpFormats).toBeUndefined();
+    expect('matchUpFormats' in eventInfo).toBe(true);
+  });
+
+  it('projects the event competitionFormat, which was previously dropped', () => {
+    const competitionFormat: any = { sport: 'PICKLEBALL' };
+    const { eventInfo }: any = extractEventInfo({ event: { eventId: 'e1', competitionFormat } });
+    expect(eventInfo.competitionFormat).toEqual(competitionFormat);
+  });
+
+  it('keeps every field it projected before', () => {
+    const event: any = {
+      eventId: 'e1',
+      eventName: 'Mens Open Singles',
+      eventType: 'SINGLES',
+      gender: 'MALE',
+      matchUpFormat: EVENT_FORMAT,
+      surfaceCategory: 'HARD',
+      discipline: 'TENNIS',
+      entries: [{}, {}, {}],
+    };
+    const { eventInfo }: any = extractEventInfo({ event });
+    expect(eventInfo.eventId).toEqual('e1');
+    expect(eventInfo.eventName).toEqual('Mens Open Singles');
+    expect(eventInfo.eventType).toEqual('SINGLES');
+    expect(eventInfo.gender).toEqual('MALE');
+    expect(eventInfo.matchUpFormat).toEqual(EVENT_FORMAT);
+    expect(eventInfo.surfaceCategory).toEqual('HARD');
+    expect(eventInfo.discipline).toEqual('TENNIS');
+    expect(eventInfo.entriesCount).toEqual(3);
+  });
+});
+
+describe('getTournamentInfo eventInfo', () => {
+  it('surfaces a generated draw format that the event itself does not declare', () => {
+    const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 8, matchUpFormat: DRAW_FORMAT }],
+      setState: true,
+      nonRandom: 1,
+    });
+    tournamentEngine.setState(tournamentRecord);
+
+    // getTournamentInfo hangs eventInfo off tournamentInfo, not the top level.
+    const { tournamentInfo }: any = tournamentEngine.getTournamentInfo();
+    const eventInfo = tournamentInfo.eventInfo;
+    expect(eventInfo.length).toEqual(1);
+    // The projection reaches the code wherever mocksEngine stored it.
+    expect(eventInfo[0].matchUpFormats).toContain(DRAW_FORMAT);
+  });
+});


### PR DESCRIPTION
## Why

`extractEventInfo` read `matchUpFormat` only from the event, and dropped `competitionFormat` entirely. In practice codes are declared lower down — a live tournament surveyed while writing this declared nothing on the event and `SET3-S:6/TB7` on its drawDefinition:

| Level | `matchUpFormat` | `competitionFormat` |
|---|---|---|
| event | — | — |
| **drawDefinition** | **`SET3-S:6/TB7`** | — |
| structure | `SET3-S:6/TB7-F:TB10` | — |

A consumer trying to identify the **sport** from a scoring code got nothing, even though the code sat two levels down. The immediate consumer is courthive-public, which picks a court-SVG fallback for venue cards and currently always defaults to tennis.

## What

- **`eventInfo.matchUpFormats`** — every distinct code declared on the event, its drawDefinitions, or their structures. Depth-first (round-robin item structures nest), deduplicated, encounter order. Omitted when nothing declares a format.
- **`eventInfo.competitionFormat`** — the event's own declaration, which carries `sport` directly. Previously dropped.

## A survey, not a resolution

`competitionFormat` documents the effective-format hierarchy as `matchUp > structure > drawDefinition > event`, with specificity flowing **downward**. This change deliberately does not invent an upward resolution that would contradict that. Ordering in `matchUpFormats` implies no precedence, and `matchUpFormats[0]` is not "the" format for the event. When draws disagree every code is kept, so a caller can tell the event is not uniform.

## Compatibility

Purely additive. `matchUpFormat` keeps its exact prior meaning — the event's own declaration — so no existing consumer changes behaviour.

## Verification

- Full suite: **10837 passed**, 1 skipped
- `pnpm lint` clean, `pnpm check-types` clean
- Falsified: reverting the two added projections fails 4 of the 11 new tests
- Docs updated in `documentation/docs/governors/query-governor.md`