### PR TITLE
feat(read-model): scope competitors by tournament and project event origin

### DIFF
--- a/documentation/docs/concepts/events/event-origin.mdx
+++ b/documentation/docs/concepts/events/event-origin.mdx
@@ -1,0 +1,104 @@
+---
+title: Event Origin & Other IDs
+---
+
+## Why an event needs its own identity
+
+A `tournamentRecord` has exactly one `tournamentId`. An **event** inside it may have been
+sanctioned somewhere else entirely — by a governing body that holds its own tournament,
+with its own internal id, in its own system.
+
+A single record can carry events from **several sanctioning systems at once**. When that
+happens there is no single "the" sanctioning tournamentId for the record, and the event's
+origin cannot be inferred from the record that carries it.
+
+`Event.eventOtherIds[]` is where that identity lives.
+
+## Shape
+
+`UnifiedEventID` is the event-grain member of the `Unified*ID` family, alongside
+`UnifiedTournamentID` (`tournament.tournamentOtherIds`), `UnifiedPersonID`
+(`person.personOtherIds`) and `UnifiedVenueID` (`venue.venueOtherIds`).
+
+```js
+event.eventOtherIds = [
+  { organisationId: 'ITA', tournamentId: 'ita-4471', eventId: 'ita-ev-9', isOrigin: true },
+  { organisationId: 'USTA', tournamentId: 'usta-88', eventId: 'usta-ev-2' },
+];
+```
+
+| attribute                | meaning                                                            |
+| ------------------------ | ------------------------------------------------------------------ |
+| `organisationId`         | the organisation whose system this id belongs to (required)        |
+| `tournamentId`           | **that organisation's** tournamentId — _not_ the carrying record's |
+| `eventId`                | that organisation's id for this event                              |
+| `isOrigin`               | marks the entry as the sanctioning source the event came from      |
+| `uniqueOrganisationName` | human-readable name of the organisation                            |
+
+Three properties of the shape are load-bearing:
+
+- **`tournamentId` is optional and belongs to `organisationId`.** It names a tournament in
+  that organisation's system, never the carrying record. It is not assumed to resolve
+  locally — see the two linking modes below.
+- **`eventId` is optional.** An event sanctioned but not yet created in the origin system
+  has no id there. It is written back after the event is copied to the origin — after the
+  fact, or through an external API integration.
+- **At most one entry carries `isOrigin`.** Everything else in the array is a system the
+  event is merely _also_ known to. An event with no flagged entry simply has no declared
+  origin, which is the ordinary single-sanction case.
+
+## Two linking modes
+
+The sanctioning workflow can attach an event to either kind of origin, and the same
+`UnifiedEventID` expresses both:
+
+| mode                                                                                                                    | `organisationId`         | does `tournamentId` resolve here?                              |
+| ----------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------------------------- |
+| **External** — a tournament sanctioned outside this ecosystem, linked in as an event of the tournament being sanctioned | a foreign governing body | usually **no**; the body may hold no record carrying the event |
+| **Internal** — a tournament already sanctioned _within_ this ecosystem, linked as an event                              | a CourtHive provider     | **yes**, it is a real tournamentRecord                         |
+
+The distinction is data, not schema: nothing branches on it, and a consumer that wants the
+origin's local record simply attempts the lookup. This is exactly why the projected
+`origin_tournament_id` **cannot** carry a foreign key — a constraint satisfiable for
+internal links is impossible for external ones. Resolution is a read-time `LEFT JOIN`,
+never a write-time constraint.
+
+## Reading the origin
+
+```js
+import { readModel } from 'tods-competition-factory';
+
+const origin = readModel.eventOrigin(event); // the isOrigin entry, or undefined
+```
+
+## Writing
+
+Through the standard mutation. The array is replaced wholesale — the natural grain, since
+a caller reconciling against a sanctioning body holds the full list. Pass `null` to clear.
+
+```js
+engine.modifyEvent({
+  eventUpdates: {
+    eventOtherIds: [{ organisationId: 'ITA', tournamentId: 'ita-4471', isOrigin: true }],
+  },
+  eventId,
+});
+```
+
+This dispatches `MODIFY_EVENT`, so any subscriber maintaining a projection of events sees
+the change.
+
+## In the read model
+
+`cast()` and the incremental projection producer both flatten the flagged entry onto the
+events row:
+
+| column                   | source                                |
+| ------------------------ | ------------------------------------- |
+| `tournament_id`          | the record that **carries** the event |
+| `origin_organisation_id` | `eventOrigin(event).organisationId`   |
+| `origin_tournament_id`   | `eventOrigin(event).tournamentId`     |
+| `origin_event_id`        | `eventOrigin(event).eventId`          |
+
+`tournament_id` and `origin_tournament_id` are independent by design. Reading one for the
+other is the mistake this concept exists to prevent.

--- a/documentation/docs/types/assets/event.ts
+++ b/documentation/docs/types/assets/event.ts
@@ -8,6 +8,8 @@ export const event = {
   endDate: '{\\"type\\":\\"string\\",\\"required\\":\\"true\\",\\"note\\":\\"\'YYYY-MM-DD\'\\"}',
   eventId: '{\\"type\\":\\"string\\",\\"required\\":\\"true\\"}',
   eventName: '{\\"type\\":\\"string\\",\\"required\\":\\"false\\"}',
+  eventOtherIds:
+    '{\\"type\\":\\"object\\",\\"array\\":\\"true\\",\\"required\\":\\"false\\",\\"note\\":\\"this event\'s identity in other organisations\' systems; the entry flagged isOrigin is the sanctioning source, and its tournamentId belongs to THAT organisation, not the carrying tournamentRecord\\"}',
   eventRank: '{\\"type\\":\\"string\\",\\"required\\":\\"false\\"}',
   eventLevel: '{\\"type\\":\\"enum\\",\\"enum\\": \\"\\",\\"required\\":\\"false\\"}',
   eventType:

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -59,6 +59,7 @@ module.exports = {
             'concepts/events/categories',
             'concepts/events/entries',
             'concepts/events/flights',
+            'concepts/events/event-origin',
           ],
         },
         {

--- a/src/mutate/events/modifyEvent.ts
+++ b/src/mutate/events/modifyEvent.ts
@@ -15,7 +15,6 @@ import { isAny } from '@Validators/isAny';
 import { unique } from '@Tools/arrays';
 
 // constants and types
-import { Category, Event, Tournament, EventTypeUnion, GenderUnion, TieFormat } from '@Types/tournamentTypes';
 import { ALTERNATE, STRUCTURE_SELECTED_STATUSES } from '@Constants/entryStatusConstants';
 import { DOUBLES, HYBRID, SINGLES, TEAM } from '@Constants/eventConstants';
 import { INDIVIDUAL, PAIR } from '@Constants/participantConstants';
@@ -23,6 +22,15 @@ import { competitionFormat } from '@Types/competitionFormat';
 import { OBJECT } from '@Constants/attributeConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 import { ResultType } from '@Types/factoryTypes';
+import {
+  Category,
+  Event,
+  Tournament,
+  EventTypeUnion,
+  GenderUnion,
+  TieFormat,
+  UnifiedEventID,
+} from '@Types/tournamentTypes';
 import {
   CATEGORY_MISMATCH,
   INVALID_CATEGORY,
@@ -40,6 +48,11 @@ type ModifyEventArgs = {
     endDate?: string;
     category?: Category;
     eventName?: string;
+    // The event's identity in other organisations' systems; the entry flagged `isOrigin`
+    // is the sanctioning source. Pass an array to replace the whole set (the natural
+    // grain — a caller reconciling against a sanctioning body holds the full list), or
+    // null to clear it. Mirrors the competitionFormat null-clears convention below.
+    eventOtherIds?: UnifiedEventID[] | null;
     // Set to a competitionFormat object to attach sport rules (timers,
     // multipliers, penalties) to the event. Pass null to clear an existing
     // value. Hierarchical resolution lets drawDefinition/structure overrides
@@ -92,6 +105,14 @@ export function modifyEvent(params: ModifyEventArgs): ResultType {
       delete event.competitionFormat;
     } else {
       event.competitionFormat = eventUpdates.competitionFormat;
+    }
+  }
+
+  if (eventUpdates.eventOtherIds !== undefined) {
+    if (eventUpdates.eventOtherIds === null) {
+      delete event.eventOtherIds;
+    } else {
+      event.eventOtherIds = eventUpdates.eventOtherIds;
     }
   }
 

--- a/src/query/readModel/index.ts
+++ b/src/query/readModel/index.ts
@@ -14,6 +14,7 @@ export type { PersonLink } from './personRule';
 export {
   tournamentRow,
   eventRow,
+  eventOrigin,
   drawRow,
   structureRow,
   seedRow,

--- a/src/query/readModel/readModelRows.ts
+++ b/src/query/readModel/readModelRows.ts
@@ -4,6 +4,7 @@ import { LINK_UNRESOLVED, resolvePersonLink } from './personRule';
 import { findExtension } from '@Acquire/findExtension';
 
 // types
+import { UnifiedEventID } from '@Types/tournamentTypes';
 import {
   ReadModelTournamentRow,
   ReadModelCompetitorRow,
@@ -83,6 +84,7 @@ export function eventRow(
   providerId: string | undefined,
   published: boolean,
 ): ReadModelEventRow {
+  const origin = eventOrigin(event);
   return {
     event_id: event?.eventId,
     tournament_id: tournamentId,
@@ -95,7 +97,23 @@ export function eventRow(
     start_date: event?.startDate ?? null,
     end_date: event?.endDate ?? null,
     published,
+    origin_organisation_id: origin?.organisationId ?? null,
+    origin_tournament_id: origin?.tournamentId ?? null,
+    origin_event_id: origin?.eventId ?? null,
   };
+}
+
+/**
+ * The `eventOtherIds[]` entry flagged `isOrigin` — the sanctioning source the event came
+ * from. Returns undefined when the event declares no origin (the ordinary single-sanction
+ * case), so every origin_* column projects null rather than picking an arbitrary entry.
+ *
+ * `find` rather than `filter`+index: at most one entry should carry the flag. If more than
+ * one does the record is malformed; taking the first is stable (array order is preserved
+ * through storage) and keeps the projection deterministic rather than throwing on a read.
+ */
+export function eventOrigin(event: any): UnifiedEventID | undefined {
+  return (event?.eventOtherIds ?? []).find((otherId: UnifiedEventID) => otherId?.isOrigin);
 }
 
 // ── draws + structures ──────────────────────────────────────────────────────────
@@ -392,6 +410,7 @@ function pairCompetitorRows(
     const link = resolvePersonLink(individual?.participantId, individual?.person?.personId);
     return {
       match_up_id: matchUpId,
+      tournament_id: ctx.tournamentId,
       side_number: sideNumber,
       competitor_index: index,
       participant_type: PAIR,
@@ -434,6 +453,7 @@ function sideCompetitorRows(
   return [
     {
       match_up_id: matchUpId,
+      tournament_id: ctx.tournamentId,
       side_number: sideNumber,
       competitor_index: 0,
       participant_type: participantType,

--- a/src/tests/mutations/events/modifyEvent.test.ts
+++ b/src/tests/mutations/events/modifyEvent.test.ts
@@ -157,3 +157,39 @@ it('supports attaching, replacing, and clearing competitionFormat on an event', 
   event = tournamentEngine.getEvent({ eventId }).event;
   expect(event.competitionFormat).toBeUndefined();
 });
+
+// The origin of an event is a tournament in ANOTHER organisation's system. Its
+// tournamentId is that organisation's and must never be confused with the carrying
+// record's — a single record can hold events sanctioned by several organisations.
+it('supports setting, replacing, and clearing eventOtherIds on an event', () => {
+  const eventId = 'origin-modify';
+  const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+    eventProfiles: [{ eventId, eventName: 'Sanctioned Event', eventType: SINGLES }],
+    nonRandom: 1,
+    setState: true,
+  });
+
+  let event = tournamentEngine.getEvent({ eventId }).event;
+  expect(event.eventOtherIds).toBeUndefined();
+
+  const origin = { organisationId: 'ITA', tournamentId: 'ita-4471', eventId: 'ita-ev-9', isOrigin: true };
+  let result: any = tournamentEngine.modifyEvent({ eventUpdates: { eventOtherIds: [origin] }, eventId });
+  expect(result.success).toEqual(true);
+  event = tournamentEngine.getEvent({ eventId }).event;
+  expect(event.eventOtherIds).toEqual([origin]);
+  // the origin's tournamentId is the ORIGIN organisation's, not the carrying record's
+  expect(event.eventOtherIds?.[0].tournamentId).not.toEqual(tournamentRecord.tournamentId);
+
+  // a copy-back to a second organisation appends its id — the array is replaced wholesale
+  const copyBack = { organisationId: 'USTA', tournamentId: 'usta-88', eventId: 'usta-ev-2' };
+  result = tournamentEngine.modifyEvent({ eventUpdates: { eventOtherIds: [origin, copyBack] }, eventId });
+  expect(result.success).toEqual(true);
+  event = tournamentEngine.getEvent({ eventId }).event;
+  expect(event.eventOtherIds).toHaveLength(2);
+  expect(event.eventOtherIds?.filter((otherId) => otherId.isOrigin)).toHaveLength(1);
+
+  result = tournamentEngine.modifyEvent({ eventUpdates: { eventOtherIds: null }, eventId });
+  expect(result.success).toEqual(true);
+  event = tournamentEngine.getEvent({ eventId }).event;
+  expect(event.eventOtherIds).toBeUndefined();
+});

--- a/src/tests/queries/readModel/castExposure.test.ts
+++ b/src/tests/queries/readModel/castExposure.test.ts
@@ -35,6 +35,7 @@ describe('cast governor/engine exposure', () => {
       readModel.matchUpResultRow,
       readModel.tournamentRow,
       readModel.eventRow,
+      readModel.eventOrigin,
       readModel.drawRow,
       readModel.structureRow,
       readModel.seedRow,

--- a/src/tests/queries/readModel/readModelRows.test.ts
+++ b/src/tests/queries/readModel/readModelRows.test.ts
@@ -2,6 +2,7 @@ import {
   courtRow,
   drawRow,
   entryRows,
+  eventOrigin,
   eventRow,
   matchUpRowSet,
   orderOfPlayRow,
@@ -49,6 +50,9 @@ describe('eventRow', () => {
       start_date: '2025-01-02',
       end_date: '2025-01-05',
       published: true,
+      origin_organisation_id: null,
+      origin_tournament_id: null,
+      origin_event_id: null,
     });
   });
 
@@ -65,7 +69,68 @@ describe('eventRow', () => {
       start_date: null,
       end_date: null,
       published: false,
+      origin_organisation_id: null,
+      origin_tournament_id: null,
+      origin_event_id: null,
     });
+  });
+
+  // The origin is the SANCTIONING source, whose tournamentId belongs to the origin
+  // organisation and is deliberately unrelated to the carrying record's tournamentId —
+  // one record can hold events sanctioned by several organisations.
+  it('projects the isOrigin eventOtherIds entry, independent of the carrying tournamentId', () => {
+    const row = eventRow(
+      {
+        eventId: 'e3',
+        eventOtherIds: [
+          { organisationId: 'USTA', tournamentId: 'usta-88', eventId: 'usta-ev-2' },
+          { organisationId: 'ITA', tournamentId: 'ita-4471', eventId: 'ita-ev-9', isOrigin: true },
+        ],
+      },
+      'carrier-record-id',
+      'PROV',
+      false,
+    );
+    expect(row.tournament_id).toEqual('carrier-record-id');
+    expect(row.origin_organisation_id).toEqual('ITA');
+    expect(row.origin_tournament_id).toEqual('ita-4471');
+    expect(row.origin_event_id).toEqual('ita-ev-9');
+  });
+
+  it('nulls every origin column when eventOtherIds carries no isOrigin entry', () => {
+    const row = eventRow(
+      { eventId: 'e4', eventOtherIds: [{ organisationId: 'USTA', tournamentId: 'usta-88' }] },
+      't1',
+      'PROV',
+      false,
+    );
+    expect(row.origin_organisation_id).toBeNull();
+    expect(row.origin_tournament_id).toBeNull();
+    expect(row.origin_event_id).toBeNull();
+  });
+
+  // An event sanctioned but not yet created in the origin system has no origin eventId;
+  // it is written back after the copy-back / API integration lands.
+  it('projects an origin with no eventId yet', () => {
+    const row = eventRow(
+      { eventId: 'e5', eventOtherIds: [{ organisationId: 'ITA', tournamentId: 'ita-4471', isOrigin: true }] },
+      't1',
+      'PROV',
+      false,
+    );
+    expect(row.origin_organisation_id).toEqual('ITA');
+    expect(row.origin_tournament_id).toEqual('ita-4471');
+    expect(row.origin_event_id).toBeNull();
+  });
+});
+
+describe('eventOrigin', () => {
+  it('finds the flagged entry, and is undefined when none is flagged or the array is absent', () => {
+    const origin = { organisationId: 'ITA', tournamentId: 'ita-4471', isOrigin: true };
+    expect(eventOrigin({ eventOtherIds: [{ organisationId: 'USTA' }, origin] })).toEqual(origin);
+    expect(eventOrigin({ eventOtherIds: [{ organisationId: 'USTA' }] })).toBeUndefined();
+    expect(eventOrigin({})).toBeUndefined();
+    expect(eventOrigin(undefined)).toBeUndefined();
   });
 });
 
@@ -551,6 +616,43 @@ describe('matchUpRowSet', () => {
     expect(competitorRows[0].link_source).toEqual('providerId');
     // i2 carries no person.personId → unresolved.
     expect(competitorRows[1].person_id).toBeNull();
+  });
+
+  // Competitor rows previously reached their tournament ONLY through match_up_id, which
+  // left the incremental producer's rename / person-claim UPDATEs unscopable — they key
+  // on a participantId alone and `buildUpdate` cannot express a join. Every grain must
+  // carry it: INDIVIDUAL, TEAM, PAIR and rubber rows.
+  it('stamps ctx.tournamentId on every competitor row, at every grain', () => {
+    const { competitorRows } = matchUpRowSet(
+      {
+        matchUpId: 'tie1',
+        matchUpType: 'TEAM',
+        sides: [
+          { sideNumber: 1, participant: { participantId: 'team1', participantType: 'TEAM', teamId: 'TEAM_A' } },
+          { sideNumber: 2, participant: { participantId: 'team2', participantType: 'TEAM' } },
+        ],
+        tieMatchUps: [
+          {
+            matchUpId: 'r1',
+            sides: [
+              { sideNumber: 1, participant: { participantId: 'p1', participantType: 'INDIVIDUAL' } },
+              {
+                sideNumber: 2,
+                participant: {
+                  participantId: 'pair1',
+                  participantType: 'PAIR',
+                  individualParticipants: [{ participantId: 'i1' }, { participantId: 'i2' }],
+                },
+              },
+            ],
+          },
+        ],
+      },
+      ctx,
+    );
+    const grains = new Set(competitorRows.map((c) => c.participant_type));
+    expect(grains).toEqual(new Set(['TEAM', 'INDIVIDUAL', 'PAIR']));
+    expect(competitorRows.every((c) => c.tournament_id === 't1')).toBe(true);
   });
 });
 

--- a/src/types/readModelTypes.ts
+++ b/src/types/readModelTypes.ts
@@ -63,6 +63,12 @@ export interface ReadModelMatchUpRow {
 
 export interface ReadModelCompetitorRow {
   match_up_id: string;
+  // Denormalized from the parent matchUp. The competitors table's tournament linkage was
+  // previously transitive ONLY (match_up_id → match_ups.tournament_id), which left the
+  // incremental producer's participant-rename and person-claim UPDATEs keyed on a
+  // participantId alone — table-wide, unscoped by tournament. Carrying the column makes
+  // those statements scopable; `buildUpdate` cannot express a join.
+  tournament_id: string;
   side_number: number | null; // 1 | 2
   competitor_index: number; // 0 (singles/team) | 0,1 (doubles)
   participant_type: string | null; // INDIVIDUAL | PAIR | TEAM
@@ -96,6 +102,14 @@ export interface ReadModelEventRow {
   start_date: string | null;
   end_date: string | null;
   published: boolean;
+  // The SANCTIONING SOURCE this event originated from — the `eventOtherIds[]` entry
+  // flagged `isOrigin`, flattened. `origin_tournament_id` is the ORIGIN organisation's
+  // tournamentId and is deliberately independent of `tournament_id` above (the record
+  // that carries the event); one record can hold events from several sanctioning
+  // systems. All three are null for an event with no declared origin.
+  origin_organisation_id: string | null;
+  origin_tournament_id: string | null;
+  origin_event_id: string | null;
 }
 
 export interface ReadModelDrawRow {

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -98,6 +98,10 @@ export interface Event {
   eventLevel?: TournamentLevelUnion;
   eventName?: string;
   eventOrder?: number;
+  // CODES first-class: this event's identity in OTHER organisations' systems, one entry
+  // per organisation. The entry flagged `isOrigin` is the sanctioning source the event
+  // came from — its `tournamentId` is that organisation's, NOT the carrying record's.
+  eventOtherIds?: UnifiedEventID[];
   eventRank?: string;
   eventTier?: TierClassification;
   eventType?: EventTypeUnion;
@@ -1720,6 +1724,40 @@ export interface UnifiedTournamentID {
   organisationId: string;
   timeItems?: TimeItem[];
   tournamentId: string;
+  uniqueOrganisationName?: string;
+  updatedAt?: Date | string;
+}
+
+/**
+ * CODES first-class: an EVENT's identity in another organisation's system —
+ * the event-grain member of the `Unified*ID` family
+ * ({@link UnifiedTournamentID}, {@link UnifiedPersonID}, {@link UnifiedVenueID}).
+ *
+ * Carried on `Event.eventOtherIds[]`. It exists because a single tournamentRecord
+ * can hold events sanctioned by SEVERAL organisations, each of which has its own
+ * internal `tournamentId`. The record has exactly one `tournamentId`; an event's
+ * sanctioning tournament is independent of it, and the sanctioning body may hold no
+ * record that carries the event at all.
+ *
+ * `tournamentId` is therefore OPTIONAL and deliberately *not* the carrying record's:
+ * it is the id of the tournament in `organisationId`'s system. `eventId` is likewise
+ * that system's id for this event, which is absent until the event exists there —
+ * an event may be copied back to its origin after the fact, or through an external
+ * API integration, at which point the returned id is written here.
+ */
+export interface UnifiedEventID {
+  createdAt?: Date | string;
+  eventId?: string;
+  extensions?: Extension[];
+  /** marks this entry as the SANCTIONING SOURCE the event originated from. At most one
+   *  entry per event should carry it; every other entry is a system the event is merely
+   *  also known to (typically acquired by copy-back). */
+  isOrigin?: boolean;
+  isMock?: boolean;
+  notes?: string;
+  organisationId: string;
+  timeItems?: TimeItem[];
+  tournamentId?: string;
   uniqueOrganisationName?: string;
   updatedAt?: Date | string;
 }


### PR DESCRIPTION
## What

Two additions the read-model projection needs.

### 1. `match_up_competitors` rows carry `tournament_id`

The competitors fact reached its tournament **transitively only** (`match_up_id → match_ups.tournament_id`). Fine for reads, which can join — but the CFS incremental producer's participant-rename and person-claim UPDATEs key on a participantId and **cannot** express a join, so they were table-wide statements:

```sql
UPDATE query_match_up_competitors SET participant_name = $1 WHERE individual_participant_id = $2
```

Correctness rested entirely on participantIds being globally unique. True for factory-generated UUIDs; **not** true for `mocksEngine` `nonRandom: 1` seeds, TODS imports that reuse ids across tournaments, or an ingest pipeline assigning deterministic ids — the ITA duals shape.

Reproduced on real Postgres: two tournaments sharing one participantId, the unscoped rename reports `UPDATE 2` and rewrites the other tournament's row; the scoped one reports `UPDATE 1`.

### 2. `Event.eventOtherIds[]` — event-level sanctioning origin

`UnifiedEventID` is the event-grain member of the `Unified*ID` family (`UnifiedTournamentID` / `UnifiedPersonID` / `UnifiedVenueID`), which had no event member. One entry may be flagged `isOrigin`.

A single `tournamentRecord` can carry events sanctioned by **several organisations**, each holding its own internal `tournamentId`. The record has exactly one `tournamentId`, so an event's origin cannot be inferred from the record that carries it.

The sanctioning workflow can link either kind of origin, and the same shape expresses both:

| mode | `organisationId` | does `tournamentId` resolve here? |
|---|---|---|
| **External** — sanctioned outside this ecosystem | a foreign governing body | usually no; they may hold no record carrying the event |
| **Internal** — already sanctioned within this ecosystem | a CourtHive provider | yes, a real tournamentRecord |

That union is why the projected `origin_tournament_id` **must not** carry a foreign key: a constraint satisfiable for internal links is impossible for external ones.

`eventRow` flattens the flagged entry to `origin_organisation_id` / `origin_tournament_id` / `origin_event_id`; `readModel.eventOrigin()` reads it; `modifyEvent` accepts the array (`null` clears) so the field is reachable through the standard mutation path and fires `MODIFY_EVENT`.

## Verification

- lint 0, check-types 0
- 10826 → **10832** tests
- coverage **95.10 / 86.83 / 98.00 / 97.63** vs the 95/85/95/95 gates; touched files at 96.7% and 97.6%

## Deploy ordering

Consumers must land in order — **courthive-query migration → this → CFS**. See `CourtHive/courthive-query` and `competition-factory-server`; the CFS change is gated on this publishing, and its conformance cases skip against the published package until the pin catches up.

## Related

Partially unblocks `Mentat/TASKS.md` item 4 (Sanctioning: Match Zone feasibility panel), which is blocked on sanctioning `eventId` threading. Note that `activateFromSanctioning` currently reuses `proposal.tournamentId` as *the record's* `tournamentId` — the assumption multi-sanctioning breaks.