### PR TITLE
fix(officiating): one conflict-input set forwarded by every route, with a conformance guard

### DIFF
--- a/documentation/docs/governors/officiating-governor.md
+++ b/documentation/docs/governors/officiating-governor.md
@@ -97,6 +97,21 @@ Validates transition. On `SUBMITTED`, validates required criterion scores agains
 { officialRecord; assignmentId: string }
 ```
 
+```ts
+// tournament-scoped declarations work on this route too
+{ officialRecord; tournamentId; roleSubtype;
+  policyDefinitions?; participants?;
+  officialParticipantId?; groupParticipants?;   // SHARED_GROUPING inputs
+  nationalityCode?; organisationIds? }
+```
+
+Both assignment routes see the same declarations. Without `officialParticipantId` + `groupParticipants`
+this route would see only registry declarations, so a GROUP-expressed conflict would block per-matchUp and
+pass here — same feature, two routes, different answers.
+
+Note `officialRecord` **is** required here, unlike `getOfficialConflicts`: `assignOfficial` mutates the
+record (it pushes an assignment onto it).
+
 The conflict gate is **opt-in**: with no `policyDefinitions` the assignment behaves exactly as before.
 Supply a conflict policy _and_ `participants` and the assignment is checked first — a `BLOCK`-severity
 conflict returns `{ error: OFFICIAL_CONFLICT_OF_INTEREST, conflicts }` and records nothing, while

--- a/documentation/docs/governors/officiating-governor.md
+++ b/documentation/docs/governors/officiating-governor.md
@@ -105,6 +105,22 @@ Validates transition. On `SUBMITTED`, validates required criterion scores agains
   nationalityCode?; organisationIds? }
 ```
 
+#### One input set, forwarded whole
+
+Every route that can evaluate a conflict accepts `ConflictEvaluationInputs` and forwards it **whole** via
+`conflictInputsFrom()`. Adding a new input means editing `CONFLICT_INPUT_KEYS` once; every route inherits
+it.
+
+This is structural, not stylistic. Routes used to hand-list the fields they forwarded, and when the
+tournament-scoped inputs (`officialParticipantId` + `groupParticipants`) were added, one route forwarded
+them and the other did not — so the same conflict blocked a per-matchUp assignment and passed on the
+tournament-level one. A rule that applies or not depending on which route the operator used is worse than
+no rule, because it looks enforced. A conformance test now fails, naming the route and the key, if any
+route drops an input.
+
+`participants` is deliberately outside the set: it is route-specific (supplied by the caller on
+`assignOfficial`, derived from the matchUp's sides on `getMatchUpOfficialConflicts`).
+
 Both assignment routes see the same declarations. Without `officialParticipantId` + `groupParticipants`
 this route would see only registry declarations, so a GROUP-expressed conflict would block per-matchUp and
 pass here — same feature, two routes, different answers.

--- a/src/mutate/officiating/assignOfficial.ts
+++ b/src/mutate/officiating/assignOfficial.ts
@@ -1,3 +1,4 @@
+import { conflictInputsFrom } from '@Query/officiating/conflictEvaluationInputs';
 import { getOfficialConflicts } from '@Query/officiating/getOfficialConflicts';
 import { UUID } from '@Tools/UUID';
 
@@ -11,10 +12,15 @@ import { INVALID_VALUES } from '@Constants/errorConditionConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 
 // Types
-import type { OfficialConflict, OfficialAssignment, OfficialRecord } from '@Types/officiatingTypes';
+import type {
+  ConflictEvaluationInputs,
+  OfficialConflict,
+  OfficialAssignment,
+  OfficialRecord,
+} from '@Types/officiatingTypes';
 import type { Participant } from '@Types/tournamentTypes';
 
-type AssignOfficialArgs = {
+type AssignOfficialArgs = ConflictEvaluationInputs & {
   officialRecord: OfficialRecord;
   assignmentId?: string;
   tournamentId: string;
@@ -25,56 +31,42 @@ type AssignOfficialArgs = {
   assignedBy?: string;
   notes?: string;
   extensions?: any[];
-  /** Conflict-of-interest gate — opt-in. Supply a policy AND the tournament's
-   *  participants to have the assignment checked; a BLOCK-severity conflict
-   *  refuses it. Omitting policyDefinitions skips the check entirely. */
-  policyDefinitions?: { [key: string]: any };
+  /** Conflict-of-interest gate — opt-in. Supply a policy (via ConflictEvaluationInputs) AND the
+   *  tournament's participants to have the assignment checked; a BLOCK-severity conflict refuses it.
+   *  Omitting policyDefinitions skips the check entirely. The rest of the conflict inputs come from
+   *  ConflictEvaluationInputs and are forwarded whole. */
   participants?: Participant[];
-  nationalityCode?: string;
-  organisationIds?: string[];
-  /** The official's participantId in the tournament being assigned to, plus that tournament's GROUP
-   *  participants. Together these enable the SHARED_GROUPING rule — a relationship declared inside the
-   *  tournamentRecord rather than in the registry. Without them this route can only see registry
-   *  declarations, which would make the same conflict visible per-matchUp and invisible here. */
-  officialParticipantId?: string;
-  groupParticipants?: Participant[];
 };
 
-export function assignOfficial({
-  officialParticipantId,
-  groupParticipants,
-  officialRecord,
-  organisationIds,
-  nationalityCode,
-  policyDefinitions,
-  assignmentId,
-  participants,
-  tournamentId,
-  roleSubtype,
-  assignedDate,
-  startDate,
-  endDate,
-  assignedBy,
-  notes,
-  extensions,
-}: AssignOfficialArgs): {
+export function assignOfficial(params: AssignOfficialArgs): {
   error?: any;
   assignment?: OfficialAssignment;
   conflicts?: OfficialConflict[];
   success?: boolean;
 } {
+  const {
+    officialRecord,
+    assignmentId,
+    participants,
+    tournamentId,
+    roleSubtype,
+    assignedDate,
+    startDate,
+    endDate,
+    assignedBy,
+    notes,
+    extensions,
+  } = params;
+
   if (!officialRecord) return { error: MISSING_OFFICIAL_RECORD };
   if (!tournamentId) return { error: INVALID_VALUES, context: { message: 'Missing tournamentId' } } as any;
   if (!roleSubtype) return { error: INVALID_VALUES, context: { message: 'Missing roleSubtype' } } as any;
 
+  // Forward the conflict inputs WHOLE. Hand-listing them here is what let this route disagree with
+  // addMatchUpOfficial about the same conflict — see conflictEvaluationInputs.ts.
   const conflictResult = getOfficialConflicts({
-    officialParticipantId,
-    groupParticipants,
-    officialRecord,
+    ...conflictInputsFrom(params),
     participants,
-    nationalityCode,
-    organisationIds,
-    policyDefinitions,
   });
   // A malformed conflict check must not fall through to an unchecked assignment.
   if (conflictResult.error) return { error: conflictResult.error };

--- a/src/mutate/officiating/assignOfficial.ts
+++ b/src/mutate/officiating/assignOfficial.ts
@@ -32,9 +32,17 @@ type AssignOfficialArgs = {
   participants?: Participant[];
   nationalityCode?: string;
   organisationIds?: string[];
+  /** The official's participantId in the tournament being assigned to, plus that tournament's GROUP
+   *  participants. Together these enable the SHARED_GROUPING rule — a relationship declared inside the
+   *  tournamentRecord rather than in the registry. Without them this route can only see registry
+   *  declarations, which would make the same conflict visible per-matchUp and invisible here. */
+  officialParticipantId?: string;
+  groupParticipants?: Participant[];
 };
 
 export function assignOfficial({
+  officialParticipantId,
+  groupParticipants,
   officialRecord,
   organisationIds,
   nationalityCode,
@@ -60,6 +68,8 @@ export function assignOfficial({
   if (!roleSubtype) return { error: INVALID_VALUES, context: { message: 'Missing roleSubtype' } } as any;
 
   const conflictResult = getOfficialConflicts({
+    officialParticipantId,
+    groupParticipants,
     officialRecord,
     participants,
     nationalityCode,

--- a/src/query/officiating/conflictEvaluationInputs.ts
+++ b/src/query/officiating/conflictEvaluationInputs.ts
@@ -1,0 +1,39 @@
+import type { ConflictEvaluationInputs } from '@Types/officiatingTypes';
+
+/**
+ * The single list of inputs that configure a conflict-of-interest evaluation.
+ *
+ * WHY THIS EXISTS. Every route that can evaluate conflicts calls `getOfficialConflicts`, and each one
+ * used to hand-list the fields it forwarded. That is silent-drift by construction: when
+ * `officialParticipantId` + `groupParticipants` were added for tournament-scoped (GROUP) declarations,
+ * `addMatchUpOfficial` forwarded them and `assignOfficial` did not — so the SAME conflict blocked a
+ * per-matchUp assignment and passed on the tournament-level one. A rule that applies or not depending on
+ * which route the operator happened to use is worse than no rule, because it looks enforced.
+ *
+ * Adding a new input now means editing this one array. Routes forward the set whole and inherit it.
+ *
+ * `participants` is deliberately NOT here: it is route-specific. `assignOfficial` takes it from the
+ * caller; `getMatchUpOfficialConflicts` derives it from the matchUp's sides. Routes pass it explicitly
+ * alongside this set.
+ */
+export const CONFLICT_INPUT_KEYS = [
+  'policyDefinitions',
+  'officialRecord',
+  'officialParticipantId',
+  'groupParticipants',
+  'nationalityCode',
+  'organisationIds',
+] as const satisfies readonly (keyof ConflictEvaluationInputs)[];
+
+/**
+ * Pick the conflict-evaluation inputs off any args object, so a route forwards the whole set rather
+ * than a hand-maintained subset. A conformance test asserts every route does this — see
+ * `src/tests/officiating/conflictInputForwarding.test.ts`.
+ */
+export function conflictInputsFrom(source: ConflictEvaluationInputs): ConflictEvaluationInputs {
+  const inputs: ConflictEvaluationInputs = {};
+  for (const key of CONFLICT_INPUT_KEYS) {
+    if (source?.[key] !== undefined) (inputs as any)[key] = source[key];
+  }
+  return inputs;
+}

--- a/src/query/officiating/getMatchUpOfficialConflicts.ts
+++ b/src/query/officiating/getMatchUpOfficialConflicts.ts
@@ -1,3 +1,4 @@
+import { conflictInputsFrom } from '@Query/officiating/conflictEvaluationInputs';
 import { getOfficialConflicts } from '@Query/officiating/getOfficialConflicts';
 import { getParticipants } from '@Query/participants/getParticipants';
 import { findDrawMatchUp } from '@Acquire/findDrawMatchUp';
@@ -11,18 +12,11 @@ import { SUCCESS } from '@Constants/resultConstants';
 
 // Types
 import type { DrawDefinition, Event, Participant, Tournament } from '@Types/tournamentTypes';
-import type { OfficialConflict, OfficialRecord } from '@Types/officiatingTypes';
+import type { ConflictEvaluationInputs, OfficialConflict } from '@Types/officiatingTypes';
 
-type GetMatchUpOfficialConflictsArgs = {
-  policyDefinitions?: { [key: string]: any };
-  /** Durable registry declarations. OPTIONAL when `officialParticipantId` is supplied. */
-  officialRecord?: OfficialRecord;
-  /** The official's participantId in this tournament — enables the SHARED_GROUPING rule. */
-  officialParticipantId?: string;
+type GetMatchUpOfficialConflictsArgs = ConflictEvaluationInputs & {
   drawDefinition: DrawDefinition;
   tournamentRecord: Tournament;
-  organisationIds?: string[];
-  nationalityCode?: string;
   matchUpId: string;
   event?: Event;
 };
@@ -52,17 +46,18 @@ type GetMatchUpOfficialConflictsResult = {
  * considered: an unresolved side has no official yet in practice, and treating
  * every possible opponent as a conflict would block most early-round assignments.
  */
-export function getMatchUpOfficialConflicts({
-  officialParticipantId,
-  policyDefinitions,
-  tournamentRecord,
-  organisationIds,
-  nationalityCode,
-  drawDefinition,
-  officialRecord,
-  matchUpId,
-  event,
-}: GetMatchUpOfficialConflictsArgs): GetMatchUpOfficialConflictsResult {
+export function getMatchUpOfficialConflicts(
+  params: GetMatchUpOfficialConflictsArgs,
+): GetMatchUpOfficialConflictsResult {
+  const {
+    officialParticipantId,
+    policyDefinitions,
+    tournamentRecord,
+    drawDefinition,
+    officialRecord,
+    matchUpId,
+    event,
+  } = params;
   if (!tournamentRecord) return { error: MISSING_TOURNAMENT_RECORD };
   if (!matchUpId) return { error: MISSING_MATCHUP_ID };
   // Either declaration source is sufficient: a registry record, or the official's participantId
@@ -112,14 +107,13 @@ export function getMatchUpOfficialConflicts({
   // and a competitor IS the relationship. Passed whole; the query resolves the official's memberships.
   const groupParticipants = tournamentParticipants.filter((participant) => participant.participantType === GROUP);
 
+  // Forward the conflict inputs WHOLE (see conflictEvaluationInputs.ts). `groupParticipants` is
+  // derived here rather than supplied, so it overrides the forwarded set; `participants` is
+  // route-specific by design.
   const conflictResult = getOfficialConflicts({
+    ...conflictInputsFrom(params),
     participants: checkedParticipants,
-    officialParticipantId,
     groupParticipants,
-    policyDefinitions,
-    organisationIds,
-    nationalityCode,
-    officialRecord,
   });
   if (conflictResult.error) return { error: conflictResult.error };
 

--- a/src/tests/officiating/conflictInputForwarding.test.ts
+++ b/src/tests/officiating/conflictInputForwarding.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Conformance guard: EVERY route that can evaluate a conflict of interest must forward EVERY
+ * conflict-evaluation input.
+ *
+ * This exists because of a real defect. When `officialParticipantId` + `groupParticipants` were added
+ * for tournament-scoped (GROUP) declarations, `addMatchUpOfficial` forwarded them and `assignOfficial`
+ * did not — so the same conflict blocked a per-matchUp assignment and passed silently on the
+ * tournament-level one. A rule that applies or not depending on which route the operator happened to use
+ * is worse than no rule, because it looks enforced.
+ *
+ * `conflictInputsFrom()` makes that unlikely by construction. This makes it LOUD: add a key to
+ * `CONFLICT_INPUT_KEYS` and any route that fails to forward it fails here, naming the route and the key.
+ */
+import { CONFLICT_INPUT_KEYS } from '@Query/officiating/conflictEvaluationInputs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getOfficialConflictsMock } = vi.hoisted(() => ({
+  getOfficialConflictsMock: vi.fn(() => ({ success: true, conflicts: [], blocked: false })),
+}));
+
+vi.mock('@Query/officiating/getOfficialConflicts', () => ({
+  getOfficialConflicts: getOfficialConflictsMock,
+}));
+
+import { getMatchUpOfficialConflicts } from '@Query/officiating/getMatchUpOfficialConflicts';
+import { assignOfficial } from '@Mutate/officiating/assignOfficial';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+
+import { POLICY_TYPE_OFFICIATING_CONFLICT } from '@Constants/policyConstants';
+
+/** Every conflict input, each set to a value distinguishable from `undefined`. */
+function fullInputs() {
+  return {
+    policyDefinitions: { [POLICY_TYPE_OFFICIATING_CONFLICT]: { conflictRules: {} } },
+    officialRecord: {
+      officialRecordId: 'rec-1',
+      personId: 'person-official',
+      certifications: [],
+      evaluations: [],
+      assignments: [],
+      suspensions: [],
+      certificationRequirements: [],
+      evaluationPolicies: [],
+      createdAt: '2025-01-01',
+      updatedAt: '2025-01-01',
+    } as any,
+    officialParticipantId: 'par-official',
+    groupParticipants: [{ participantId: 'grp-1', participantType: 'GROUP', individualParticipantIds: [] }] as any,
+    nationalityCode: 'FRA',
+    organisationIds: ['org-1'],
+  };
+}
+
+/** Each route, invoked with the full input set plus whatever else it needs. */
+const ROUTES: { name: string; invoke: (inputs: any) => void }[] = [
+  {
+    name: 'assignOfficial',
+    invoke: (inputs) =>
+      assignOfficial({ ...inputs, tournamentId: 't-1', roleSubtype: 'CHAIR_UMPIRE', participants: [] }),
+  },
+  {
+    name: 'getMatchUpOfficialConflicts',
+    invoke: (inputs) => {
+      const {
+        tournamentRecord,
+        drawIds: [drawId],
+      } = mocksEngine.generateTournamentRecord({ drawProfiles: [{ drawSize: 4 }], setState: true, nonRandom: 1 });
+      const drawDefinition = tournamentRecord.events[0].drawDefinitions.find((d: any) => d.drawId === drawId);
+      const { matchUps } = tournamentEngine.allTournamentMatchUps();
+      const matchUp = matchUps.find((m: any) => m.sides?.every((s: any) => s?.participantId));
+      getMatchUpOfficialConflicts({ ...inputs, tournamentRecord, drawDefinition, matchUpId: matchUp.matchUpId });
+    },
+  },
+];
+
+describe('conflict-input forwarding conformance', () => {
+  beforeEach(() => getOfficialConflictsMock.mockClear());
+
+  it('covers every known route', () => {
+    // A new evaluation route must be added to ROUTES. If you are here because you added one, add it.
+    expect(ROUTES.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it.each(ROUTES)('$name forwards every conflict-evaluation input', ({ invoke }) => {
+    const inputs = fullInputs();
+    invoke(inputs);
+
+    expect(getOfficialConflictsMock).toHaveBeenCalled();
+    const forwarded = getOfficialConflictsMock.mock.calls.at(-1)?.[0] as any;
+
+    const dropped = CONFLICT_INPUT_KEYS.filter((key) => forwarded?.[key] === undefined);
+    expect(dropped).toEqual([]);
+  });
+
+  it.each(ROUTES)('$name forwards the input VALUES unchanged, not just the keys', ({ name, invoke }) => {
+    const inputs = fullInputs();
+    invoke(inputs);
+    const forwarded = getOfficialConflictsMock.mock.calls.at(-1)?.[0] as any;
+
+    for (const key of CONFLICT_INPUT_KEYS) {
+      // groupParticipants is legitimately derived (not forwarded verbatim) by the matchUp route: it
+      // reads the tournament's GROUP participants rather than trusting a caller-supplied list.
+      if (key === 'groupParticipants' && name === 'getMatchUpOfficialConflicts') {
+        expect(Array.isArray(forwarded[key])).toBe(true);
+        continue;
+      }
+      expect(forwarded[key]).toEqual((inputs as any)[key]);
+    }
+  });
+});

--- a/src/tests/officiating/officiatingConflicts.test.ts
+++ b/src/tests/officiating/officiatingConflicts.test.ts
@@ -14,6 +14,7 @@ import {
   OFFICIAL_CONFLICT_OF_INTEREST,
   MISSING_CONFLICT_PARTICIPANTS,
   CONFLICT_DECLARED_RELATIONSHIP,
+  CONFLICT_SHARED_GROUPING,
   MISSING_CONFLICT_SOURCE,
   MISSING_OFFICIAL_RECORD,
   CONFLICT_ORGANISATION,
@@ -393,6 +394,57 @@ describe('assignOfficial conflict gate', () => {
     expect(result.success).toBe(true);
     expect(result.conflicts).toHaveLength(1);
     expect(result.conflicts[0].severity).toEqual(CONFLICT_WARN);
+    expect(officialRecord.assignments).toHaveLength(1);
+  });
+
+  it('sees a tournament GROUP relationship — parity with addMatchUpOfficial', () => {
+    // Without officialParticipantId + groupParticipants this route can only see registry declarations,
+    // so the SAME conflict would block per-matchUp and pass here. Same feature, two routes, one answer.
+    const officialRecord = makeRecord();
+    const result: any = assignOfficial({
+      officialRecord,
+      tournamentId: 't-1',
+      roleSubtype: 'CHAIR_UMPIRE',
+      participants: [makeParticipant({ participantId: 'par-competitor' })],
+      officialParticipantId: 'par-official',
+      groupParticipants: [
+        {
+          participantId: 'grp-1',
+          participantType: 'GROUP',
+          participantName: 'Team Alpha',
+          participantRole: 'COACH',
+          individualParticipantIds: ['par-official', 'par-competitor'],
+        } as any,
+      ],
+      policyDefinitions: POLICY_OFFICIATING_CONFLICT_OF_INTEREST,
+    });
+
+    expect(result.error).toEqual(OFFICIAL_CONFLICT_OF_INTEREST);
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0].conflictType).toEqual(CONFLICT_SHARED_GROUPING);
+    expect(result.conflicts[0].groupRole).toEqual('COACH');
+    expect(officialRecord.assignments).toHaveLength(0);
+  });
+
+  it('does not flag a grouping the official is not a member of', () => {
+    const officialRecord = makeRecord();
+    const result: any = assignOfficial({
+      officialRecord,
+      tournamentId: 't-1',
+      roleSubtype: 'CHAIR_UMPIRE',
+      participants: [makeParticipant({ participantId: 'par-competitor' })],
+      officialParticipantId: 'par-official',
+      groupParticipants: [
+        {
+          participantId: 'grp-1',
+          participantType: 'GROUP',
+          participantRole: 'COACH',
+          individualParticipantIds: ['someone-else', 'par-competitor'],
+        } as any,
+      ],
+      policyDefinitions: POLICY_OFFICIATING_CONFLICT_OF_INTEREST,
+    });
+    expect(result.success).toBe(true);
     expect(officialRecord.assignments).toHaveLength(1);
   });
 

--- a/src/types/officiatingTypes.ts
+++ b/src/types/officiatingTypes.ts
@@ -1,4 +1,4 @@
-import type { Extension, TimeItem } from './tournamentTypes';
+import type { Extension, Participant, TimeItem } from './tournamentTypes';
 import type { DocumentReference } from './sanctioningTypes';
 
 // ---------------------------------------------------------------------------
@@ -173,6 +173,31 @@ export interface ConflictRule {
    * groupings merely warn.
    */
   roleSeverity?: Record<string, ConflictSeverity>;
+}
+
+/**
+ * The inputs that configure a conflict-of-interest evaluation.
+ *
+ * Every route able to evaluate conflicts accepts this set and forwards it WHOLE to
+ * `getOfficialConflicts` via `conflictInputsFrom()`. Hand-listing the fields per route is what allowed
+ * `assignOfficial` and `addMatchUpOfficial` to disagree about the same conflict. Add a new input here and
+ * to `CONFLICT_INPUT_KEYS`; every route inherits it, and a conformance test proves they do.
+ *
+ * `participants` is intentionally excluded — it is route-specific (supplied by the caller on one route,
+ * derived from the matchUp's sides on the other).
+ */
+export interface ConflictEvaluationInputs {
+  policyDefinitions?: { [key: string]: any };
+  /** Durable registry declarations (courthive-ams). */
+  officialRecord?: OfficialRecord;
+  /** The official's participantId in this tournament — enables SHARED_GROUPING. */
+  officialParticipantId?: string;
+  /** The tournament's GROUP participants — the tournament-scoped declaration source. */
+  groupParticipants?: Participant[];
+  /** The official's own nationality — required for the NATIONALITY rule. */
+  nationalityCode?: string;
+  /** Organisations the official is affiliated with, beyond any declared ones. */
+  organisationIds?: string[];
 }
 
 export interface ConflictOfInterestPolicy {


### PR DESCRIPTION
Two commits: the gap, then the **class of gap**.

## The defect

`getOfficialConflicts` gained a tournament-scoped declaration source in 6.26.0 — `officialParticipantId` + `groupParticipants` (GROUP membership) — and `addMatchUpOfficial` forwarded them. **`assignOfficial` did not.**

So the same conflict **blocked** a per-matchUp assignment and **passed silently** on the tournament-level one. Whichever route an operator happened to use decided whether the rule applied. That is worse than the rule not existing, because it looks enforced.

## Why the first commit wasn't enough

Adding the two params to `assignOfficial` closes today's gap and leaves the structure that produced it: every route called `getOfficialConflicts` with a **hand-listed** set of fields, so the next input — or the next route — drifts the same way, and silently.

## The fix

**1. One named set, one funnel.** `ConflictEvaluationInputs` collects the inputs; `conflictInputsFrom()` is the single place that lists them; both routes forward the set **whole**. Adding an input is now one edit and every route inherits it.

```ts
const conflictResult = getOfficialConflicts({
  ...conflictInputsFrom(params),
  participants,                    // route-specific, passed explicitly
});
```

(The officiating engine already spread `...params` and was drift-proof by construction — only the two hand-listed routes were exposed.)

**2. A conformance guard.** `conflictInputForwarding.test.ts` mocks `getOfficialConflicts`, invokes each route with every input populated, and fails — **naming the route and the key** — if any input is dropped or altered. Structure makes drift unlikely; the guard makes it loud.

`participants` stays outside the set: it is genuinely route-specific (supplied by the caller on `assignOfficial`, derived from the matchUp's sides on `getMatchUpOfficialConflicts`). `groupParticipants` is likewise derived by the matchUp route, which the guard accounts for **explicitly** rather than by silently skipping it.

## Verification

- lint 0, `check-types` clean, `verify:generated` in sync (engine-methods 657).
- **10833 tests passed / 1 skipped** (+7), 0 regressions.
- **Falsified against the real defect**, each red then restored:
  - reproducing the original hand-listed `assignOfficial` forwarding → 2 failures
  - dropping a single input (`nationalityCode`) from the matchUp route → 2 failures
  - adding a **new** key that no route forwards — the future-drift case → 2 failures

`officialRecord` remains required on `assignOfficial` (unlike the query) because that function mutates the record — it pushes an assignment onto it. That asymmetry is inherent, not accidental, and is documented.
