### PR TITLE
fix(types): Address latitude/longitude accept string or number

### DIFF
--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -1509,8 +1509,13 @@ export interface Address {
   createdAt?: Date | string;
   extensions?: Extension[];
   isMock?: boolean;
-  latitude?: string;
-  longitude?: string;
+  /**
+   * Stored as a number in production records, but written as a string by some
+   * producers (e.g. `activateFromSanctioning` stringifies sanctioning coordinates).
+   * Both forms are real; consumers must coerce rather than assume.
+   */
+  latitude?: string | number;
+  longitude?: string | number;
   notes?: string;
   postalCode?: string;
   state?: string;


### PR DESCRIPTION
Declared type said `string`, production records store numbers (`26.3816192`), and consumers gate on `typeof === 'number'`. Three-way disagreement — and the factory itself emits both forms: `activateFromSanctioning` stringifies sanctioning coordinates while venue records carry numbers.

Widening to `string | number` makes the type describe the data that actually exists, and documents that consumers must coerce.

Found while scoping a venue coordinate backfill: writing strings per the declared type would have populated every target record and rendered **no map anywhere**, silently, with the records looking correct.

Paired with courthive-components [#fix/coerce-venue-coordinates](https://github.com/CourtHive/courthive-components/pull/new/fix/coerce-venue-coordinates), which makes the venue mappers coerce rather than gate.

`Court.latitude/longitude` carry the same string-only declaration and the same mixed reality — left alone here pending a separate decision.

Full suite **10843 passed**, lint and check-types clean.