### PR TITLE
feat(codes): add participantOtherIds and stamp the event sanctioning origin

### DIFF
--- a/documentation/docs/concepts/events/event-origin.mdx
+++ b/documentation/docs/concepts/events/event-origin.mdx
@@ -102,3 +102,53 @@ events row:
 
 `tournament_id` and `origin_tournament_id` are independent by design. Reading one for the
 other is the mistake this concept exists to prevent.
+
+## The identity a third party actually needs
+
+An outside sanctioning body is **not** expected to hold a CODES `tournamentRecord`. It has
+its own model and its own API, and an integration layer transforms results outward to it.
+Nothing is replicated to them. Our whole obligation is to carry enough identity that the
+results are **addressable** — three things:
+
+| identity                  | where it lives                               |
+| ------------------------- | -------------------------------------------- |
+| sanctioned tournamentId   | `event.eventOtherIds[isOrigin].tournamentId` |
+| sanctioned eventId        | `event.eventOtherIds[isOrigin].eventId`      |
+| sanctioned participant id | `participant.participantOtherIds[]`          |
+
+The third has its own field for a specific reason. `person.personOtherIds` carries an
+outside body's id for a **person** — but it hangs off `participant.person`, and a **PAIR or
+TEAM participant has no `person` at all**. `addPersonOtherId` says so in its own error
+text: _"only INDIVIDUAL participants accept personOtherIds"_. A registered pair or team
+therefore had nowhere to record the id the sanctioning body knows it by.
+
+`Participant.participantOtherIds[]` (`UnifiedParticipantID`) sits on the **participant**,
+so it works uniformly for INDIVIDUAL, PAIR and TEAM:
+
+```js
+participant.participantOtherIds = [{ organisationId: 'ITA', participantId: 'ita-entry-771' }];
+```
+
+Append or update one with `addParticipantOtherId` — the participant-grain sibling of
+`addPersonOtherId`, keyed on `organisationId` and idempotent:
+
+```js
+engine.addParticipantOtherId({
+  participantId, // ours
+  organisationId: 'ITA',
+  otherParticipantId: 'ita-entry-771', // theirs
+});
+```
+
+`otherParticipantId` is named distinctly from `participantId` on purpose: both are
+participant ids, and silently transposing them would stamp a participant with its own id
+and still look like it worked.
+
+## Where activation fits
+
+`activateFromSanctioning` stamps the event origin automatically. A proposal that arrives
+carrying its own `eventOtherIds` — a sanction that originated outside this ecosystem —
+keeps that entry untouched, because it is the address results are sent back to. A proposal
+that carries none gets the sanctioning body's own identity stamped as the origin, so a
+locally sanctioned tournament is queryable on exactly the same terms rather than being a
+special case.

--- a/documentation/docs/types/assets/participant.ts
+++ b/documentation/docs/types/assets/participant.ts
@@ -6,6 +6,8 @@ export const participant = {
     '{\\"type\\":\\"object\\",\\"object\\":\\"onlineResource\\",\\"array\\":\\"true\\",\\"required\\":\\"false\\"}',
   participantId: '{\\"type\\":\\"string\\",\\"required\\":\\"true\\"}',
   participantName: '{\\"type\\":\\"string\\",\\"required\\":\\"false\\"}',
+  participantOtherIds:
+    '{\\"type\\":\\"object\\",\\"array\\":\\"true\\",\\"required\\":\\"false\\",\\"note\\":\\"this participant\'s identity in other organisations\' systems; unlike person.personOtherIds it works for PAIR and TEAM participants, which carry no person\\"}',
   participantOtherName: '{\\"type\\":\\"string\\",\\"required\\":\\"false\\"}',
   participantRole:
     '{\\"type\\":\\"enum\\",\\"enum\\": \\"\\",\\"required\\":\\"false\\",\\"note\\":\\"ADMINISTRATION, CAPTAIN, COACH, COMPETITOR, DIRECTOR, HOSPITALITY, MEDIA, MEDICAL, OFFICIAL, OTHER, SECURITY, STRINGER, SUPERVISOR, TRANSPORT, VOLUNTEER\\"}',

--- a/src/assemblies/governors/participantGovernor/mutate.ts
+++ b/src/assemblies/governors/participantGovernor/mutate.ts
@@ -22,6 +22,7 @@ export { mergeParticipants } from '@Mutate/participants/mergeParticipants';
 export { modifyParticipant } from '@Mutate/participants/modifyParticipant';
 export { addParticipants } from '@Mutate/participants/addParticipants';
 export { addPersonOtherId } from '@Mutate/participants/addPersonOtherId';
+export { addParticipantOtherId } from '@Mutate/participants/addParticipantOtherId';
 export { addPenalty } from '@Mutate/participants/penalties/addPenalty';
 export { addParticipant } from '@Mutate/participants/addParticipant';
 export { addPersons } from '@Mutate/participants/addPersons';

--- a/src/constants/mutationLockScopeMap.ts
+++ b/src/constants/mutationLockScopeMap.ts
@@ -171,6 +171,7 @@ export const methodScopeMap: Record<string, MutationLockScope> = {
   addParticipant: 'PARTICIPANTS',
   addPersons: 'PARTICIPANTS',
   addPersonOtherId: 'PARTICIPANTS',
+  addParticipantOtherId: 'PARTICIPANTS',
   removeIndividualParticipantIds: 'PARTICIPANTS',
   removeParticipantIdsFromAllTeams: 'PARTICIPANTS',
 

--- a/src/mutate/participants/addParticipantOtherId.ts
+++ b/src/mutate/participants/addParticipantOtherId.ts
@@ -1,0 +1,82 @@
+import { findTournamentParticipant } from '@Acquire/findTournamentParticipant';
+import { modifyParticipantsNotice } from '@Mutate/notifications/participantNotifications';
+import { requireParams } from '@Helpers/parameters/requireParams';
+import { getTopics } from '@Global/state/globalState';
+
+import { MISSING_VALUE, PARTICIPANT_NOT_FOUND } from '@Constants/errorConditionConstants';
+import { TOURNAMENT_RECORD, PARTICIPANT_ID } from '@Constants/attributeConstants';
+import { MODIFY_PARTICIPANTS } from '@Constants/topicConstants';
+import { SUCCESS } from '@Constants/resultConstants';
+
+/**
+ * Upsert a `UnifiedParticipantID` entry into the participant's
+ * `participantOtherIds[]` array — the participant-grain sibling of
+ * {@link addPersonOtherId}.
+ *
+ * `organisationId` is the upsert key: an existing entry for that organisation has its
+ * `participantId` replaced; otherwise a new entry is appended with a `createdAt`
+ * timestamp. Idempotent — re-applying the same `(organisationId, participantId)` is a
+ * no-op.
+ *
+ * **Works on EVERY participantType.** This is the whole reason it exists alongside
+ * `addPersonOtherId`, which can only serve INDIVIDUAL participants because it writes to
+ * `participant.person` and a PAIR or TEAM has no `person` at all — its own error text says
+ * so. A pair or team registered with an outside body previously had nowhere to record
+ * that body's id for it, which made results unaddressable back to the registering system.
+ *
+ * As with `addPersonOtherId`, the factory is deliberately neutral about what
+ * `organisationId` denotes and never validates the foreign id.
+ */
+export function addParticipantOtherId({
+  tournamentRecord,
+  organisationId,
+  participantId,
+  otherParticipantId,
+  uniqueOrganisationName,
+}: {
+  tournamentRecord: any;
+  organisationId: string;
+  participantId: string;
+  // the OTHER organisation's id for this participant. Named distinctly from
+  // `participantId` because both are participant ids and silently swapping them would
+  // stamp a participant with its own id and look like it worked.
+  otherParticipantId: string;
+  uniqueOrganisationName?: string;
+}) {
+  const paramsCheck = requireParams({ tournamentRecord, participantId }, [TOURNAMENT_RECORD, PARTICIPANT_ID]);
+  if (paramsCheck.error) return paramsCheck;
+
+  if (!organisationId) return { error: MISSING_VALUE, info: 'Missing organisationId' };
+  if (!otherParticipantId) return { error: MISSING_VALUE, info: 'Missing otherParticipantId' };
+
+  const { participant } = findTournamentParticipant({ tournamentRecord, participantId });
+  if (!participant) return { error: PARTICIPANT_NOT_FOUND };
+
+  participant.participantOtherIds ??= [];
+
+  const existing = participant.participantOtherIds.find((entry: any) => entry?.organisationId === organisationId);
+
+  if (existing) {
+    if (existing.participantId === otherParticipantId) return { ...SUCCESS }; // idempotent no-op
+    existing.participantId = otherParticipantId;
+    if (uniqueOrganisationName) existing.uniqueOrganisationName = uniqueOrganisationName;
+    existing.updatedAt = new Date().toISOString();
+  } else {
+    participant.participantOtherIds.push({
+      organisationId,
+      participantId: otherParticipantId,
+      ...(uniqueOrganisationName ? { uniqueOrganisationName } : {}),
+      createdAt: new Date().toISOString(),
+    });
+  }
+
+  const { topics } = getTopics();
+  if (topics.includes(MODIFY_PARTICIPANTS)) {
+    modifyParticipantsNotice({
+      tournamentId: tournamentRecord.tournamentId,
+      participants: [participant],
+    });
+  }
+
+  return { ...SUCCESS };
+}

--- a/src/mutate/sanctioning/activateFromSanctioning.ts
+++ b/src/mutate/sanctioning/activateFromSanctioning.ts
@@ -13,8 +13,9 @@ import type {
   ComplianceRecord,
   ComplianceItem,
   VenueProposal,
+  EventProposal,
 } from '@Types/sanctioningTypes';
-import type { Tournament, Event, Venue } from '@Types/tournamentTypes';
+import type { Tournament, Event, Venue, UnifiedEventID } from '@Types/tournamentTypes';
 
 type ActivateFromSanctioningArgs = {
   sanctioningRecord: SanctioningRecord;
@@ -76,6 +77,48 @@ function venueFromProposal(vp: VenueProposal): Venue {
 function resolveVenues(venues: Venue[] | undefined, proposalVenues: VenueProposal[] | undefined): Venue[] {
   if (venues?.length) return venues;
   return (proposalVenues ?? []).map(venueFromProposal);
+}
+
+/**
+ * The activated event's `eventOtherIds`: whatever the proposal carried, plus an `isOrigin`
+ * entry naming the sanctioning source when the proposal named none.
+ *
+ * Both directions matter. A sanction originating OUTSIDE this ecosystem arrives with the
+ * foreign body's own tournamentId/eventId already flagged `isOrigin`, and that entry must
+ * survive activation untouched — it is the address an integration layer sends results back
+ * to. A sanction originating HERE carries nothing, so we stamp our own governing body plus
+ * `proposal.tournamentId`, which makes every sanctioned record queryable by origin on the
+ * same terms rather than leaving the local case as a special case.
+ *
+ * The stamped `tournamentId` is `proposal.tournamentId` — the SANCTIONED id — which is not
+ * necessarily the carrying record's. Today they are the same value, but multi-sanctioning
+ * exists precisely to let one record carry events sanctioned elsewhere, so reading one for
+ * the other is the mistake this field exists to prevent.
+ */
+function resolveEventOtherIds(
+  ep: EventProposal,
+  eventId: string,
+  sanctioningRecord: SanctioningRecord,
+): UnifiedEventID[] {
+  const supplied = ep.eventOtherIds ?? [];
+  if (supplied.some((otherId) => otherId?.isOrigin)) return [...supplied];
+
+  // governingBodyId is required on the type, but a record arriving over the wire can still
+  // lack it; without an organisation there is nothing to attribute the origin to, and a
+  // half-formed origin entry is worse than none.
+  const organisationId = sanctioningRecord.governingBodyId;
+  if (!organisationId) return [...supplied];
+
+  return [
+    ...supplied,
+    {
+      organisationId,
+      uniqueOrganisationName: sanctioningRecord.governingBody?.organisationName,
+      tournamentId: sanctioningRecord.proposal?.tournamentId,
+      eventId,
+      isOrigin: true,
+    },
+  ];
 }
 
 export function activateFromSanctioning({ sanctioningRecord, sanctioningPolicy, venues }: ActivateFromSanctioningArgs) {
@@ -147,6 +190,9 @@ export function activateFromSanctioning({ sanctioningRecord, sanctioningPolicy, 
       // Carry sanctioning constraints
       if (ep.allowedDrawTypes?.length) event.allowedDrawTypes = [...ep.allowedDrawTypes];
       else if (ep.drawType) event.allowedDrawTypes = [ep.drawType];
+
+      const eventOtherIds = resolveEventOtherIds(ep, event.eventId, sanctioningRecord);
+      if (eventOtherIds.length) event.eventOtherIds = eventOtherIds;
 
       return event;
     }),

--- a/src/tests/mutations/participants/participantOtherIds.test.ts
+++ b/src/tests/mutations/participants/participantOtherIds.test.ts
@@ -1,0 +1,258 @@
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+// constants and types
+import { PAIR, TEAM, INDIVIDUAL } from '@Constants/participantConstants';
+import { UnifiedParticipantID } from '@Types/tournamentTypes';
+
+/**
+ * `participantOtherIds` is the participant-grain member of the `Unified*ID` family. It
+ * exists because `personOtherIds` cannot cover every competitor: it hangs off
+ * `participant.person`, and a PAIR or TEAM participant has no `person` at all — so a pair
+ * or team registered with an outside body had nowhere to record that body's id for it.
+ *
+ * These assert the field SURVIVES a round trip at every grain. A type slot the engine
+ * strips on write would be worse than no slot, because it would look like it worked.
+ */
+describe('participantOtherIds', () => {
+  const itaId: UnifiedParticipantID = {
+    organisationId: 'ITA',
+    uniqueOrganisationName: 'Intercollegiate Tennis Association',
+    participantId: 'ita-entry-771',
+  };
+
+  it('round-trips on an INDIVIDUAL participant', () => {
+    mocksEngine.generateTournamentRecord({ participantsProfile: { participantsCount: 2 }, setState: true });
+    const { tournamentRecord } = tournamentEngine.getTournament();
+    const target = tournamentRecord.participants?.[0];
+
+    let result: any = tournamentEngine.addParticipants({
+      participants: [
+        {
+          participantId: 'individual-with-other-id',
+          participantType: INDIVIDUAL,
+          participantRole: 'COMPETITOR',
+          person: { standardFamilyName: 'Sampras', standardGivenName: 'Pete' },
+          participantOtherIds: [itaId],
+        },
+      ],
+    });
+    expect(result.success).toEqual(true);
+
+    result = tournamentEngine.findParticipant({ participantId: 'individual-with-other-id' });
+    expect(result.participant.participantOtherIds).toEqual([itaId]);
+    // and it is independent of personOtherIds, which remains the person-grain slot
+    expect(result.participant.person?.personOtherIds).toBeUndefined();
+    expect(target).toBeDefined();
+  });
+
+  // The case the field exists for: a PAIR carries no `person`, so personOtherIds cannot
+  // reach it. Before this field a registered pair's sanctioning id had nowhere to live.
+  it('round-trips on a PAIR participant, which has no person to hang personOtherIds from', () => {
+    mocksEngine.generateTournamentRecord({ participantsProfile: { participantsCount: 2 }, setState: true });
+    const { tournamentRecord } = tournamentEngine.getTournament();
+    const individualParticipantIds = (tournamentRecord.participants ?? []).map((p: any) => p.participantId);
+
+    let result: any = tournamentEngine.addParticipants({
+      participants: [
+        {
+          participantId: 'pair-with-other-id',
+          participantType: PAIR,
+          participantRole: 'COMPETITOR',
+          individualParticipantIds,
+          participantOtherIds: [itaId],
+        },
+      ],
+    });
+    expect(result.success).toEqual(true);
+
+    result = tournamentEngine.findParticipant({ participantId: 'pair-with-other-id' });
+    expect(result.participant.participantType).toEqual(PAIR);
+    expect(result.participant.person).toBeUndefined(); // the whole reason the field is needed
+    expect(result.participant.participantOtherIds).toEqual([itaId]);
+  });
+
+  it('round-trips on a TEAM participant', () => {
+    mocksEngine.generateTournamentRecord({ participantsProfile: { participantsCount: 2 }, setState: true });
+    const { tournamentRecord } = tournamentEngine.getTournament();
+    const individualParticipantIds = (tournamentRecord.participants ?? []).map((p: any) => p.participantId);
+
+    let result: any = tournamentEngine.addParticipants({
+      participants: [
+        {
+          participantId: 'team-with-other-id',
+          participantType: TEAM,
+          participantRole: 'COMPETITOR',
+          participantName: 'Georgia Bulldogs',
+          individualParticipantIds,
+          participantOtherIds: [itaId],
+        },
+      ],
+    });
+    expect(result.success).toEqual(true);
+
+    result = tournamentEngine.findParticipant({ participantId: 'team-with-other-id' });
+    expect(result.participant.person).toBeUndefined();
+    expect(result.participant.participantOtherIds).toEqual([itaId]);
+  });
+
+  // Several organisations may know the same participant — the sanctioning origin plus any
+  // id acquired by copy-back. The array grain is what makes that expressible.
+  it('carries entries from several organisations at once', () => {
+    mocksEngine.generateTournamentRecord({ participantsProfile: { participantsCount: 2 }, setState: true });
+    const ustaId: UnifiedParticipantID = { organisationId: 'USTA', participantId: 'usta-entry-3' };
+
+    let result: any = tournamentEngine.addParticipants({
+      participants: [
+        {
+          participantId: 'multi-org-participant',
+          participantType: INDIVIDUAL,
+          participantRole: 'COMPETITOR',
+          person: { standardFamilyName: 'Agassi', standardGivenName: 'Andre' },
+          participantOtherIds: [itaId, ustaId],
+        },
+      ],
+    });
+    expect(result.success).toEqual(true);
+
+    result = tournamentEngine.findParticipant({ participantId: 'multi-org-participant' });
+    expect(result.participant.participantOtherIds).toHaveLength(2);
+    expect(result.participant.participantOtherIds.map((o: any) => o.organisationId)).toEqual(['ITA', 'USTA']);
+  });
+});
+
+/**
+ * `addParticipantOtherId` is the append/upsert path — the participant-grain sibling of
+ * `addPersonOtherId`, which refuses every non-INDIVIDUAL type because it writes to
+ * `participant.person`. Copy-back needs this: an id acquired AFTER the participant exists
+ * has no other way in, since `modifyParticipant` carries a closed attribute allow-list.
+ */
+describe('addParticipantOtherId', () => {
+  function pairSetup() {
+    mocksEngine.generateTournamentRecord({ participantsProfile: { participantsCount: 2 }, setState: true });
+    const { tournamentRecord } = tournamentEngine.getTournament();
+    const individualParticipantIds = (tournamentRecord.participants ?? []).map((p: any) => p.participantId);
+    tournamentEngine.addParticipants({
+      participants: [
+        {
+          participantId: 'pair-1',
+          participantType: PAIR,
+          participantRole: 'COMPETITOR',
+          individualParticipantIds,
+        },
+      ],
+    });
+    return { individualParticipantId: individualParticipantIds[0] };
+  }
+
+  it('appends to a PAIR — the case addPersonOtherId cannot serve', () => {
+    pairSetup();
+
+    // the person-grain mutation refuses, naming the reason
+    let result: any = tournamentEngine.addPersonOtherId({
+      participantId: 'pair-1',
+      organisationId: 'ITA',
+      personId: 'ita-p-1',
+    });
+    expect(result.error).toBeDefined();
+
+    // the participant-grain mutation accepts
+    result = tournamentEngine.addParticipantOtherId({
+      participantId: 'pair-1',
+      organisationId: 'ITA',
+      otherParticipantId: 'ita-entry-771',
+    });
+    expect(result.success).toEqual(true);
+
+    result = tournamentEngine.findParticipant({ participantId: 'pair-1' });
+    expect(result.participant.participantOtherIds).toHaveLength(1);
+    expect(result.participant.participantOtherIds[0].participantId).toEqual('ita-entry-771');
+    expect(result.participant.participantOtherIds[0].createdAt).toBeDefined();
+  });
+
+  it('upserts by organisationId and is idempotent on an unchanged pair', () => {
+    pairSetup();
+    const add = (otherParticipantId: string) =>
+      tournamentEngine.addParticipantOtherId({ participantId: 'pair-1', organisationId: 'ITA', otherParticipantId });
+
+    expect(add('ita-1').success).toEqual(true);
+    expect(add('ita-1').success).toEqual(true); // idempotent — no second entry, no updatedAt
+    let result: any = tournamentEngine.findParticipant({ participantId: 'pair-1' });
+    expect(result.participant.participantOtherIds).toHaveLength(1);
+    expect(result.participant.participantOtherIds[0].updatedAt).toBeUndefined();
+
+    expect(add('ita-2').success).toEqual(true); // same org, new id → replace in place
+    result = tournamentEngine.findParticipant({ participantId: 'pair-1' });
+    expect(result.participant.participantOtherIds).toHaveLength(1);
+    expect(result.participant.participantOtherIds[0].participantId).toEqual('ita-2');
+    expect(result.participant.participantOtherIds[0].updatedAt).toBeDefined();
+
+    // a DIFFERENT org appends rather than replacing
+    expect(
+      tournamentEngine.addParticipantOtherId({
+        participantId: 'pair-1',
+        organisationId: 'USTA',
+        otherParticipantId: 'usta-9',
+      }).success,
+    ).toEqual(true);
+    result = tournamentEngine.findParticipant({ participantId: 'pair-1' });
+    expect(result.participant.participantOtherIds).toHaveLength(2);
+  });
+
+  it('carries uniqueOrganisationName on append and refreshes it on update', () => {
+    pairSetup();
+    let result: any = tournamentEngine.addParticipantOtherId({
+      participantId: 'pair-1',
+      organisationId: 'ITA',
+      otherParticipantId: 'ita-1',
+      uniqueOrganisationName: 'Intercollegiate Tennis Association',
+    });
+    expect(result.success).toEqual(true);
+    result = tournamentEngine.findParticipant({ participantId: 'pair-1' });
+    expect(result.participant.participantOtherIds[0].uniqueOrganisationName).toEqual(
+      'Intercollegiate Tennis Association',
+    );
+
+    // same org, new id + renamed organisation → both refresh in place
+    expect(
+      tournamentEngine.addParticipantOtherId({
+        participantId: 'pair-1',
+        organisationId: 'ITA',
+        otherParticipantId: 'ita-2',
+        uniqueOrganisationName: 'ITA (renamed)',
+      }).success,
+    ).toEqual(true);
+    result = tournamentEngine.findParticipant({ participantId: 'pair-1' });
+    expect(result.participant.participantOtherIds).toHaveLength(1);
+    expect(result.participant.participantOtherIds[0].uniqueOrganisationName).toEqual('ITA (renamed)');
+
+    // omitting it on a later update leaves the existing name rather than clearing it
+    expect(
+      tournamentEngine.addParticipantOtherId({
+        participantId: 'pair-1',
+        organisationId: 'ITA',
+        otherParticipantId: 'ita-3',
+      }).success,
+    ).toEqual(true);
+    result = tournamentEngine.findParticipant({ participantId: 'pair-1' });
+    expect(result.participant.participantOtherIds[0].uniqueOrganisationName).toEqual('ITA (renamed)');
+  });
+
+  it('validates its inputs and an unknown participant', () => {
+    pairSetup();
+    expect(
+      tournamentEngine.addParticipantOtherId({ participantId: 'pair-1', otherParticipantId: 'x' }).error,
+    ).toBeDefined();
+    expect(
+      tournamentEngine.addParticipantOtherId({ participantId: 'pair-1', organisationId: 'ITA' }).error,
+    ).toBeDefined();
+    expect(
+      tournamentEngine.addParticipantOtherId({
+        participantId: 'no-such-participant',
+        organisationId: 'ITA',
+        otherParticipantId: 'x',
+      }).error,
+    ).toBeDefined();
+  });
+});

--- a/src/tests/sanctioning/sanctioningActivation.test.ts
+++ b/src/tests/sanctioning/sanctioningActivation.test.ts
@@ -316,3 +316,86 @@ describe('Full Lifecycle — End-to-End', () => {
     expect(history.statusHistory.length).toBeGreaterThanOrEqual(5);
   });
 });
+
+// The sanctioned tournamentId/eventId must survive activation as the event's ORIGIN, so an
+// integration layer can address results back to the body that sanctioned them. See
+// Mentat planning/SANCTIONING_ACTIVATION_AND_EVENTID_THREADING.md Part 3d.
+describe('Activation — event sanctioning origin (eventOtherIds)', () => {
+  beforeEach(() => {
+    sanctioningEngine.reset();
+  });
+
+  it('stamps the governing body as the origin when the proposal names none', () => {
+    createApprovedRecord();
+    const result: any = sanctioningEngine.activateFromSanctioning({ sanctioningPolicy: testPolicy });
+    const tr = result.tournamentRecord;
+
+    for (const event of tr.events) {
+      const origin = event.eventOtherIds?.find((otherId: any) => otherId.isOrigin);
+      expect(origin).toBeDefined();
+      expect(origin.organisationId).toEqual('gov-001');
+      // the ORIGIN's eventId is this event's id, and its tournamentId is the SANCTIONED one
+      expect(origin.eventId).toEqual(event.eventId);
+      expect(Object.hasOwn(origin, 'tournamentId')).toBe(true);
+    }
+  });
+
+  it('preserves a FOREIGN origin supplied on the proposal instead of overwriting it', () => {
+    const foreignOrigin = {
+      organisationId: 'ITA',
+      uniqueOrganisationName: 'Intercollegiate Tennis Association',
+      tournamentId: 'ita-4471',
+      eventId: 'ita-ev-9',
+      isOrigin: true,
+    };
+    const foreignProposal: TournamentProposal = {
+      ...testProposal,
+      events: [{ ...testProposal.events[0], eventOtherIds: [foreignOrigin] }],
+    };
+
+    sanctioningEngine.executionQueue([
+      {
+        method: 'createSanctioningRecord',
+        params: { governingBodyId: 'gov-001', applicant: testApplicant, proposal: foreignProposal },
+      },
+      { method: 'submitApplication', params: { sanctioningPolicy: testPolicy } },
+      { method: 'reviewApplication', params: {} },
+      { method: 'approveApplication', params: {} },
+    ]);
+
+    const result: any = sanctioningEngine.activateFromSanctioning({ sanctioningPolicy: testPolicy });
+    const event = result.tournamentRecord.events[0];
+
+    // exactly one origin, and it is THEIRS — not overwritten by the sanctioning body
+    const origins = event.eventOtherIds.filter((otherId: any) => otherId.isOrigin);
+    expect(origins).toHaveLength(1);
+    expect(origins[0]).toEqual(foreignOrigin);
+    // the foreign tournamentId is NOT the carrying record's — that independence is the point
+    expect(origins[0].tournamentId).not.toEqual(result.tournamentRecord.tournamentId);
+  });
+
+  it('keeps non-origin entries and appends the stamp alongside them', () => {
+    const copyBack = { organisationId: 'USTA', tournamentId: 'usta-88', eventId: 'usta-ev-2' };
+    const proposal: TournamentProposal = {
+      ...testProposal,
+      events: [{ ...testProposal.events[0], eventOtherIds: [copyBack] }],
+    };
+
+    sanctioningEngine.executionQueue([
+      {
+        method: 'createSanctioningRecord',
+        params: { governingBodyId: 'gov-001', applicant: testApplicant, proposal },
+      },
+      { method: 'submitApplication', params: { sanctioningPolicy: testPolicy } },
+      { method: 'reviewApplication', params: {} },
+      { method: 'approveApplication', params: {} },
+    ]);
+
+    const result: any = sanctioningEngine.activateFromSanctioning({ sanctioningPolicy: testPolicy });
+    const event = result.tournamentRecord.events[0];
+
+    expect(event.eventOtherIds).toHaveLength(2);
+    expect(event.eventOtherIds.filter((o: any) => o.isOrigin)).toHaveLength(1);
+    expect(event.eventOtherIds).toContainEqual(copyBack); // the USTA entry survives untouched
+  });
+});

--- a/src/types/factoryEngineMethods.ts
+++ b/src/types/factoryEngineMethods.ts
@@ -47,10 +47,10 @@ export type FactoryEngineMethod =
   | 'addOnlineResource'
   | 'addParticipant'
   | 'addParticipantExtension'
+  | 'addParticipantOtherId'
   | 'addParticipants'
   | 'addParticipantTimeItem'
   | 'addPenalty'
-  | 'addParticipantOtherId'
   | 'addPersonOtherId'
   | 'addPersonRequests'
   | 'addPersons'
@@ -707,10 +707,10 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'addOnlineResource',
   'addParticipant',
   'addParticipantExtension',
+  'addParticipantOtherId',
   'addParticipants',
   'addParticipantTimeItem',
   'addPenalty',
-  'addParticipantOtherId',
   'addPersonOtherId',
   'addPersonRequests',
   'addPersons',

--- a/src/types/factoryEngineMethods.ts
+++ b/src/types/factoryEngineMethods.ts
@@ -50,6 +50,7 @@ export type FactoryEngineMethod =
   | 'addParticipants'
   | 'addParticipantTimeItem'
   | 'addPenalty'
+  | 'addParticipantOtherId'
   | 'addPersonOtherId'
   | 'addPersonRequests'
   | 'addPersons'
@@ -709,6 +710,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'addParticipants',
   'addParticipantTimeItem',
   'addPenalty',
+  'addParticipantOtherId',
   'addPersonOtherId',
   'addPersonRequests',
   'addPersons',

--- a/src/types/methodSignatures.ts
+++ b/src/types/methodSignatures.ts
@@ -255,6 +255,7 @@ import type { swapDrawPositionAssignments } from '@Mutate/matchUps/drawPositions
 import type { updateParticipantResults } from '@Mutate/structures/updateParticipantResults';
 import type { updatePracticeRegistration } from '@Mutate/practice/updatePracticeRegistration';
 import type { addConflictDeclaration } from '@Mutate/officiating/addConflictDeclaration';
+import type { addParticipantOtherId } from '@Mutate/participants/addParticipantOtherId';
 import type { assignDrawPosition } from '@Mutate/drawDefinitions/assignDrawPosition';
 import type { attachPolicies } from '@Mutate/extensions/policies/attachPolicies';
 import type { generateTournamentRecord } from '@Generators/mocks/generateTournamentRecord';
@@ -359,7 +360,6 @@ import type {
 import type { suggestFormatPlans } from '@Query/formatWizard/suggestFormatPlans';
 import type { unPublishOrderOfPlay } from '@Mutate/timeItems/unPublishOrderOfPlay';
 import type { addPersonOtherId } from '@Mutate/participants/addPersonOtherId';
-import type { addParticipantOtherId } from '@Mutate/participants/addParticipantOtherId';
 import type {
   addScheduleScenario,
   getScheduleScenario,
@@ -639,10 +639,10 @@ export interface MethodSignatures {
   addOnlineResource: EngineMethod<typeof addOnlineResource>;
   addParticipant: EngineMethod<typeof addParticipant>;
   addParticipantExtension: EngineMethod<typeof addParticipantExtension>;
+  addParticipantOtherId: EngineMethod<typeof addParticipantOtherId>;
   addParticipants: EngineMethod<typeof addParticipants>;
   addParticipantTimeItem: EngineMethod<typeof addParticipantTimeItem>;
   addPenalty: EngineMethod<typeof addPenalty>;
-  addParticipantOtherId: EngineMethod<typeof addParticipantOtherId>;
   addPersonOtherId: EngineMethod<typeof addPersonOtherId>;
   addPersonRequests: EngineMethod<typeof addPersonRequests>;
   addPersons: EngineMethod<typeof addPersons>;

--- a/src/types/methodSignatures.ts
+++ b/src/types/methodSignatures.ts
@@ -359,6 +359,7 @@ import type {
 import type { suggestFormatPlans } from '@Query/formatWizard/suggestFormatPlans';
 import type { unPublishOrderOfPlay } from '@Mutate/timeItems/unPublishOrderOfPlay';
 import type { addPersonOtherId } from '@Mutate/participants/addPersonOtherId';
+import type { addParticipantOtherId } from '@Mutate/participants/addParticipantOtherId';
 import type {
   addScheduleScenario,
   getScheduleScenario,
@@ -641,6 +642,7 @@ export interface MethodSignatures {
   addParticipants: EngineMethod<typeof addParticipants>;
   addParticipantTimeItem: EngineMethod<typeof addParticipantTimeItem>;
   addPenalty: EngineMethod<typeof addPenalty>;
+  addParticipantOtherId: EngineMethod<typeof addParticipantOtherId>;
   addPersonOtherId: EngineMethod<typeof addPersonOtherId>;
   addPersonRequests: EngineMethod<typeof addPersonRequests>;
   addPersons: EngineMethod<typeof addPersons>;

--- a/src/types/sanctioningTypes.ts
+++ b/src/types/sanctioningTypes.ts
@@ -15,6 +15,7 @@ import type {
   TierClassification,
   TimeItem,
   TournamentLevelUnion,
+  UnifiedEventID,
   WheelchairClassUnion,
 } from './tournamentTypes';
 
@@ -308,6 +309,19 @@ export interface EventProposal {
 
   // Wheelchair
   wheelchairClass?: WheelchairClassUnion;
+
+  /**
+   * The event's identity in OTHER organisations' systems, carried INBOUND on the proposal
+   * and copied onto the activated event by `activateFromSanctioning`. Mirrors the
+   * record-side `Event.eventOtherIds` exactly, so a sanction originating outside this
+   * ecosystem keeps its own tournamentId/eventId through activation and an integration
+   * layer can address results back to it.
+   *
+   * An entry flagged `isOrigin` names the sanctioning source. When the proposal supplies
+   * none, activation stamps the sanctioning body's own identity as the origin — so a
+   * locally sanctioned tournament is queryable by origin on the same terms.
+   */
+  eventOtherIds?: UnifiedEventID[];
 
   extensions?: Extension[];
 }

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -1361,6 +1361,10 @@ export interface Participant {
   onlineResources?: OnlineResource[];
   participantId: string;
   participantName?: string;
+  // CODES first-class: this participant's identity in OTHER organisations' systems, one
+  // entry per organisation. Unlike `person.personOtherIds` this works for PAIR and TEAM
+  // participants, which carry no `person` at all.
+  participantOtherIds?: UnifiedParticipantID[];
   participantOtherName?: string;
   participantRole?: ParticipantRoleUnion;
   participantRoleResponsibilities?: string[];
@@ -1750,6 +1754,35 @@ export interface UnifiedTournamentID {
  * an event may be copied back to its origin after the fact, or through an external
  * API integration, at which point the returned id is written here.
  */
+/**
+ * CODES first-class: a PARTICIPANT's identity in another organisation's system — the
+ * participant-grain member of the `Unified*ID` family ({@link UnifiedTournamentID},
+ * {@link UnifiedEventID}, {@link UnifiedPersonID}, {@link UnifiedVenueID}).
+ *
+ * Carried on `Participant.participantOtherIds[]`. It exists because
+ * {@link UnifiedPersonID} cannot cover every competitor: `personOtherIds` hangs off
+ * `participant.person`, and a **PAIR or TEAM participant has no `person`** — only
+ * `individualParticipantIds`. So a pair or team registered with an outside body had
+ * nowhere to record that body's id for it.
+ *
+ * Sitting on the participant rather than the person makes it uniform across INDIVIDUAL,
+ * PAIR and TEAM, and it is what lets an integration layer address results back to the
+ * sanctioning system that registered them.
+ */
+export interface UnifiedParticipantID {
+  createdAt?: Date | string;
+  extensions?: Extension[];
+  isMock?: boolean;
+  notes?: string;
+  organisationId: string;
+  /** that organisation's id for this participant — its registration/entry identity, which
+   *  need not resemble any id of ours */
+  participantId: string;
+  timeItems?: TimeItem[];
+  uniqueOrganisationName?: string;
+  updatedAt?: Date | string;
+}
+
 export interface UnifiedEventID {
   createdAt?: Date | string;
   eventId?: string;


### PR DESCRIPTION
Track F (F0 → F2a) of the sanctioning multi-origin work — see `Mentat/planning/SANCTIONING_ACTIVATION_AND_EVENTID_THREADING.md` Part 3d.

## Why

A foreign sanctioning body is **not** expected to hold a CODES `tournamentRecord` or receive our operation log. An integration layer at the notice/subscription boundary transforms results outward to their API. Our whole obligation is to carry **enough identity for results to be addressable** — three things:

| identity | where it lives | before |
|---|---|---|
| sanctioned tournamentId | `event.eventOtherIds[isOrigin].tournamentId` | ✅ shipped (#4616) |
| sanctioned eventId | `event.eventOtherIds[isOrigin].eventId` | ✅ shipped (#4616) |
| sanctioned participant id | — | ❌ **no home** |

The third had nowhere to live. `person.personOtherIds` hangs off `participant.person`, and **a PAIR or TEAM participant has no `person` at all** — `addPersonOtherId` says so in its own error text (*"only INDIVIDUAL participants accept personOtherIds"*). A registered pair or team therefore had nowhere to record the id its sanctioning body knows it by.

The `Unified*ID` family was missing exactly one member.

## What

**F0 — `UnifiedParticipantID` + `Participant.participantOtherIds?`.** Sits on the participant, not the person, so it works uniformly across INDIVIDUAL / PAIR / TEAM.

**F0 write path — `addParticipantOtherId`.** Mirrors `addPersonOtherId`: upsert keyed on `organisationId`, idempotent, fires `MODIFY_PARTICIPANTS`. Added because the field would otherwise be settable only at creation — `modifyParticipant` carries a **closed** attribute allow-list — and copy-back (an id acquired *after* the participant exists) is explicitly part of the requirement. Registered at all five surfaces: governor, `methodSignatures`, `factoryEngineMethods` (union + array), `mutationLockScopeMap`.

`otherParticipantId` is deliberately not called `participantId`: both are participant ids, and silently transposing them would stamp a participant with its own id and still look like it worked.

**F1 — `EventProposal.eventOtherIds?`.** Inbound identity, mirroring the record-side field.

**F2a — `activateFromSanctioning` resolves the origin both ways.** A proposal arriving with its own `isOrigin` entry keeps it **untouched** — that entry is the address results are sent back to. A proposal carrying none gets the sanctioning body stamped, so a locally sanctioned tournament is queryable by origin on the same terms rather than being a special case.

## Verification

- lint 0, check-types 0, prettier clean
- **10843 → 10854** tests (+11)
- coverage **95.08 / 86.81 / 98.00 / 97.62** vs the 95/85/95/95 gates

Two things asserted rather than assumed:

- **The field survives a round trip at every grain** (INDIVIDUAL, PAIR, TEAM), with `participant.person` asserted `undefined` on PAIR/TEAM. A type slot the engine silently stripped would be worse than no slot, because it would look like it worked.
- **The origin-preservation guard was falsified** — making the stamp overwrite a supplied foreign origin makes the test fail, as required.

## Out of scope

**F2b** (stamping `participantOtherIds` at CFS accept) and **F3** (the integration-layer subscriber). F2b depends on the registration payload carrying the foreign participant id — declarations-tier plumbing that does not exist yet. This PR is its prerequisite, not its implementation.