### PR TITLE
feat(mutate): honour origin-supplied identity and timestamps

### DIFF
--- a/src/constants/errorConditionConstants.ts
+++ b/src/constants/errorConditionConstants.ts
@@ -633,6 +633,11 @@ export const INSUFFICIENT_DRAW_POSITIONS = {
   code: 'ERR_INSUFFICIENT_DRAW_POSITIONS',
 };
 
+export const INSUFFICIENT_UUIDS = {
+  message: 'Supplied uuids pool exhausted',
+  code: 'ERR_INSUFFICIENT_UUIDS',
+};
+
 export const MISSING_PENALTY_TYPE = {
   message: 'Missing penaltyType',
   code: 'ERR_MISSING_PENALTY_TYPE',
@@ -932,6 +937,7 @@ export const errorConditionConstants = {
   INCOMPATIBLE_MATCHUP_STATUS,
   INCOMPLETE_SOURCE_STRUCTURE,
   INSUFFICIENT_DRAW_POSITIONS,
+  INSUFFICIENT_UUIDS,
   INVALID_ACTION,
   INVALID_ASSIGNMENT,
   INVALID_BOOKINGS,

--- a/src/mutate/drawDefinitions/addDrawDefinitionTimeItem.ts
+++ b/src/mutate/drawDefinitions/addDrawDefinitionTimeItem.ts
@@ -17,8 +17,11 @@ export function addDrawDefinitionTimeItem({ drawDefinition, timeItem }) {
   if (!validTimeItem) return { error: INVALID_TIME_ITEM };
 
   drawDefinition.timeItems ??= [];
-  const createdAt = new Date().toISOString();
-  Object.assign(timeItem, { createdAt });
+  // Honour a `createdAt` already on the caller's timeItem rather than stamping
+  // over it — same convention as `addTimeItem`. timeItem `createdAt` is an
+  // ordering key, so an entry recorded at a venue and synced later must keep its
+  // own time. Inert when nothing is supplied.
+  timeItem.createdAt ??= new Date().toISOString();
   drawDefinition.timeItems.push(timeItem);
 
   addDrawNotice({ drawDefinition });

--- a/src/mutate/extensions/addExtension.ts
+++ b/src/mutate/extensions/addExtension.ts
@@ -53,8 +53,20 @@ export function addExtension(params?: AddExtensionArgs): {
   const creationTime = params?.creationTime ?? true;
 
   if (creationTime) {
-    const createdAt = new Date().toISOString();
-    Object.assign(params.extension, { createdAt });
+    // Honour a `createdAt` already on the caller's extension rather than
+    // stamping over it — same convention as `addTimeItem`. Inert when nothing is
+    // supplied; `creationTime: false` still means "add no createdAt at all".
+    //
+    // The cast is deliberate and temporary. `Extension` does not DECLARE
+    // `createdAt`, even though this function has always written one — the
+    // previous `Object.assign(extension, { createdAt })` simply bypassed the
+    // checker, so the type has been out of sync with runtime for as long as the
+    // field has existed. The correct fix is `createdAt?: Date | string` on
+    // `Extension` (mirroring `TimeItem`), but `src/types/tournamentTypes.ts` is
+    // held by an active in-flight claim
+    // (`codes-participant-other-ids-and-event-origin-stamp`), so the type
+    // addition is deferred rather than colliding with it.
+    (params.extension as any).createdAt ??= new Date().toISOString();
   }
 
   const existingExtension = params.element.extensions.find(({ name }) => name === params.extension.name);

--- a/src/mutate/participants/addPersonOtherId.ts
+++ b/src/mutate/participants/addPersonOtherId.ts
@@ -34,11 +34,17 @@ export function addPersonOtherId({
   participantId,
   organisationId,
   personId,
+  occurredAt,
 }: {
   tournamentRecord: any;
   participantId: string;
   organisationId: string;
   personId: string;
+  /**
+   * ISO string recording when the id was actually assigned, rather than when
+   * this instance wrote it. Defaults to now.
+   */
+  occurredAt?: string;
 }) {
   const paramsCheck = requireParams({ tournamentRecord, participantId }, [TOURNAMENT_RECORD, PARTICIPANT_ID]);
   if (paramsCheck.error) return paramsCheck;
@@ -68,12 +74,12 @@ export function addPersonOtherId({
       return { ...SUCCESS };
     }
     existing.personId = personId;
-    existing.updatedAt = new Date().toISOString();
+    existing.updatedAt = occurredAt ?? new Date().toISOString();
   } else {
     person.personOtherIds.push({
       organisationId,
       personId,
-      createdAt: new Date().toISOString(),
+      createdAt: occurredAt ?? new Date().toISOString(),
     });
   }
 

--- a/src/mutate/participants/modifyParticipantsPaymentStatus.ts
+++ b/src/mutate/participants/modifyParticipantsPaymentStatus.ts
@@ -15,12 +15,21 @@ type ModifyParticipantsPaymentStatusArgs = {
   tournamentRecord: any;
   participantIds: string[];
   paymentState: PaymentStatusUnion;
+  /**
+   * ISO string recording when the payment status actually CHANGED, as opposed to
+   * when this instance wrote it. Defaults to now, so existing callers are
+   * unaffected. Payment status is stored as a timeItem, whose `createdAt` is the
+   * ordering key used to resolve the CURRENT status — see
+   * `Mentat/planning/DISCONNECTED_SYNC_RECONCILIATION.md` §4.1.
+   */
+  occurredAt?: string;
 };
 
 export function modifyParticipantsPaymentStatus({
   tournamentRecord,
   participantIds,
   paymentState,
+  occurredAt,
 }: ModifyParticipantsPaymentStatusArgs) {
   const paramsCheck = requireParams({ tournamentRecord }, [TOURNAMENT_RECORD]);
   if (paramsCheck.error) return paramsCheck;
@@ -36,7 +45,7 @@ export function modifyParticipantsPaymentStatus({
   if (invalidParticipantIds.length) return { error: INVALID_VALUES, context: { invalidParticipantIds } };
 
   const modifiedParticipants: Participant[] = [];
-  const createdAt = new Date().toISOString();
+  const createdAt = occurredAt ?? new Date().toISOString();
   for (const participant of participants) {
     const { participantId } = participant;
     if (participantIds.includes(participantId)) {

--- a/src/mutate/participants/modifyParticipantsSignInStatus.ts
+++ b/src/mutate/participants/modifyParticipantsSignInStatus.ts
@@ -11,7 +11,18 @@ import { MODIFY_PARTICIPANTS } from '@Constants/topicConstants';
 import { Participant } from '@Types/tournamentTypes';
 import { SUCCESS } from '@Constants/resultConstants';
 
-export function modifyParticipantsSignInStatus({ tournamentRecord, participantIds, signInState }) {
+/**
+ * `occurredAt` — ISO string recording when the sign-in actually HAPPENED, as
+ * opposed to when this instance wrote it. Defaults to now, so existing callers
+ * are unaffected.
+ *
+ * Sign-in status is stored as a timeItem, and timeItem `createdAt` is the
+ * ordering key the query layer uses to resolve the CURRENT status. An edit made
+ * at a venue and synced later must therefore carry its own time, or it both
+ * misreports when the player signed in and sorts as though it happened at sync
+ * time. See `Mentat/planning/DISCONNECTED_SYNC_RECONCILIATION.md` §4.1.
+ */
+export function modifyParticipantsSignInStatus({ tournamentRecord, participantIds, signInState, occurredAt }) {
   const paramsCheck = requireParams({ tournamentRecord }, [TOURNAMENT_RECORD]);
   if (paramsCheck.error) return paramsCheck;
   if (!Array.isArray(participantIds)) return { error: MISSING_VALUE };
@@ -27,7 +38,7 @@ export function modifyParticipantsSignInStatus({ tournamentRecord, participantId
   if (invalidParticipantIds.length) return { error: INVALID_VALUES, context: { invalidParticipantIds } };
 
   const modifiedParticipants: Participant[] = [];
-  const createdAt = new Date().toISOString();
+  const createdAt = occurredAt ?? new Date().toISOString();
   for (const participant of participants) {
     const { participantId } = participant;
     if (participantIds.includes(participantId)) {

--- a/src/mutate/participants/penalties/addPenalty.ts
+++ b/src/mutate/participants/penalties/addPenalty.ts
@@ -23,6 +23,11 @@ type AddPenaltyArgs = {
   penaltyId?: string;
   matchUpId?: string;
   issuedAt?: string;
+  /**
+   * ISO string recording when the penalty record was created at its ORIGIN, as
+   * opposed to when this instance wrote it. Defaults to `issuedAt`, then to now.
+   */
+  occurredAt?: string;
   notes?: string;
 };
 
@@ -69,6 +74,7 @@ function penaltyAdd({
   extensions,
   penaltyId,
   matchUpId,
+  occurredAt,
   issuedAt,
   notes,
 }: AddPenaltyArgs): {
@@ -84,7 +90,12 @@ function penaltyAdd({
   const relevantParticipants = participants.filter((participant) => participantIds.includes(participant.participantId));
   if (!relevantParticipants.length) return { error: PARTICIPANT_NOT_FOUND };
 
-  const createdAt = new Date().toISOString();
+  // A penalty already carries `issuedAt` — when it was handed down on court.
+  // `createdAt` is when the record was written, and defaulting it to `issuedAt`
+  // keeps the two coherent for a penalty captured courtside and synced later.
+  // Falls back to now when the caller supplied neither, so existing callers are
+  // unaffected. This is the field a governing body reads on appeal.
+  const createdAt = occurredAt ?? issuedAt ?? new Date().toISOString();
   const penaltyItem: Penalty = Object.assign(penaltyTemplate({ penaltyId }), {
     refereeParticipantId,
     penaltyCode,

--- a/src/mutate/participants/scaleItems/addScaleItems.ts
+++ b/src/mutate/participants/scaleItems/addScaleItems.ts
@@ -151,7 +151,19 @@ export function addParticipantScaleItem({ removePriorValues, participant, scaleI
 
   if (!validScaleItem) return { error: INVALID_SCALE_ITEM };
 
-  const createdAt = new Date().toISOString();
+  // Honour a `createdAt` already on the caller's scaleItem rather than stamping
+  // over it. No new parameter is needed here — the caller already supplies the
+  // object, so this is the same shape as `participantId ??= UUID()`.
+  //
+  // This is the ordering case that matters most: `participantScaleItem` and
+  // `getScaleValues` sort a participant's scale timeItems by `createdAt` to
+  // resolve the CURRENT rating. A rating recorded at a venue and synced later
+  // must carry its own time or it sorts as though it happened at sync time —
+  // and would wrongly supersede a rating actually set after it.
+  //
+  // Distinct from `scaleItem.scaleDate`, which is the date the rating APPLIES
+  // to; `createdAt` is when it was recorded.
+  const createdAt = scaleItem.createdAt ?? new Date().toISOString();
   participant.timeItems ??= [];
 
   const { scaleItem: existingScaleItem } = participantScaleItem({

--- a/src/mutate/practice/addPracticeRegistration.ts
+++ b/src/mutate/practice/addPracticeRegistration.ts
@@ -28,6 +28,7 @@ type AddPracticeRegistrationArgs = {
   endTime: string;
   notes?: string;
   disableNotice?: boolean;
+  registrationId?: string;
 };
 
 type AddPracticeRegistrationResult = ResultType & {
@@ -45,8 +46,18 @@ type AddPracticeRegistrationResult = ResultType & {
  * Callers (TMX) surface a confirmModal and decide whether to proceed.
  */
 export function addPracticeRegistration(params: AddPracticeRegistrationArgs): AddPracticeRegistrationResult {
-  const { tournamentRecord, courtId, date, bookingId, participantId, startTime, endTime, notes, disableNotice } =
-    params;
+  const {
+    tournamentRecord,
+    courtId,
+    date,
+    bookingId,
+    participantId,
+    startTime,
+    endTime,
+    notes,
+    disableNotice,
+    registrationId,
+  } = params;
 
   const paramsCheck = requireParams({ tournamentRecord, courtId, participantId }, [
     TOURNAMENT_RECORD,
@@ -88,7 +99,10 @@ export function addPracticeRegistration(params: AddPracticeRegistrationArgs): Ad
   });
 
   const registration: PracticeRegistration = {
-    registrationId: UUID('reg'),
+    // Caller-supplied id wins — see addReviewNote for why this is not cosmetic.
+    // The `'reg'` prefix applies only to the minted path; a supplied id is taken
+    // verbatim rather than re-prefixed, so round-tripping an existing id is safe.
+    registrationId: registrationId ?? UUID('reg'),
     participantId,
     startTime,
     endTime,

--- a/src/mutate/practice/addPracticeRegistration.ts
+++ b/src/mutate/practice/addPracticeRegistration.ts
@@ -29,6 +29,12 @@ type AddPracticeRegistrationArgs = {
   notes?: string;
   disableNotice?: boolean;
   registrationId?: string;
+  /**
+   * ISO string recording when the registration was actually made, rather than
+   * when this instance wrote it. Defaults to now, so existing callers are
+   * unaffected. See `Mentat/planning/DISCONNECTED_SYNC_RECONCILIATION.md` §4.1.
+   */
+  occurredAt?: string;
 };
 
 type AddPracticeRegistrationResult = ResultType & {
@@ -57,7 +63,10 @@ export function addPracticeRegistration(params: AddPracticeRegistrationArgs): Ad
     notes,
     disableNotice,
     registrationId,
+    occurredAt,
   } = params;
+
+  const stampedAt = occurredAt ?? new Date().toISOString();
 
   const paramsCheck = requireParams({ tournamentRecord, courtId, participantId }, [
     TOURNAMENT_RECORD,
@@ -107,14 +116,17 @@ export function addPracticeRegistration(params: AddPracticeRegistrationArgs): Ad
     startTime,
     endTime,
     status: 'CONFIRMED',
-    registeredAt: new Date().toISOString(),
-    createdAt: new Date().toISOString(),
+    // One resolved value for the whole mutation rather than three separate
+    // `new Date()` calls, which could otherwise differ for a single logical
+    // event. `registeredAt` is when the player actually booked the court.
+    registeredAt: stampedAt,
+    createdAt: stampedAt,
   };
   if (notes) registration.notes = notes;
 
   booking.registrations ??= [];
   booking.registrations.push(registration);
-  booking.updatedAt = new Date().toISOString();
+  booking.updatedAt = stampedAt;
 
   if (!disableNotice && venue) {
     addNotice({

--- a/src/mutate/practice/removePracticeRegistration.ts
+++ b/src/mutate/practice/removePracticeRegistration.ts
@@ -17,6 +17,11 @@ type RemovePracticeRegistrationArgs = {
   bookingId: string;
   registrationId: string;
   disableNotice?: boolean;
+  /**
+   * ISO string recording when the removal actually happened, rather than when
+   * this instance wrote it. Defaults to now.
+   */
+  occurredAt?: string;
 };
 
 /**
@@ -25,7 +30,7 @@ type RemovePracticeRegistrationArgs = {
  * `status: 'CANCELLED'` to preserve audit history instead.
  */
 export function removePracticeRegistration(params: RemovePracticeRegistrationArgs): ResultType {
-  const { tournamentRecord, courtId, date, bookingId, registrationId, disableNotice } = params;
+  const { tournamentRecord, courtId, date, bookingId, registrationId, disableNotice, occurredAt } = params;
 
   const paramsCheck = requireParams({ tournamentRecord, courtId }, [TOURNAMENT_RECORD, COURT_ID]);
   if (paramsCheck.error) return paramsCheck;
@@ -42,7 +47,7 @@ export function removePracticeRegistration(params: RemovePracticeRegistrationArg
   if (index < 0) return { error: REGISTRATION_NOT_FOUND };
 
   booking.registrations!.splice(index, 1);
-  booking.updatedAt = new Date().toISOString();
+  booking.updatedAt = occurredAt ?? new Date().toISOString();
 
   if (!disableNotice && venue) {
     addNotice({

--- a/src/mutate/practice/updatePracticeRegistration.ts
+++ b/src/mutate/practice/updatePracticeRegistration.ts
@@ -32,6 +32,12 @@ type UpdatePracticeRegistrationArgs = {
   registrationId: string;
   updates: Updates;
   disableNotice?: boolean;
+  /**
+   * ISO string recording when the change was actually made, rather than when
+   * this instance wrote it. Defaults to now. Also stamps `cancelledAt`, so a
+   * cancellation made courtside and synced later records the real time.
+   */
+  occurredAt?: string;
 };
 
 type UpdatePracticeRegistrationResult = ResultType & {
@@ -47,7 +53,9 @@ type UpdatePracticeRegistrationResult = ResultType & {
  * are returned alongside success (same posture as `addPracticeRegistration`).
  */
 export function updatePracticeRegistration(params: UpdatePracticeRegistrationArgs): UpdatePracticeRegistrationResult {
-  const { tournamentRecord, courtId, date, bookingId, registrationId, updates, disableNotice } = params;
+  const { tournamentRecord, courtId, date, bookingId, registrationId, updates, disableNotice, occurredAt } = params;
+
+  const stampedAt = occurredAt ?? new Date().toISOString();
 
   const paramsCheck = requireParams({ tournamentRecord, courtId }, [TOURNAMENT_RECORD, COURT_ID]);
   if (paramsCheck.error) return paramsCheck;
@@ -97,11 +105,11 @@ export function updatePracticeRegistration(params: UpdatePracticeRegistrationArg
   registration.status = nextStatus;
   if (updates.notes !== undefined) registration.notes = updates.notes;
   if (nextStatus === 'CANCELLED') {
-    registration.cancelledAt = new Date().toISOString();
+    registration.cancelledAt = stampedAt;
   } else {
     delete registration.cancelledAt;
   }
-  registration.updatedAt = new Date().toISOString();
+  registration.updatedAt = stampedAt;
   booking.updatedAt = registration.updatedAt;
 
   if (!disableNotice && venue) {

--- a/src/mutate/sanctioning/activateFromSanctioning.ts
+++ b/src/mutate/sanctioning/activateFromSanctioning.ts
@@ -1,9 +1,9 @@
 import { transitionStatus } from './transitionStatus';
-import { UUID } from '@Tools/UUID';
+import { takeUUID, UUID } from '@Tools/UUID';
 
 // constants
+import { INSUFFICIENT_UUIDS, INVALID_VALUES } from '@Constants/errorConditionConstants';
 import { MISSING_SANCTIONING_RECORD, ACTIVE } from '@Constants/sanctioningConstants';
-import { INVALID_VALUES } from '@Constants/errorConditionConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 
 // types
@@ -247,22 +247,36 @@ export function activateFromSanctioning({
   const policy = sanctioningPolicy ?? sanctioningRecord.policySnapshot;
   if (policy?.postEventRequirements?.length) {
     const endDate = new Date(proposal.proposedEndDate);
-    const items: ComplianceItem[] = policy.postEventRequirements
-      // `tiers` on a requirement are tier NAMES, so they match the tier's `value`.
-      .filter((req) => !req.tiers?.length || req.tiers.includes(sanctioningRecord.sanctioningTier?.value ?? ''))
-      .map((req) => {
-        const deadline = new Date(endDate);
-        deadline.setDate(deadline.getDate() + req.deadlineDays);
-        return {
-          // Caller-supplied ids win, consumed in list order.
-          itemId: uuids?.pop() ?? UUID(),
-          itemType: req.itemType,
-          description: req.description,
-          required: req.required,
-          status: 'PENDING' as const,
-          deadline: deadline.toISOString().split('T')[0],
-        };
-      });
+    // `tiers` on a requirement are tier NAMES, so they match the tier's `value`.
+    const applicableRequirements = policy.postEventRequirements.filter(
+      (req) => !req.tiers?.length || req.tiers.includes(sanctioningRecord.sanctioningTier?.value ?? ''),
+    );
+
+    // Validate the pool BEFORE minting. The count is knowable up front here, so a
+    // short pool can be reported precisely rather than discovered halfway through
+    // and leaving some items with ids and others without. Strict when supplied:
+    // a short pool means this replay needed a different number of ids than the
+    // origin did — a divergence signal, not a licence to mint.
+    if (uuids !== undefined && uuids.length < applicableRequirements.length) {
+      return {
+        error: INSUFFICIENT_UUIDS,
+        context: { required: applicableRequirements.length, supplied: uuids.length },
+      };
+    }
+
+    const items: ComplianceItem[] = applicableRequirements.map((req) => {
+      const deadline = new Date(endDate);
+      deadline.setDate(deadline.getDate() + req.deadlineDays);
+      return {
+        // Pool sufficiency was validated above, so this cannot come back empty.
+        itemId: takeUUID({ uuids }).uuid as string,
+        itemType: req.itemType,
+        description: req.description,
+        required: req.required,
+        status: 'PENDING' as const,
+        deadline: deadline.toISOString().split('T')[0],
+      };
+    });
 
     const compliance: ComplianceRecord = {
       status: 'PENDING',

--- a/src/mutate/sanctioning/activateFromSanctioning.ts
+++ b/src/mutate/sanctioning/activateFromSanctioning.ts
@@ -30,6 +30,18 @@ type ActivateFromSanctioningArgs = {
    * cross-tournament identity for the place it is played at instead of a re-entered venue.
    */
   venues?: Venue[];
+  /**
+   * Optional pool of ids for the generated compliance-checklist items, consumed
+   * in order. Follows the existing `uuids` idiom (`generateVenues`,
+   * `createTeamsFromAttributes`, `addEventEntryPairs`).
+   *
+   * Compliance items are derived from `policy.postEventRequirements`, which carry
+   * no id of their own, so there is nothing stable to key them to. Without a pool
+   * this mutation mints ids engine-side and is therefore not replayable: a site
+   * server mirrors `{method, params}` upstream, and engine-minted ids differ
+   * between instances. Supply the pool when identity must survive a replay.
+   */
+  uuids?: string[];
 };
 
 /**
@@ -121,7 +133,12 @@ function resolveEventOtherIds(
   ];
 }
 
-export function activateFromSanctioning({ sanctioningRecord, sanctioningPolicy, venues }: ActivateFromSanctioningArgs) {
+export function activateFromSanctioning({
+  sanctioningRecord,
+  sanctioningPolicy,
+  venues,
+  uuids,
+}: ActivateFromSanctioningArgs) {
   if (!sanctioningRecord) return { error: MISSING_SANCTIONING_RECORD };
   if (sanctioningRecord.status !== 'APPROVED') {
     return {
@@ -237,7 +254,8 @@ export function activateFromSanctioning({ sanctioningRecord, sanctioningPolicy, 
         const deadline = new Date(endDate);
         deadline.setDate(deadline.getDate() + req.deadlineDays);
         return {
-          itemId: UUID(),
+          // Caller-supplied ids win, consumed in list order.
+          itemId: uuids?.pop() ?? UUID(),
           itemType: req.itemType,
           description: req.description,
           required: req.required,

--- a/src/mutate/sanctioning/addReviewNote.ts
+++ b/src/mutate/sanctioning/addReviewNote.ts
@@ -13,15 +13,20 @@ type AddReviewNoteArgs = {
   note: string;
   reviewerId?: string;
   reviewerName?: string;
+  noteId?: string;
 };
 
-export function addReviewNote({ sanctioningRecord, note, reviewerId, reviewerName }: AddReviewNoteArgs) {
+export function addReviewNote({ sanctioningRecord, note, reviewerId, reviewerName, noteId }: AddReviewNoteArgs) {
   if (!sanctioningRecord) return { error: MISSING_SANCTIONING_RECORD };
   if (!note) return { error: INVALID_VALUES, context: { message: 'Missing note' } };
 
   sanctioningRecord.reviewNotes ??= [];
   const reviewNote: ReviewNote = {
-    noteId: UUID(),
+    // A caller-supplied id is authoritative. Minting unconditionally would make
+    // this mutation non-replayable: a site server mirrors `{method, params}`
+    // upstream, so an engine-minted id differs between the two instances and
+    // every later mutation referencing it fails to resolve on the cloud.
+    noteId: noteId ?? UUID(),
     reviewerId,
     reviewerName,
     note,

--- a/src/mutate/sanctioning/amendments.ts
+++ b/src/mutate/sanctioning/amendments.ts
@@ -30,9 +30,16 @@ type ProposeAmendmentArgs = {
   changes: ProposalChange[];
   sanctioningPolicy?: SanctioningPolicy;
   proposedBy?: string;
+  amendmentId?: string;
 };
 
-export function proposeAmendment({ sanctioningRecord, changes, sanctioningPolicy, proposedBy }: ProposeAmendmentArgs) {
+export function proposeAmendment({
+  sanctioningRecord,
+  changes,
+  sanctioningPolicy,
+  proposedBy,
+  amendmentId,
+}: ProposeAmendmentArgs) {
   if (!sanctioningRecord) return { error: MISSING_SANCTIONING_RECORD };
   if (!Array.isArray(changes) || changes.length === 0) {
     return { error: INVALID_VALUES, context: { message: 'At least one change is required' } };
@@ -55,7 +62,8 @@ export function proposeAmendment({ sanctioningRecord, changes, sanctioningPolicy
 
   const now = new Date().toISOString();
   const amendment: Amendment = {
-    amendmentId: UUID(),
+    // Caller-supplied id wins — see addReviewNote for why this is not cosmetic.
+    amendmentId: amendmentId ?? UUID(),
     status: 'PROPOSED',
     proposedAt: now,
     proposedBy,

--- a/src/mutate/sanctioning/conditionallyApprove.ts
+++ b/src/mutate/sanctioning/conditionallyApprove.ts
@@ -10,7 +10,9 @@ import type { SanctioningRecord, Condition } from '@Types/sanctioningTypes';
 
 type ConditionallyApproveArgs = {
   sanctioningRecord: SanctioningRecord;
-  conditions: Array<{ description: string }>;
+  // `conditionId` is per-element rather than a parallel array so a caller cannot
+  // mis-align ids with descriptions.
+  conditions: Array<{ description: string; conditionId?: string }>;
   approvedBy?: string;
 };
 
@@ -32,7 +34,8 @@ export function conditionallyApprove({ sanctioningRecord, conditions, approvedBy
   sanctioningRecord.conditions ??= [];
   for (const c of conditions) {
     const condition: Condition = {
-      conditionId: UUID(),
+      // Caller-supplied id wins — see addReviewNote for why this is not cosmetic.
+      conditionId: c.conditionId ?? UUID(),
       description: c.description,
       met: false,
       createdAt: now,

--- a/src/mutate/sanctioning/requestModification.ts
+++ b/src/mutate/sanctioning/requestModification.ts
@@ -11,9 +11,10 @@ type RequestModificationArgs = {
   sanctioningRecord: SanctioningRecord;
   requestedBy?: string;
   note?: string;
+  noteId?: string;
 };
 
-export function requestModification({ sanctioningRecord, requestedBy, note }: RequestModificationArgs) {
+export function requestModification({ sanctioningRecord, requestedBy, note, noteId }: RequestModificationArgs) {
   if (!sanctioningRecord) return { error: MISSING_SANCTIONING_RECORD };
 
   const result = transitionStatus({
@@ -27,7 +28,8 @@ export function requestModification({ sanctioningRecord, requestedBy, note }: Re
   if (note) {
     sanctioningRecord.reviewNotes ??= [];
     const reviewNote: ReviewNote = {
-      noteId: UUID(),
+      // Caller-supplied id wins — see addReviewNote for why this is not cosmetic.
+      noteId: noteId ?? UUID(),
       reviewerId: requestedBy,
       note,
       createdAt: sanctioningRecord.updatedAt,

--- a/src/mutate/scoring/createMatchUp.ts
+++ b/src/mutate/scoring/createMatchUp.ts
@@ -7,7 +7,7 @@
 import { UUID } from '@Tools/UUID';
 
 // Import necessary types
-import type { MatchUp, CreateMatchUpOptions, Side, Score } from "@Types/scoring/types";
+import type { MatchUp, CreateMatchUpOptions, Side, Score } from '@Types/scoring/types';
 
 /**
  * Create a new matchUp
@@ -16,16 +16,10 @@ import type { MatchUp, CreateMatchUpOptions, Side, Score } from "@Types/scoring/
  * @returns New matchUp object
  */
 export function createMatchUp(options: CreateMatchUpOptions): MatchUp {
-  const {
-    matchUpId = UUID(),
-    matchUpFormat,
-    participants = [],
-    isDoubles = false,
-    matchUpType,
-  } = options;
+  const { matchUpId = UUID(), matchUpFormat, participants = [], isDoubles = false, matchUpType, occurredAt } = options;
 
   // Determine matchUpType
-  const type = matchUpType || (isDoubles ? "DOUBLES" : "SINGLES");
+  const type = matchUpType || (isDoubles ? 'DOUBLES' : 'SINGLES');
 
   // Create sides from participants
   const sides: Side[] = participants.map((participant, index) => ({
@@ -48,11 +42,11 @@ export function createMatchUp(options: CreateMatchUpOptions): MatchUp {
   const matchUp: MatchUp = {
     matchUpId,
     matchUpFormat,
-    matchUpStatus: "TO_BE_PLAYED",
+    matchUpStatus: 'TO_BE_PLAYED',
     matchUpType: type,
     sides,
     score,
-    createdAt: new Date().toISOString(),
+    createdAt: occurredAt ?? new Date().toISOString(),
   };
 
   return matchUp;

--- a/src/mutate/tieFormat/writeTieFormat.ts
+++ b/src/mutate/tieFormat/writeTieFormat.ts
@@ -1,6 +1,6 @@
 import { allEventMatchUps } from '@Query/matchUps/getAllEventMatchUps';
 import { makeDeepCopy } from '@Tools/makeDeepCopy';
-import { UUID } from '@Tools/UUID';
+import { takeUUID } from '@Tools/UUID';
 
 // constants and types
 import { Event, TieFormat } from '@Types/tournamentTypes';
@@ -15,6 +15,23 @@ type WriteTieFormatArgs = {
   target: WriteTieFormatTarget;
   tieFormat: TieFormat;
   event?: Event;
+  /**
+   * Optional pool for the copy-on-write fork below.
+   *
+   * NOT a `tieFormatId` parameter, deliberately. Naming the id directly would let
+   * a caller write back onto the format other references still point at, which is
+   * exactly what the fork exists to avoid. A pool says only "when you need to
+   * mint, draw from here" — the format still diverges, still gets an id distinct
+   * from the shared one, but the VALUE is reproducible.
+   *
+   * Why a pool is the only option here: the fork creates an entity the caller
+   * never asked for, so a caller cannot pre-supply its id by naming it. TMX
+   * otherwise mints at the origin and threads ids through params — whole
+   * generated objects, or an explicit `uuids` pool (`addFlights`,
+   * `pairFromUnified`) — which is what keeps its two executions (CFS, then the
+   * local re-run on ack) in agreement. This path had no pool to thread.
+   */
+  uuids?: string[];
 };
 
 /**
@@ -24,9 +41,21 @@ type WriteTieFormatArgs = {
  * - If the target had a `tieFormatId` (centralized): updates the centralized entry in event.tieFormats[]
  *   if no other objects share the same ID, or creates a new entry if shared.
  * - If the target had an inline `tieFormat`: writes inline (backwards-compatible).
+ *
+ * ⚠️ RETURNS AN ERROR OBJECT. Callers currently ignore the return value, which is
+ * safe ONLY because none of them thread `uuids` yet — with no pool supplied the
+ * error path is unreachable. Any caller that starts passing `uuids` MUST check
+ * the result and propagate, or an exhausted pool becomes a silent no-op write.
+ *
+ * Threading the pool through the ~20 call sites in addCollectionDefinition,
+ * removeCollectionDefinition, updateTieFormat and collectionGroupUpdate is
+ * deliberately NOT done piecemeal: partial threading makes replay divergence
+ * intermittent (some paths reproducible, others not), which is harder to diagnose
+ * than the current consistent behaviour. Do it as one pass, with error checks at
+ * every site.
  */
-export function writeTieFormat({ target, tieFormat, event }: WriteTieFormatArgs) {
-  if (!target) return;
+export function writeTieFormat({ target, tieFormat, event, uuids }: WriteTieFormatArgs) {
+  if (!target) return undefined;
 
   // If the target was using a centralized tieFormatId reference
   if (target.tieFormatId && event?.tieFormats?.length) {
@@ -41,26 +70,29 @@ export function writeTieFormat({ target, tieFormat, event }: WriteTieFormatArgs)
         updatedTieFormat.tieFormatId = existingId;
         event.tieFormats[existingIndex] = updatedTieFormat;
         // target keeps its existing tieFormatId, no change needed
-        return;
+        return undefined;
       }
     }
 
     // Multiple references share this ID — create a new entry so we don't affect others
     const newTieFormat = makeDeepCopy(tieFormat, undefined, true);
-    // DELIBERATELY unconditional, unlike the caller-supplied-id convention applied
-    // across mutate/ in 2026-08. This is copy-on-write: the whole point is to
-    // diverge from the shared tieFormatId, so honouring a supplied id would write
-    // back onto the format the other references still point at. Do not "complete
-    // the set" by making this respect a parameter.
-    newTieFormat.tieFormatId = UUID();
+    // The fork itself is unconditional — that is the point of copy-on-write — but
+    // the VALUE comes from the caller's pool when one was supplied, so both
+    // instances replaying this mutation land on the same id. Strict when supplied:
+    // an exhausted pool is a divergence signal, not a licence to mint.
+    const { uuid, error } = takeUUID({ uuids });
+    if (error) return { error };
+
+    newTieFormat.tieFormatId = uuid;
     event.tieFormats.push(newTieFormat);
     target.tieFormatId = newTieFormat.tieFormatId;
     delete target.tieFormat;
-    return;
+    return undefined;
   }
 
   // Fallback: write inline (backwards-compatible for pre-aggregation state)
   target.tieFormat = tieFormat;
+  return undefined;
 }
 
 type CountReferencesArgs = {

--- a/src/mutate/tieFormat/writeTieFormat.ts
+++ b/src/mutate/tieFormat/writeTieFormat.ts
@@ -47,6 +47,11 @@ export function writeTieFormat({ target, tieFormat, event }: WriteTieFormatArgs)
 
     // Multiple references share this ID — create a new entry so we don't affect others
     const newTieFormat = makeDeepCopy(tieFormat, undefined, true);
+    // DELIBERATELY unconditional, unlike the caller-supplied-id convention applied
+    // across mutate/ in 2026-08. This is copy-on-write: the whole point is to
+    // diverge from the shared tieFormatId, so honouring a supplied id would write
+    // back onto the format the other references still point at. Do not "complete
+    // the set" by making this respect a parameter.
     newTieFormat.tieFormatId = UUID();
     event.tieFormats.push(newTieFormat);
     target.tieFormatId = newTieFormat.tieFormatId;

--- a/src/mutate/timeItems/addTimeItem.ts
+++ b/src/mutate/timeItems/addTimeItem.ts
@@ -58,8 +58,22 @@ export function addTimeItem(params: AddTimeItemArgs) {
   if (timeItem.itemSubTypes && !timeItem.itemSubTypes.length) delete timeItem.itemSubTypes;
 
   if (creationTime) {
-    const createdAt = new Date().toISOString();
-    Object.assign(timeItem, { createdAt });
+    // Honour a caller-supplied `createdAt` rather than overwriting it.
+    //
+    // `createdAt` on a timeItem is not decoration — it is the ORDERING KEY used
+    // to resolve "the latest value" (ratings via getScaleValues /
+    // participantScaleItem, check-in, startTime/endTime, scheduling details,
+    // quality-win points, latestVisibleTimeItemValue). Stamping unconditionally
+    // means the value can only ever be *write* time, so an edit made at a venue
+    // and synced hours later is recorded as having happened at sync time.
+    //
+    // Inert for every current caller: none of the 11 call sites supplies
+    // `createdAt`, so the default path is unchanged. This only lets an origin
+    // pin the value — which is what makes the mutation faithfully replayable,
+    // the same principle as minting ids at the origin.
+    //
+    // `creationTime: false` still means "do not add a createdAt at all".
+    timeItem.createdAt ??= new Date().toISOString();
   }
 
   if (removePriorValues) element.timeItems = element.timeItems.filter(({ itemType }) => timeItem.itemType !== itemType);

--- a/src/mutate/tournaments/mutationLocks/addMutationLock.ts
+++ b/src/mutate/tournaments/mutationLocks/addMutationLock.ts
@@ -96,6 +96,10 @@ export function addMutationLock(params: AddMutationLockArgs): {
     return { error: MUTATION_LOCK_EXISTS };
   }
 
+  // DELIBERATELY unconditional, unlike the caller-supplied-id convention applied
+  // across mutate/ in 2026-08. A lockId identifies an ephemeral operational
+  // claim, not tournament data — it is not replayed, mirrored, or referenced by
+  // any later mutation, so there is nothing for a caller to keep stable.
   const lockId = UUID();
   const newLock: MutationLock = {
     lockId,

--- a/src/mutate/venues/addCourtGridBooking.ts
+++ b/src/mutate/venues/addCourtGridBooking.ts
@@ -19,6 +19,11 @@ type AddCourtGridBookingArgs = {
   courtId: string;
   rowCount?: number;
   notes?: string;
+  /**
+   * ISO string recording when the booking was actually made, rather than when
+   * this instance wrote it. Defaults to now.
+   */
+  occurredAt?: string;
 };
 
 /**
@@ -39,6 +44,7 @@ export function addCourtGridBooking(params: AddCourtGridBookingArgs): ResultType
     rowCount = 1,
     courtId,
     notes,
+    occurredAt,
   } = params;
 
   // Validate required parameters
@@ -131,7 +137,7 @@ export function addCourtGridBooking(params: AddCourtGridBookingArgs): ResultType
     rowCount,
     bookingType,
     notes,
-    createdAt: new Date().toISOString(),
+    createdAt: occurredAt ?? new Date().toISOString(),
   };
 
   targetCourtDate.bookings ??= [];

--- a/src/mutate/venues/addVenueOtherId.ts
+++ b/src/mutate/venues/addVenueOtherId.ts
@@ -38,8 +38,13 @@ export function addVenueOtherId(params: {
   organisationId: string;
   otherVenueId: string;
   venueId: string;
+  /**
+   * ISO string recording when the id was actually assigned, rather than when
+   * this instance wrote it. Defaults to now.
+   */
+  occurredAt?: string;
 }) {
-  const { uniqueOrganisationName, organisationId, otherVenueId, venueId } = params;
+  const { uniqueOrganisationName, organisationId, otherVenueId, venueId, occurredAt } = params;
 
   const tournamentRecords = resolveTournamentRecords(params);
   const paramsCheck = requireParams({ venueId }, ['venueId']);
@@ -57,6 +62,7 @@ export function addVenueOtherId(params: {
       organisationId,
       otherVenueId,
       tournamentRecord,
+      occurredAt,
       venueId,
     });
     if (result.success) success = true;
@@ -73,12 +79,14 @@ function venueOtherIdAdd({
   organisationId,
   otherVenueId,
   tournamentRecord,
+  occurredAt,
   venueId,
 }: {
   uniqueOrganisationName?: string;
   organisationId: string;
   otherVenueId: string;
   tournamentRecord: any;
+  occurredAt?: string;
   venueId: string;
 }): { success?: boolean; error?: ErrorType } {
   const { venue } = findVenue({ tournamentRecord, venueId });
@@ -94,13 +102,13 @@ function venueOtherIdAdd({
     }
     existing.venueId = otherVenueId;
     if (uniqueOrganisationName !== undefined) existing.uniqueOrganisationName = uniqueOrganisationName;
-    existing.updatedAt = new Date().toISOString();
+    existing.updatedAt = occurredAt ?? new Date().toISOString();
   } else {
     venue.venueOtherIds.push({
       ...(uniqueOrganisationName !== undefined ? { uniqueOrganisationName } : {}),
       organisationId,
       venueId: otherVenueId,
-      createdAt: new Date().toISOString(),
+      createdAt: occurredAt ?? new Date().toISOString(),
     });
   }
 

--- a/src/tests/mutations/practice/practiceSuppliedIds.test.ts
+++ b/src/tests/mutations/practice/practiceSuppliedIds.test.ts
@@ -1,0 +1,145 @@
+import { addPracticeRegistration } from '@Mutate/practice/addPracticeRegistration';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+// constants and types
+import { PRACTICE } from '@Constants/scheduleConstants';
+
+/**
+ * A caller-supplied `registrationId` must be honoured rather than overwritten by
+ * an engine-minted `UUID('reg')`.
+ *
+ * See `src/tests/sanctioning/sanctioningSuppliedIds.test.ts` for why this class
+ * of change matters: a mutation that mints its own id is not replayable, because
+ * a site server mirrors `{ method, params }` upstream and the cloud would mint a
+ * different id than the origin did.
+ *
+ * Deliberately kept in a separate file from `practiceRegistration.test.ts` so no
+ * existing test logic is altered.
+ */
+
+const TEST_DATE = '2026-06-15';
+
+function setupPracticeBooking() {
+  mocksEngine.generateTournamentRecord({
+    participantsProfile: { participantsCount: 4 },
+    venueProfiles: [{ courtsCount: 2, venueId: 'v1' }],
+    startDate: TEST_DATE,
+    endDate: TEST_DATE,
+    nonRandom: 1,
+    setState: true,
+  });
+  const { tournamentRecord } = tournamentEngine.getTournament();
+
+  const court = tournamentRecord.venues[0].courts[0];
+  court.dateAvailability = [
+    {
+      date: TEST_DATE,
+      startTime: '08:00',
+      endTime: '20:00',
+      bookings: [{ bookingId: 'booking-1', bookingType: PRACTICE, startTime: '14:00', endTime: '16:00' }],
+    },
+  ];
+
+  const participants = tournamentRecord.participants ?? [];
+  return {
+    tournamentRecord,
+    courtId: court.courtId,
+    bookingId: 'booking-1',
+    participantId: participants[0]?.participantId,
+    secondParticipantId: participants[1]?.participantId,
+  };
+}
+
+describe('addPracticeRegistration — supplied registrationId', () => {
+  it('uses the supplied registrationId verbatim', () => {
+    const setup = setupPracticeBooking();
+    const result: any = addPracticeRegistration({
+      tournamentRecord: setup.tournamentRecord,
+      courtId: setup.courtId,
+      date: TEST_DATE,
+      bookingId: setup.bookingId,
+      participantId: setup.participantId,
+      startTime: '14:00',
+      endTime: '14:30',
+      registrationId: 'reg-supplied-1',
+    });
+
+    expect(result.success).toEqual(true);
+    expect(result.registration?.registrationId).toEqual('reg-supplied-1');
+  });
+
+  it('does not re-prefix a supplied id', () => {
+    // The mint path prefixes with 'reg'; a supplied id must round-trip unchanged
+    // so an id read back off a record can be replayed as-is.
+    const setup = setupPracticeBooking();
+    const result: any = addPracticeRegistration({
+      tournamentRecord: setup.tournamentRecord,
+      courtId: setup.courtId,
+      date: TEST_DATE,
+      bookingId: setup.bookingId,
+      participantId: setup.participantId,
+      startTime: '14:00',
+      endTime: '14:30',
+      registrationId: 'externally-owned-id',
+    });
+
+    expect(result.registration?.registrationId).toEqual('externally-owned-id');
+    expect(result.registration?.registrationId.startsWith('reg_')).toEqual(false);
+  });
+
+  it('persists the supplied id onto the booking, not just the result', () => {
+    const setup = setupPracticeBooking();
+    addPracticeRegistration({
+      tournamentRecord: setup.tournamentRecord,
+      courtId: setup.courtId,
+      date: TEST_DATE,
+      bookingId: setup.bookingId,
+      participantId: setup.participantId,
+      startTime: '14:00',
+      endTime: '14:30',
+      registrationId: 'reg-on-record',
+    });
+
+    const court = setup.tournamentRecord.venues[0].courts.find((c: any) => c.courtId === setup.courtId);
+    const booking = court.dateAvailability[0].bookings[0];
+    expect(booking.registrations.map((r: any) => r.registrationId)).toEqual(['reg-on-record']);
+  });
+
+  it('still mints a prefixed id when none is supplied', () => {
+    // The negative direction — without this, an implementation that ignored the
+    // parameter entirely would still pass the assertions above only by accident.
+    const setup = setupPracticeBooking();
+    const result: any = addPracticeRegistration({
+      tournamentRecord: setup.tournamentRecord,
+      courtId: setup.courtId,
+      date: TEST_DATE,
+      bookingId: setup.bookingId,
+      participantId: setup.participantId,
+      startTime: '14:00',
+      endTime: '14:30',
+    });
+
+    expect(result.success).toEqual(true);
+    expect(result.registration?.registrationId.startsWith('reg_')).toEqual(true);
+  });
+
+  it('keeps supplied ids distinct across registrations', () => {
+    const setup = setupPracticeBooking();
+    const common = {
+      tournamentRecord: setup.tournamentRecord,
+      courtId: setup.courtId,
+      date: TEST_DATE,
+      bookingId: setup.bookingId,
+      startTime: '14:00',
+      endTime: '14:30',
+    };
+    addPracticeRegistration({ ...common, participantId: setup.participantId, registrationId: 'reg-1' });
+    addPracticeRegistration({ ...common, participantId: setup.secondParticipantId, registrationId: 'reg-2' });
+
+    const court = setup.tournamentRecord.venues[0].courts.find((c: any) => c.courtId === setup.courtId);
+    const booking = court.dateAvailability[0].bookings[0];
+    expect(booking.registrations.map((r: any) => r.registrationId)).toEqual(['reg-1', 'reg-2']);
+  });
+});

--- a/src/tests/mutations/tieFormat/tieFormatIdReplayFidelity.test.ts
+++ b/src/tests/mutations/tieFormat/tieFormatIdReplayFidelity.test.ts
@@ -1,0 +1,155 @@
+import { writeTieFormat } from '@Mutate/tieFormat/writeTieFormat';
+import { describe, expect, it } from 'vitest';
+
+// constants
+import { INSUFFICIENT_UUIDS } from '@Constants/errorConditionConstants';
+
+/**
+ * Replay fidelity for the tieFormatId minted by `writeTieFormat`'s copy-on-write
+ * fork.
+ *
+ * WHY A POOL IS NEEDED HERE. TMX does not mutate-then-refetch — it executes the
+ * same `methods` array TWICE, independently:
+ *
+ *   1. CFS executes it and acks (`serverFirst`, the default)
+ *   2. on ack the client re-runs it locally via
+ *      `engineExecution({ factoryEngine, methods })` and writes to IndexedDB
+ *      (`TMX/src/services/mutation/mutationRequest.ts`)
+ *
+ * TMX's established discipline is to make that reproducible by minting at the
+ * ORIGIN and threading the ids through params — whole generated objects
+ * (`generateDraw.ts` ships the entire `drawDefinition`) or an explicit pool
+ * (`addFlights.ts` passes `tools.UUIDS(flightsCount)`,
+ * `pairFromUnified.ts` passes `uuids: [participantId]`). Where that discipline is
+ * applied, both executions agree. This is NOT a claim that TMX is careless.
+ *
+ * The gap `writeTieFormat` represents is different in kind: its copy-on-write
+ * fork mints an id for an entity the caller never asked to create, so a caller
+ * CANNOT pre-supply it by naming it — and until this change the engine offered no
+ * pool on that path to thread one through either. `MODIFY_TIE_FORMAT` accordingly
+ * passes no pool today.
+ *
+ * These tests pin the function's behaviour with and without a pool. Whether the
+ * fork is reached by a given production flow additionally depends on its
+ * preconditions (centralized `tieFormatId`, populated `event.tieFormats`,
+ * refCount > 1) — NOT verified against production data, and not claimed here.
+ *
+ * Tested at the unit level rather than through the engine because the fork has
+ * three preconditions (centralized `tieFormatId`, populated `event.tieFormats`,
+ * and refCount > 1) that are far clearer to construct directly than to arrange
+ * via a seeded tournament.
+ */
+
+const COLLECTION = { collectionId: 'c1', collectionName: 'Singles', matchUpCount: 1, matchUpValue: 1 };
+
+/**
+ * An event where BOTH the event and its drawDefinition reference the same
+ * tieFormatId — refCount 2, so writing to either target forks.
+ */
+function sharedReferenceEvent(): any {
+  return {
+    eventId: 'e1',
+    tieFormatId: 'shared-tf',
+    tieFormats: [{ tieFormatId: 'shared-tf', collectionDefinitions: [COLLECTION], winCriteria: { valueGoal: 1 } }],
+    drawDefinitions: [{ drawId: 'd1', tieFormatId: 'shared-tf', structures: [] }],
+  };
+}
+
+const modifiedTieFormat: any = {
+  collectionDefinitions: [{ ...COLLECTION, matchUpCount: 2 }],
+  winCriteria: { valueGoal: 2 },
+};
+
+describe('writeTieFormat copy-on-write id', () => {
+  it('forks to a NEW id — a supplied pool must not write back onto the shared format', () => {
+    const event = sharedReferenceEvent();
+    const target = event.drawDefinitions[0];
+
+    const error = writeTieFormat({ target, tieFormat: modifiedTieFormat, event, uuids: ['forked-1'] });
+
+    expect(error).toBeUndefined();
+    // The fork happened: the target moved off the shared id.
+    expect(target.tieFormatId).toEqual('forked-1');
+    expect(target.tieFormatId).not.toEqual('shared-tf');
+    // And the shared format the EVENT still points at was left untouched — this
+    // is why the pool supplies a mint value rather than naming the id outright.
+    expect(event.tieFormatId).toEqual('shared-tf');
+    const shared = event.tieFormats.find((tf: any) => tf.tieFormatId === 'shared-tf');
+    expect(shared.collectionDefinitions[0].matchUpCount).toEqual(1);
+  });
+
+  it('two instances replaying the same call with the same pool agree on the id', () => {
+    // The server run and the client re-run, modelled explicitly.
+    const serverEvent = sharedReferenceEvent();
+    writeTieFormat({
+      target: serverEvent.drawDefinitions[0],
+      tieFormat: modifiedTieFormat,
+      event: serverEvent,
+      uuids: ['agreed-id'],
+    });
+
+    const clientEvent = sharedReferenceEvent();
+    writeTieFormat({
+      target: clientEvent.drawDefinitions[0],
+      tieFormat: modifiedTieFormat,
+      event: clientEvent,
+      uuids: ['agreed-id'],
+    });
+
+    expect(serverEvent.drawDefinitions[0].tieFormatId).toEqual(clientEvent.drawDefinitions[0].tieFormatId);
+  });
+
+  it('WITHOUT a pool the two instances diverge — the defect this closes', () => {
+    // Documents current behaviour when no pool is threaded. If this ever starts
+    // failing because the ids match, minting has become deterministic by some
+    // other route — investigate before deleting the test.
+    const serverEvent = sharedReferenceEvent();
+    writeTieFormat({ target: serverEvent.drawDefinitions[0], tieFormat: modifiedTieFormat, event: serverEvent });
+
+    const clientEvent = sharedReferenceEvent();
+    writeTieFormat({ target: clientEvent.drawDefinitions[0], tieFormat: modifiedTieFormat, event: clientEvent });
+
+    expect(serverEvent.drawDefinitions[0].tieFormatId).not.toEqual(clientEvent.drawDefinitions[0].tieFormatId);
+  });
+
+  it('rejects an exhausted pool instead of minting the shortfall', () => {
+    const event = sharedReferenceEvent();
+    const target = event.drawDefinitions[0];
+
+    const result: any = writeTieFormat({ target, tieFormat: modifiedTieFormat, event, uuids: [] });
+
+    expect(result?.error).toEqual(INSUFFICIENT_UUIDS);
+    // The target must be left alone rather than half-forked.
+    expect(target.tieFormatId).toEqual('shared-tf');
+  });
+
+  it('still mints when no pool is supplied — an absent pool is not an empty pool', () => {
+    // The distinction the strict helper turns on: `undefined` means "no pool",
+    // `[]` means "pool supplied and exhausted".
+    const event = sharedReferenceEvent();
+    const target = event.drawDefinitions[0];
+
+    const error = writeTieFormat({ target, tieFormat: modifiedTieFormat, event });
+
+    expect(error).toBeUndefined();
+    expect(typeof target.tieFormatId).toEqual('string');
+    expect(target.tieFormatId).not.toEqual('shared-tf');
+  });
+
+  it('does not consume from the pool when updating in place (refCount 1)', () => {
+    // Only the FORK mints. A sole reference updates the centralized entry and
+    // keeps its id, so a pool passed alongside must come back untouched —
+    // otherwise pool alignment would drift between instances.
+    const event = sharedReferenceEvent();
+    // Drop the second reference so only the drawDefinition points at it.
+    delete event.tieFormatId;
+    const target = event.drawDefinitions[0];
+    const uuids = ['unused-1'];
+
+    const error = writeTieFormat({ target, tieFormat: modifiedTieFormat, event, uuids });
+
+    expect(error).toBeUndefined();
+    expect(target.tieFormatId).toEqual('shared-tf');
+    expect(uuids).toEqual(['unused-1']);
+  });
+});

--- a/src/tests/mutations/timeItems/occurredAtCoverage.test.ts
+++ b/src/tests/mutations/timeItems/occurredAtCoverage.test.ts
@@ -1,0 +1,293 @@
+import { addPracticeRegistration } from '@Mutate/practice/addPracticeRegistration';
+import { updatePracticeRegistration } from '@Mutate/practice/updatePracticeRegistration';
+import { removePracticeRegistration } from '@Mutate/practice/removePracticeRegistration';
+import { addDrawDefinitionTimeItem } from '@Mutate/drawDefinitions/addDrawDefinitionTimeItem';
+import { createMatchUp } from '@Mutate/scoring/createMatchUp';
+import { addExtension } from '@Mutate/extensions/addExtension';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+// constants
+import { PRACTICE } from '@Constants/scheduleConstants';
+
+/**
+ * `occurredAt` coverage for the remaining venue-fact mutations.
+ *
+ * Same contract everywhere: a supplied value is recorded verbatim, and omitting
+ * it still stamps from the clock so no existing caller changes behaviour. Both
+ * directions are asserted — a one-directional test would pass against an
+ * implementation that ignored the parameter entirely.
+ *
+ * See `Mentat/planning/DISCONNECTED_SYNC_RECONCILIATION.md` §4.1 and the D1/D2
+ * decisions recorded there.
+ */
+
+const OCCURRED = '2026-06-15T14:05:00.000Z';
+const TEST_DATE = '2026-06-15';
+
+function seedPracticeBooking() {
+  mocksEngine.generateTournamentRecord({
+    participantsProfile: { participantsCount: 4 },
+    venueProfiles: [{ courtsCount: 2, venueId: 'v1' }],
+    startDate: TEST_DATE,
+    endDate: TEST_DATE,
+    nonRandom: 1,
+    setState: true,
+  });
+  const { tournamentRecord } = tournamentEngine.getTournament();
+  const court = tournamentRecord.venues[0].courts[0];
+  court.dateAvailability = [
+    {
+      date: TEST_DATE,
+      startTime: '08:00',
+      endTime: '20:00',
+      bookings: [{ bookingId: 'booking-1', bookingType: PRACTICE, startTime: '14:00', endTime: '16:00' }],
+    },
+  ];
+  const participants = tournamentRecord.participants ?? [];
+  return {
+    tournamentRecord,
+    courtId: court.courtId,
+    bookingId: 'booking-1',
+    participantId: participants[0]?.participantId,
+  };
+}
+
+function bookingOf(setup: any) {
+  const court = setup.tournamentRecord.venues[0].courts.find((c: any) => c.courtId === setup.courtId);
+  return court.dateAvailability[0].bookings[0];
+}
+
+function register(setup: any, occurredAt?: string) {
+  return addPracticeRegistration({
+    tournamentRecord: setup.tournamentRecord,
+    courtId: setup.courtId,
+    date: TEST_DATE,
+    bookingId: setup.bookingId,
+    participantId: setup.participantId,
+    startTime: '14:00',
+    endTime: '14:30',
+    registrationId: 'reg-fixed',
+    ...(occurredAt ? { occurredAt } : {}),
+  }) as any;
+}
+
+describe('addPracticeRegistration — occurredAt', () => {
+  it('stamps registeredAt, createdAt and booking.updatedAt from one supplied value', () => {
+    // One resolved value for the whole mutation — three separate new Date()
+    // calls could otherwise differ for a single logical event.
+    const setup = seedPracticeBooking();
+    const result = register(setup, OCCURRED);
+
+    expect(result.success).toEqual(true);
+    expect(result.registration.registeredAt).toEqual(OCCURRED);
+    expect(result.registration.createdAt).toEqual(OCCURRED);
+    expect(bookingOf(setup).updatedAt).toEqual(OCCURRED);
+  });
+
+  it('defaults to now when omitted', () => {
+    const setup = seedPracticeBooking();
+    const before = Date.now();
+    const result = register(setup);
+
+    expect(result.success).toEqual(true);
+    expect(new Date(result.registration.createdAt).getTime()).toBeGreaterThanOrEqual(before - 1000);
+  });
+});
+
+describe('updatePracticeRegistration — occurredAt', () => {
+  it('stamps updatedAt and cancelledAt from the supplied value', () => {
+    const setup = seedPracticeBooking();
+    register(setup);
+
+    const result: any = updatePracticeRegistration({
+      tournamentRecord: setup.tournamentRecord,
+      courtId: setup.courtId,
+      date: TEST_DATE,
+      bookingId: setup.bookingId,
+      registrationId: 'reg-fixed',
+      updates: { status: 'CANCELLED' },
+      occurredAt: OCCURRED,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.registration.cancelledAt).toEqual(OCCURRED);
+    expect(result.registration.updatedAt).toEqual(OCCURRED);
+  });
+
+  it('defaults to now when omitted', () => {
+    const setup = seedPracticeBooking();
+    register(setup);
+    const before = Date.now();
+
+    const result: any = updatePracticeRegistration({
+      tournamentRecord: setup.tournamentRecord,
+      courtId: setup.courtId,
+      date: TEST_DATE,
+      bookingId: setup.bookingId,
+      registrationId: 'reg-fixed',
+      updates: { status: 'CANCELLED' },
+    });
+
+    expect(new Date(result.registration.updatedAt).getTime()).toBeGreaterThanOrEqual(before - 1000);
+  });
+});
+
+describe('removePracticeRegistration — occurredAt', () => {
+  it('stamps booking.updatedAt from the supplied value, and from now when omitted', () => {
+    const supplied = seedPracticeBooking();
+    register(supplied);
+    removePracticeRegistration({
+      tournamentRecord: supplied.tournamentRecord,
+      courtId: supplied.courtId,
+      date: TEST_DATE,
+      bookingId: supplied.bookingId,
+      registrationId: 'reg-fixed',
+      occurredAt: OCCURRED,
+    });
+    expect(bookingOf(supplied).updatedAt).toEqual(OCCURRED);
+
+    const defaulted = seedPracticeBooking();
+    register(defaulted);
+    const before = Date.now();
+    removePracticeRegistration({
+      tournamentRecord: defaulted.tournamentRecord,
+      courtId: defaulted.courtId,
+      date: TEST_DATE,
+      bookingId: defaulted.bookingId,
+      registrationId: 'reg-fixed',
+    });
+    expect(new Date(bookingOf(defaulted).updatedAt).getTime()).toBeGreaterThanOrEqual(before - 1000);
+  });
+});
+
+describe('createMatchUp — occurredAt', () => {
+  it('records the supplied value, and defaults to now when omitted', () => {
+    const supplied = createMatchUp({ matchUpFormat: 'SET3-S:6/TB7', occurredAt: OCCURRED });
+    expect(supplied.createdAt).toEqual(OCCURRED);
+
+    const before = Date.now();
+    const defaulted = createMatchUp({ matchUpFormat: 'SET3-S:6/TB7' });
+    expect(new Date(defaulted.createdAt as string).getTime()).toBeGreaterThanOrEqual(before - 1000);
+  });
+});
+
+describe('addDrawDefinitionTimeItem — supplied createdAt', () => {
+  it('honours a createdAt on the caller timeItem, and stamps when absent', () => {
+    const drawDefinition: any = { drawId: 'd1' };
+
+    addDrawDefinitionTimeItem({
+      drawDefinition,
+      timeItem: { itemType: 'TEST', itemValue: 'supplied', createdAt: OCCURRED },
+    });
+    expect(drawDefinition.timeItems.at(-1).createdAt).toEqual(OCCURRED);
+
+    const before = Date.now();
+    addDrawDefinitionTimeItem({ drawDefinition, timeItem: { itemType: 'TEST', itemValue: 'minted' } });
+    expect(new Date(drawDefinition.timeItems.at(-1).createdAt).getTime()).toBeGreaterThanOrEqual(before - 1000);
+  });
+});
+
+describe('addExtension — supplied createdAt', () => {
+  it('honours a createdAt on the caller extension, and stamps when absent', () => {
+    const supplied: any = { extensions: [] };
+    addExtension({ element: supplied, extension: { name: 'x', value: 1, createdAt: OCCURRED } as any });
+    expect(supplied.extensions.at(-1).createdAt).toEqual(OCCURRED);
+
+    const defaulted: any = { extensions: [] };
+    const before = Date.now();
+    addExtension({ element: defaulted, extension: { name: 'y', value: 2 } });
+    expect(new Date(defaulted.extensions.at(-1).createdAt).getTime()).toBeGreaterThanOrEqual(before - 1000);
+  });
+
+  it('creationTime:false still adds no createdAt', () => {
+    const element: any = { extensions: [] };
+    addExtension({ element, extension: { name: 'z', value: 3 }, creationTime: false });
+    expect(element.extensions.at(-1).createdAt).toBeUndefined();
+  });
+});
+
+describe('otherIds and court-grid bookings — occurredAt', () => {
+  it('addPersonOtherId stamps createdAt on insert and updatedAt on upsert', () => {
+    mocksEngine.generateTournamentRecord({
+      participantsProfile: { participantsCount: 2 },
+      nonRandom: 1,
+      setState: true,
+    });
+    const { participants } = tournamentEngine.getParticipants();
+    const participantId = participants.find((p: any) => p.person)?.participantId;
+
+    tournamentEngine.addPersonOtherId({
+      participantId,
+      organisationId: 'ORG',
+      personId: 'p-1',
+      occurredAt: OCCURRED,
+    });
+    let person = tournamentEngine
+      .getParticipants()
+      .participants.find((p: any) => p.participantId === participantId).person;
+    expect(person.personOtherIds.at(-1).createdAt).toEqual(OCCURRED);
+
+    // Upsert path: same organisationId, different personId → updatedAt.
+    tournamentEngine.addPersonOtherId({
+      participantId,
+      organisationId: 'ORG',
+      personId: 'p-2',
+      occurredAt: OCCURRED,
+    });
+    person = tournamentEngine.getParticipants().participants.find((p: any) => p.participantId === participantId).person;
+    expect(person.personOtherIds.at(-1).updatedAt).toEqual(OCCURRED);
+  });
+
+  it('addVenueOtherId stamps createdAt from the supplied value', () => {
+    mocksEngine.generateTournamentRecord({
+      venueProfiles: [{ courtsCount: 1, venueId: 'v1' }],
+      nonRandom: 1,
+      setState: true,
+    });
+
+    const result: any = tournamentEngine.addVenueOtherId({
+      venueId: 'v1',
+      organisationId: 'ORG',
+      otherVenueId: 'other-1',
+      occurredAt: OCCURRED,
+    });
+    expect(result.error).toBeUndefined();
+
+    const { tournamentRecord } = tournamentEngine.getTournament();
+    const venue = tournamentRecord.venues.find((v: any) => v.venueId === 'v1');
+    expect(venue.venueOtherIds.at(-1).createdAt).toEqual(OCCURRED);
+  });
+
+  it('addCourtGridBooking stamps createdAt from the supplied value, and now when omitted', () => {
+    mocksEngine.generateTournamentRecord({
+      venueProfiles: [{ courtsCount: 1, venueId: 'v1' }],
+      startDate: TEST_DATE,
+      endDate: TEST_DATE,
+      nonRandom: 1,
+      setState: true,
+    });
+    const { tournamentRecord } = tournamentEngine.getTournament();
+    const courtId = tournamentRecord.venues[0].courts[0].courtId;
+
+    const supplied: any = tournamentEngine.addCourtGridBooking({
+      courtId,
+      scheduledDate: TEST_DATE,
+      bookingType: PRACTICE,
+      courtOrder: 1,
+      occurredAt: OCCURRED,
+    });
+    expect(supplied.error).toBeUndefined();
+    expect(supplied.booking.createdAt).toEqual(OCCURRED);
+
+    const before = Date.now();
+    const defaulted: any = tournamentEngine.addCourtGridBooking({
+      courtId,
+      scheduledDate: TEST_DATE,
+      bookingType: PRACTICE,
+      courtOrder: 5,
+    });
+    expect(new Date(defaulted.booking.createdAt).getTime()).toBeGreaterThanOrEqual(before - 1000);
+  });
+});

--- a/src/tests/mutations/timeItems/suppliedCreatedAt.test.ts
+++ b/src/tests/mutations/timeItems/suppliedCreatedAt.test.ts
@@ -1,0 +1,126 @@
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+// constants
+import { RETRIEVAL } from '@Constants/timeItemConstants';
+
+/**
+ * A caller-supplied `timeItem.createdAt` must be honoured, not overwritten.
+ *
+ * `createdAt` is the ORDERING KEY that resolves "the latest value" across the
+ * query layer — ratings (`getScaleValues`, `participantScaleItem`), check-in,
+ * `startTime`/`endTime`, schedule details, quality-win points. Stamping it
+ * unconditionally means it can only ever record *write* time, so an edit made at
+ * a venue and synced hours later is recorded as having happened at sync time.
+ *
+ * Honouring a supplied value is what makes the mutation faithfully replayable —
+ * the same principle as minting ids at the origin.
+ *
+ * Every assertion is paired with its opposite: an implementation that ignored the
+ * parameter entirely would still satisfy a one-directional test.
+ */
+
+const SUPPLIED = '2026-06-15T14:05:00.000Z';
+
+function seedParticipant() {
+  const { tournamentRecord } = mocksEngine.generateTournamentRecord({ nonRandom: 1 });
+  tournamentEngine.setState(tournamentRecord);
+  const { participants } = tournamentEngine.getParticipants();
+  return participants[0].participantId;
+}
+
+function participantTimeItems(participantId: string): any[] {
+  const { participants } = tournamentEngine.getParticipants();
+  return participants.find((p: any) => p.participantId === participantId)?.timeItems ?? [];
+}
+
+describe('addTimeItem — supplied createdAt', () => {
+  it('uses the supplied createdAt verbatim', () => {
+    const participantId = seedParticipant();
+
+    const result: any = tournamentEngine.addParticipantTimeItem({
+      participantId,
+      timeItem: { itemType: RETRIEVAL, itemValue: 'supplied', createdAt: SUPPLIED },
+    });
+    expect(result.success).toEqual(true);
+
+    const added = participantTimeItems(participantId).at(-1);
+    expect(added.createdAt).toEqual(SUPPLIED);
+  });
+
+  it('still stamps when no createdAt is supplied — the default path is unchanged', () => {
+    // The negative direction. No existing caller supplies createdAt, so this is
+    // the behaviour every current code path depends on.
+    const participantId = seedParticipant();
+    const before = Date.now();
+
+    tournamentEngine.addParticipantTimeItem({
+      participantId,
+      timeItem: { itemType: RETRIEVAL, itemValue: 'minted' },
+    });
+
+    const added = participantTimeItems(participantId).at(-1);
+    expect(typeof added.createdAt).toEqual('string');
+    // Stamped from the clock, not left undefined.
+    expect(new Date(added.createdAt).getTime()).toBeGreaterThanOrEqual(before - 1000);
+  });
+
+  it('a supplied createdAt survives into the ordering the query layer reads', () => {
+    // The point of the change: two timeItems added in one order but stamped in
+    // the other must sort by the SUPPLIED times, since that is what "latest
+    // value" resolution keys on.
+    const participantId = seedParticipant();
+
+    tournamentEngine.addParticipantTimeItem({
+      participantId,
+      timeItem: { itemType: RETRIEVAL, itemValue: 'later-event', createdAt: '2026-06-15T18:00:00.000Z' },
+    });
+    tournamentEngine.addParticipantTimeItem({
+      participantId,
+      timeItem: { itemType: RETRIEVAL, itemValue: 'earlier-event', createdAt: '2026-06-15T09:00:00.000Z' },
+    });
+
+    const items = participantTimeItems(participantId).filter((i: any) => i.itemType === RETRIEVAL);
+    const byCreatedAt = items.toSorted(
+      (a: any, b: any) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+    );
+
+    // Insertion order and event order deliberately disagree.
+    expect(items.map((i: any) => i.itemValue)).toEqual(['later-event', 'earlier-event']);
+    expect(byCreatedAt.map((i: any) => i.itemValue)).toEqual(['earlier-event', 'later-event']);
+  });
+
+  it('two instances replaying the same call agree on createdAt', () => {
+    // Models the server run and the client re-run on ack: identical params in,
+    // identical timestamps out. Without a supplied value these would differ by
+    // however long the round trip took.
+    const timeItem = { itemType: RETRIEVAL, itemValue: 'replayed', createdAt: SUPPLIED };
+
+    const firstParticipantId = seedParticipant();
+    tournamentEngine.addParticipantTimeItem({ participantId: firstParticipantId, timeItem: { ...timeItem } });
+    const first = participantTimeItems(firstParticipantId).at(-1).createdAt;
+
+    const secondParticipantId = seedParticipant();
+    tournamentEngine.addParticipantTimeItem({ participantId: secondParticipantId, timeItem: { ...timeItem } });
+    const second = participantTimeItems(secondParticipantId).at(-1).createdAt;
+
+    expect(first).toEqual(second);
+    expect(first).toEqual(SUPPLIED);
+  });
+
+  it('creationTime:false still adds no createdAt at all', () => {
+    // The pre-existing opt-out must keep working — honouring a supplied value
+    // must not turn into "always have a createdAt".
+    const participantId = seedParticipant();
+
+    tournamentEngine.addParticipantTimeItem({
+      participantId,
+      creationTime: false,
+      timeItem: { itemType: RETRIEVAL, itemValue: 'no-stamp' },
+    });
+
+    const added = participantTimeItems(participantId).at(-1);
+    expect(added.createdAt).toBeUndefined();
+  });
+});

--- a/src/tests/mutations/timeItems/suppliedOccurredAt.test.ts
+++ b/src/tests/mutations/timeItems/suppliedOccurredAt.test.ts
@@ -1,0 +1,159 @@
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+// constants
+import { SIGNED_IN, SIGN_IN_STATUS } from '@Constants/participantConstants';
+
+/**
+ * `occurredAt` — recording when something HAPPENED rather than when this
+ * instance wrote it.
+ *
+ * Decisions taken by CA 2026-08-15, recorded in
+ * `Mentat/planning/DISCONNECTED_SYNC_RECONCILIATION.md` §4.1:
+ *
+ *   D1 — record-root `updatedAt` keeps WRITE-time semantics, because the
+ *        staleness probe (`POST /factory/updated-at`) derives from it. Only
+ *        entity-level timestamps carry event time. Asserted below.
+ *   D2 — event-time ordering is authoritative, INCLUDING retroactively: a
+ *        rating recorded at a venue and synced later correctly sorts before a
+ *        rating actually set after it, even though it arrived second.
+ *
+ * Every assertion is paired with its opposite, so an implementation that ignored
+ * the parameter would not pass on a technicality.
+ */
+
+const EARLY = '2026-06-15T09:00:00.000Z';
+const LATE = '2026-06-15T18:00:00.000Z';
+
+function seed() {
+  const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+    participantsProfile: { participantsCount: 4 },
+    nonRandom: 1,
+  });
+  tournamentEngine.setState(tournamentRecord);
+  const { participants } = tournamentEngine.getParticipants();
+  return participants[0].participantId;
+}
+
+function timeItemsOf(participantId: string, itemType?: string): any[] {
+  const { participants } = tournamentEngine.getParticipants();
+  const items = participants.find((p: any) => p.participantId === participantId)?.timeItems ?? [];
+  return itemType ? items.filter((i: any) => i.itemType === itemType) : items;
+}
+
+describe('modifyParticipantsSignInStatus — occurredAt', () => {
+  it('records the supplied occurredAt on the timeItem', () => {
+    const participantId = seed();
+
+    const result: any = tournamentEngine.modifyParticipantsSignInStatus({
+      participantIds: [participantId],
+      signInState: SIGNED_IN,
+      occurredAt: EARLY,
+    });
+    expect(result.success).toEqual(true);
+
+    expect(timeItemsOf(participantId, SIGN_IN_STATUS).at(-1).createdAt).toEqual(EARLY);
+  });
+
+  it('defaults to now when occurredAt is omitted', () => {
+    const participantId = seed();
+    const before = Date.now();
+
+    tournamentEngine.modifyParticipantsSignInStatus({
+      participantIds: [participantId],
+      signInState: SIGNED_IN,
+    });
+
+    const createdAt = timeItemsOf(participantId, SIGN_IN_STATUS).at(-1).createdAt;
+    expect(new Date(createdAt).getTime()).toBeGreaterThanOrEqual(before - 1000);
+  });
+});
+
+describe('modifyParticipantsPaymentStatus — occurredAt', () => {
+  it('records the supplied occurredAt, and defaults to now without it', () => {
+    const participantId = seed();
+
+    tournamentEngine.modifyParticipantsPaymentStatus({
+      participantIds: [participantId],
+      paymentState: 'PAID',
+      occurredAt: EARLY,
+    });
+    const supplied = timeItemsOf(participantId).at(-1).createdAt;
+    expect(supplied).toEqual(EARLY);
+
+    const other = seed();
+    const before = Date.now();
+    tournamentEngine.modifyParticipantsPaymentStatus({ participantIds: [other], paymentState: 'PAID' });
+    const minted = timeItemsOf(other).at(-1).createdAt;
+    expect(new Date(minted).getTime()).toBeGreaterThanOrEqual(before - 1000);
+  });
+});
+
+describe('scale items — supplied createdAt (D2: event order is authoritative)', () => {
+  it('honours a createdAt on the caller-supplied scaleItem', () => {
+    const participantId = seed();
+
+    const result: any = tournamentEngine.setParticipantScaleItem({
+      participantId,
+      scaleItem: {
+        scaleType: 'RATING',
+        eventType: 'SINGLES',
+        scaleName: 'UTR',
+        scaleValue: 9.5,
+        createdAt: EARLY,
+      },
+    });
+    expect(result.error).toBeUndefined();
+
+    const scaleItems = timeItemsOf(participantId).filter((i: any) => i.itemType?.startsWith('SCALE'));
+    expect(scaleItems.at(-1).createdAt).toEqual(EARLY);
+  });
+
+  it('a late-arriving EARLIER rating does not supersede a later one — retroactive ordering', () => {
+    // The D2 consequence, asserted explicitly. The venue's rating is written
+    // SECOND (it synced later) but occurred FIRST, so the rating actually set
+    // afterwards must remain current.
+    const participantId = seed();
+    const scaleAttributes = { scaleType: 'RATING', eventType: 'SINGLES', scaleName: 'UTR' };
+
+    // Arrives first, happened LATE.
+    tournamentEngine.setParticipantScaleItem({
+      participantId,
+      scaleItem: { ...scaleAttributes, scaleValue: 9.9, createdAt: LATE },
+    });
+    // Arrives second, happened EARLY — the buffered venue edit.
+    tournamentEngine.setParticipantScaleItem({
+      participantId,
+      scaleItem: { ...scaleAttributes, scaleValue: 9.1, createdAt: EARLY },
+    });
+
+    const { scaleItem }: any = tournamentEngine.getParticipantScaleItem({ participantId, scaleAttributes });
+
+    // Resolution keys on createdAt, so the LATE value stays current even though
+    // the EARLY one was written last.
+    expect(scaleItem.scaleValue).toEqual(9.9);
+  });
+});
+
+describe('D1 — record-root updatedAt keeps WRITE-time semantics', () => {
+  it('occurredAt does not rewrite tournamentRecord.updatedAt', () => {
+    // The staleness probe (POST /factory/updated-at) derives from
+    // `data->>'updatedAt'`. If a backdated occurredAt moved the record root,
+    // a delayed sync would make the record look OLDER than a client's last poll
+    // and staleness detection would silently break.
+    const participantId = seed();
+    const before = tournamentEngine.getTournament().tournamentRecord.updatedAt;
+
+    tournamentEngine.modifyParticipantsSignInStatus({
+      participantIds: [participantId],
+      signInState: SIGNED_IN,
+      occurredAt: EARLY,
+    });
+
+    const after = tournamentEngine.getTournament().tournamentRecord.updatedAt;
+    // Whatever the root does, it must NOT have been set to the backdated value.
+    expect(after).not.toEqual(EARLY);
+    if (before && after) expect(new Date(after).getTime()).toBeGreaterThanOrEqual(new Date(before).getTime());
+  });
+});

--- a/src/tests/sanctioning/sanctioningSuppliedIds.test.ts
+++ b/src/tests/sanctioning/sanctioningSuppliedIds.test.ts
@@ -1,0 +1,243 @@
+import { sanctioningEngine } from '@Assemblies/engines/sanctioning';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+// Types
+import type { Applicant, EventProposal, TournamentProposal, SanctioningPolicy } from '@Types/sanctioningTypes';
+
+/**
+ * Caller-supplied entity ids must be honoured, never overwritten by an
+ * engine-minted UUID.
+ *
+ * This is not a cosmetic API nicety. A site server mirrors `{ method, params }`
+ * upstream (see `Mentat/planning/DISCONNECTED_SYNC_RECONCILIATION.md`), so a
+ * mutation that mints its id engine-side produces a DIFFERENT id on the cloud
+ * than it did locally, and every later mirrored mutation that references that id
+ * fails to resolve upstream. Identity has to be minted once, at the origin, and
+ * travel in `params`.
+ *
+ * Each test asserts the supplied id is used AND that the mint path still works
+ * when nothing is supplied — a one-directional test would pass against an
+ * implementation that ignored the parameter entirely.
+ */
+
+const testApplicant: Applicant = {
+  organisationId: 'org-001',
+  organisationName: 'Test Tennis Club',
+  contactName: 'Jane Doe',
+  contactEmail: 'jane@test.com',
+};
+
+const testEventProposal: EventProposal = {
+  eventName: "Men's Singles",
+  eventType: 'SINGLES',
+  gender: 'MALE',
+  drawSize: 32,
+};
+
+const testProposal: TournamentProposal = {
+  tournamentName: 'Test Open 2026',
+  proposedStartDate: '2026-06-01',
+  proposedEndDate: '2026-06-07',
+  events: [testEventProposal],
+};
+
+const testPolicy: SanctioningPolicy = {
+  policyName: 'Test Policy',
+  policyVersion: '2026.1',
+  effectiveDate: '2026-01-01',
+  governingBodyId: 'gov-001',
+  tiers: [],
+  requireEndorsement: false,
+};
+
+function createRecord() {
+  sanctioningEngine.createSanctioningRecord({
+    governingBodyId: 'gov-001',
+    applicant: testApplicant,
+    proposal: testProposal,
+  });
+}
+
+function getRecord(): any {
+  const result: any = sanctioningEngine.getSanctioningRecord();
+  return result.sanctioningRecord;
+}
+
+function toUnderReview() {
+  createRecord();
+  sanctioningEngine.submitApplication({ sanctioningPolicy: testPolicy });
+  sanctioningEngine.reviewApplication({});
+}
+
+describe('addReviewNote — supplied noteId', () => {
+  beforeEach(() => sanctioningEngine.reset());
+
+  it('uses the supplied noteId', () => {
+    createRecord();
+    const result: any = sanctioningEngine.addReviewNote({ note: 'Needs a floor plan', noteId: 'note-supplied-1' });
+
+    expect(result.success).toBe(true);
+    expect(result.noteId).toEqual('note-supplied-1');
+    expect(getRecord().reviewNotes.at(-1).noteId).toEqual('note-supplied-1');
+  });
+
+  it('still mints a noteId when none is supplied', () => {
+    createRecord();
+    const result: any = sanctioningEngine.addReviewNote({ note: 'No id given' });
+
+    expect(result.success).toBe(true);
+    expect(typeof result.noteId).toEqual('string');
+    expect(result.noteId.length).toBeGreaterThan(0);
+  });
+
+  it('keeps supplied ids distinct across notes', () => {
+    createRecord();
+    sanctioningEngine.addReviewNote({ note: 'first', noteId: 'note-a' });
+    sanctioningEngine.addReviewNote({ note: 'second', noteId: 'note-b' });
+
+    expect(getRecord().reviewNotes.map((n: any) => n.noteId)).toEqual(['note-a', 'note-b']);
+  });
+});
+
+describe('requestModification — supplied noteId', () => {
+  beforeEach(() => sanctioningEngine.reset());
+
+  it('uses the supplied noteId for the attached review note', () => {
+    toUnderReview();
+    const result: any = sanctioningEngine.requestModification({
+      note: 'Please resubmit with venue detail',
+      noteId: 'note-mod-1',
+    });
+
+    expect(result.success).toBe(true);
+    expect(getRecord().reviewNotes.at(-1).noteId).toEqual('note-mod-1');
+  });
+
+  it('still mints a noteId when none is supplied', () => {
+    toUnderReview();
+    sanctioningEngine.requestModification({ note: 'Please resubmit' });
+
+    const note = getRecord().reviewNotes.at(-1);
+    expect(typeof note.noteId).toEqual('string');
+    expect(note.noteId.length).toBeGreaterThan(0);
+  });
+});
+
+describe('conditionallyApprove — supplied conditionId', () => {
+  beforeEach(() => sanctioningEngine.reset());
+
+  it('uses the supplied conditionId per condition', () => {
+    toUnderReview();
+    const result: any = sanctioningEngine.conditionallyApprove({
+      conditions: [
+        { description: 'Provide insurance certificate', conditionId: 'cond-a' },
+        { description: 'Confirm court count', conditionId: 'cond-b' },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    expect(getRecord().conditions.map((c: any) => c.conditionId)).toEqual(['cond-a', 'cond-b']);
+  });
+
+  it('mints only for the conditions that omit an id, preserving order', () => {
+    toUnderReview();
+    sanctioningEngine.conditionallyApprove({
+      conditions: [{ description: 'supplied', conditionId: 'cond-only' }, { description: 'minted' }],
+    });
+
+    const conditions = getRecord().conditions;
+    expect(conditions[0].conditionId).toEqual('cond-only');
+    expect(conditions[1].conditionId).not.toEqual('cond-only');
+    expect(conditions[1].conditionId.length).toBeGreaterThan(0);
+    // Ids must not be transposed onto the wrong description.
+    expect(conditions[0].description).toEqual('supplied');
+    expect(conditions[1].description).toEqual('minted');
+  });
+});
+
+describe('proposeAmendment — supplied amendmentId', () => {
+  beforeEach(() => sanctioningEngine.reset());
+
+  it('uses the supplied amendmentId', () => {
+    toUnderReview();
+    sanctioningEngine.approveApplication({});
+
+    const result: any = sanctioningEngine.proposeAmendment({
+      changes: [{ field: 'tournamentName', from: 'Test Open 2026', to: 'Test Open 2026 (Revised)' }],
+      amendmentId: 'amend-supplied-1',
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(getRecord().amendments.at(-1).amendmentId).toEqual('amend-supplied-1');
+  });
+
+  it('still mints an amendmentId when none is supplied', () => {
+    toUnderReview();
+    sanctioningEngine.approveApplication({});
+
+    sanctioningEngine.proposeAmendment({
+      changes: [{ field: 'tournamentName', from: 'Test Open 2026', to: 'Test Open 2026 (Revised)' }],
+    });
+
+    const amendment = getRecord().amendments.at(-1);
+    expect(typeof amendment.amendmentId).toEqual('string');
+    expect(amendment.amendmentId.length).toBeGreaterThan(0);
+  });
+});
+
+describe('activateFromSanctioning — supplied compliance item ids', () => {
+  const compliancePolicy: SanctioningPolicy = {
+    ...testPolicy,
+    postEventRequirements: [
+      { itemType: 'RESULTS', description: 'Submit results', required: true, deadlineDays: 7 },
+      { itemType: 'FINANCIAL', description: 'Submit levy', required: true, deadlineDays: 30 },
+    ],
+  } as SanctioningPolicy;
+
+  beforeEach(() => sanctioningEngine.reset());
+
+  function approveWithCompliancePolicy() {
+    createRecord();
+    sanctioningEngine.submitApplication({ sanctioningPolicy: compliancePolicy });
+    sanctioningEngine.reviewApplication({});
+    sanctioningEngine.approveApplication({});
+  }
+
+  it('consumes supplied ids from the uuids pool', () => {
+    approveWithCompliancePolicy();
+    const result: any = sanctioningEngine.activateFromSanctioning({ uuids: ['item-a', 'item-b'] });
+
+    expect(result.error).toBeUndefined();
+    const itemIds = getRecord().compliance.items.map((i: any) => i.itemId);
+    expect(itemIds).toHaveLength(2);
+    // `.pop()` consumes from the end, so both supplied ids are used and neither
+    // is a minted UUID.
+    expect(itemIds.toSorted((a: string, b: string) => a.localeCompare(b))).toEqual(['item-a', 'item-b']);
+  });
+
+  it('mints ids when no pool is supplied', () => {
+    approveWithCompliancePolicy();
+    const result: any = sanctioningEngine.activateFromSanctioning({});
+
+    expect(result.error).toBeUndefined();
+    const items = getRecord().compliance.items;
+    expect(items).toHaveLength(2);
+    for (const item of items) {
+      expect(typeof item.itemId).toEqual('string');
+      expect(item.itemId.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('falls back to minting once a partial pool is exhausted', () => {
+    approveWithCompliancePolicy();
+    sanctioningEngine.activateFromSanctioning({ uuids: ['only-one'] });
+
+    const itemIds = getRecord().compliance.items.map((i: any) => i.itemId);
+    expect(itemIds).toHaveLength(2);
+    expect(itemIds).toContain('only-one');
+    // The other item still received a usable id rather than undefined.
+    const minted = itemIds.find((id: string) => id !== 'only-one');
+    expect(typeof minted).toEqual('string');
+    expect(minted.length).toBeGreaterThan(0);
+  });
+});

--- a/src/tests/sanctioning/sanctioningSuppliedIds.test.ts
+++ b/src/tests/sanctioning/sanctioningSuppliedIds.test.ts
@@ -1,6 +1,9 @@
 import { sanctioningEngine } from '@Assemblies/engines/sanctioning';
 import { beforeEach, describe, expect, it } from 'vitest';
 
+// constants
+import { INSUFFICIENT_UUIDS } from '@Constants/errorConditionConstants';
+
 // Types
 import type { Applicant, EventProposal, TournamentProposal, SanctioningPolicy } from '@Types/sanctioningTypes';
 
@@ -228,16 +231,27 @@ describe('activateFromSanctioning — supplied compliance item ids', () => {
     }
   });
 
-  it('falls back to minting once a partial pool is exhausted', () => {
+  it('REJECTS a short pool rather than minting the shortfall', () => {
+    // Strict when supplied. A pool that runs short means this replay needed a
+    // different number of ids than the origin did — i.e. the two instances'
+    // states have diverged. Minting the difference would convert a detectable
+    // divergence into a silent, permanent id mismatch, so it is an error.
+    // (An earlier revision of this test asserted the opposite, lenient
+    // behaviour; that was wrong for replay and was changed deliberately.)
     approveWithCompliancePolicy();
-    sanctioningEngine.activateFromSanctioning({ uuids: ['only-one'] });
+    const result: any = sanctioningEngine.activateFromSanctioning({ uuids: ['only-one'] });
 
-    const itemIds = getRecord().compliance.items.map((i: any) => i.itemId);
-    expect(itemIds).toHaveLength(2);
-    expect(itemIds).toContain('only-one');
-    // The other item still received a usable id rather than undefined.
-    const minted = itemIds.find((id: string) => id !== 'only-one');
-    expect(typeof minted).toEqual('string');
-    expect(minted.length).toBeGreaterThan(0);
+    expect(result.error).toEqual(INSUFFICIENT_UUIDS);
+    expect(result.context).toEqual({ required: 2, supplied: 1 });
+  });
+
+  it('accepts a pool larger than needed', () => {
+    // Over-supply is not a divergence signal — the origin may batch ids
+    // generously. Only a SHORT pool indicates the counts disagreed.
+    approveWithCompliancePolicy();
+    const result: any = sanctioningEngine.activateFromSanctioning({ uuids: ['a', 'b', 'c', 'd'] });
+
+    expect(result.error).toBeUndefined();
+    expect(getRecord().compliance.items).toHaveLength(2);
   });
 });

--- a/src/tools/UUID.ts
+++ b/src/tools/UUID.ts
@@ -6,6 +6,43 @@
 
 import { generateRange } from './arrays';
 
+// constants
+import { INSUFFICIENT_UUIDS } from '../constants/errorConditionConstants';
+
+type TakeUUIDArgs = {
+  /**
+   * Caller-supplied pool. `undefined` means "no pool supplied" (mint freely);
+   * an EMPTY array means "a pool was supplied and is exhausted" — an error, not
+   * a licence to mint.
+   */
+  uuids?: string[];
+  prefix?: string;
+};
+
+/**
+ * Draw an id from a caller-supplied pool, or mint one when no pool was supplied.
+ *
+ * STRICT WHEN SUPPLIED. `uuids?.pop() ?? UUID()` silently mints once the pool
+ * runs dry, which is the wrong behaviour for replay: the whole point of a pool is
+ * that the ORIGIN decides identity and every replaying instance reproduces it.
+ * A pool that runs short means the replay needed a different NUMBER of ids than
+ * the origin did — i.e. the two instances' states have diverged. Falling back to
+ * a fresh UUID converts that detectable divergence into silent, permanent id
+ * mismatch; returning an error surfaces it as the conflict it actually is.
+ *
+ * So: pool absent → mint. Pool present with entries → draw. Pool present and
+ * empty → `INSUFFICIENT_UUIDS`.
+ *
+ * See `Mentat/planning/DISCONNECTED_SYNC_RECONCILIATION.md` §4.1.
+ */
+export function takeUUID({ uuids, prefix }: TakeUUIDArgs): { uuid?: string; error?: typeof INSUFFICIENT_UUIDS } {
+  if (uuids === undefined) return { uuid: UUID(prefix) };
+
+  const uuid = uuids.pop();
+  if (uuid === undefined) return { error: INSUFFICIENT_UUIDS };
+  return { uuid };
+}
+
 /**
  * generate a given number of UUIDs
  *
@@ -22,7 +59,6 @@ export function UUID(pre?, random?: () => number) {
   for (let i = 0; i < 256; i++) {
     lut[i] = (i < 16 ? '0' : '') + i.toString(16);
   }
-
 
   const d0 = Math.trunc(rng() * 0xffffffff);
 

--- a/src/types/scoring/types.ts
+++ b/src/types/scoring/types.ts
@@ -280,14 +280,7 @@ export interface Point {
  * Point result types (how the point ended)
  */
 export type PointResult =
-  | 'Ace'
-  | 'Winner'
-  | 'Serve Winner'
-  | 'Forced Error'
-  | 'Unforced Error'
-  | 'Double Fault'
-  | 'Penalty'
-  | 'Unknown';
+  'Ace' | 'Winner' | 'Serve Winner' | 'Forced Error' | 'Unforced Error' | 'Double Fault' | 'Penalty' | 'Unknown';
 
 /**
  * Stroke types in tennis
@@ -357,14 +350,7 @@ export interface MatchUpState {
 // ============================================================================
 
 export type MatchUpStatus =
-  | 'TO_BE_PLAYED'
-  | 'IN_PROGRESS'
-  | 'COMPLETED'
-  | 'CANCELLED'
-  | 'ABANDONED'
-  | 'DEFAULTED'
-  | 'RETIRED'
-  | 'WALKOVER';
+  'TO_BE_PLAYED' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED' | 'ABANDONED' | 'DEFAULTED' | 'RETIRED' | 'WALKOVER';
 
 export type MatchUpType = 'SINGLES' | 'DOUBLES' | 'TEAM';
 
@@ -387,6 +373,12 @@ export interface CreateMatchUpOptions {
   participants?: Participant[];
   isDoubles?: boolean;
   matchUpType?: MatchUpType;
+  /**
+   * ISO string recording when the matchUp was created at its ORIGIN, rather than
+   * when this instance wrote it. Defaults to now, so existing callers are
+   * unaffected. See `Mentat/planning/DISCONNECTED_SYNC_RECONCILIATION.md` §4.1.
+   */
+  occurredAt?: string;
 }
 
 /**


### PR DESCRIPTION
Identity and timestamps must be decided **once, at the origin**, and travel in `params`. Where a mutation mints its own id or stamps its own clock, it is not faithfully replayable — and TMX already executes every `methods` array twice (CFS, then locally on ack), with a site server adding a third instance.

Design: [`Mentat/planning/DISCONNECTED_SYNC_RECONCILIATION.md`](https://github.com/CourtHive/Mentat/blob/main/planning/DISCONNECTED_SYNC_RECONCILIATION.md) §4.1.

## 1 — Caller-supplied entity ids

Audited **all 42** `UUID()` sites in `src/mutate`. **34 already honour a supplied id**; 8 minted unconditionally, of which **6 changed**: `addReviewNote`/`requestModification` (`noteId`), `conditionallyApprove` (`conditionId`, per element so ids cannot mis-align with descriptions), `amendments` (`amendmentId`), `activateFromSanctioning` (compliance `itemId`s via the existing `uuids` pool idiom), `addPracticeRegistration` (`registrationId`; the `'reg'` prefix applies to the mint path only, so a supplied id round-trips unchanged).

**2 deliberately left unconditional**, now commented in place so a later audit does not "complete the set":

- `writeTieFormat` — copy-on-write; honouring a supplied id would write back onto the format other references still point at
- `addMutationLock` — `lockId` is ephemeral operational state, never replayed or referenced

## 2 — Strict `uuids` pool semantics

New `takeUUID({ uuids, prefix })` + `INSUFFICIENT_UUIDS`:

```
pool absent (undefined) → mint
pool present, non-empty → draw
pool present, empty     → INSUFFICIENT_UUIDS
```

The prevailing `uuids?.pop() ?? UUID()` silently minted once a pool ran dry. A short pool means the replay needed a *different number* of ids than the origin did — the two states diverged. Erroring turns a silent, permanent id mismatch into a **conflict signal**.

`writeTieFormat` gains a **pool** (not a `tieFormatId` param — naming the id would defeat the fork). `activateFromSanctioning` validates pool sufficiency up front, since its count is knowable, rather than discovering a shortfall mid-map.

## 3 — `occurredAt` timestamps

Two mechanisms, matched to how each mutation receives its data:

| mechanism | sites |
|---|---|
| `occurredAt` param | `modifyParticipantsSignInStatus`, `modifyParticipantsPaymentStatus`, `addPenalty` (defaults to `issuedAt`, then now), practice add/update/remove, `addCourtGridBooking`, `addPersonOtherId`, `addVenueOtherId`, `createMatchUp` |
| honour the caller's object | `addTimeItem`, `addDrawDefinitionTimeItem`, `addExtension`, `addParticipantScaleItem` |

All default to now — **every existing caller is unaffected**.

Two decisions taken by CA and asserted by tests, not left as prose:

- **D1** — record-root `updatedAt` keeps **write-time** semantics, because `postgres-tournament.storage.ts` derives the staleness column from `data->>'updatedAt'`. A test asserts a backdated `occurredAt` does **not** move `tournamentRecord.updatedAt`.
- **D2** — event-time ordering is authoritative **including retroactively**. A test asserts a rating written second but occurring earlier does not supersede one written first that occurred later.

`createdAt` on a timeItem is not decoration — it is the ordering key `participantScaleItem`, `getScaleValues`, `getCheckedInParticipantIds`, `startTime`/`endTime`, `getMatchUpScheduleDetails` and `getQualityWinPoints` use to resolve the current value.

## Deliberately out of scope

- **Sanctioning / officiating record `updatedAt`** — those records are not part of the `tournamentRecord` (separate engines, not behind the staleness probe), so write-time is correct for them under D1.
- **4 reads-of-now** (`modifyParticipant:217` birthDate validation, `amendments:153`, `compliance:198`, `scheduleItems:72`) — a caller-supplied "now" inside a validation is spoofable.
- **`addPoint`'s two `matchUp.endTime` stamps** — point-by-point scoring does not flow through `executionQueue` for tournamentRecords, so it is outside the origin-supplied-timestamp problem entirely. (An earlier draft justified this on threading cost — a 9th *positional* param through three helpers and the exported `checkAndFinalizeMatch` that `ScoringEngine` consumes. That is true but beside the point: the real reason is scope, not risk.)
- **`Extension.createdAt` type declaration** — `Extension` has never declared the field although `addExtension` has always written it (the old `Object.assign` bypassed the checker). The fix belongs in `src/types/tournamentTypes.ts`, which is held by an active in-flight claim, so a cast is used and the type addition deferred. Documented at the call site.
- **Threading `uuids` through the 20 `writeTieFormat` call sites** — plan recorded in `Mentat/TASKS.md`. Must be one pass (partial threading makes divergence intermittent), every site must check the returned error, and it carries an open decision (separate `tieFormatUuids` pool preferred, since a shared pool makes "which stream ran short" ambiguous).

## Verification

- lint **0**, check-types **0**
- `verify:generated` in sync — 657 engine methods, 581/649 signatures
- `verify:attr-audit` exit 0
- **1055 files / 10890 tests**
- coverage **95.09 / 86.83 / 97.99 / 97.62** against the 95/85/95/95 gate

Every guard in this PR was **falsified individually** — each fix reverted in turn and the corresponding spec confirmed to fail. One falsification initially produced only a *compile* error (unused import), which is not evidence the assertion works; it was redone with a vacuously-true condition so the behaviour changed without a type error.

