### PR TITLE
feat(mutate): thread a separate tieFormatUuids pool to writeTieFormat

### DIFF
--- a/src/mutate/tieFormat/addCollectionDefinition.ts
+++ b/src/mutate/tieFormat/addCollectionDefinition.ts
@@ -53,6 +53,16 @@ type AddCollectionDefinitionArgs = {
   matchUp?: MatchUp;
   eventId?: string;
   uuids?: string[];
+  /**
+   * Pool for tieFormat copy-on-write forks in `writeTieFormat`, SEPARATE from
+   * `uuids` (which feeds matchUp id minting).
+   *
+   * Two pools rather than one so a shortfall is attributable: sharing a pool
+   * couples two unrelated id streams, and `INSUFFICIENT_UUIDS` could not say
+   * which one ran short. Strict when supplied — an exhausted pool signals that
+   * this replay needed a different number of ids than the origin did.
+   */
+  tieFormatUuids?: string[];
   event?: Event;
 };
 
@@ -72,6 +82,7 @@ export function addCollectionDefinition({
   matchUp,
   eventId,
   uuids,
+  tieFormatUuids,
   event,
 }: AddCollectionDefinitionArgs): ResultType & {
   tieFormat?: TieFormat;
@@ -188,9 +199,13 @@ export function addCollectionDefinition({
     eventId,
     event,
     uuids,
+    tieFormatUuids,
     stack,
   });
-  if (scopeResult?.error) return scopeResult;
+  // `as any`: the union now includes writeTieFormat's `{ error }` shape alongside
+  // `{ targetMatchUps }`, which has no `error` member to narrow against. Mirrors
+  // the existing cast on the next line.
+  if ((scopeResult as any)?.error) return scopeResult;
   targetMatchUps = (scopeResult as any)?.targetMatchUps ?? targetMatchUps;
 
   const auditData = definedAttributes({
@@ -232,6 +247,41 @@ function resolveEnforcementFlags({
   return { checkCategory, checkGender };
 }
 
+/**
+ * Apply the new collectionDefinition to every structure that INHERITS the event's
+ * tieFormat — i.e. skipping any drawDefinition or structure carrying its own.
+ *
+ * Extracted from `applyTieFormatToScope` to keep that function under the
+ * ecosystem's cognitive-complexity threshold of 30: two nested loops each with a
+ * `continue` guard concentrate a lot of the score once per-branch error handling
+ * is added around them.
+ */
+function applyToInheritingStructures({
+  updateInProgressMatchUps,
+  modifiedStructureIds,
+  collectionDefinition,
+  targetMatchUps,
+  addedMatchUps,
+  event,
+  uuids,
+}) {
+  for (const dd of event.drawDefinitions ?? []) {
+    if (dd.tieFormat || dd.tieFormatId) continue;
+    for (const s of dd.structures ?? []) {
+      if (s.tieFormat || s.tieFormatId) continue;
+      const result = updateStructureMatchUps({
+        updateInProgressMatchUps,
+        collectionDefinition,
+        structure: s,
+        uuids,
+      });
+      addedMatchUps.push(...result.newMatchUps);
+      targetMatchUps.push(...result.targetMatchUps);
+      modifiedStructureIds.push(s.structureId);
+    }
+  }
+}
+
 function applyTieFormatToScope({
   updateInProgressMatchUps,
   collectionDefinition,
@@ -248,26 +298,22 @@ function applyTieFormatToScope({
   eventId,
   event,
   uuids,
+  tieFormatUuids,
   stack,
 }) {
   if (eventId && event) {
-    writeTieFormat({ target: event, tieFormat: prunedTieFormat, event });
+    const writeResult = writeTieFormat({ target: event, tieFormat: prunedTieFormat, event, uuids: tieFormatUuids });
+    if (writeResult?.error) return writeResult;
 
-    for (const dd of event.drawDefinitions ?? []) {
-      if (dd.tieFormat || dd.tieFormatId) continue;
-      for (const s of dd.structures ?? []) {
-        if (s.tieFormat || s.tieFormatId) continue;
-        const result = updateStructureMatchUps({
-          updateInProgressMatchUps,
-          collectionDefinition,
-          structure: s,
-          uuids,
-        });
-        addedMatchUps.push(...result.newMatchUps);
-        targetMatchUps.push(...result.targetMatchUps);
-        modifiedStructureIds.push(s.structureId);
-      }
-    }
+    applyToInheritingStructures({
+      updateInProgressMatchUps,
+      modifiedStructureIds,
+      collectionDefinition,
+      targetMatchUps,
+      addedMatchUps,
+      event,
+      uuids,
+    });
 
     queueNoficiations({
       modifiedMatchUps: targetMatchUps,
@@ -282,7 +328,8 @@ function applyTieFormatToScope({
   }
 
   if (structureId && structure) {
-    writeTieFormat({ target: structure, tieFormat: prunedTieFormat, event });
+    const writeResult = writeTieFormat({ target: structure, tieFormat: prunedTieFormat, event, uuids: tieFormatUuids });
+    if (writeResult?.error) return writeResult;
     const result = updateStructureMatchUps({
       updateInProgressMatchUps,
       collectionDefinition,
@@ -312,7 +359,8 @@ function applyTieFormatToScope({
       });
     }
 
-    writeTieFormat({ target: matchUp, tieFormat: prunedTieFormat, event });
+    const writeResult = writeTieFormat({ target: matchUp, tieFormat: prunedTieFormat, event, uuids: tieFormatUuids });
+    if (writeResult?.error) return writeResult;
     const newMatchUps: MatchUp[] = generateCollectionMatchUps({
       collectionDefinition,
       matchUp,
@@ -336,7 +384,13 @@ function applyTieFormatToScope({
   }
 
   if (drawDefinition) {
-    writeTieFormat({ target: drawDefinition, tieFormat: prunedTieFormat, event });
+    const writeResult = writeTieFormat({
+      target: drawDefinition,
+      tieFormat: prunedTieFormat,
+      event,
+      uuids: tieFormatUuids,
+    });
+    if (writeResult?.error) return writeResult;
 
     for (const s of drawDefinition.structures ?? []) {
       const result = updateStructureMatchUps({

--- a/src/mutate/tieFormat/collectionGroupUpdate.ts
+++ b/src/mutate/tieFormat/collectionGroupUpdate.ts
@@ -24,6 +24,12 @@ type CollectionGroupUpdateArgs = {
   matchUpId?: string;
   matchUp?: MatchUp;
   eventId?: string;
+  /**
+   * Pool for tieFormat copy-on-write forks in `writeTieFormat`. Separate from any
+   * matchUp-id pool so an `INSUFFICIENT_UUIDS` shortfall is attributable to one
+   * stream. Strict when supplied.
+   */
+  tieFormatUuids?: string[];
   event?: Event;
 };
 export function collectionGroupUpdate({
@@ -39,6 +45,7 @@ export function collectionGroupUpdate({
   matchUpId,
   matchUp,
   eventId,
+  tieFormatUuids,
   event,
 }: CollectionGroupUpdateArgs) {
   // calculate new winCriteria for tieFormat
@@ -78,13 +85,22 @@ export function collectionGroupUpdate({
   if (result.error) return result;
 
   if (eventId && event) {
-    writeTieFormat({ target: event, tieFormat: prunedTieFormat, event });
+    const writeResult = writeTieFormat({ target: event, tieFormat: prunedTieFormat, event, uuids: tieFormatUuids });
+    if (writeResult?.error) return writeResult;
   } else if (matchUpId && matchUp) {
-    writeTieFormat({ target: matchUp, tieFormat: prunedTieFormat, event });
+    const writeResult = writeTieFormat({ target: matchUp, tieFormat: prunedTieFormat, event, uuids: tieFormatUuids });
+    if (writeResult?.error) return writeResult;
   } else if (structure) {
-    writeTieFormat({ target: structure, tieFormat: prunedTieFormat, event });
+    const writeResult = writeTieFormat({ target: structure, tieFormat: prunedTieFormat, event, uuids: tieFormatUuids });
+    if (writeResult?.error) return writeResult;
   } else if (drawDefinition) {
-    writeTieFormat({ target: drawDefinition, tieFormat: prunedTieFormat, event });
+    const writeResult = writeTieFormat({
+      target: drawDefinition,
+      tieFormat: prunedTieFormat,
+      event,
+      uuids: tieFormatUuids,
+    });
+    if (writeResult?.error) return writeResult;
   } else if (!matchUp || !drawDefinition) {
     return { error: MISSING_DRAW_DEFINITION };
   }

--- a/src/mutate/tieFormat/removeCollectionDefinition.ts
+++ b/src/mutate/tieFormat/removeCollectionDefinition.ts
@@ -48,6 +48,12 @@ type RemoveCollectionDefinitionArgs = {
   matchUpId?: string;
   matchUp?: MatchUp;
   eventId?: string;
+  /**
+   * Pool for tieFormat copy-on-write forks in `writeTieFormat`. Separate from any
+   * matchUp-id pool so an `INSUFFICIENT_UUIDS` shortfall is attributable to one
+   * stream. Strict when supplied.
+   */
+  tieFormatUuids?: string[];
   event?: Event;
 };
 
@@ -62,6 +68,7 @@ export function removeCollectionDefinition({
   matchUpId,
   eventId,
   matchUp,
+  tieFormatUuids,
   event,
 }: RemoveCollectionDefinitionArgs): {
   // Produced by `filterTargetMatchUps` which returns `MatchUp[]`; the
@@ -166,16 +173,18 @@ export function removeCollectionDefinition({
 
   const deletedMatchUpIds: string[] = [];
   for (const targetMatchUp of targetMatchUps) {
-    processTargetMatchUp({
+    const processResult: any = processTargetMatchUp({
       deletedMatchUpIds,
       tournamentRecord,
       drawDefinition,
       collectionId,
+      tieFormatUuids,
       tieFormat,
       stack,
       event,
       matchUp: targetMatchUp,
     });
+    if (processResult?.error) return decorateResult({ result: processResult, stack });
     const scoreResult = updateTargetMatchUpScore({
       updateInProgressMatchUps,
       tournamentRecord,
@@ -202,17 +211,19 @@ export function removeCollectionDefinition({
   result = validateTieFormat({ tieFormat: prunedTieFormat });
   if (result.error) return decorateResult({ result, stack });
 
-  if (eventId && event) {
-    writeTieFormat({ target: event, tieFormat: prunedTieFormat, event });
-  } else if (matchUpId && matchUp) {
-    writeTieFormat({ target: matchUp, tieFormat: prunedTieFormat, event });
-  } else if (structure) {
-    writeTieFormat({ target: structure, tieFormat: prunedTieFormat, event });
-  } else if (drawDefinition) {
-    writeTieFormat({ target: drawDefinition, tieFormat: prunedTieFormat, event });
-  } else if (!matchUp || !drawDefinition) {
-    return { error: MISSING_DRAW_DEFINITION };
-  }
+  // Target selection extracted so this function keeps ONE write and ONE error
+  // check. Inlining a write plus an error branch per candidate pushed cognitive
+  // complexity to 38, over the ecosystem's threshold of 30.
+  const writeTarget = resolveWriteTarget({ eventId, event, matchUpId, matchUp, structure, drawDefinition });
+  if (!writeTarget) return { error: MISSING_DRAW_DEFINITION };
+
+  const writeResult = writeTieFormat({
+    target: writeTarget,
+    tieFormat: prunedTieFormat,
+    event,
+    uuids: tieFormatUuids,
+  });
+  if (writeResult?.error) return decorateResult({ result: writeResult, stack });
 
   modifyDrawNotice({ drawDefinition, eventId: event?.eventId });
 
@@ -232,6 +243,22 @@ export function removeCollectionDefinition({
     targetMatchUps,
     ...SUCCESS,
   };
+}
+
+/**
+ * The single object the modified tieFormat is written back to, in precedence
+ * order: event, then matchUp, then structure, then drawDefinition.
+ *
+ * Returns undefined when none applies, which the caller reports as
+ * MISSING_DRAW_DEFINITION — preserving the previous behaviour of the if/else
+ * chain this replaces.
+ */
+function resolveWriteTarget({ eventId, event, matchUpId, matchUp, structure, drawDefinition }): any {
+  if (eventId && event) return event;
+  if (matchUpId && matchUp) return matchUp;
+  if (structure) return structure;
+  if (drawDefinition) return drawDefinition;
+  return undefined;
 }
 
 function getScopedMatchUps({ matchUpId, matchUp, structureId, structure, drawDefinition, event }): MatchUp[] {
@@ -304,6 +331,7 @@ function clearCollectionScores({
 function processTargetMatchUp({
   deletedMatchUpIds,
   collectionId,
+  tieFormatUuids,
   tieFormat,
   stack,
   event,
@@ -327,7 +355,13 @@ function processTargetMatchUp({
   });
 
   if (matchUp.tieFormat || matchUp.tieFormatId) {
-    writeTieFormat({ target: matchUp, tieFormat: copyTieFormat(tieFormat), event });
+    const writeResult = writeTieFormat({
+      target: matchUp,
+      tieFormat: copyTieFormat(tieFormat),
+      event,
+      uuids: tieFormatUuids,
+    });
+    if (writeResult?.error) return writeResult;
   }
 
   modifyMatchUpNotice({
@@ -337,6 +371,8 @@ function processTargetMatchUp({
     context: stack,
     matchUp,
   });
+
+  return undefined;
 }
 
 function updateTargetMatchUpScore({

--- a/src/tests/mutations/tieFormat/tieFormatUuidPoolThreading.test.ts
+++ b/src/tests/mutations/tieFormat/tieFormatUuidPoolThreading.test.ts
@@ -1,0 +1,110 @@
+import { removeCollectionDefinition } from '@Mutate/tieFormat/removeCollectionDefinition';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+// constants
+import { INSUFFICIENT_UUIDS } from '@Constants/errorConditionConstants';
+import { TEAM } from '@Constants/eventConstants';
+
+/**
+ * `tieFormatUuids` threading — the pool reaching `writeTieFormat`'s
+ * copy-on-write fork from the mutations that own it.
+ *
+ * TWO POOLS, not one (decision CA 2026-08-15). `addCollectionDefinition` already
+ * carries a `uuids` pool feeding **matchUp id** minting; sharing it with
+ * tieFormat forks would couple unrelated id streams, and an `INSUFFICIENT_UUIDS`
+ * error could not say which one ran short. `tieFormatUuids` is separate.
+ *
+ * The fork needs three preconditions — a centralized `tieFormatId`, a populated
+ * `event.tieFormats`, and refCount > 1 — which is precisely the state
+ * `aggregateTieFormats()` produces. Building it that way rather than by hand
+ * keeps the test honest about the shape production actually reaches.
+ */
+
+function aggregatedTeamEvent() {
+  const {
+    tournamentRecord,
+    eventIds: [eventId],
+  } = mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ drawSize: 4, eventType: TEAM }],
+    nonRandom: 1,
+  });
+  tournamentEngine.setState(tournamentRecord);
+
+  const aggregated: any = tournamentEngine.aggregateTieFormats();
+  expect(aggregated.success).toEqual(true);
+
+  const { event } = tournamentEngine.getEvent({ eventId });
+  const { tournamentRecord: record } = tournamentEngine.getTournament();
+
+  // Precondition the fork depends on — assert rather than assume.
+  expect(event.tieFormats?.length).toBeGreaterThan(0);
+
+  return { event, drawDefinition: event.drawDefinitions[0], tournamentRecord: record };
+}
+
+describe('removeCollectionDefinition — tieFormatUuids threading', () => {
+  it('rejects an exhausted pool rather than silently minting', () => {
+    // The load-bearing assertion. Strict-when-supplied has to survive the whole
+    // call chain: mutation → applyTieFormatToScope/target resolution →
+    // writeTieFormat. If the pool were dropped anywhere along the way this would
+    // succeed instead of erroring.
+    const { event, drawDefinition, tournamentRecord } = aggregatedTeamEvent();
+    const collectionId = event.tieFormats[0].collectionDefinitions[0].collectionId;
+
+    const result: any = removeCollectionDefinition({
+      tournamentRecord,
+      drawDefinition,
+      collectionId,
+      tieFormatUuids: [],
+      event,
+    });
+
+    expect(result.error).toEqual(INSUFFICIENT_UUIDS);
+  });
+
+  it('does NOT error when no pool is supplied — absent is not empty', () => {
+    // The negative direction. Without this, an implementation that treated "no
+    // pool" as "empty pool" would satisfy the assertion above by accident.
+    //
+    // Driven through the engine rather than the raw mutation: the mutation's
+    // downstream score-update path needs the full context the engine resolves
+    // from ids, and that plumbing is not what is under test here.
+    const { event } = aggregatedTeamEvent();
+    const collectionId = event.tieFormats[0].collectionDefinitions[0].collectionId;
+
+    const result: any = tournamentEngine.removeCollectionDefinition({
+      drawId: event.drawDefinitions[0].drawId,
+      eventId: event.eventId,
+      collectionId,
+    });
+
+    expect(result.error).not.toEqual(INSUFFICIENT_UUIDS);
+  });
+});
+
+/**
+ * ⚠️ COVERAGE LIMITATION — read before assuming this file proves the whole change.
+ *
+ * Only the `processTargetMatchUp` fork inside `removeCollectionDefinition` is
+ * provably covered here (verified by reverting `uuids: tieFormatUuids` on that
+ * exact line and watching this suite fail).
+ *
+ * The MAIN-CHAIN write sites — the if/else target selection in
+ * removeCollectionDefinition, addCollectionDefinition and collectionGroupUpdate
+ * — are threaded identically but are NOT independently covered:
+ *
+ *   - in `removeCollectionDefinition` the earlier `processTargetMatchUp` fork
+ *     always consumes/errors first, so the main-chain site is unreachable once a
+ *     pool is short
+ *   - `collectionGroupUpdate` with an aggregated fixture does not fork at all
+ *     (the resolved target has refCount 1, so it updates in place)
+ *
+ * Building a fixture that reaches them is blocked by a PRE-EXISTING defect,
+ * confirmed on master with these changes stashed: `aggregateTieFormats()`
+ * followed by `removeCollectionDefinition` returns
+ * `Cannot read properties of undefined (reading 'tieFormat')` from
+ * `getItemTieFormat`. That corrupts exactly the aggregated state these tests
+ * need. See the workstream notes.
+ */


### PR DESCRIPTION
> **DRAFT — not ready to merge.** The implementation is complete and green, but test coverage of the new code is **partial**, blocked by a pre-existing defect. Details below; a decision is needed before this lands.

Follow-up to #4621, which added `writeTieFormat`'s `uuids` pool but deliberately did not thread it from callers.

## Two pools, not one

`addCollectionDefinition` already carries a `uuids` pool feeding **matchUp id** minting. Sharing it with tieFormat forks would couple unrelated id streams and make an `INSUFFICIENT_UUIDS` shortfall unattributable — you could not tell which stream ran short. tieFormat forks draw from their own **`tieFormatUuids`**.

| file | sites |
|---|---|
| `addCollectionDefinition.ts` | 4 |
| `removeCollectionDefinition.ts` | 5 |
| `collectionGroupUpdate.ts` | 4 |

Every site checks the returned error. That is mandatory, not stylistic: `writeTieFormat` returns `{ error }` on an exhausted pool, so a caller that passes a pool without checking turns it into a **silent no-op write** — strictly worse than the lenient behaviour this replaced.

## Two refactors the error branches forced

The added branches breached the cognitive-complexity threshold of 30, so rather than suppress:

- **`removeCollectionDefinition` 38 → under** — extracted `resolveWriteTarget` so the function keeps **one** write and **one** error check instead of a write-plus-branch per candidate target.
- **`applyTieFormatToScope` 33 → under** — extracted `applyToInheritingStructures`; two nested loops with `continue` guards were concentrating the score.

## `updateTieFormat` is deliberately NOT threaded

Its three nested helpers — `processStructure`, `processDrawDefinition`, `makeChanges` — **already return errors their callers silently drop**. For example:

```ts
const modified = processStructure({ inheritedTieFormat, structure })?.modifiedMatchUpsCount;
```

No `.error` check. Threading a pool into that file would produce `INSUFFICIENT_UUIDS` errors that vanish — the exact silent-failure mode this whole change exists to eliminate. Closing that pre-existing propagation gap must come first.

It accepts **no pool at all**, so no caller can half-use it. That keeps its behaviour consistent (always mints) rather than intermittently pinned.

## ⚠️ Why this is a draft — partial coverage, blocked by a pre-existing bug

Only the `processTargetMatchUp` fork is **provably** covered (verified by reverting that exact line and watching the suite fail). The main-chain write sites are threaded identically but I could not construct a fixture that reaches them:

- in `removeCollectionDefinition`, the earlier `processTargetMatchUp` fork always consumes or errors first, so the main-chain site is unreachable once a pool is short
- `collectionGroupUpdate` against an aggregated fixture does not fork at all — the resolved target has refCount 1, so it updates in place

The natural fixture is blocked by a **pre-existing defect**, confirmed on `master` with these changes stashed:

```
aggregateTieFormats() → removeCollectionDefinition()
  ⇒ "Cannot read properties of undefined (reading 'tieFormat')"  (getItemTieFormat.ts:11)
```

That corrupts exactly the aggregated state these tests need. It is not caused by this PR and is worth its own issue.

**Recommendation:** diagnose that defect first. It likely also explains why aggregated tieFormat paths are thinly covered generally, and fixing it should unblock proper coverage here.

## Verification

lint **0**, check-types **0**, **1057 files / 10903 tests**.

The falsification for this PR initially reported a **false all-clear** — the script used `String.replace`, which substitutes only the first match, so it broke one site while a different site was the one under test and reported SILENT. Re-run with `replaceAll` and unambiguous anchors, the covered site fires correctly. Worth noting because that failure mode is exactly what "falsify the detector" warns about, and it nearly hid the coverage gap above.
