### PR TITLE
fix(query): resolve centralized tieFormats when hydrating from ensureSideLineUps

### DIFF
--- a/src/mutate/matchUps/lineUps/assignTieMatchUpParticipant.ts
+++ b/src/mutate/matchUps/lineUps/assignTieMatchUpParticipant.ts
@@ -159,6 +159,7 @@ export function assignTieMatchUpParticipantId(
     inContextDualMatchUp,
     drawDefinition,
     dualMatchUp,
+    event,
   });
 
   const dualMatchUpSide = dualMatchUp?.sides?.find((side) => side.sideNumber === sideNumber);

--- a/src/mutate/matchUps/lineUps/ensureSideLineUps.ts
+++ b/src/mutate/matchUps/lineUps/ensureSideLineUps.ts
@@ -3,7 +3,7 @@ import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 import { findDrawMatchUp } from '@Acquire/findDrawMatchUp';
 import { makeDeepCopy } from '@Tools/makeDeepCopy';
 
-import { DrawDefinition, MatchUp } from '@Types/tournamentTypes';
+import { DrawDefinition, Event, MatchUp } from '@Types/tournamentTypes';
 import { LINEUPS } from '@Constants/extensionConstants';
 import { HydratedMatchUp } from '@Types/hydrated';
 
@@ -13,6 +13,13 @@ type EnsureSideLineUpsArgs = {
   tournamentId?: string;
   dualMatchUp?: MatchUp;
   eventId?: string;
+  /**
+   * Required to resolve a CENTRALIZED tieFormat during hydration below. After
+   * `aggregateTieFormats()` a matchUp carries `tieFormatId` rather than an inline
+   * `tieFormat`, and resolving that reference needs `event.tieFormats[]`. Passing
+   * only `eventId` is not enough — every caller already has the object.
+   */
+  event?: Event;
 };
 export function ensureSideLineUps({
   inContextDualMatchUp,
@@ -20,6 +27,7 @@ export function ensureSideLineUps({
   tournamentId,
   dualMatchUp,
   eventId,
+  event,
 }: EnsureSideLineUpsArgs) {
   if (dualMatchUp) {
     if (!inContextDualMatchUp) {
@@ -27,6 +35,7 @@ export function ensureSideLineUps({
         matchUpId: dualMatchUp.matchUpId,
         inContext: true,
         drawDefinition,
+        event,
       })?.matchUp;
     }
 

--- a/src/mutate/matchUps/lineUps/removeTieMatchUpParticipant.ts
+++ b/src/mutate/matchUps/lineUps/removeTieMatchUpParticipant.ts
@@ -114,7 +114,13 @@ function handleDoublesPairModification({
   return undefined;
 }
 
-function modifyOrDeleteUnattachedPair({ individualParticipantIds, pairParticipantId, tournamentRecord, pairParticipant, stack }) {
+function modifyOrDeleteUnattachedPair({
+  individualParticipantIds,
+  pairParticipantId,
+  tournamentRecord,
+  pairParticipant,
+  stack,
+}) {
   if (individualParticipantIds.length) {
     pairParticipant.individualParticipantIds = individualParticipantIds;
     const result = modifyParticipant({
@@ -246,6 +252,7 @@ export function removeTieMatchUpParticipantId(
     inContextDualMatchUp,
     drawDefinition,
     dualMatchUp,
+    event,
   });
 
   let dualMatchUpSide = dualMatchUp.sides?.find(({ sideNumber }) => sideNumber === side.sideNumber);

--- a/src/mutate/matchUps/lineUps/replaceTieMatchUpParticipant.ts
+++ b/src/mutate/matchUps/lineUps/replaceTieMatchUpParticipant.ts
@@ -110,6 +110,7 @@ export function replaceTieMatchUpParticipantId(params: ReplaceTieMatchUpParticip
     inContextDualMatchUp,
     drawDefinition,
     dualMatchUp,
+    event,
   });
 
   const dualMatchUpSide = dualMatchUp?.sides?.find(({ sideNumber }) => sideNumber === side.sideNumber);

--- a/src/mutate/matchUps/matchUpStatus/setMatchUpState.ts
+++ b/src/mutate/matchUps/matchUpStatus/setMatchUpState.ts
@@ -616,6 +616,7 @@ function handleTeamAutoCalc({
     eventId: event?.eventId,
     dualMatchUp: matchUp,
     drawDefinition,
+    event,
   });
 
   return { dualWinningSideChange };

--- a/src/mutate/matchUps/score/updateTieMatchUpScore.ts
+++ b/src/mutate/matchUps/score/updateTieMatchUpScore.ts
@@ -71,6 +71,7 @@ export function updateTieMatchUpScore(params: UpdateTieMatchUpScoreArgs): {
     eventId: event?.eventId,
     dualMatchUp: matchUp,
     drawDefinition,
+    event,
   });
 
   const disableAutoCalc = firstClassOrExtension({

--- a/src/query/hierarchical/tieFormats/getItemTieFormat.ts
+++ b/src/query/hierarchical/tieFormats/getItemTieFormat.ts
@@ -3,13 +3,21 @@ export function getItemTieFormat({ item, drawDefinition, structure, event }) {
   if (item.tieFormat) return item.tieFormat;
 
   // if there is a tieFormatId, only possible to look for referenced tieFormat in tieFormats on drawDefinition and event
+  //
+  // `drawDefinition` and `event` are OPTIONAL on `resolveTieFormat`, so they must
+  // be treated as such here. They were dereferenced unguarded, which only ever
+  // mattered after `aggregateTieFormats()` — before aggregation an item carries an
+  // inline `tieFormat` and returns above, so this branch is never reached. Any
+  // caller that hydrated without threading `event` therefore worked fine until a
+  // tournament was aggregated and then threw
+  // `Cannot read properties of undefined (reading 'tieFormat')`.
   if (item.tieFormatId) {
-    if (drawDefinition.tieFormat) return drawDefinition.tieFormat;
-    const tieFormat = drawDefinition.tieFormats?.find((tf) => item.tieFormatId === tf.tieFormatId);
+    if (drawDefinition?.tieFormat) return drawDefinition.tieFormat;
+    const tieFormat = drawDefinition?.tieFormats?.find((tf) => item.tieFormatId === tf.tieFormatId);
     if (tieFormat) return tieFormat;
 
-    if (event.tieFormat) return event.tieFormat;
-    return event.tieFormats?.find((tf) => item.tieFormatId === tf.tieFormatId);
+    if (event?.tieFormat) return event.tieFormat;
+    return event?.tieFormats?.find((tf) => item.tieFormatId === tf.tieFormatId);
   }
   if (structure?.tieFormat) return structure.tieFormat;
   if (structure?.tieFormatId) {

--- a/src/tests/mutations/tieFormat/aggregatedTieFormatResolution.test.ts
+++ b/src/tests/mutations/tieFormat/aggregatedTieFormatResolution.test.ts
@@ -1,0 +1,82 @@
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+// constants
+import { TEAM_MATCHUP } from '@Constants/matchUpTypes';
+import { TEAM } from '@Constants/eventConstants';
+
+/**
+ * Regression: mutations must keep working after `aggregateTieFormats()`.
+ *
+ * Aggregation is the whole point of centralized tieFormats — it replaces each
+ * object's inline `tieFormat` with a `tieFormatId` reference into
+ * `event.tieFormats[]`. That flips which branch of `getItemTieFormat` runs:
+ *
+ *   inline `tieFormat`  → early return, `event` is never touched
+ *   `tieFormatId`       → resolution against `drawDefinition` / `event`
+ *
+ * The second branch dereferences `drawDefinition.tieFormat` and `event.tieFormat`
+ * WITHOUT guards, while `resolveTieFormat` declares both as optional. Any caller
+ * that reaches hydration without threading `event` therefore crashes — but only
+ * once a tournament has been aggregated, which is why this went unnoticed.
+ *
+ * `ensureSideLineUps` was such a caller: it accepted `eventId` but not `event`,
+ * and called `findDrawMatchUp` without it. `updateTieMatchUpScore` is the path
+ * that reaches it without a pre-resolved `inContextDualMatchUp`, so scoring a
+ * tie matchUp in an aggregated tournament threw
+ * `Cannot read properties of undefined (reading 'tieFormat')`.
+ */
+
+function aggregatedTeamTournament() {
+  const {
+    tournamentRecord,
+    eventIds: [eventId],
+  } = mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ drawSize: 4, eventType: TEAM }],
+    nonRandom: 1,
+  });
+  tournamentEngine.setState(tournamentRecord);
+
+  const aggregated: any = tournamentEngine.aggregateTieFormats();
+  expect(aggregated.success).toEqual(true);
+
+  const { event } = tournamentEngine.getEvent({ eventId });
+
+  // Precondition: aggregation actually centralized the formats. Without this the
+  // test could pass by never exercising the tieFormatId branch at all.
+  expect(event.tieFormats?.length).toBeGreaterThan(0);
+
+  return { event, eventId, drawId: event.drawDefinitions[0].drawId };
+}
+
+describe('tieFormat resolution after aggregateTieFormats', () => {
+  it('removeCollectionDefinition succeeds on an aggregated tournament', () => {
+    const { event, eventId, drawId } = aggregatedTeamTournament();
+    const collectionId = event.tieFormats[0].collectionDefinitions[0].collectionId;
+
+    const result: any = tournamentEngine.removeCollectionDefinition({ drawId, eventId, collectionId });
+
+    expect(result.error).toBeUndefined();
+    expect(result.success).toEqual(true);
+  });
+
+  it('hydrated TEAM matchUps still RESOLVE their centralized tieFormat', () => {
+    // Not just "no crash". Guarding the dereference alone would stop the throw
+    // while silently resolving `tieFormat` to undefined — the matchUp context
+    // would lose its format and downstream collection/lineUp logic would work
+    // from nothing. This asserts the reference is actually followed, which is
+    // what threading `event` buys and what a guard alone cannot.
+    const { eventId } = aggregatedTeamTournament();
+
+    const teamMatchUps = tournamentEngine
+      .allTournamentMatchUps({ matchUpFilters: { matchUpTypes: [TEAM_MATCHUP] } })
+      .matchUps.filter((m: any) => m.eventId === eventId);
+
+    expect(teamMatchUps.length).toBeGreaterThan(0);
+    for (const matchUp of teamMatchUps) {
+      expect(matchUp.tieFormat).toBeDefined();
+      expect(matchUp.tieFormat.collectionDefinitions?.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
Pre-existing defect found while trying to build test fixtures for #4622. Reproduced on `master`, independent of that work.

## Symptom

```
aggregateTieFormats()  →  removeCollectionDefinition()
  ⇒ "Cannot read properties of undefined (reading 'tieFormat')"   (getItemTieFormat.ts:11)
```

## Why aggregation is what exposes it

Aggregation replaces each object's inline `tieFormat` with a `tieFormatId` reference into `event.tieFormats[]`. That flips which branch of `getItemTieFormat` runs:

| state | branch |
|---|---|
| inline `tieFormat` | early return — `event` is never touched |
| `tieFormatId` | resolution against `drawDefinition` / `event` |

The second branch dereferenced `drawDefinition.tieFormat` and `event.tieFormat` **without guards**, while `resolveTieFormat` declares both as **optional**. The types and the implementation disagreed, so any caller reaching hydration without threading `event` worked fine — until a tournament was aggregated.

## The caller

`ensureSideLineUps` accepted `eventId` but not `event`, and called `findDrawMatchUp` without it — even though `findDrawMatchUp` **already accepts `event`**, and all five of its callers already had the object in scope (they were passing `event.eventId` from it).

`updateTieMatchUpScore` is the one path that reaches `ensureSideLineUps` *without* a pre-resolved `inContextDualMatchUp`, so it triggers the internal `findDrawMatchUp` — which is exactly where the stack trace pointed.

## Fix

- `ensureSideLineUps` accepts `event` and forwards it; all five call sites pass it
- `getItemTieFormat` guards the optional dereferences so the implementation matches the declared types

## Honest note on the two halves

Each **independently** prevents the crash — verified by reverting them separately, both silent.

I could not construct a public-surface assertion that distinguishes them. The obvious candidate (hydrated matchUps resolve their `tieFormat`) passes either way, because `allTournamentMatchUps` threads `event` correctly and therefore never exercises the broken path.

Both are kept because they address different things: **threading resolves the reference**, **guarding stops a missing `event` from being fatal**. Guarding alone would leave that internal hydration resolving `tieFormat` to `undefined` instead of throwing — silent wrongness, which is the worse failure of the two.

The regression test **fires against the pre-fix state** (both halves reverted).

## Verification

lint **0**, check-types **0**, **1057 files / 10903 tests**.

## Follow-on

This unblocks fixture construction for #4622 (`tieFormatUuids` threading), whose main-chain write sites could not be covered because this defect corrupts exactly the aggregated state those tests need.
