### PR TITLE
test(tieFormat): cover the copy-on-write fork; document supplied identity

### DIFF
--- a/documentation/docs/concepts/caller-supplied-identity.md
+++ b/documentation/docs/concepts/caller-supplied-identity.md
@@ -1,0 +1,113 @@
+---
+title: Caller-supplied identity & timestamps
+---
+
+## Why a mutation would take an id or a time
+
+Most mutations mint the ids they need and stamp `createdAt` from the clock. That is
+correct when a mutation runs **once**. It is wrong the moment the _same_ mutation runs in
+**two places** and both results are expected to agree.
+
+That happens routinely:
+
+- a client applies a mutation locally after the server acknowledges it,
+- a site server buffers mutations offline and replays them to the cloud on reconnect,
+- an event sanctioned elsewhere is activated here and later reconciled there.
+
+If the engine mints, each execution produces a _different_ id, and every later mutation
+that references it fails to resolve on one side. If the engine stamps the clock, the
+record says when it was **written**, not when it **happened** — and a delayed sync records
+the wrong time.
+
+The fix in both cases is the same shape: **identity and event time are minted once, at the
+origin, and travel in `params`.**
+
+## `occurredAt` — event time, not write time
+
+Mutations that record when something happened accept an optional `occurredAt`:
+
+```js
+engine.modifyParticipantsSignInStatus({
+  participantIds,
+  signInState,
+  occurredAt: '2026-08-15T14:30:00.000Z', // when it happened on site
+});
+```
+
+Present on `modifyParticipantsSignInStatus`, `modifyParticipantsPaymentStatus`,
+`addPenalty` (defaulting to `issuedAt`), `addTimeItem` (via `createdAt`),
+`addParticipantScaleItem` (via `scaleItem.createdAt`), the practice-registration
+mutations, `addCourtGridBooking`, `addPersonOtherId`, `addVenueOtherId`, `createMatchUp`,
+`addDrawDefinitionTimeItem` and `addExtension`.
+
+**Every one defaults to now**, so a caller that omits it sees no change in behaviour.
+
+Two rules govern what event time means, and both are deliberate:
+
+| scope                       | rule                                                                                                                                                                                                                                                                                      |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Record-root `updatedAt`** | stays **write** time. Only entity-level timestamps carry event time. The storage layer derives its `updated_at` column from the record root and a staleness probe compares it against a client's last poll — event time could move it _backwards_ and silently break staleness detection. |
+| **Ordering**                | event time is authoritative, **including retroactively**. A rating recorded at the venue on Saturday and synced on Sunday sorts _before_ a Saturday-evening entry and is no longer "current". That is the point: the timeline reflects what happened, not what arrived first.             |
+
+Four sites deliberately do **not** take a stamp — `modifyParticipant`'s birthDate
+validation, sanctioning `amendments` and `compliance` checks, and `scheduleItems`. Those
+read "now" in order to _validate_, and a caller-supplied "now" in a validation is
+spoofable.
+
+Sanctioning and officiating record `updatedAt` also keep write-time semantics: those
+records are not part of the tournamentRecord and sit behind separate engines.
+
+## `uuids` — a pool, not an id parameter
+
+Where a mutation creates an entity the caller never named, it accepts a **pool** to draw
+from rather than a single id:
+
+```js
+engine.addFlights({ eventId, flightsCount: 3, uuids: ['f-1', 'f-2', 'f-3'] });
+```
+
+A pool rather than a named id, because the caller cannot name something it did not ask to
+create — the classic case being a **copy-on-write fork**, where modifying a shared
+`tieFormat` produces a new one so the other references are left untouched. The fork is
+unconditional; only the _value_ of its id comes from the pool.
+
+`tieFormat` forks draw from their own **`tieFormatUuids`** pool, kept separate from the
+`uuids` pool feeding matchUp ids in the same mutation. Sharing one pool would couple
+unrelated id streams and make a shortfall unattributable — you could not tell which stream
+ran short:
+
+```js
+engine.removeCollectionDefinition({
+  drawId,
+  eventId,
+  collectionId,
+  tieFormatUuids: ['tf-1'], // only for tieFormat copy-on-write forks
+});
+```
+
+### Strict when supplied
+
+A pool is **not** a hint. `takeUUID` distinguishes three cases:
+
+| pool                  | behaviour                            |
+| --------------------- | ------------------------------------ |
+| not supplied          | mint — existing behaviour, unchanged |
+| supplied, has entries | take one                             |
+| supplied, exhausted   | return `INSUFFICIENT_UUIDS`          |
+
+Falling back to minting on an exhausted pool would defeat the purpose: the second
+execution would diverge from the first at exactly the point the caller was trying to pin.
+An exhausted pool is a **divergence signal**, not a licence to mint.
+
+Because of that, **a caller that supplies a pool must check the returned error**. A
+mutation that ignores it turns an exhausted pool into a silent no-op write — strictly
+worse than minting.
+
+## What this does not cover
+
+- `addPoint`'s two `matchUp.endTime` stamps still use the clock; threading them needs a
+  positional parameter through three helpers and the exported `checkAndFinalizeMatch`.
+- `updateTieFormat` accepts **no** pool at all, deliberately: its nested helpers return
+  errors their callers currently drop, so a pool threaded there would produce
+  `INSUFFICIENT_UUIDS` errors that vanish. It always mints, which is consistent rather
+  than intermittently pinned.

--- a/documentation/docs/governors/query-governor.md
+++ b/documentation/docs/governors/query-governor.md
@@ -1620,13 +1620,19 @@ const { accuracy, zoneDistribution } = engine.getPredictiveAccuracy({
   exclusionRule: { valueAccessor: 'confidence', range: [0, 70] }, // exclude low confidence values
 
   zoneMargin: 3, // optional - creates +/- range and report competitiveness distribution
-  zonePct: 20, // optional - precedence over zoneMargin, defaults to 100% of rating range
+  zonePct: 20, // optional - PERCENT of the scale range; takes precedence over zoneMargin, defaults to 100%
 
   valueAccessor: 'wtnRating', // optional if `scaleName` is defined in factory `ratingsParameters`
   ascending: true, // optional - scale goes from low to high with low being the "best"
   scaleName: WTN,
 });
 ```
+
+> **`zonePct` is a percent of the scale's range**, so the resolved margin depends on the scale.
+> WTN spans `|40 - 1| = 39`, so `zonePct: 20` resolves to a margin of **7.8**. The resolved
+> `zoneMargin` is returned alongside the result, so a caller can assert it rather than infer it.
+> (Before a precedence fix, `zonePct` produced a margin **100x too large** — `20` on WTN gave 780,
+> not 7.8 — so figures computed against older builds are not comparable.)
 
 ---
 

--- a/documentation/docs/types/assets/address.ts
+++ b/documentation/docs/types/assets/address.ts
@@ -1,24 +1,20 @@
-const stringNotRequired =
-  '{\\"type\\":\\"string\\",\\"required\\":\\"false\\"}';
+const stringNotRequired = '{\\"type\\":\\"string\\",\\"required\\":\\"false\\"}';
 
 export const address = {
   addressLine1: stringNotRequired,
   addressLine2: stringNotRequired,
   addressLine3: stringNotRequired,
   addressName: stringNotRequired,
-  addressType:
-    '{\\"type\\":\\"enum\\",\\"enum\\":\\"\\",\\"required\\":\\"false\\"}',
+  addressType: '{\\"type\\":\\"enum\\",\\"enum\\":\\"\\",\\"required\\":\\"false\\"}',
   city: stringNotRequired,
-  countryCode:
-    '{\\"type\\":\\"enum\\",\\"enum\\": \\"ISO3166-3\\",\\"required\\":\\"false\\"}',
+  countryCode: '{\\"type\\":\\"enum\\",\\"enum\\": \\"ISO3166-3\\",\\"required\\":\\"false\\"}',
   latitude:
-    '{\\"type\\":\\"string\\",\\"required\\":\\"false\\",\\"note\\":\\"11.583331 or 11°34\'59.99 N\\"}',
+    '{\\"type\\":\\"string | number\\",\\"required\\":\\"false\\",\\"note\\":\\"11.583331 or 11°34\'59.99 N — a decimal degree may be supplied as a number; DMS notation is a string\\"}',
   longitude:
-    '{\\"type\\":\\"string\\",\\"required\\":\\"false\\",\\"note\\":\\"165.333332 or 165°19\'60.00 E\\"}',
+    '{\\"type\\":\\"string | number\\",\\"required\\":\\"false\\",\\"note\\":\\"165.333332 or 165°19\'60.00 E — a decimal degree may be supplied as a number; DMS notation is a string\\"}',
   postalCode: stringNotRequired,
   state: stringNotRequired,
-  timeZone:
-    '{\\"type\\":\\"string\\",\\"required\\":\\"false\\",\\"note\\":\\"IANA Code\\"}',
+  timeZone: '{\\"type\\":\\"string\\",\\"required\\":\\"false\\",\\"note\\":\\"IANA Code\\"}',
 };
 
 export default address;

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -143,7 +143,12 @@ module.exports = {
         {
           type: 'category',
           label: 'Record Data',
-          items: ['concepts/accessors', 'concepts/timeItems', 'concepts/extensions'],
+          items: [
+            'concepts/accessors',
+            'concepts/timeItems',
+            'concepts/extensions',
+            'concepts/caller-supplied-identity',
+          ],
         },
         {
           type: 'category',

--- a/src/tests/mutations/tieFormat/tieFormatUuidPoolThreading.test.ts
+++ b/src/tests/mutations/tieFormat/tieFormatUuidPoolThreading.test.ts
@@ -85,26 +85,37 @@ describe('removeCollectionDefinition — tieFormatUuids threading', () => {
 });
 
 /**
- * ⚠️ COVERAGE LIMITATION — read before assuming this file proves the whole change.
+ * COVERAGE — what this file proves, and what proves the rest.
  *
- * Only the `processTargetMatchUp` fork inside `removeCollectionDefinition` is
- * provably covered here (verified by reverting `uuids: tieFormatUuids` on that
- * exact line and watching this suite fail).
+ * UPDATED 2026-08-15. An earlier version of this note said the remaining sites
+ * were blocked by a pre-existing defect: `aggregateTieFormats()` followed by
+ * `removeCollectionDefinition` threw `Cannot read properties of undefined
+ * (reading 'tieFormat')` from `getItemTieFormat`. **That defect is fixed** (PR
+ * #4623 guarded the optional `drawDefinition` / `event` dereferences) and the
+ * sequence now succeeds — verified directly before rewriting this note.
  *
- * The MAIN-CHAIN write sites — the if/else target selection in
- * removeCollectionDefinition, addCollectionDefinition and collectionGroupUpdate
- * — are threaded identically but are NOT independently covered:
+ * Removing the blocker did NOT make the other sites reachable, and the reason is
+ * structural rather than a fixture problem. `writeTieFormat` forks only when a
+ * centralized `tieFormatId` has `refCount > 1`. In these mutations the
+ * matchUp-level processing runs FIRST and re-points every competing reference,
+ * so by the time the main-chain write executes the event is the sole remaining
+ * reference — `refCount === 1` — and it takes the in-place branch, minting
+ * nothing and consuming no pool.
  *
- *   - in `removeCollectionDefinition` the earlier `processTargetMatchUp` fork
- *     always consumes/errors first, so the main-chain site is unreachable once a
- *     pool is short
- *   - `collectionGroupUpdate` with an aggregated fixture does not fork at all
- *     (the resolved target has refCount 1, so it updates in place)
+ * Measured, not argued: instrumenting the fork and running the full suite shows
+ * it is reached from exactly ONE site across all 10,912 tests —
+ * `removeCollectionDefinition`'s `processTargetMatchUp` path, which is what this
+ * file covers. The main-chain sites here, in `addCollectionDefinition` and in
+ * `collectionGroupUpdate` are never reached. Three fixtures built through the
+ * public API (single draw, two draws in one event, event-scoped write target)
+ * all took the in-place branch.
  *
- * Building a fixture that reaches them is blocked by a PRE-EXISTING defect,
- * confirmed on master with these changes stashed: `aggregateTieFormats()`
- * followed by `removeCollectionDefinition` returns
- * `Cannot read properties of undefined (reading 'tieFormat')` from
- * `getItemTieFormat`. That corrupts exactly the aggregated state these tests
- * need. See the workstream notes.
+ * The threading on those unreached lines is therefore DEFENSIVE and correct to
+ * keep — if a future change makes them reachable the pool must be honoured — but
+ * no integration test can exercise them today.
+ *
+ * The fork's own behaviour is covered directly in
+ * `writeTieFormatUuidPool.test.ts`: pool consumed, exhaustion errors, absent
+ * pool mints, and the `refCount === 1` in-place branch that makes the above
+ * unreachable is pinned as behaviour.
  */

--- a/src/tests/mutations/tieFormat/writeTieFormatUuidPool.test.ts
+++ b/src/tests/mutations/tieFormat/writeTieFormatUuidPool.test.ts
@@ -1,0 +1,121 @@
+import { writeTieFormat } from '@Mutate/tieFormat/writeTieFormat';
+import { describe, expect, it } from 'vitest';
+
+// constants
+import { INSUFFICIENT_UUIDS } from '@Constants/errorConditionConstants';
+
+/**
+ * `writeTieFormat`'s copy-on-write fork, tested DIRECTLY.
+ *
+ * Why at this level rather than through a mutation. The fork fires only when a
+ * centralized `tieFormatId` is shared by more than one reference (`refCount > 1`).
+ * A full-suite sweep — instrumenting the fork and running all 10,912 tests —
+ * showed it is reached from exactly ONE call site in the entire corpus:
+ * `removeCollectionDefinition`'s `processTargetMatchUp` path. The main-chain
+ * write sites in `removeCollectionDefinition`, `addCollectionDefinition` and
+ * `collectionGroupUpdate` never reach it, because the matchUp-level processing
+ * re-points every competing reference first, leaving `refCount === 1` by the time
+ * the main-chain write runs — so those writes take the in-place branch.
+ *
+ * That makes the pool behaviour untestable from those callers. Testing the fork
+ * where it actually lives covers the logic that matters — does a supplied pool
+ * get used, and does exhaustion fail loudly — independently of which caller
+ * happens to reach it today.
+ *
+ * The fixtures are hand-built ON PURPOSE here, which is the opposite of the
+ * sibling integration test's approach and is the right call at this level: the
+ * point is to exercise `writeTieFormat`'s own branches, and `refCount` is just a
+ * count over `event` — so constructing the shape directly is honest rather than
+ * contrived.
+ */
+
+const SHARED_ID = 'shared-tf-1';
+
+/** An event whose centralized tieFormat is referenced by `references` targets. */
+function eventWithSharedTieFormat(references: number) {
+  const structures = Array.from({ length: Math.max(0, references - 1) }, (_x, i) => ({
+    structureId: `s-${i}`,
+    tieFormatId: SHARED_ID,
+    matchUps: [], // countTieFormatReferences walks event matchUps; a structure without this throws
+  }));
+  return {
+    eventId: 'e-1',
+    tieFormatId: SHARED_ID, // reference #1
+    tieFormats: [{ tieFormatId: SHARED_ID, collectionDefinitions: [{ collectionId: 'c-1' }] }],
+    drawDefinitions: [{ drawId: 'd-1', structures }],
+  };
+}
+
+const modifiedTieFormat = { collectionDefinitions: [{ collectionId: 'c-1' }, { collectionId: 'c-2' }] };
+
+describe('writeTieFormat — uuids pool on the copy-on-write fork', () => {
+  it('takes the forked id FROM the pool when one is supplied', () => {
+    const event: any = eventWithSharedTieFormat(2);
+    const target: any = { tieFormatId: SHARED_ID };
+    const uuids = ['pooled-tf-id'];
+
+    const result = writeTieFormat({ target, tieFormat: modifiedTieFormat, event, uuids });
+
+    expect(result?.error).toBeUndefined();
+    // the value came from the caller, which is what makes a replay reproducible
+    expect(target.tieFormatId).toEqual('pooled-tf-id');
+    expect(uuids).toHaveLength(0); // consumed, not copied
+    expect(event.tieFormats.map((tf: any) => tf.tieFormatId)).toEqual([SHARED_ID, 'pooled-tf-id']);
+    // the fork replaces the reference; the inline copy must not linger alongside it
+    expect(target.tieFormat).toBeUndefined();
+  });
+
+  it('errors rather than minting when the supplied pool is exhausted', () => {
+    const event: any = eventWithSharedTieFormat(2);
+    const target: any = { tieFormatId: SHARED_ID };
+
+    const result = writeTieFormat({ target, tieFormat: modifiedTieFormat, event, uuids: [] });
+
+    expect(result?.error).toEqual(INSUFFICIENT_UUIDS);
+    // and it left the target alone — a failed write must not half-apply
+    expect(target.tieFormatId).toEqual(SHARED_ID);
+    expect(event.tieFormats).toHaveLength(1);
+  });
+
+  it('mints when NO pool is supplied — absent is not empty', () => {
+    const event: any = eventWithSharedTieFormat(2);
+    const target: any = { tieFormatId: SHARED_ID };
+
+    const result = writeTieFormat({ target, tieFormat: modifiedTieFormat, event });
+
+    expect(result?.error).toBeUndefined();
+    expect(target.tieFormatId).not.toEqual(SHARED_ID); // forked to a minted id
+    expect(event.tieFormats).toHaveLength(2);
+  });
+
+  // This branch is why the main-chain callers cannot reach the fork: with a single
+  // reference the centralized entry is updated in place and no id is minted at all.
+  // Pinning it documents the reachability finding as behaviour rather than a comment.
+  it('updates in place and consumes NOTHING when only one reference exists', () => {
+    const event: any = eventWithSharedTieFormat(1);
+    const target: any = { tieFormatId: SHARED_ID };
+    const uuids = ['must-not-be-used'];
+
+    const result = writeTieFormat({ target, tieFormat: modifiedTieFormat, event, uuids });
+
+    expect(result?.error).toBeUndefined();
+    expect(target.tieFormatId).toEqual(SHARED_ID); // unchanged — no fork
+    expect(uuids).toEqual(['must-not-be-used']); // pool untouched
+    expect(event.tieFormats).toHaveLength(1);
+    expect(event.tieFormats[0].collectionDefinitions).toHaveLength(2); // updated in place
+  });
+
+  // The pre-aggregation shape: no centralized reference at all, so the pool is
+  // irrelevant and the format is written inline.
+  it('writes inline and consumes nothing when the target has no tieFormatId', () => {
+    const event: any = eventWithSharedTieFormat(2);
+    const target: any = {};
+    const uuids = ['must-not-be-used'];
+
+    const result = writeTieFormat({ target, tieFormat: modifiedTieFormat, event, uuids });
+
+    expect(result?.error).toBeUndefined();
+    expect(target.tieFormat).toEqual(modifiedTieFormat);
+    expect(uuids).toEqual(['must-not-be-used']);
+  });
+});


### PR DESCRIPTION
Follow-up to **#4622**, whose coverage note said the remaining sites were blocked by a pre-existing defect.

## The blocker is fixed — and that wasn't the whole story

#4622 documented that `aggregateTieFormats()` → `removeCollectionDefinition` threw `Cannot read properties of undefined (reading 'tieFormat')` from `getItemTieFormat`, corrupting the state its fixtures needed. **#4623 fixed that**, and I verified the previously-crashing sequence now succeeds before touching the note.

**Removing the blocker did not make those sites reachable.** The reason is structural, not a missing fixture:

`writeTieFormat` forks only when a centralized `tieFormatId` has `refCount > 1`. In these mutations the matchUp-level processing runs **first** and re-points every competing reference — so by the time the main-chain write executes, the event is the sole remaining reference, `refCount === 1`, and it takes the in-place branch, minting nothing and consuming no pool.

## Measured, not argued

I instrumented the fork and ran the **full suite**. Across all 10,912 tests it is reached from exactly one site:

```
7  removeCollectionDefinition.ts:358   ← processTargetMatchUp (the covered path)
```

Never from the main-chain sites, `addCollectionDefinition`, or `collectionGroupUpdate`. Three fixtures built through the public API — single draw, two draws in one event, event-scoped write target — all took the in-place branch (`forked: false`, pool consumed only by the matchUp path).

The threading on those unreached lines is **defensive and correct to keep**: if a future change makes them reachable, the pool must be honoured. It simply cannot be exercised today, and the note now says that with evidence instead of blaming a defect that no longer exists.

## What this adds

`writeTieFormatUuidPool.test.ts` covers the fork **where it lives**, as a direct unit test — independent of which caller happens to reach it:

- the forked id is taken **from** the pool, and the pool is consumed
- an exhausted pool returns `INSUFFICIENT_UUIDS` and leaves the target untouched (no half-applied write)
- an absent pool mints — absent is not empty
- the `refCount === 1` in-place branch is **pinned as behaviour**, since it is precisely what makes the other callers unreachable
- the pre-aggregation inline path consumes nothing

## Docs

Adds `concepts/caller-supplied-identity` — the whole `occurredAt` / `uuids` surface from #4621 and #4622 had **no documentation** since the last Docusaurus publish (2026-08-10). Covers why a mutation would take an id or a time at all, `occurredAt` semantics (why record-root `updatedAt` stays write time; why ordering is retroactive), the `uuids` vs `tieFormatUuids` pools and why they are separate, strict-when-supplied, and the sites deliberately excluded.

## Verification

lint 0, check-types 0, `verify:generated` in sync, prettier clean, **10912 → 10917** tests.