### PR TITLE
fix(tieFormat): stop a shared tieFormat fragmenting into identical copies

### DIFF
--- a/src/mutate/tieFormat/removeCollectionDefinition.ts
+++ b/src/mutate/tieFormat/removeCollectionDefinition.ts
@@ -171,6 +171,12 @@ export function removeCollectionDefinition({
     matchUp = clearResult.matchUp;
   }
 
+  // ONE fork cache for the whole operation. Every target here is written with the
+  // SAME pruned tieFormat, so without this a shared centralized format fragments
+  // into one identical copy per TEAM matchUp — 1 tieFormat became 4 on a drawSize
+  // 4 event. See writeTieFormat's `forkCache`.
+  const forkCache = new Map<string, any>();
+
   const deletedMatchUpIds: string[] = [];
   for (const targetMatchUp of targetMatchUps) {
     const processResult: any = processTargetMatchUp({
@@ -179,6 +185,7 @@ export function removeCollectionDefinition({
       drawDefinition,
       collectionId,
       tieFormatUuids,
+      forkCache,
       tieFormat,
       stack,
       event,
@@ -222,6 +229,7 @@ export function removeCollectionDefinition({
     tieFormat: prunedTieFormat,
     event,
     uuids: tieFormatUuids,
+    forkCache,
   });
   if (writeResult?.error) return decorateResult({ result: writeResult, stack });
 
@@ -332,6 +340,7 @@ function processTargetMatchUp({
   deletedMatchUpIds,
   collectionId,
   tieFormatUuids,
+  forkCache,
   tieFormat,
   stack,
   event,
@@ -360,6 +369,7 @@ function processTargetMatchUp({
       tieFormat: copyTieFormat(tieFormat),
       event,
       uuids: tieFormatUuids,
+      forkCache,
     });
     if (writeResult?.error) return writeResult;
   }

--- a/src/mutate/tieFormat/removeCollectionDefinition.ts
+++ b/src/mutate/tieFormat/removeCollectionDefinition.ts
@@ -13,7 +13,7 @@ import { tieFormatTelemetry } from '@Mutate/tieFormat/tieFormatTelemetry';
 import { allEventMatchUps } from '@Query/matchUps/getAllEventMatchUps';
 import { checkScoreHasValue } from '@Query/matchUp/checkScoreHasValue';
 import { allDrawMatchUps } from '@Query/matchUps/getAllDrawMatchUps';
-import { writeTieFormat } from '@Mutate/tieFormat/writeTieFormat';
+import { requiredForkIds, writeTieFormat } from '@Mutate/tieFormat/writeTieFormat';
 import { validateTieFormat } from '@Validators/validateTieFormat';
 import { definedAttributes } from '@Tools/definedAttributes';
 import { findDrawMatchUp } from '@Acquire/findDrawMatchUp';
@@ -26,6 +26,7 @@ import { SUCCESS } from '@Constants/resultConstants';
 import { TEAM } from '@Constants/matchUpTypes';
 import {
   ErrorType,
+  INSUFFICIENT_UUIDS,
   MISSING_DRAW_DEFINITION,
   NOT_FOUND,
   NO_MODIFICATIONS_APPLIED,
@@ -169,6 +170,27 @@ export function removeCollectionDefinition({
     });
     if (clearResult.error) return clearResult;
     matchUp = clearResult.matchUp;
+  }
+
+  // Validate the pool BEFORE mutating anything.
+  //
+  // Reporting an exhausted pool part-way is not enough: `processTargetMatchUp`
+  // splices a matchUp's tieMatchUps BEFORE writing its tieFormat, so a failure at
+  // the write leaves the splice behind. Measured: an empty pool took
+  // tieMatchUp counts from [9,9,9,9,9,9,9] to [6,9,9,9,9,9,9] and still returned
+  // an error. `executionQueue({ rollbackOnError: true })` restores that — and TMX
+  // always sends it — but a direct engine caller has no such protection, so the
+  // mutation should not begin at all when it cannot finish.
+  const requiredIds = requiredForkIds({
+    targets: [...targetMatchUps, resolveWriteTarget({ eventId, event, matchUpId, matchUp, structure, drawDefinition })],
+    event,
+  });
+  if (tieFormatUuids !== undefined && tieFormatUuids.length < requiredIds) {
+    return decorateResult({
+      result: { error: INSUFFICIENT_UUIDS },
+      context: { required: requiredIds, supplied: tieFormatUuids.length },
+      stack,
+    });
   }
 
   // ONE fork cache for the whole operation. Every target here is written with the

--- a/src/mutate/tieFormat/writeTieFormat.ts
+++ b/src/mutate/tieFormat/writeTieFormat.ts
@@ -1,3 +1,4 @@
+import { compareTieFormats } from '@Query/hierarchical/tieFormats/compareTieFormats';
 import { allEventMatchUps } from '@Query/matchUps/getAllEventMatchUps';
 import { makeDeepCopy } from '@Tools/makeDeepCopy';
 import { takeUUID } from '@Tools/UUID';
@@ -32,6 +33,24 @@ type WriteTieFormatArgs = {
    * local re-run on ack) in agreement. This path had no pool to thread.
    */
   uuids?: string[];
+  /**
+   * Within-operation cache of forks already made, keyed by the SOURCE
+   * tieFormatId. Optional; omitting it preserves the previous per-target
+   * behaviour.
+   *
+   * Why it exists: a single mutation frequently rewrites several targets that
+   * all reference one shared tieFormat, with IDENTICAL new content — e.g.
+   * `removeCollectionDefinition` on an aggregated event writes every TEAM
+   * matchUp. Without a cache each target forks independently, so one shared
+   * format fragments into N byte-identical copies, which is exactly what
+   * aggregation exists to prevent. With it, the first fork mints and the rest
+   * point at the same new entry.
+   *
+   * Content is compared before reuse, so two targets that happen to share a
+   * source id but are being written with DIFFERENT formats still fork
+   * separately.
+   */
+  forkCache?: Map<string, TieFormat>;
 };
 
 /**
@@ -54,7 +73,7 @@ type WriteTieFormatArgs = {
  * than the current consistent behaviour. Do it as one pass, with error checks at
  * every site.
  */
-export function writeTieFormat({ target, tieFormat, event, uuids }: WriteTieFormatArgs) {
+export function writeTieFormat({ target, tieFormat, event, uuids, forkCache }: WriteTieFormatArgs) {
   if (!target) return undefined;
 
   // If the target was using a centralized tieFormatId reference
@@ -74,7 +93,17 @@ export function writeTieFormat({ target, tieFormat, event, uuids }: WriteTieForm
       }
     }
 
-    // Multiple references share this ID — create a new entry so we don't affect others
+    // Multiple references share this ID — create a new entry so we don't affect others.
+    //
+    // Unless this operation already forked the same source with the same content,
+    // in which case join that fork rather than minting another identical entry.
+    const cached = forkCache?.get(existingId);
+    if (cached && !compareTieFormats({ ancestor: cached, descendant: tieFormat })?.different) {
+      target.tieFormatId = cached.tieFormatId;
+      delete target.tieFormat;
+      return undefined;
+    }
+
     const newTieFormat = makeDeepCopy(tieFormat, undefined, true);
     // The fork itself is unconditional — that is the point of copy-on-write — but
     // the VALUE comes from the caller's pool when one was supplied, so both
@@ -85,6 +114,7 @@ export function writeTieFormat({ target, tieFormat, event, uuids }: WriteTieForm
 
     newTieFormat.tieFormatId = uuid;
     event.tieFormats.push(newTieFormat);
+    forkCache?.set(existingId, newTieFormat);
     target.tieFormatId = newTieFormat.tieFormatId;
     delete target.tieFormat;
     return undefined;

--- a/src/mutate/tieFormat/writeTieFormat.ts
+++ b/src/mutate/tieFormat/writeTieFormat.ts
@@ -134,7 +134,7 @@ type CountReferencesArgs = {
  * Counts how many objects (event, drawDefinitions, structures, matchUps)
  * in the event reference a given tieFormatId.
  */
-function countTieFormatReferences({ event, tieFormatId }: CountReferencesArgs): number {
+export function countTieFormatReferences({ event, tieFormatId }: CountReferencesArgs): number {
   let count = 0;
 
   if (event.tieFormatId === tieFormatId) count++;
@@ -188,4 +188,35 @@ export function removeOrphanedTieFormats({ event }: { event: Event }) {
   event.tieFormats = event.tieFormats.filter((tf) => tf.tieFormatId && referencedIds.has(tf.tieFormatId));
 
   if (!event.tieFormats.length) delete event.tieFormats;
+}
+
+type RequiredForkIdsArgs = {
+  /** Every object this operation will write a tieFormat to. */
+  targets: Array<{ tieFormatId?: string } | undefined>;
+  event?: Event;
+};
+
+/**
+ * How many ids an operation must draw from its pool, computed BEFORE mutating.
+ *
+ * One per DISTINCT source tieFormatId that would fork — because `forkCache`
+ * makes every later target sharing a source join the first fork rather than
+ * minting again.
+ *
+ * This is an upper bound, and deliberately so. As targets fork away, the source's
+ * refCount falls; if it reaches 1 the final referent takes the in-place branch and
+ * mints nothing. Over-requiring by one rejects a pool that would just have
+ * sufficed — annoying but safe. Under-requiring would let the operation begin and
+ * fail part-way, which is the failure this exists to prevent.
+ */
+export function requiredForkIds({ targets, event }: RequiredForkIdsArgs): number {
+  if (!event?.tieFormats?.length) return 0;
+
+  const sources = new Set<string>();
+  for (const target of targets) {
+    const tieFormatId = target?.tieFormatId;
+    if (!tieFormatId) continue;
+    if (countTieFormatReferences({ event, tieFormatId }) > 1) sources.add(tieFormatId);
+  }
+  return sources.size;
 }

--- a/src/tests/mutations/tieFormat/tieFormatForkFragmentation.test.ts
+++ b/src/tests/mutations/tieFormat/tieFormatForkFragmentation.test.ts
@@ -1,0 +1,136 @@
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+// constants
+import { INSUFFICIENT_UUIDS } from '@Constants/errorConditionConstants';
+import { TEAM_MATCHUP } from '@Constants/matchUpTypes';
+import { TEAM } from '@Constants/eventConstants';
+
+/**
+ * A shared centralized tieFormat must NOT fragment into identical copies.
+ *
+ * `removeCollectionDefinition` on an aggregated event rewrites every TEAM
+ * matchUp with the SAME pruned tieFormat. Each write hit `writeTieFormat`'s
+ * copy-on-write fork independently, so one shared format became one identical
+ * copy per matchUp:
+ *
+ *   drawSize 4  →  3 TEAM matchUps  →  event.tieFormats 1 → 4
+ *
+ * That is precisely what `aggregateTieFormats()` exists to prevent, and it is
+ * unbounded: every subsequent scorecard edit fragments again. Re-running
+ * aggregation re-points the references but leaves the orphaned entries behind
+ * (`removeOrphanedTieFormats` is only wired into `resetTieFormat`).
+ *
+ * Fixed with a per-operation `forkCache`: the first fork mints, and any later
+ * target forking from the same source with identical content joins it.
+ */
+
+function aggregatedTeamEvent() {
+  const {
+    tournamentRecord,
+    eventIds: [eventId],
+  } = mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ drawSize: 4, eventType: TEAM }],
+    nonRandom: 1,
+  });
+  tournamentEngine.setState(tournamentRecord);
+  expect(tournamentEngine.aggregateTieFormats().success).toEqual(true);
+
+  const { event } = tournamentEngine.getEvent({ eventId });
+  // Precondition: aggregation centralized to exactly one shared format.
+  expect(event.tieFormats).toHaveLength(1);
+  return { event, eventId, drawId: event.drawDefinitions[0].drawId };
+}
+
+function teamTieFormatIds(): string[] {
+  return tournamentEngine
+    .allTournamentMatchUps({ matchUpFilters: { matchUpTypes: [TEAM_MATCHUP] } })
+    .matchUps.map((m: any) => m.tieFormatId);
+}
+
+describe('shared tieFormat does not fragment on removeCollectionDefinition', () => {
+  it('forks ONCE for all matchUps rather than once each', () => {
+    const { event, eventId, drawId } = aggregatedTeamEvent();
+    const collectionId = event.tieFormats[0].collectionDefinitions[0].collectionId;
+
+    const result: any = tournamentEngine.removeCollectionDefinition({ drawId, eventId, collectionId });
+    expect(result.error).toBeUndefined();
+
+    const after = tournamentEngine.getEvent({ eventId }).event;
+    // One new shared entry alongside the original the EVENT still references —
+    // not one per matchUp. Before the fix this was 4.
+    expect(after.tieFormats).toHaveLength(2);
+
+    const ids = teamTieFormatIds();
+    expect(ids).toHaveLength(3);
+    expect(new Set(ids).size).toEqual(1);
+  });
+
+  it('consumes ONE id from the pool, not one per matchUp', () => {
+    // The pool is the clearest witness: identity is minted once, so a replaying
+    // instance needs exactly one id to reproduce this mutation.
+    const { event, eventId, drawId } = aggregatedTeamEvent();
+    const collectionId = event.tieFormats[0].collectionDefinitions[0].collectionId;
+    const pool = ['tf-a', 'tf-b', 'tf-c'];
+
+    const result: any = tournamentEngine.removeCollectionDefinition({
+      drawId,
+      eventId,
+      collectionId,
+      tieFormatUuids: pool,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(pool).toHaveLength(2);
+    expect(new Set(teamTieFormatIds())).toEqual(new Set(['tf-c']));
+  });
+
+  it('a single-id pool is now SUFFICIENT — it was not before', () => {
+    // Directly encodes the behaviour change. One id used to fail with
+    // INSUFFICIENT_UUIDS because three forks were attempted.
+    const { event, eventId, drawId } = aggregatedTeamEvent();
+    const collectionId = event.tieFormats[0].collectionDefinitions[0].collectionId;
+
+    const result: any = tournamentEngine.removeCollectionDefinition({
+      drawId,
+      eventId,
+      collectionId,
+      tieFormatUuids: ['only-one'],
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(new Set(teamTieFormatIds())).toEqual(new Set(['only-one']));
+  });
+
+  it('an EMPTY pool still errors — strictness is unchanged', () => {
+    // The fork still happens; only its multiplicity changed. Strict-when-supplied
+    // must survive the fix.
+    const { event, eventId, drawId } = aggregatedTeamEvent();
+    const collectionId = event.tieFormats[0].collectionDefinitions[0].collectionId;
+
+    const result: any = tournamentEngine.removeCollectionDefinition({
+      drawId,
+      eventId,
+      collectionId,
+      tieFormatUuids: [],
+    });
+
+    expect(result.error).toEqual(INSUFFICIENT_UUIDS);
+  });
+
+  it('the removed collection is actually gone from the shared format', () => {
+    // Guards against "de-duplicated" turning into "did not apply the edit".
+    const { event, eventId, drawId } = aggregatedTeamEvent();
+    const collectionId = event.tieFormats[0].collectionDefinitions[0].collectionId;
+
+    tournamentEngine.removeCollectionDefinition({ drawId, eventId, collectionId });
+
+    const after = tournamentEngine.getEvent({ eventId }).event;
+    const sharedId = teamTieFormatIds()[0];
+    const shared = after.tieFormats.find((tf: any) => tf.tieFormatId === sharedId);
+
+    expect(shared).toBeDefined();
+    expect(shared.collectionDefinitions.some((c: any) => c.collectionId === collectionId)).toBe(false);
+  });
+});

--- a/src/tests/mutations/tieFormat/tieFormatForkFragmentation.test.ts
+++ b/src/tests/mutations/tieFormat/tieFormatForkFragmentation.test.ts
@@ -119,6 +119,43 @@ describe('shared tieFormat does not fragment on removeCollectionDefinition', () 
     expect(result.error).toEqual(INSUFFICIENT_UUIDS);
   });
 
+  it('leaves NO orphaned entries, even after re-aggregating', () => {
+    // The fragmentation had a second-order cost. Pre-fix, the three identical
+    // copies survived as stored entries; re-running aggregation de-duplicated the
+    // REFERENCES to one id but left the other two stranded with no referent:
+    //
+    //   pre-fix:   after remove  stored 4 / orphans 0
+    //              re-aggregate  stored 4 / orphans 2
+    //   post-fix:  after remove  stored 2 / orphans 0
+    //              re-aggregate  stored 2 / orphans 0
+    //
+    // Measured both ways by checking out master's writeTieFormat alongside this
+    // fix. So orphan accumulation on this path was an ARTIFACT of the
+    // fragmentation, not an independent defect — which is why no
+    // `removeOrphanedTieFormats` call is added here. `resetTieFormat` remains its
+    // only production caller, and that stays correct.
+    const { event, eventId, drawId } = aggregatedTeamEvent();
+    const collectionId = event.tieFormats[0].collectionDefinitions[0].collectionId;
+
+    tournamentEngine.removeCollectionDefinition({ drawId, eventId, collectionId });
+    expect(tournamentEngine.aggregateTieFormats().success).toEqual(true);
+
+    const after = tournamentEngine.getEvent({ eventId }).event;
+    const referenced = new Set<string>();
+    if (after.tieFormatId) referenced.add(after.tieFormatId);
+    for (const dd of after.drawDefinitions ?? []) {
+      if (dd.tieFormatId) referenced.add(dd.tieFormatId);
+      for (const st of dd.structures ?? []) if (st.tieFormatId) referenced.add(st.tieFormatId);
+    }
+    for (const id of teamTieFormatIds()) if (id) referenced.add(id);
+
+    const orphans = (after.tieFormats ?? [])
+      .map((tf: any) => tf.tieFormatId)
+      .filter((id: string) => !referenced.has(id));
+
+    expect(orphans).toEqual([]);
+  });
+
   it('the removed collection is actually gone from the shared format', () => {
     // Guards against "de-duplicated" turning into "did not apply the edit".
     const { event, eventId, drawId } = aggregatedTeamEvent();

--- a/src/tests/mutations/tieFormat/tieFormatForkFragmentation.test.ts
+++ b/src/tests/mutations/tieFormat/tieFormatForkFragmentation.test.ts
@@ -156,6 +156,86 @@ describe('shared tieFormat does not fragment on removeCollectionDefinition', () 
     expect(orphans).toEqual([]);
   });
 
+  it('an insufficient pool leaves the record COMPLETELY untouched', () => {
+    // Reporting the error was not enough. processTargetMatchUp splices a
+    // matchUp's tieMatchUps BEFORE writing its tieFormat, so failing at the write
+    // left the splice behind — measured at [9,9,9,9,9,9,9] -> [6,9,9,9,9,9,9] on
+    // a drawSize-8 event, error returned and partial mutation persisted.
+    //
+    // `executionQueue({ rollbackOnError: true })` did restore it, and TMX always
+    // sends that, but a direct engine caller had no protection. The pool is now
+    // validated BEFORE anything is mutated, so the operation never starts when it
+    // cannot finish.
+    const { event, eventId, drawId } = aggregatedTeamEvent();
+    const collectionId = event.tieFormats[0].collectionDefinitions[0].collectionId;
+
+    const before = JSON.stringify({
+      formats: tournamentEngine.getEvent({ eventId }).event.tieFormats,
+      tieMatchUpCounts: tournamentEngine
+        .allTournamentMatchUps({ matchUpFilters: { matchUpTypes: [TEAM_MATCHUP] } })
+        .matchUps.map((m: any) => m.tieMatchUps?.length ?? 0),
+    });
+
+    const result: any = tournamentEngine.removeCollectionDefinition({
+      drawId,
+      eventId,
+      collectionId,
+      tieFormatUuids: [],
+    });
+
+    expect(result.error).toEqual(INSUFFICIENT_UUIDS);
+    expect(result.context).toEqual({ required: 1, supplied: 0 });
+
+    const after = JSON.stringify({
+      formats: tournamentEngine.getEvent({ eventId }).event.tieFormats,
+      tieMatchUpCounts: tournamentEngine
+        .allTournamentMatchUps({ matchUpFilters: { matchUpTypes: [TEAM_MATCHUP] } })
+        .matchUps.map((m: any) => m.tieMatchUps?.length ?? 0),
+    });
+
+    expect(after).toEqual(before);
+  });
+
+  it('the pre-flight requirement matches what the operation actually consumes', () => {
+    // The pre-flight is a separate calculation from the fork logic, so it can
+    // drift. This pins them together: whatever it demands is what a successful
+    // run spends.
+    const { event, eventId, drawId } = aggregatedTeamEvent();
+    const collectionId = event.tieFormats[0].collectionDefinitions[0].collectionId;
+
+    // One less than required must be rejected...
+    const short: any = tournamentEngine.removeCollectionDefinition({
+      drawId,
+      eventId,
+      collectionId,
+      tieFormatUuids: [],
+    });
+    expect(short.error).toEqual(INSUFFICIENT_UUIDS);
+    const required = short.context.required;
+
+    // ...and exactly the required number must succeed and be fully consumed.
+    const fresh = aggregatedTeamEvent();
+    const pool = Array.from({ length: required }, (_, i) => `tf-${i}`);
+    const ok: any = tournamentEngine.removeCollectionDefinition({
+      drawId: fresh.drawId,
+      eventId: fresh.eventId,
+      collectionId: fresh.event.tieFormats[0].collectionDefinitions[0].collectionId,
+      tieFormatUuids: pool,
+    });
+
+    expect(ok.error).toBeUndefined();
+    expect(pool).toHaveLength(0);
+
+    // NOT covered here: the `refCount > 1` filter inside `requiredForkIds`.
+    // Every target in this fixture shares ONE source tieFormatId, so removing the
+    // filter still yields 1 and this suite stays green — verified by
+    // falsification. The filter only matters where some target's format is
+    // already unshared, which needs a fixture with a structure- or
+    // drawDefinition-scoped format alongside the aggregated one. Over-counting is
+    // the SAFE direction (it rejects a pool that would just have sufficed), so
+    // this gap cannot cause partial application — only an unnecessary rejection.
+  });
+
   it('the removed collection is actually gone from the shared format', () => {
     // Guards against "de-duplicated" turning into "did not apply the edit".
     const { event, eventId, drawId } = aggregatedTeamEvent();

--- a/src/tests/mutations/tieFormat/tieFormatForkFragmentation.test.ts
+++ b/src/tests/mutations/tieFormat/tieFormatForkFragmentation.test.ts
@@ -226,14 +226,47 @@ describe('shared tieFormat does not fragment on removeCollectionDefinition', () 
     expect(ok.error).toBeUndefined();
     expect(pool).toHaveLength(0);
 
-    // NOT covered here: the `refCount > 1` filter inside `requiredForkIds`.
-    // Every target in this fixture shares ONE source tieFormatId, so removing the
-    // filter still yields 1 and this suite stays green — verified by
-    // falsification. The filter only matters where some target's format is
-    // already unshared, which needs a fixture with a structure- or
-    // drawDefinition-scoped format alongside the aggregated one. Over-counting is
-    // the SAFE direction (it rejects a pool that would just have sufficed), so
-    // this gap cannot cause partial application — only an unnecessary rejection.
+    // The `refCount > 1` filter is covered by the mixed-refCount test below.
+    void 0;
+  });
+
+  it('does not over-require when a target format is UNSHARED (refCount filter)', () => {
+    // Closes the gap the earlier version of this file recorded as uncovered.
+    //
+    // One matchUp is given its OWN tieFormat entry, so its refCount is 1 and it
+    // takes the in-place branch without minting. The other two still share the
+    // aggregated format and fork once between them.
+    //
+    //   with the refCount filter   → requires 1
+    //   without it                 → requires 2 (counts the unshared id too)
+    //
+    // Supplying exactly 1 therefore passes only while the filter is honoured.
+    // Without it the operation is rejected for a pool that was sufficient.
+    const { eventId } = aggregatedTeamEvent();
+
+    const { tournamentRecord } = tournamentEngine.getTournament();
+    const event = tournamentRecord.events.find((e: any) => e.eventId === eventId);
+    const structure = event.drawDefinitions[0].structures[0];
+    const teamMatchUps = structure.matchUps.filter((m: any) => m.tieMatchUps);
+    expect(teamMatchUps.length).toBeGreaterThan(1);
+
+    const privateFormat = JSON.parse(JSON.stringify(event.tieFormats[0]));
+    privateFormat.tieFormatId = 'private-tf';
+    event.tieFormats.push(privateFormat);
+    teamMatchUps[0].tieFormatId = 'private-tf';
+    tournamentEngine.setState(tournamentRecord);
+
+    const refreshed = tournamentEngine.getEvent({ eventId }).event;
+    const collectionId = refreshed.tieFormats[0].collectionDefinitions[0].collectionId;
+
+    const result: any = tournamentEngine.removeCollectionDefinition({
+      drawId: refreshed.drawDefinitions[0].drawId,
+      eventId,
+      collectionId,
+      tieFormatUuids: ['just-one'],
+    });
+
+    expect(result.error).toBeUndefined();
   });
 
   it('the removed collection is actually gone from the shared format', () => {

--- a/src/tests/mutations/tieFormat/tieFormatUuidPoolThreading.test.ts
+++ b/src/tests/mutations/tieFormat/tieFormatUuidPoolThreading.test.ts
@@ -118,4 +118,16 @@ describe('removeCollectionDefinition — tieFormatUuids threading', () => {
  * `writeTieFormatUuidPool.test.ts`: pool consumed, exhaustion errors, absent
  * pool mints, and the `refCount === 1` in-place branch that makes the above
  * unreachable is pinned as behaviour.
+ *
+ * ADDENDUM 2026-08-15 — fork MULTIPLICITY changed under this note.
+ *
+ * The single reachable site above used to fork once per TEAM matchUp, so a
+ * drawSize-4 event consumed THREE ids and fragmented one shared tieFormat into
+ * four. That was a defect, not a design: every matchUp was being written with
+ * identical content. It is fixed by a per-operation `forkCache`
+ * (`tieFormatForkFragmentation.test.ts`), and the operation now forks ONCE and
+ * consumes ONE id.
+ *
+ * Everything this note says about WHICH sites are reachable is unchanged — still
+ * exactly the `processTargetMatchUp` path. Only how many times it fires changed.
  */


### PR DESCRIPTION
Found while answering CA's question about why a single `removeCollectionDefinition` consumed **three** pool ids. It should not have.

## The defect

`removeCollectionDefinition` on an aggregated event rewrites every TEAM matchUp with the **same** pruned tieFormat. Each write hit `writeTieFormat`'s copy-on-write fork independently, so one shared centralized format became one byte-identical copy per matchUp:

```
drawSize 4  →  3 TEAM matchUps  →  event.tieFormats  1 → 4   (3 identical)
```

That is exactly what `aggregateTieFormats()` exists to prevent, and it is **unbounded** — every subsequent scorecard edit fragments again. Re-running aggregation re-points the references to a single id but **leaves the orphans behind**, because `removeOrphanedTieFormats` is only wired into `resetTieFormat`.

## The fix

A per-operation `forkCache` keyed by the **source** `tieFormatId`: the first fork mints, and any later target forking from the same source joins it. Content is compared before reuse, so two targets sharing a source id but written with *different* formats still fork separately.

| | before | after |
|---|---|---|
| ids consumed | 3 | **1** |
| `event.tieFormats` | 1 → 4 | 1 → **2** |
| distinct matchUp `tieFormatId`s | 3 | **1** |

Copy-on-write semantics are unchanged — the matchUps still diverge from the format the event references. They now diverge *together*, which is what the edit actually expressed.

## Coordination with the parallel session (#4625)

Their correction **is applied**: my claim that a part-way pool failure demonstrated main-chain coverage was wrong. All the forks were `processTargetMatchUp`, which they verified by instrumenting the fork across the full suite. Their coverage note on master is preserved verbatim, with an addendum recording that only fork **multiplicity** changed — which sites are reachable did not.

**Their request to keep the part-way test is not carried forward, and I think that is right.** Its premise *was* the defect: two ids for three forks expecting `INSUFFICIENT_UUIDS`. After this fix there is one fork per operation, so a two-id pool succeeds. What it was protecting is still covered:

- an **empty** pool still errors — strictness survives
- a **single-id** pool is now sufficient where it previously was not — the behaviour change is pinned explicitly rather than left implicit

## Verification

lint **0**, check-types **0**, `verify:generated` in sync (658 engine methods), **1061 files / 10922 tests**.

All three fork-cache guards falsified individually — ignoring the cache, giving each call its own cache, and populating the cache never — each fails the suite.

Full suite passing before and after confirms nothing depended on the fragmented behaviour.