### PR TITLE
fix(types): declare Extension.createdAt, which runtime has always written

### DIFF
--- a/src/mutate/extensions/addExtension.ts
+++ b/src/mutate/extensions/addExtension.ts
@@ -56,17 +56,7 @@ export function addExtension(params?: AddExtensionArgs): {
     // Honour a `createdAt` already on the caller's extension rather than
     // stamping over it — same convention as `addTimeItem`. Inert when nothing is
     // supplied; `creationTime: false` still means "add no createdAt at all".
-    //
-    // The cast is deliberate and temporary. `Extension` does not DECLARE
-    // `createdAt`, even though this function has always written one — the
-    // previous `Object.assign(extension, { createdAt })` simply bypassed the
-    // checker, so the type has been out of sync with runtime for as long as the
-    // field has existed. The correct fix is `createdAt?: Date | string` on
-    // `Extension` (mirroring `TimeItem`), but `src/types/tournamentTypes.ts` is
-    // held by an active in-flight claim
-    // (`codes-participant-other-ids-and-event-origin-stamp`), so the type
-    // addition is deferred rather than colliding with it.
-    (params.extension as any).createdAt ??= new Date().toISOString();
+    params.extension.createdAt ??= new Date().toISOString();
   }
 
   const existingExtension = params.element.extensions.find(({ name }) => name === params.extension.name);

--- a/src/tests/mutations/timeItems/occurredAtCoverage.test.ts
+++ b/src/tests/mutations/timeItems/occurredAtCoverage.test.ts
@@ -192,7 +192,8 @@ describe('addDrawDefinitionTimeItem — supplied createdAt', () => {
 describe('addExtension — supplied createdAt', () => {
   it('honours a createdAt on the caller extension, and stamps when absent', () => {
     const supplied: any = { extensions: [] };
-    addExtension({ element: supplied, extension: { name: 'x', value: 1, createdAt: OCCURRED } as any });
+    // no cast — `Extension` now declares `createdAt`, which is the point of the type fix
+    addExtension({ element: supplied, extension: { name: 'x', value: 1, createdAt: OCCURRED } });
     expect(supplied.extensions.at(-1).createdAt).toEqual(OCCURRED);
 
     const defaulted: any = { extensions: [] };

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -189,6 +189,11 @@ export enum BallTypeEnum {
 export type BallTypeUnion = `${BallTypeEnum}`;
 
 export interface Extension {
+  // Written by `addExtension` whenever `creationTime` is not disabled, and honoured when
+  // the caller supplies one. Declared here to match runtime: the field has always been
+  // written, but an `Object.assign` bypassed the checker, so the type was silently out of
+  // sync for as long as the field existed. Mirrors {@link TimeItem}.
+  createdAt?: Date | string;
   description?: string;
   name: string;
   value: any;


### PR DESCRIPTION
Closes the deferral #4621 documented in its own comment.

## The gap

`addExtension` has **always** stamped `createdAt`. The old `Object.assign(extension, { createdAt })` bypassed the type checker, so `Extension` never declared the field and the type has been out of sync with runtime for as long as the field existed.

#4621 replaced the assign with a direct write, which surfaced the gap — and had to carry a cast:

```ts
// ...but `src/types/tournamentTypes.ts` is held by an active in-flight claim
// (`codes-participant-other-ids-and-event-origin-stamp`), so the type addition is deferred
(params.extension as any).createdAt ??= new Date().toISOString();
```

That claim is archived, so the deferral is over.

## What changed

- `createdAt?: Date | string` on `Extension`, mirroring its sibling `TimeItem`.
- The cast dropped from `addExtension`.
- The cast dropped from `occurredAtCoverage.test.ts`, which constructed an extension carrying a `createdAt` and needed `as any` for exactly this reason. Removing it is the visible proof the declaration works — no assertion changed.

## Falsified

Removing the declaration reproduces the error at the call site, so the declaration is doing the work the cast used to:

```
src/mutate/extensions/addExtension.ts(59,22): error TS2339:
  Property 'createdAt' does not exist on type 'Extension'.
```

## Verification

lint 0, check-types 0, `verify:generated` in sync, prettier clean, full suite **10917** passing.

Coordination note: the other factory session's worktree is confined to `src/mutate/tieFormat/**`, so this does not collide with `fix/tieformat-fork-fragmentation`.