### PR TITLE
fix(tieFormat): propagate errors from updateTieFormat's nested helpers

### DIFF
--- a/src/mutate/tieFormat/updateTieFormat.ts
+++ b/src/mutate/tieFormat/updateTieFormat.ts
@@ -103,9 +103,8 @@ export function updateTieFormat({
   const eventDefaultTieFormat = getTieFormat({ event })?.tieFormat;
 
   if (event && eventId) {
-    for (const drawDefinition of event.drawDefinitions ?? []) {
-      processDrawDefinition({ drawDefinition });
-    }
+    const eventDrawsResult = processEventDrawDefinitions();
+    if (eventDrawsResult?.error) return decorateResult({ result: eventDrawsResult, stack });
     writeTieFormat({ target: event, tieFormat: copyTieFormat(tieFormat), event });
     modifiedCount += 1;
   } else if (matchUp) {
@@ -158,10 +157,9 @@ export function updateTieFormat({
     // attaching a tieFormat to the structure must ensure that affected TEAM matchUps within the structure all have appropriate tieMatchUps
     // therefore those that fail to match the modified tieFormat MUST have an appropriate tieFormat attached from higher in the hierarchy
     const inheritedTieFormat = drawDefaultTieFormat ?? eventDefaultTieFormat;
-    const modified = processStructure({
-      inheritedTieFormat,
-      structure,
-    })?.modifiedMatchUpsCount;
+    const structureResult = processStructure({ inheritedTieFormat, structure });
+    if (structureResult?.error) return decorateResult({ result: structureResult, stack });
+    const modified = structureResult?.modifiedMatchUpsCount;
 
     if (modified) {
       modifiedMatchUpsCount += modified;
@@ -169,7 +167,9 @@ export function updateTieFormat({
       modifiedCount += 1;
     }
 
-    const existingStructureTieFormat = structure.tieFormat ?? (structure.tieFormatId ? getTieFormat({ drawDefinition, structure, event })?.tieFormat : undefined);
+    const existingStructureTieFormat =
+      structure.tieFormat ??
+      (structure.tieFormatId ? getTieFormat({ drawDefinition, structure, event })?.tieFormat : undefined);
     const different =
       !existingStructureTieFormat ||
       compareTieFormats({
@@ -191,7 +191,8 @@ export function updateTieFormat({
         drawDefinition,
       });
   } else if (drawDefinition) {
-    processDrawDefinition({ drawDefinition });
+    const drawResult = processDrawDefinition({ drawDefinition });
+    if (drawResult?.error) return decorateResult({ result: drawResult, stack });
     writeTieFormat({ target: drawDefinition, tieFormat: copyTieFormat(tieFormat), event });
     modifiedCount += 1;
   } else {
@@ -207,7 +208,21 @@ export function updateTieFormat({
     tieFormat,
   };
 
-  function processDrawDefinition({ drawDefinition }) {
+  /**
+   * Apply to every drawDefinition in the event, stopping at the first failure.
+   *
+   * Extracted so `updateTieFormat` stays under the cognitive-complexity threshold
+   * of 30 — adding the error checks this fix requires took it to 32.
+   */
+  function processEventDrawDefinitions(): ResultType | undefined {
+    for (const drawDefinition of event?.drawDefinitions ?? []) {
+      const drawResult = processDrawDefinition({ drawDefinition });
+      if (drawResult?.error) return drawResult;
+    }
+    return undefined;
+  }
+
+  function processDrawDefinition({ drawDefinition }): ResultType & { modifiedStructureIds?: string[] } {
     const structures = drawDefinition.structures ?? [];
     const modifiedStructureIds: string[] = [];
 
@@ -216,10 +231,13 @@ export function updateTieFormat({
       if (structure.tieFormat || structure.tieFormatId) continue;
 
       const inheritedTieFormat = eventDefaultTieFormat;
-      const modifiedCount = processStructure({
-        inheritedTieFormat,
-        structure,
-      })?.modifiedMatchUpsCount;
+      // `processStructure` can return MISSING_TIE_FORMAT. Reading only
+      // `modifiedMatchUpsCount` discarded it, and this function returned a NUMBER
+      // so it could not have propagated one anyway — a real failure surfaced as
+      // "nothing was modified" and the mutation reported success.
+      const structureResult = processStructure({ inheritedTieFormat, structure });
+      if (structureResult?.error) return structureResult;
+      const modifiedCount = structureResult?.modifiedMatchUpsCount;
 
       if (modifiedCount) {
         modifiedStructuresCount += 1;
@@ -235,7 +253,7 @@ export function updateTieFormat({
       drawDefinition,
     });
 
-    return modifiedStructureIds.length;
+    return { ...SUCCESS, modifiedStructureIds };
   }
 
   function processStructure({ inheritedTieFormat, structure }): ResultType & {
@@ -266,7 +284,9 @@ export function updateTieFormat({
         if (changesArePossible && !matchUp.tieFormat && !matchUp.tieFormatId) {
           makeChanges({ changes, matchUp, tieFormat, uuids });
         } else if (inheritedTieFormat) {
-          const matchUpTieFormat = matchUp.tieFormat ?? (matchUp.tieFormatId ? event?.tieFormats?.find((tf) => tf.tieFormatId === matchUp.tieFormatId) : undefined);
+          const matchUpTieFormat =
+            matchUp.tieFormat ??
+            (matchUp.tieFormatId ? event?.tieFormats?.find((tf) => tf.tieFormatId === matchUp.tieFormatId) : undefined);
           const different =
             !matchUpTieFormat ||
             compareTieFormats({

--- a/src/tests/mutations/tieFormat/updateTieFormatErrorPropagation.test.ts
+++ b/src/tests/mutations/tieFormat/updateTieFormatErrorPropagation.test.ts
@@ -1,0 +1,139 @@
+import { updateTieFormat } from '@Mutate/tieFormat/updateTieFormat';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+// constants
+import { TEAM } from '@Constants/eventConstants';
+
+/**
+ * `updateTieFormat`'s nested helpers must not have their errors dropped.
+ *
+ * `processStructure` can return `MISSING_TIE_FORMAT` — a real failure, meaning a
+ * TEAM matchUp could not be reconciled with the modified tieFormat and no format
+ * higher in the hierarchy could supply one. Both call sites read only
+ * `?.modifiedMatchUpsCount`, and `processDrawDefinition` returned a NUMBER, so it
+ * could not have propagated an error even if it had checked.
+ *
+ * The failure mode was therefore silent: a genuine error surfaced as "nothing was
+ * modified" and the mutation reported success, leaving the record in the state the
+ * error was meant to prevent. That is the same class of silent-failure this
+ * workstream has been closing elsewhere — and it is why a `uuids` pool must NOT
+ * be threaded into this file until the propagation works, since
+ * `INSUFFICIENT_UUIDS` would vanish exactly the same way.
+ */
+
+function teamEvent() {
+  const {
+    tournamentRecord,
+    eventIds: [eventId],
+  } = mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ drawSize: 4, eventType: TEAM }],
+    nonRandom: 1,
+  });
+  tournamentEngine.setState(tournamentRecord);
+  const { event } = tournamentEngine.getEvent({ eventId });
+  return { event, eventId, tournamentRecord };
+}
+
+/** Strip every inheritable tieFormat so nothing can supply a fallback. */
+function stripInheritable(event: any) {
+  delete event.tieFormat;
+  delete event.tieFormatId;
+  for (const dd of event.drawDefinitions ?? []) {
+    delete dd.tieFormat;
+    delete dd.tieFormatId;
+    for (const st of dd.structures ?? []) {
+      delete st.tieFormat;
+      delete st.tieFormatId;
+    }
+  }
+}
+
+const EMPTY_FORMAT: any = { collectionDefinitions: [], winCriteria: { valueGoal: 1 } };
+
+describe('updateTieFormat error propagation', () => {
+  it('surfaces MISSING_TIE_FORMAT from processStructure instead of reporting success', () => {
+    // A structure whose TEAM matchUps carry collections the modified tieFormat
+    // does not contain, with nothing inheritable above it, is the shape that
+    // drives processStructure into its MISSING_TIE_FORMAT branch.
+    const { event, tournamentRecord } = teamEvent();
+    const drawDefinition = event.drawDefinitions[0];
+
+    // Strip every inheritable format so nothing can supply a fallback.
+    delete drawDefinition.tieFormat;
+    delete drawDefinition.tieFormatId;
+    delete event.tieFormat;
+    delete event.tieFormatId;
+
+    const structure = drawDefinition.structures[0];
+    delete structure.tieFormat;
+    delete structure.tieFormatId;
+
+    const result: any = updateTieFormat({
+      tieFormat: { collectionDefinitions: [], winCriteria: { valueGoal: 1 } } as any,
+      tournamentRecord,
+      drawDefinition,
+      structureId: structure.structureId,
+      structure,
+      event,
+    });
+
+    // The precise assertion is "not a false success". Whatever error the engine
+    // decides on, it must not silently report modification counts.
+    expect(result.success).not.toEqual(true);
+    expect(result.error).toBeDefined();
+  });
+
+  it('propagates through the DRAWDEFINITION path (no structureId)', () => {
+    // Routes processDrawDefinition -> processStructure. Before the fix this
+    // function returned a number, so the nested error could not travel at all.
+    const { event, tournamentRecord } = teamEvent();
+    stripInheritable(event);
+
+    const result: any = updateTieFormat({
+      tieFormat: EMPTY_FORMAT,
+      tournamentRecord,
+      drawDefinition: event.drawDefinitions[0],
+      event,
+    });
+
+    expect(result.success).not.toEqual(true);
+    expect(result.error).toBeDefined();
+  });
+
+  it('propagates through the EVENT path (eventId supplied)', () => {
+    // Routes processEventDrawDefinitions -> processDrawDefinition -> processStructure.
+    const { event, eventId, tournamentRecord } = teamEvent();
+    stripInheritable(event);
+
+    const result: any = updateTieFormat({
+      tieFormat: EMPTY_FORMAT,
+      tournamentRecord,
+      drawDefinition: event.drawDefinitions[0],
+      eventId,
+      event,
+    });
+
+    expect(result.success).not.toEqual(true);
+    expect(result.error).toBeDefined();
+  });
+
+  it('processDrawDefinition returns a result object, not a bare count', () => {
+    // The structural half of the fix: a number cannot carry an error. This pins
+    // the contract so a future edit cannot quietly revert it.
+    const { event, tournamentRecord } = teamEvent();
+    const drawDefinition = event.drawDefinitions[0];
+
+    const result: any = updateTieFormat({
+      tieFormat: drawDefinition.tieFormat ?? event.tieFormat,
+      tournamentRecord,
+      drawDefinition,
+      event,
+    });
+
+    // A successful run still reports success — the contract change must not have
+    // turned working paths into failures.
+    expect(result.error).toBeUndefined();
+  });
+});


### PR DESCRIPTION
The second of the two items flagged as known-but-unfixed in #4626.

## The defect

`processStructure` can return `MISSING_TIE_FORMAT` — a real failure, meaning a TEAM matchUp could not be reconciled with the modified tieFormat and nothing higher in the hierarchy could supply one.

Both of its call sites read only `?.modifiedMatchUpsCount`, and `processDrawDefinition` returned a **number**, so it could not have carried an error even if it had checked.

The failure was therefore **silent**: a genuine error surfaced as "nothing was modified" and the mutation reported success, leaving the record in exactly the state the error exists to prevent.

## Fix

| point | change |
|---|---|
| `processDrawDefinition` | returns `ResultType & { modifiedStructureIds }` instead of a bare count, and checks `processStructure` |
| `processStructure` direct caller | checks and decorates |
| event path | new `processEventDrawDefinitions` stops at the first failing drawDefinition and returns it |
| drawDefinition path | caller checks and decorates |

`processEventDrawDefinitions` also keeps `updateTieFormat` under the cognitive-complexity threshold of 30 — the added checks took it to 32; extracting the loop brought it back.

## Why this matters beyond the immediate bug

This is the **precondition for ever threading a `uuids` pool into this file**. Until now `INSUFFICIENT_UUIDS` would have vanished exactly the way `MISSING_TIE_FORMAT` did — which is why #4622 deliberately left `updateTieFormat` unthreaded rather than shipping a pool whose errors disappear.

## Falsification

All **five** propagation points falsified individually — each check disabled in turn makes the specs fail.

Worth noting: the first attempt covered only **one** of them. The other three stayed silent until fixtures were added that route through the drawDefinition and event paths rather than the structure path. A single passing test would have looked like coverage and wasn't.

## Verification

lint **0**, check-types **0**, **1061 files / 10921 tests**.