### PR TITLE
feat(notifications): carry event identity on the notice envelope

### DIFF
--- a/src/forge/topicTypes.ts
+++ b/src/forge/topicTypes.ts
@@ -21,6 +21,28 @@
 import type { MatchUp, Event, DrawDefinition, Tournament } from '@Types/tournamentTypes';
 
 // ============================================================================
+// Identity envelope
+// ============================================================================
+
+/**
+ * The identity a subscriber needs to route a change WITHOUT resolving the entity it describes.
+ *
+ * Topics touching events / draws / structures / matchUps carry as much of this as applies, on the
+ * payload itself rather than only nested inside `event`, `matchUp` or `eventData`. That distinction is
+ * what lets a subscriber drive cache eviction and data fan-out from the notice alone — see
+ * `Mentat/planning/FACTORY_NOTICE_IDENTITY_AUDIT.md`.
+ *
+ * Fields are optional because scope genuinely differs: a venue change has no `eventId`, and forcing one
+ * would invent precision that does not exist.
+ */
+export interface NoticeIdentity {
+  tournamentId?: string;
+  eventId?: string;
+  drawId?: string;
+  structureId?: string;
+}
+
+// ============================================================================
 // Per-topic payload shapes
 // ============================================================================
 
@@ -53,9 +75,11 @@ export interface AddMatchUpsPayload {
   matchUps: MatchUp[];
 }
 
-export interface ModifyMatchUpPayload {
+export interface ModifyMatchUpPayload extends NoticeIdentity {
   tournamentId: string;
   matchUp: MatchUp;
+  /** `drawDefinition` is optional at the emit site, so this is best-effort. */
+  drawId?: string;
   context?: { [key: string]: any };
 }
 
@@ -82,13 +106,55 @@ export interface DeleteParticipantsPayload {
   participantIds: string[];
 }
 
-export interface PublishEventPayload {
+export interface PublishEventPayload extends NoticeIdentity {
   tournamentId: string;
+  /** On the envelope, not only inside `eventData.eventInfo` — a subscriber needing just the id
+   *  should not have to reach through the payload for it. */
+  eventId?: string;
   eventData: any;
 }
 
 export interface ModifyTournamentDetailPayload {
   tournamentRecord: Tournament;
+}
+
+export interface ModifyPositionAssignmentsPayload extends NoticeIdentity {
+  tournamentId: string;
+  eventId: string;
+  drawId: string;
+  structureId: string;
+  positionAssignments: any[];
+}
+
+export interface ModifySeedAssignmentsPayload extends NoticeIdentity {
+  tournamentId: string;
+  eventId: string;
+  drawId: string;
+  structureId: string;
+  seedAssignments: any[];
+}
+
+export interface ModifyDrawEntriesPayload extends NoticeIdentity {
+  tournamentId: string;
+  eventId: string;
+  drawId: string;
+  drawEntries: any[];
+}
+
+export interface ModifyEventEntriesPayload extends NoticeIdentity {
+  tournamentId: string;
+  eventId: string;
+  entries: any[];
+}
+
+export interface UnPublishEventPayload extends NoticeIdentity {
+  tournamentId: string;
+  eventId: string;
+}
+
+export interface ModifyEventPayload {
+  tournamentId: string;
+  event: Event;
 }
 
 // ============================================================================
@@ -121,6 +187,12 @@ export interface TopicPayloadMap {
   modifyParticipants: ModifyParticipantsPayload;
   deleteParticipants: DeleteParticipantsPayload;
   publishEvent: PublishEventPayload;
+  unPublishEvent: UnPublishEventPayload;
+  modifyEvent: ModifyEventPayload;
+  modifyPositionAssignments: ModifyPositionAssignmentsPayload;
+  modifySeedAssignments: ModifySeedAssignmentsPayload;
+  modifyDrawEntries: ModifyDrawEntriesPayload;
+  modifyEventEntries: ModifyEventEntriesPayload;
   modifyTournamentDetail: ModifyTournamentDetailPayload;
 
   // Catch-all for un-typed topics — keeps the bus typeable without forcing

--- a/src/mutate/notifications/drawNotifications.ts
+++ b/src/mutate/notifications/drawNotifications.ts
@@ -145,7 +145,17 @@ export function modifyMatchUpNotice({
   stampMatchUpUpdatedAt(matchUp);
   addNotice({
     topic: MODIFY_MATCHUP,
-    payload: { matchUp, tournamentId, context },
+    // eventId/drawId/structureId ride the ENVELOPE, not just the entity. A subscriber that only needs
+    // to know WHICH event changed — cache eviction, fan-out routing — should not have to resolve the
+    // matchUp to find out. `drawDefinition` is optional here, so drawId is best-effort.
+    payload: {
+      matchUp,
+      tournamentId,
+      eventId,
+      drawId: drawDefinition?.drawId ?? (matchUp as any)?.drawId,
+      structureId,
+      context,
+    },
     key: matchUp.matchUpId,
   });
 

--- a/src/mutate/publishing/publishEvent.ts
+++ b/src/mutate/publishing/publishEvent.ts
@@ -100,7 +100,14 @@ export function publishEvent(params: PublishEventType): ResultType & { eventData
 
   const drawDetails = buildExistingDrawDetails({ pubStatus, eventDrawIds });
 
-  applyDrawIdPublishState({ drawDetails, eventDrawIds, drawIdsToValidate, drawIdsToRemove, drawIdsToAdd, specifiedDrawIds });
+  applyDrawIdPublishState({
+    drawDetails,
+    eventDrawIds,
+    drawIdsToValidate,
+    drawIdsToRemove,
+    drawIdsToAdd,
+    specifiedDrawIds,
+  });
 
   for (const drawId of eventDrawIds) {
     if (params.drawDetails?.[drawId]) {
@@ -133,7 +140,11 @@ export function publishEvent(params: PublishEventType): ResultType & { eventData
 
   if (notify)
     addNotice({
-      payload: { eventData, tournamentId: tournamentRecord.tournamentId },
+      // eventId is carried on the envelope, NOT only inside eventData.eventInfo. Consumers that need
+      // just the id (cache eviction, fan-out routing) previously had to reach through the whole
+      // payload for it — which is what keeps `eventData` mandatory. See
+      // Mentat/planning/FACTORY_NOTICE_IDENTITY_AUDIT.md.
+      payload: { eventData, eventId: event?.eventId, tournamentId: tournamentRecord.tournamentId },
       topic: PUBLISH_EVENT,
     });
 
@@ -207,7 +218,14 @@ function buildExistingDrawDetails({ pubStatus, eventDrawIds }) {
     }, {});
 }
 
-function applyDrawIdPublishState({ drawDetails, eventDrawIds, drawIdsToValidate, drawIdsToRemove, drawIdsToAdd, specifiedDrawIds }) {
+function applyDrawIdPublishState({
+  drawDetails,
+  eventDrawIds,
+  drawIdsToValidate,
+  drawIdsToRemove,
+  drawIdsToAdd,
+  specifiedDrawIds,
+}) {
   for (const drawId of eventDrawIds) {
     if (!drawIdsToValidate.length || drawIdsToValidate.includes(drawId)) {
       if (drawIdsToRemove?.includes(drawId) || (specifiedDrawIds?.length && !specifiedDrawIds.includes(drawId))) {
@@ -246,7 +264,14 @@ function mergeDrawDetail({ drawDetails, drawId, newDetail, event }) {
   };
 
   if (structureIdsToAdd.length || structureIdsToRemove.length) {
-    const result = applyStructureChanges({ drawDetails, drawId, structureIdsToAdd, structureIdsToRemove, structureDetails, event });
+    const result = applyStructureChanges({
+      drawDetails,
+      drawId,
+      structureIdsToAdd,
+      structureIdsToRemove,
+      structureDetails,
+      event,
+    });
     if (result?.error) return result;
   }
 
@@ -263,14 +288,19 @@ function mergeDrawDetail({ drawDetails, drawId, newDetail, event }) {
   return undefined;
 }
 
-function applyStructureChanges({ drawDetails, drawId, structureIdsToAdd, structureIdsToRemove, structureDetails, event }) {
+function applyStructureChanges({
+  drawDetails,
+  drawId,
+  structureIdsToAdd,
+  structureIdsToRemove,
+  structureDetails,
+  event,
+}) {
   const drawStructureIds = (
     event?.drawDefinitions?.find((drawDefinition) => drawDefinition.drawId === drawId)?.structures ?? []
   ).map(({ structureId }) => structureId);
   const structureIdsToValidate = (structureIdsToAdd ?? []).concat(structureIdsToRemove ?? []);
-  const invalidStructureIds = structureIdsToValidate.filter(
-    (structureId) => !drawStructureIds.includes(structureId),
-  );
+  const invalidStructureIds = structureIdsToValidate.filter((structureId) => !drawStructureIds.includes(structureId));
   if (invalidStructureIds.length) {
     return decorateResult({
       result: { error: STRUCTURE_NOT_FOUND },

--- a/src/tests/mutations/notifications/noticeIdentity.test.ts
+++ b/src/tests/mutations/notifications/noticeIdentity.test.ts
@@ -1,0 +1,95 @@
+import { setSubscriptions } from '@Global/state/globalState';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { expect, it, describe } from 'vitest';
+
+// constants and types
+import { MODIFY_MATCHUP, PUBLISH_EVENT } from '@Constants/topicConstants';
+import * as topicConstants from '@Constants/topicConstants';
+import { SINGLE_ELIMINATION } from '@Constants/drawDefinitionConstants';
+
+/**
+ * Notices must carry enough identity on the ENVELOPE for a subscriber to route a change without
+ * resolving the entity it describes — cache eviction, data fan-out. See
+ * Mentat/planning/FACTORY_NOTICE_IDENTITY_AUDIT.md.
+ */
+describe('notice identity envelope', () => {
+  it('MODIFY_MATCHUP carries eventId and drawId, not only the matchUp', () => {
+    const notices: any[] = [];
+    setSubscriptions({ subscriptions: { [MODIFY_MATCHUP]: (n: any[]) => notices.push(...n) } });
+
+    const {
+      drawIds: [drawId],
+      eventIds: [eventId],
+    } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 8, drawType: SINGLE_ELIMINATION }],
+      participantsProfile: { nonRandom: 1 },
+      setState: true,
+    });
+
+    const { outcome } = mocksEngine.generateOutcomeFromScoreString({
+      scoreString: '6-4 6-2',
+      matchUpStatus: 'COMPLETED',
+      winningSide: 1,
+    });
+    const { matchUps } = tournamentEngine.allTournamentMatchUps();
+    const target = matchUps.find(
+      (m: any) => !m.winningSide && (m.sides ?? []).filter((s: any) => s?.participantId).length === 2,
+    );
+    const result: any = tournamentEngine.setMatchUpStatus({ matchUpId: target.matchUpId, drawId, outcome });
+    expect(result.success).toEqual(true);
+
+    expect(notices.length).toBeGreaterThan(0);
+    // Previously the payload was only { matchUp, tournamentId, context } — a consumer wanting the
+    // event had to resolve the matchUp, or ride a sibling topic.
+    const payload = notices[0];
+    expect(payload.eventId).toEqual(eventId);
+    expect(payload.drawId).toEqual(drawId);
+    expect(payload.tournamentId).toBeDefined();
+    // additive: the entity is still there
+    expect(payload.matchUp?.matchUpId).toEqual(target.matchUpId);
+
+    setSubscriptions({ subscriptions: {} });
+  });
+
+  it('PUBLISH_EVENT carries eventId on the envelope, not only inside eventData', () => {
+    const notices: any[] = [];
+    setSubscriptions({ subscriptions: { [PUBLISH_EVENT]: (n: any[]) => notices.push(...n) } });
+
+    const {
+      eventIds: [eventId],
+    } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 8, drawType: SINGLE_ELIMINATION }],
+      participantsProfile: { nonRandom: 1 },
+      setState: true,
+    });
+
+    const result: any = tournamentEngine.publishEvent({ eventId });
+    expect(result.success).toEqual(true);
+
+    expect(notices.length).toBeGreaterThan(0);
+    // The whole point: a subscriber that needs only the id must not have to reach through eventData,
+    // which is what keeps the (expensive) eventData build mandatory.
+    expect(notices[0].eventId).toEqual(eventId);
+    expect(notices[0].tournamentId).toBeDefined();
+
+    setSubscriptions({ subscriptions: {} });
+  });
+
+  it('every precisely-typed TopicPayloadMap key is a real topic constant', async () => {
+    // Guards the drift the map is most exposed to: its keys are hand-written strings that must match
+    // topicConstants exactly. A renamed or mistyped key silently types nothing and never fires.
+    const topicValues = new Set(Object.values(topicConstants).filter((v) => typeof v === 'string'));
+
+    // Read the map's declared keys from source — the type itself is erased at runtime.
+    const fs = await import('fs');
+    const path = await import('path');
+    const src = fs.readFileSync(path.resolve(__dirname, '../../../forge/topicTypes.ts'), 'utf8');
+    const body = src.slice(src.indexOf('export interface TopicPayloadMap'));
+    const keys = [...body.matchAll(/^\s{2}(\w+):\s/gm)].map((m) => m[1]);
+
+    expect(keys.length).toBeGreaterThan(10);
+    const unknown = keys.filter((k) => !topicValues.has(k));
+    expect({ unknown }).toEqual({ unknown: [] });
+  });
+});


### PR DESCRIPTION
Items **1–3** of the [notice-identity audit](https://github.com/CourtHive/Mentat/blob/main/planning/FACTORY_NOTICE_IDENTITY_AUDIT.md). **Additive only** — nothing existing changes shape.

## Why

A mechanical audit of all 72 non-test `addNotice` call sites found identity is carried three different ways: scalar ids, buried inside a nested entity, or absent. Two cases cost something concrete.

**`MODIFY_MATCHUP`** — `modifyMatchUpNotice` already *receives* `eventId` and threads it into `modifyDrawNotice`, then omits it from its own payload. That is why CFS's per-event cache eviction for a **score** has to ride `MODIFY_DRAW_DEFINITION` rather than the topic that actually describes the change.

**`PUBLISH_EVENT`** — an event-scoped topic whose only route to the id was `eventData.eventInfo.eventId`. A consumer needing just the id had to reach through the entire payload, which is exactly what keeps the expensive `eventData` build mandatory. **This is the prerequisite for making `eventData` lazy or opt-in** — the 92 ms item.

## Changes

- `MODIFY_MATCHUP` gains `eventId`, `drawId`, `structureId`
- `PUBLISH_EVENT` gains `eventId`
- `TopicPayloadMap` gains a documented `NoticeIdentity` envelope + six more precisely-typed topics
- **New drift guard**: every precisely-typed map key must be a real topic constant

Topics that are tournament-scoped by nature — venues, tournament detail, participants — are deliberately left without an `eventId` rather than given invented precision.

## On the map's fragility

`TopicPayloadMap` keys are hand-written strings that must match `topicConstants` exactly; a typo silently types nothing and never fires. The new guard catches that by name. The broader item — generating/verifying the map against real call sites — is tracked separately and has been raised in priority.

## Verification

- lint 0, types 0, `verify:generated` OK
- full suite **10,940 tests**
- **all three guards falsified**: reverting each payload fails its test, and typo-ing a map key produces `unknown: ['modifySeedAssignmnts']`

## Release note

Intended to ride the **same factory release as #4629** (`drawsProfile`), which is merged and unpublished — landing both before publish avoids a second consumer-bump cascade.