### PR TITLE
feat(notifications): carry the sanctioning origin on MODIFY_MATCHUP

### DIFF
--- a/src/mutate/drawDefinitions/matchUpGovernor/setDelegatedOutcome.ts
+++ b/src/mutate/drawDefinitions/matchUpGovernor/setDelegatedOutcome.ts
@@ -65,6 +65,7 @@ export function setDelegatedOutcome({
       tournamentId: tournamentRecord?.tournamentId,
       structureId: matchUp.structureId,
       eventId: event?.eventId,
+      event,
       matchUp,
     });
   }

--- a/src/mutate/drawDefinitions/structureGovernor/adHocRounds/modifyMappedMatchUps.ts
+++ b/src/mutate/drawDefinitions/structureGovernor/adHocRounds/modifyMappedMatchUps.ts
@@ -8,6 +8,7 @@ export function modifyMappedMatchUps({ params, modMap, structure }) {
       modifyMatchUpNotice({
         tournamentId: tournamentRecord?.tournamentId,
         eventId: event?.eventId,
+        event,
         drawDefinition,
         matchUp,
       });

--- a/src/mutate/drawDefinitions/structureGovernor/removeStructure.ts
+++ b/src/mutate/drawDefinitions/structureGovernor/removeStructure.ts
@@ -100,6 +100,7 @@ export function removeStructure(params: RemoveStructureArgs) {
       tournamentId: tournamentRecord?.tournamentId,
       context: ['removeStructure'],
       eventId: event?.eventId,
+      event,
       matchUp,
     });
   }

--- a/src/mutate/matchUps/drawPositions/adHocPositionSwap.ts
+++ b/src/mutate/matchUps/drawPositions/adHocPositionSwap.ts
@@ -67,6 +67,7 @@ export function adHocPositionSwap(params: AdHocPositionSwapArgs): ResultType {
       modifyMatchUpNotice({
         tournamentId: tournamentRecord?.tournamentId,
         eventId: event?.eventId,
+        event,
         drawDefinition,
         matchUp,
       });

--- a/src/mutate/matchUps/drawPositions/assignDrawPositionBye.ts
+++ b/src/mutate/matchUps/drawPositions/assignDrawPositionBye.ts
@@ -546,6 +546,7 @@ function advanceWinner({
     tournamentId: tournamentRecord?.tournamentId,
     matchUp: noContextWinnerMatchUp,
     eventId: event?.eventId,
+    event,
     context: stack,
     drawDefinition,
   });
@@ -636,6 +637,7 @@ function resolvePropagatedExitOnAdvance({
   modifyMatchUpNotice({
     tournamentId: tournamentRecord?.tournamentId,
     eventId: event?.eventId,
+    event,
     context: stack,
     drawDefinition,
     matchUp,

--- a/src/mutate/matchUps/drawPositions/removeDirectedParticipants.ts
+++ b/src/mutate/matchUps/drawPositions/removeDirectedParticipants.ts
@@ -259,6 +259,7 @@ export function removeDirectedWinner({
       modifyMatchUpNotice({
         tournamentId: tournamentRecord?.tournamentId,
         eventId: event?.eventId,
+        event,
         matchUp: targetMatchUp,
         context: stack,
         drawDefinition,
@@ -339,6 +340,7 @@ function removeDirectedLoser({
       modifyMatchUpNotice({
         tournamentId: tournamentRecord?.tournamentId,
         eventId: event?.eventId,
+        event,
         matchUp: targetMatchUp,
         context: stack,
         drawDefinition,

--- a/src/mutate/matchUps/lineUps/resetLineUps.ts
+++ b/src/mutate/matchUps/lineUps/resetLineUps.ts
@@ -69,6 +69,7 @@ export function resetLineUps({
             tournamentId: tournamentRecord?.tournamentId,
             context: 'resetLineUps',
             eventId: event?.eventId,
+            event,
             drawDefinition,
             matchUp,
           });

--- a/src/mutate/matchUps/lineUps/resetMatchUpLineUps.ts
+++ b/src/mutate/matchUps/lineUps/resetMatchUpLineUps.ts
@@ -64,6 +64,7 @@ export function resetMatchUpLineUps({
       tournamentId: tournamentRecord?.tournamentId,
       context: 'resetMatchUpLineUps',
       eventId: event?.eventId,
+      event,
       drawDefinition,
       matchUp,
     });

--- a/src/mutate/matchUps/lineUps/updateSideLineUp.ts
+++ b/src/mutate/matchUps/lineUps/updateSideLineUp.ts
@@ -54,6 +54,7 @@ export function updateSideLineUp({
     tournamentId: tournamentRecord?.tournamentId,
     context: 'updateSidLineUp',
     eventId: event?.eventId,
+    event,
     drawDefinition,
     matchUp,
   });

--- a/src/mutate/matchUps/matchUpFormat/setMatchUpFormat.ts
+++ b/src/mutate/matchUps/matchUpFormat/setMatchUpFormat.ts
@@ -235,6 +235,7 @@ function applyFormatToStructures({
           modifyMatchUpNotice({
             tournamentId: tournamentRecord?.tournamentId,
             eventId: event?.eventId,
+            event,
             context: stack,
             drawDefinition,
             matchUp,

--- a/src/mutate/matchUps/matchUpFormat/setMatchUpMatchUpFormat.ts
+++ b/src/mutate/matchUps/matchUpFormat/setMatchUpMatchUpFormat.ts
@@ -62,6 +62,7 @@ export function setMatchUpMatchUpFormat(params: SetMatchUpMatchUpFormatArgs): {
       modifyMatchUpNotice({
         tournamentId: tournamentRecord?.tournamentId,
         eventId: event?.eventId,
+        event,
         context: stack,
         drawDefinition,
         matchUp,

--- a/src/mutate/matchUps/schedule/clearScheduledMatchUps.ts
+++ b/src/mutate/matchUps/schedule/clearScheduledMatchUps.ts
@@ -166,6 +166,7 @@ function clearSchedules({
         modifyMatchUpNotice({
           context: 'clear schedules',
           eventId: event?.eventId,
+          event,
           drawDefinition,
           tournamentId,
           matchUp,

--- a/src/mutate/matchUps/schedule/clearScheduledMatchUps.ts
+++ b/src/mutate/matchUps/schedule/clearScheduledMatchUps.ts
@@ -166,7 +166,6 @@ function clearSchedules({
         modifyMatchUpNotice({
           context: 'clear schedules',
           eventId: event?.eventId,
-          event,
           drawDefinition,
           tournamentId,
           matchUp,

--- a/src/mutate/matchUps/schedule/scheduleItems/scheduleItems.ts
+++ b/src/mutate/matchUps/schedule/scheduleItems/scheduleItems.ts
@@ -466,6 +466,7 @@ export function addMatchUpScheduleItems(params: AddMatchUpScheduleItemsArgs): {
     modifyMatchUpNotice({
       tournamentId: tournamentRecord?.tournamentId,
       eventId: event?.eventId,
+      event,
       context: stack,
       drawDefinition,
       matchUp,

--- a/src/mutate/matchUps/schedule/scheduleItems/scheduleItems.ts
+++ b/src/mutate/matchUps/schedule/scheduleItems/scheduleItems.ts
@@ -466,7 +466,6 @@ export function addMatchUpScheduleItems(params: AddMatchUpScheduleItemsArgs): {
     modifyMatchUpNotice({
       tournamentId: tournamentRecord?.tournamentId,
       eventId: event?.eventId,
-      event,
       context: stack,
       drawDefinition,
       matchUp,

--- a/src/mutate/matchUps/score/modifyMatchUpScore.ts
+++ b/src/mutate/matchUps/score/modifyMatchUpScore.ts
@@ -181,6 +181,7 @@ export function modifyMatchUpScore(params: ModifyMatchUpScoreArgs) {
 
   modifyMatchUpNotice({
     eventId: event?.eventId,
+    event,
     context: stack,
     drawDefinition,
     tournamentId,

--- a/src/mutate/notifications/drawNotifications.ts
+++ b/src/mutate/notifications/drawNotifications.ts
@@ -1,7 +1,7 @@
 import { getPositionAssignments } from '@Query/drawDefinition/positionsGetter';
 import { addNotice, deleteNotice } from '@Global/state/globalState';
-import { eventOrigin } from '@Query/readModel/readModelRows';
 import { requireParams } from '@Helpers/parameters/requireParams';
+import { eventOrigin } from '@Query/readModel/readModelRows';
 
 // Constants and types
 import { ErrorType, MISSING_DRAW_DEFINITION, MISSING_MATCHUP } from '@Constants/errorConditionConstants';

--- a/src/mutate/notifications/drawNotifications.ts
+++ b/src/mutate/notifications/drawNotifications.ts
@@ -1,5 +1,6 @@
 import { getPositionAssignments } from '@Query/drawDefinition/positionsGetter';
 import { addNotice, deleteNotice } from '@Global/state/globalState';
+import { eventOrigin } from '@Query/readModel/readModelRows';
 import { requireParams } from '@Helpers/parameters/requireParams';
 
 // Constants and types
@@ -116,6 +117,16 @@ type ModifyMatchUpNoticeArgs = {
   matchUp: MatchUp;
   eventId?: string;
   context?: any;
+  /**
+   * The event this matchUp belongs to. Supplied so the notice can carry the SANCTIONING ORIGIN —
+   * one tournamentRecord can hold events sanctioned by several organisations, and a subscriber
+   * driving fan-out must be able to attribute a change without resolving the event itself.
+   *
+   * Callers rarely need to add it: `paramsMiddleware` already resolves `drawId` (or
+   * `matchUp.drawId`) into `params.event`, so most engine-entry methods receive it and only need to
+   * destructure it.
+   */
+  event?: any;
 };
 
 export function modifyMatchUpNotice({
@@ -125,6 +136,7 @@ export function modifyMatchUpNotice({
   context,
   eventId,
   matchUp,
+  event,
 }: ModifyMatchUpNoticeArgs) {
   if (!matchUp) {
     console.log(MISSING_MATCHUP);
@@ -143,6 +155,7 @@ export function modifyMatchUpNotice({
   // was just touched (complements the drawDefinition + structure
   // timestamps written above via `modifyDrawNotice`).
   stampMatchUpUpdatedAt(matchUp);
+  const origin = eventOrigin(event);
   addNotice({
     topic: MODIFY_MATCHUP,
     // eventId/drawId/structureId ride the ENVELOPE, not just the entity. A subscriber that only needs
@@ -151,9 +164,15 @@ export function modifyMatchUpNotice({
     payload: {
       matchUp,
       tournamentId,
-      eventId,
+      eventId: eventId ?? event?.eventId,
       drawId: drawDefinition?.drawId ?? (matchUp as any)?.drawId,
       structureId,
+      // The sanctioning source, flattened — same vocabulary as the read-model's
+      // origin_organisation_id / origin_tournament_id / origin_event_id. Absent when the event
+      // declares no origin, which is the ordinary single-sanction case.
+      originOrganisationId: origin?.organisationId,
+      originTournamentId: origin?.tournamentId,
+      originEventId: origin?.eventId,
       context,
     },
     key: matchUp.matchUpId,

--- a/src/mutate/structures/deleteAdHocMatchUps.ts
+++ b/src/mutate/structures/deleteAdHocMatchUps.ts
@@ -94,6 +94,7 @@ export function deleteAdHocMatchUps(params: DeleteAdHocMatchUpsArgs): ResultType
               tournamentId: tournamentRecord?.tournamentId,
               context: ['adHoc round deletion'],
               eventId: event?.eventId,
+              event,
               drawDefinition,
               matchUp,
             });

--- a/src/mutate/tieFormat/orderCollectionDefinitions.ts
+++ b/src/mutate/tieFormat/orderCollectionDefinitions.ts
@@ -84,6 +84,7 @@ export function orderCollectionDefinitions({
     modifyMatchUpNotice({
       tournamentId: tournamentRecord?.tournamentId,
       eventId: event?.eventId,
+      event,
       drawDefinition,
       matchUp,
     });

--- a/src/mutate/tieFormat/removeCollectionDefinition.ts
+++ b/src/mutate/tieFormat/removeCollectionDefinition.ts
@@ -399,6 +399,7 @@ function processTargetMatchUp({
   modifyMatchUpNotice({
     tournamentId: tournamentRecord?.tournamentId,
     eventId: event?.eventId,
+    event,
     drawDefinition,
     context: stack,
     matchUp,

--- a/src/mutate/tieFormat/resetTieFormat.ts
+++ b/src/mutate/tieFormat/resetTieFormat.ts
@@ -140,6 +140,7 @@ export function resetTieFormat(params: ResetTieFormatArgs): ResultType & {
     modifyMatchUpNotice({
       structureId: structure?.structureId,
       eventId: event?.eventId,
+      event,
       context: stack,
       drawDefinition,
       tournamentId,

--- a/src/mutate/tieFormat/updateTargetTeamMatchUps.ts
+++ b/src/mutate/tieFormat/updateTargetTeamMatchUps.ts
@@ -41,6 +41,7 @@ export function updateTargetTeamMatchUps({
         tournamentId: tournamentRecord?.tournamentId,
         context: 'updateTargetTeamMatchUps',
         eventId: event?.eventId,
+        event,
         matchUp: targetMatchUp,
         drawDefinition,
       });

--- a/src/mutate/tieFormat/updateTieFormat.ts
+++ b/src/mutate/tieFormat/updateTieFormat.ts
@@ -147,6 +147,7 @@ export function updateTieFormat({
     modifiedMatchUpsCount += 1;
     modifyMatchUpNotice({
       eventId: event?.eventId,
+      event,
       context: stack,
       drawDefinition,
       tournamentId,

--- a/src/mutate/timeItems/matchUps/matchUpTimeItems.ts
+++ b/src/mutate/timeItems/matchUps/matchUpTimeItems.ts
@@ -45,6 +45,7 @@ export function addMatchUpTimeItem({
     modifyMatchUpNotice({
       tournamentId: tournamentRecord?.tournamentId,
       eventId: event?.eventId,
+      event,
       context: 'addTimeItem',
       drawDefinition,
       matchUp,
@@ -72,6 +73,7 @@ export function resetMatchUpTimeItems({
     tournamentId: tournamentRecord?.tournamentId,
     context: 'resetTimeItems',
     eventId: event?.eventId,
+    event,
     drawDefinition,
     matchUp,
   });

--- a/src/mutate/timeItems/matchUps/setMatchUpFirstClassOrTimeItem.ts
+++ b/src/mutate/timeItems/matchUps/setMatchUpFirstClassOrTimeItem.ts
@@ -66,6 +66,7 @@ export function setMatchUpFirstClassOrTimeItem({
     modifyMatchUpNotice({
       tournamentId: tournamentRecord?.tournamentId,
       eventId: event?.eventId,
+      event,
       context: 'setFirstClassOrTimeItem',
       drawDefinition,
       matchUp,

--- a/src/tests/mutations/notifications/noticeOrigin.test.ts
+++ b/src/tests/mutations/notifications/noticeOrigin.test.ts
@@ -43,15 +43,13 @@ describe('MODIFY_MATCHUP carries the sanctioning origin', () => {
     const { drawId, eventId } = seed();
 
     const origin = { organisationId: 'ORG-EXTERNAL', tournamentId: 'THEIR-TID', eventId: 'THEIR-EID', isOrigin: true };
-    const modified: any = tournamentEngine.modifyEvent({
-      eventId,
-      eventUpdates: { eventOtherIds: [origin] },
-    });
-    expect(modified.success).toEqual(true);
+    let result: any = tournamentEngine.modifyEvent({ eventId, eventUpdates: { eventOtherIds: [origin] } });
+    expect(result.success).toEqual(true);
 
     const notices: any[] = [];
     setSubscriptions({ subscriptions: { [MODIFY_MATCHUP]: (n: any[]) => notices.push(...n) } });
-    expect(scoreOne(drawId).success).toEqual(true);
+    result = scoreOne(drawId);
+    expect(result.success).toEqual(true);
     setSubscriptions({ subscriptions: {} });
 
     expect(notices.length).toBeGreaterThan(0);
@@ -70,7 +68,8 @@ describe('MODIFY_MATCHUP carries the sanctioning origin', () => {
 
     const notices: any[] = [];
     setSubscriptions({ subscriptions: { [MODIFY_MATCHUP]: (n: any[]) => notices.push(...n) } });
-    expect(scoreOne(drawId).success).toEqual(true);
+    const result: any = scoreOne(drawId);
+    expect(result.success).toEqual(true);
     setSubscriptions({ subscriptions: {} });
 
     expect(notices.length).toBeGreaterThan(0);

--- a/src/tests/mutations/notifications/noticeOrigin.test.ts
+++ b/src/tests/mutations/notifications/noticeOrigin.test.ts
@@ -1,0 +1,80 @@
+import { setSubscriptions } from '@Global/state/globalState';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { expect, it, describe } from 'vitest';
+
+// constants and types
+import { SINGLE_ELIMINATION } from '@Constants/drawDefinitionConstants';
+import { MODIFY_MATCHUP } from '@Constants/topicConstants';
+
+/**
+ * The sanctioning origin must reach the notice, so a subscriber can attribute a change without
+ * resolving the event. One tournamentRecord can hold events sanctioned by several organisations —
+ * `Event.eventOtherIds[]`, the entry flagged `isOrigin`. Vocabulary mirrors the read-model's
+ * origin_organisation_id / origin_tournament_id / origin_event_id.
+ */
+describe('MODIFY_MATCHUP carries the sanctioning origin', () => {
+  function seed() {
+    const {
+      drawIds: [drawId],
+      eventIds: [eventId],
+    } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 8, drawType: SINGLE_ELIMINATION }],
+      participantsProfile: { nonRandom: 1 },
+      setState: true,
+    });
+    return { drawId, eventId };
+  }
+
+  function scoreOne(drawId: string) {
+    const { outcome } = mocksEngine.generateOutcomeFromScoreString({
+      scoreString: '6-4 6-2',
+      matchUpStatus: 'COMPLETED',
+      winningSide: 1,
+    });
+    const { matchUps } = tournamentEngine.allTournamentMatchUps();
+    const target = matchUps.find(
+      (m: any) => !m.winningSide && (m.sides ?? []).filter((s: any) => s?.participantId).length === 2,
+    );
+    return tournamentEngine.setMatchUpStatus({ matchUpId: target.matchUpId, drawId, outcome });
+  }
+
+  it('flattens the isOrigin entry onto the payload', () => {
+    const { drawId, eventId } = seed();
+
+    const origin = { organisationId: 'ORG-EXTERNAL', tournamentId: 'THEIR-TID', eventId: 'THEIR-EID', isOrigin: true };
+    const modified: any = tournamentEngine.modifyEvent({
+      eventId,
+      eventUpdates: { eventOtherIds: [origin] },
+    });
+    expect(modified.success).toEqual(true);
+
+    const notices: any[] = [];
+    setSubscriptions({ subscriptions: { [MODIFY_MATCHUP]: (n: any[]) => notices.push(...n) } });
+    expect(scoreOne(drawId).success).toEqual(true);
+    setSubscriptions({ subscriptions: {} });
+
+    expect(notices.length).toBeGreaterThan(0);
+    const payload = notices[0];
+    expect(payload.originOrganisationId).toEqual('ORG-EXTERNAL');
+    // deliberately NOT the carrying record's tournamentId — that is the whole point
+    expect(payload.originTournamentId).toEqual('THEIR-TID');
+    expect(payload.originTournamentId).not.toEqual(payload.tournamentId);
+    expect(payload.originEventId).toEqual('THEIR-EID');
+    // local identity still present
+    expect(payload.eventId).toEqual(eventId);
+  });
+
+  it('omits origin fields when the event declares none (the ordinary case)', () => {
+    const { drawId } = seed();
+
+    const notices: any[] = [];
+    setSubscriptions({ subscriptions: { [MODIFY_MATCHUP]: (n: any[]) => notices.push(...n) } });
+    expect(scoreOne(drawId).success).toEqual(true);
+    setSubscriptions({ subscriptions: {} });
+
+    expect(notices.length).toBeGreaterThan(0);
+    expect(notices[0].originOrganisationId).toBeUndefined();
+    expect(notices[0].originTournamentId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
One `tournamentRecord` can hold events sanctioned by **several organisations**. A subscriber driving data fan-out must be able to attribute a change **without resolving the event itself** — which is the resolution step notices exist to avoid.

## What

`modifyMatchUpNotice` accepts the `event`, resolves origin **once** via `eventOrigin()` — the same helper the read-model projection uses — and emits the flat triple:

```
originOrganisationId   originTournamentId   originEventId
```

Vocabulary deliberately mirrors the read-model's `origin_organisation_id` / `origin_tournament_id` / `origin_event_id`. A subscriber and a projection consumer should not need two names for one concept. `originTournamentId` is the **origin organisation's** id and is independent of the carrying record's `tournamentId`.

## Two design points

**`UnifiedEventID` is not a replacement for `eventId`.** Its `eventId` is the *other* organisation's id and is optional; ours is the local primary key. Both are carried.

**Origin is resolved at the notice boundary, not threaded through the call graph.** It is a property of the event, and a threaded copy can go stale if origin is written after a path captured it. The read-model resolves the same way.

## Why the call-site change is small

`paramsMiddleware` (`assemblies/engines/parts/paramsMiddleware.ts:18-37`) resolves `drawId` — or `matchUp.drawId` — via `findEvent` and sets `params.drawDefinition`, `params.tournamentId` **and `params.event`**. So most engine-entry methods already receive the event and only need to destructure it.

**26 call sites** updated in this PR, including the score path.

## Verification

- lint 0, types 0, full suite **10,945 tests**
- **falsified at both ends**: removing the resolution in the helper, and stripping the `event` pass from `modifyMatchUpScore`, each fail the end-to-end test
- the test sets an external `isOrigin` entry and asserts the notice carries `THEIR-TID`, explicitly asserting it is **not** the carrying record's `tournamentId`

## Remaining

34 call sites still to convert; the rule is now mechanical (destructure `event` where `drawDefinition` is destructured; depth-1 chains for internal helpers). Follow-up on this branch.