### PR TITLE
feat(scheduling): schedule locks pin a matchUp placement against bulk clears

### DIFF
--- a/attr-audit.allow.json
+++ b/attr-audit.allow.json
@@ -31,6 +31,7 @@
   "sanctioningRecords",
   "scaleItems",
   "SCHEDULED",
+  "scheduledDate",
   "serve",
   "test",
   "time",

--- a/documentation/docs/concepts/schedule-locks.mdx
+++ b/documentation/docs/concepts/schedule-locks.mdx
@@ -1,0 +1,90 @@
+---
+title: Schedule Locks
+---
+
+## Overview
+
+A **Schedule Lock** is a tournament director's declaration that a matchUp's placement is deliberate and must not be moved by bulk or automated scheduling. The marquee match promised centre court at 19:00 survives a "Clear this day", a re-schedule of everything around it, or a committed [schedule scenario](./schedule-scenarios.mdx).
+
+**Key characteristics:**
+
+- **Persisted first-class** on `matchUp.schedule.lock` — no legacy `timeItem` mirror, no `LEGACY` / `DUAL` / `NATIVE` branching.
+- **Guards placement only.** `startTime`, `stopTime`, `resumeTime` and `endTime` record actual play and are never guarded — a pinned match must still be startable, suspendable and completable.
+- **Skipped, never fatal, in bulk paths.** One pinned matchUp cannot abort the clear of the other two hundred; the skipped ids come back as `lockedMatchUpIds`.
+- **Inert rather than removed** once the matchUp completes, or while it has no placement to guard. Nothing is ever unwritten.
+- **Invisible to published views** — a lock is an internal operations annotation, and `lock.reason` is the director's own note.
+- **Unrelated to `mutationLocks`**, which gate whole methods at tournament grain. Different mechanism, different scope; only the word is shared.
+
+## Data Structure
+
+```ts
+type ScheduleLock = {
+  attributes?: ScheduleLockAttribute[]; // absent ⇒ the whole placement is pinned
+  lockedAt?: string; // caller-provided ISO string (factory does not stamp wall-clock)
+  lockedBy?: string;
+  reason?: string; // 'featured' | 'broadcast' | free text
+};
+
+type ScheduleLockAttribute =
+  'allocatedCourts' | 'courtId' | 'courtOrder' | 'scheduledDate' | 'scheduledTime' | 'venueId';
+```
+
+The **presence** of the object is the lock. `{}` pins the entire placement; `{ attributes: ['scheduledTime'] }` pins the time and leaves the court free to move.
+
+## Setting and clearing
+
+```js
+// pin the whole placement
+engine.setMatchUpScheduleLock({
+  lock: { reason: 'featured', lockedBy: userId, lockedAt: new Date().toISOString() },
+  matchUpId,
+  drawId,
+});
+
+// pin only the clock time
+engine.setMatchUpScheduleLock({ lock: { attributes: ['scheduledTime'] }, matchUpId, drawId });
+
+// unlock
+engine.setMatchUpScheduleLock({ lock: null, matchUpId, drawId });
+```
+
+## What a lock stops
+
+The predicate is enforced at every mutation that writes or wipes placement, so there is no path that quietly bypasses it:
+
+| Mutation                                                  | Behaviour on a locked matchUp                                              |
+| --------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `addMatchUpScheduleItems`                                 | Returns `SCHEDULE_LOCKED`; `info` names the locked attributes              |
+| `bulkScheduleMatchUps` / `bulkScheduleTournamentMatchUps` | **Skips** the matchUp, continues with the rest, returns `lockedMatchUpIds` |
+| `clearScheduledMatchUps`                                  | Skips the matchUp, returns `lockedMatchUpIds`                              |
+| `clearMatchUpSchedule`                                    | Returns `SCHEDULE_LOCKED`                                                  |
+| `applyScheduleScenario`                                   | Skips (hand-off to `bulkScheduleMatchUps`), returns `lockedMatchUpIds`     |
+
+Every one of them accepts **`overrideScheduleLock: true`** for callers that have confirmed the intent with the operator — the TMX grid, for example, confirms a drag of a pinned matchUp and then passes the override. **An override moves the placement but does not remove the lock**: only `setMatchUpScheduleLock` does that.
+
+Two paths deliberately ignore locks:
+
+- **`deleteCourt` / `deleteVenue`.** A lock cannot survive the deletion of the court it pins to — keeping the assignment would leave a dangling `courtId`.
+- **`resetDrawDefinition`.** A draw reset discards the schedule wholesale, lock included.
+
+## What a lock does not stop
+
+Automated scheduling never needed guarding: `proAutoSchedule` only fills **empty** grid cells, and `processAlreadyScheduledMatchUps` already counts existing placements against court capacity. A locked matchUp therefore reserves its own slot in every scheduler run for free. The one scheduler path that could have moved it — `clearScheduleDates`, which routes through `clearScheduledMatchUps` — is covered by the table above.
+
+Annotations on a placement stay editable while pinned: `courtAnnotation`, `timeModifiers`, and the official / scorekeeper / timekeeper assignments.
+
+## Release on completion
+
+A lock is **inert** — not deleted — once the matchUp reaches a status in `completedMatchUpStatuses`:
+
+```js
+isScheduleLocked({ matchUp }); // false once matchUpStatus is COMPLETED / RETIRED / WALKOVER / …
+```
+
+This is deliberate. Completed matchUps are already skipped by every bulk scheduling path unless `scheduleCompletedMatchUps` is passed, so a lock has nothing left to guard; releasing it lazily keeps schedule writes off the scoring path entirely and leaves nothing to undo if a score is later removed.
+
+The same inertness applies when a matchUp has **no placement**. A lock left behind by an overridden clear must not make the matchUp silently unschedulable — a failure that would present as "auto-schedule keeps ignoring this match" with nothing in the record to explain it.
+
+## Write-mode parity
+
+`LEGACY` and `DUAL` records keep placement in `timeItems[]`; `NATIVE` keeps it in first-class `matchUp.schedule.*`. The lock predicate reads **both** surfaces, so a lock behaves identically in every `schemaWriteMode`. A first-class-only read would have made locks silently inert in `LEGACY` — the same divergence that once made unscheduling a no-op in `NATIVE`.

--- a/documentation/docs/concepts/schedule-locks.mdx
+++ b/documentation/docs/concepts/schedule-locks.mdx
@@ -71,7 +71,9 @@ Two paths deliberately ignore locks:
 
 Automated scheduling never needed guarding: `proAutoSchedule` only fills **empty** grid cells, and `processAlreadyScheduledMatchUps` already counts existing placements against court capacity. A locked matchUp therefore reserves its own slot in every scheduler run for free. The one scheduler path that could have moved it — `clearScheduleDates`, which routes through `clearScheduledMatchUps` — is covered by the table above.
 
-Annotations on a placement stay editable while pinned: `courtAnnotation`, `timeModifiers`, and the official / scorekeeper / timekeeper assignments.
+Annotations on a placement stay editable while pinned: `courtAnnotation`, `timeModifiers`, and the official / scorekeeper / timekeeper assignments. **Assigning an official is never blocked by a lock, and an officiating conflict-of-interest refusal is never masked by one** — the two gates live in different mutations (`addMatchUpOfficial` vs `addMatchUpScheduleItems`) and are asserted independently, so a director cannot unlock, retry, and meet a second refusal they were never warned about.
+
+A write that changes nothing is also permitted: re-writing the same values does not trip a lock. That includes court allocations, which are compared by court identity rather than structurally — `allocatedCourts` is written as bare courtIds but stored as hydrated court objects, and re-ordering the same courts is not a move.
 
 ## Release on completion
 

--- a/documentation/docs/governors/schedule-governor.md
+++ b/documentation/docs/governors/schedule-governor.md
@@ -206,6 +206,39 @@ engine.removeMatchUpTimekeeper({ matchUpId, drawId });
 
 ---
 
+### setMatchUpScheduleLock
+
+Pins a matchUp's **placement** so bulk and automated scheduling cannot move it —
+the marquee match that must keep centre court at 19:00 while the rest of the day
+is rebuilt around it. Stored first-class as `matchUp.schedule.lock`. Presence of
+the object is the lock; `attributes` narrows it to specific placement fields.
+
+Guards placement only: `startTime` / `stopTime` / `resumeTime` / `endTime` stay
+writable so a pinned matchUp can still be played. Every placement mutation
+accepts `overrideScheduleLock: true` for callers that have confirmed the move
+with the operator; an override moves the placement but never removes the lock.
+The lock goes inert (it is not deleted) once the matchUp completes, or while it
+has no placement to guard.
+
+See [Schedule Locks](../concepts/schedule-locks.mdx) for the full model.
+
+```js
+engine.setMatchUpScheduleLock({
+  matchUpId, // required
+  drawId, // required
+  lock, // required - a ScheduleLock object, or null to unlock
+  disableNotice, // optional boolean - suppress notifications
+});
+
+// pin only the clock time; the court stays free to move
+engine.setMatchUpScheduleLock({ matchUpId, drawId, lock: { attributes: ['scheduledTime'] } });
+
+// unlock
+engine.setMatchUpScheduleLock({ matchUpId, drawId, lock: null });
+```
+
+---
+
 ## Automated Scheduling Methods
 
 ### scheduleMatchUps

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -120,6 +120,7 @@ module.exports = {
             'concepts/scheduling-policy',
             'concepts/scheduling-profile',
             'concepts/schedule-scenarios',
+            'concepts/schedule-locks',
             'concepts/automated-scheduling',
             'concepts/pro-scheduling',
             'concepts/scheduling-conflicts',

--- a/src/assemblies/governors/scheduleGovernor/mutate.ts
+++ b/src/assemblies/governors/scheduleGovernor/mutate.ts
@@ -28,6 +28,7 @@ export { assignMatchUpCourt } from '@Mutate/matchUps/schedule/assignMatchUpCourt
 export { assignMatchUpScorekeeper, removeMatchUpScorekeeper } from '@Mutate/matchUps/schedule/assignMatchUpScorekeeper';
 export { assignMatchUpTimekeeper, removeMatchUpTimekeeper } from '@Mutate/matchUps/schedule/assignMatchUpTimekeeper';
 export { assignMatchUpVenue } from '@Mutate/matchUps/schedule/assignMatchUpVenue';
+export { setMatchUpScheduleLock } from '@Mutate/matchUps/schedule/setMatchUpScheduleLock';
 export { setMatchUpCalledAt } from '@Mutate/matchUps/schedule/setMatchUpCalledAt';
 export { generateBookings } from '@Generators/scheduling/utils/generateBookings';
 export {

--- a/src/constants/errorConditionConstants.ts
+++ b/src/constants/errorConditionConstants.ts
@@ -74,6 +74,10 @@ export const SCHEDULE_NOT_CLEARED = {
   message: 'Schedule not cleared',
   code: 'ERR_UNCHANGED_SCHEDULE_NOT_CLEARED',
 };
+export const SCHEDULE_LOCKED = {
+  message: 'matchUp schedule is locked',
+  code: 'ERR_SCHEDULE_LOCKED',
+};
 export const MATCHUPS_SCHEDULED_OUTSIDE_DATES = {
   message: 'MatchUps are scheduled outside the new tournament dates',
   code: 'ERR_MATCHUPS_SCHEDULED_OUTSIDE_DATES',
@@ -1069,6 +1073,7 @@ export const errorConditionConstants = {
   PENALTY_NOT_FOUND,
   POLICY_NOT_ATTACHED,
   POLICY_NOT_FOUND,
+  SCHEDULE_LOCKED,
   SCHEDULE_NOT_CLEARED,
   SCHEDULE_CONFLICT_DOUBLE_BOOKING,
   SCHEDULE_CONFLICT_COURT_UNAVAILABLE,

--- a/src/constants/mutationLockScopeMap.ts
+++ b/src/constants/mutationLockScopeMap.ts
@@ -28,6 +28,7 @@ export const methodScopeMap: Record<string, MutationLockScope> = {
   bulkScheduleMatchUps: 'SCHEDULING',
   scheduleProfileRounds: 'SCHEDULING',
   clearMatchUpSchedule: 'SCHEDULING',
+  setMatchUpScheduleLock: 'SCHEDULING',
   addMatchUpScheduledTime: 'SCHEDULING',
   setMatchUpDailyLimits: 'SCHEDULING',
   assignMatchUpCourt: 'SCHEDULING',

--- a/src/mutate/matchUps/schedule/applyScheduleScenario.ts
+++ b/src/mutate/matchUps/schedule/applyScheduleScenario.ts
@@ -8,6 +8,7 @@ import { TournamentRecords } from '@Types/factoryTypes';
 type ApplyScheduleScenarioArgs = {
   tournamentRecords?: TournamentRecords;
   scheduleCompletedMatchUps?: boolean;
+  overrideScheduleLock?: boolean;
   tournamentRecord?: Tournament;
   removePriorValues?: boolean;
   scenarioId: string;
@@ -23,9 +24,20 @@ type ApplyScheduleScenarioArgs = {
  * to `true` to match TMX grid-drop semantics (re-dated matchUps shed stale grid
  * position). The scenario is left in place; the caller decides whether to remove
  * it post-commit. Drift / rebase reconciliation lands in Phase 1.
+ *
+ * Schedule-locked matchUps are skipped for the same reason and by the same
+ * mechanism, and come back as `lockedMatchUpIds` — a scenario cannot silently
+ * move a placement a director pinned. Pass `overrideScheduleLock` to apply the
+ * scenario over locks.
  */
 export function applyScheduleScenario(params: ApplyScheduleScenarioArgs) {
-  const { tournamentRecord, scenarioId, removePriorValues = true, scheduleCompletedMatchUps = false } = params;
+  const {
+    scheduleCompletedMatchUps = false,
+    removePriorValues = true,
+    overrideScheduleLock,
+    tournamentRecord,
+    scenarioId,
+  } = params;
 
   const tournamentRecords =
     params.tournamentRecords ?? (tournamentRecord ? { [tournamentRecord.tournamentId]: tournamentRecord } : undefined);
@@ -42,6 +54,7 @@ export function applyScheduleScenario(params: ApplyScheduleScenarioArgs) {
   const result = bulkScheduleMatchUps({
     scheduleCompletedMatchUps,
     matchUpDetails: scenario.placements,
+    overrideScheduleLock,
     removePriorValues,
     tournamentRecords,
   });

--- a/src/mutate/matchUps/schedule/bulkScheduleMatchUps.ts
+++ b/src/mutate/matchUps/schedule/bulkScheduleMatchUps.ts
@@ -12,6 +12,7 @@ import { Tournament } from '@Types/tournamentTypes';
 type BulkScheduleMatchUpsArgs = {
   tournamentRecords: { [key: string]: Tournament };
   scheduleCompletedMatchUps?: boolean;
+  overrideScheduleLock?: boolean;
   tournamentRecord?: Tournament;
   scheduleByeMatchUps?: boolean;
   errorOnAnachronism?: boolean;
@@ -26,6 +27,7 @@ export function bulkScheduleMatchUps(params: BulkScheduleMatchUpsArgs) {
   const {
     scheduleCompletedMatchUps = false,
     scheduleByeMatchUps = false,
+    overrideScheduleLock,
     errorOnAnachronism,
     matchUpContextIds,
     removePriorValues,
@@ -50,6 +52,7 @@ export function bulkScheduleMatchUps(params: BulkScheduleMatchUpsArgs) {
   if ((!matchUpDetails || matchUpContextIds) && !schedule)
     return { error: MISSING_VALUE, info: 'schedule is required' };
 
+  const lockedMatchUpIds: string[] = [];
   const warnings: any[] = [];
   let scheduled = 0;
 
@@ -69,6 +72,7 @@ export function bulkScheduleMatchUps(params: BulkScheduleMatchUpsArgs) {
       const result = bulkScheduleTournamentMatchUps({
         matchUpDetails: tournamentMatchUpDetails,
         scheduleCompletedMatchUps,
+        overrideScheduleLock,
         scheduleByeMatchUps,
         matchUpDependencies,
         errorOnAnachronism,
@@ -80,10 +84,16 @@ export function bulkScheduleMatchUps(params: BulkScheduleMatchUpsArgs) {
         schedule,
       });
       if (result.warnings?.length) warnings.push(...result.warnings);
+      if (result.lockedMatchUpIds?.length) lockedMatchUpIds.push(...result.lockedMatchUpIds);
       if (result.scheduled) scheduled += result.scheduled;
       if (result.error) return result;
     }
   }
 
-  return warnings.length ? { ...SUCCESS, scheduled, warnings } : { ...SUCCESS, scheduled };
+  return {
+    ...SUCCESS,
+    ...(warnings.length ? { warnings } : {}),
+    ...(lockedMatchUpIds.length ? { lockedMatchUpIds } : {}),
+    scheduled,
+  };
 }

--- a/src/mutate/matchUps/schedule/bulkScheduleTournamentMatchUps.ts
+++ b/src/mutate/matchUps/schedule/bulkScheduleTournamentMatchUps.ts
@@ -10,6 +10,7 @@ import { Tournament } from '@Types/tournamentTypes';
 import { SUCCESS } from '@Constants/resultConstants';
 import {
   MISSING_SCHEDULE,
+  SCHEDULE_LOCKED,
   MISSING_MATCHUP_IDS,
   MISSING_TOURNAMENT_RECORD,
   ErrorType,
@@ -18,6 +19,7 @@ import {
 type BulkScheduleMachUpsArgs = {
   tournamentRecords?: { [key: string]: Tournament };
   scheduleCompletedMatchUps?: boolean;
+  overrideScheduleLock?: boolean;
   tournamentRecord?: Tournament;
   scheduleByeMatchUps?: boolean;
   errorOnAnachronism?: boolean;
@@ -34,6 +36,7 @@ export function bulkScheduleTournamentMatchUps({
   scheduleByeMatchUps = false,
   errorOnAnachronism = false,
   checkChronology = true,
+  overrideScheduleLock,
   matchUpDependencies,
   removePriorValues,
   tournamentRecords,
@@ -42,6 +45,7 @@ export function bulkScheduleTournamentMatchUps({
   matchUpIds,
   schedule,
 }: BulkScheduleMachUpsArgs): {
+  lockedMatchUpIds?: string[];
   error?: ErrorType;
   scheduled?: number;
   warnings?: any[];
@@ -52,6 +56,7 @@ export function bulkScheduleTournamentMatchUps({
   if (!matchUpDetails && (!schedule || typeof schedule !== 'object')) return { error: MISSING_SCHEDULE };
 
   let inContextMatchUps;
+  const lockedMatchUpIds: string[] = [];
   const warnings: any[] = [];
   let scheduled = 0;
 
@@ -114,6 +119,7 @@ export function bulkScheduleTournamentMatchUps({
       const matchUpSchedule = matchUpDetails?.find((details) => details.matchUpId === matchUpId)?.schedule || schedule;
       const result = addMatchUpScheduleItems({
         schedule: matchUpSchedule,
+        overrideScheduleLock,
         matchUpDependencies,
         errorOnAnachronism,
         removePriorValues,
@@ -127,9 +133,21 @@ export function bulkScheduleTournamentMatchUps({
       });
       if (result?.warnings?.length) warnings.push(...result.warnings);
       if (result?.success) scheduled += 1;
+      // A locked matchUp is SKIPPED, never fatal: one pinned marquee match must
+      // not abort a Clear or a bulk re-schedule of the other 200. Reported back
+      // so the caller can say what it preserved.
+      if (result.error === SCHEDULE_LOCKED) {
+        lockedMatchUpIds.push(matchUpId);
+        continue;
+      }
       if (result.error) return result;
     }
   }
 
-  return warnings.length ? { ...SUCCESS, scheduled, warnings } : { ...SUCCESS, scheduled };
+  return {
+    ...SUCCESS,
+    ...(warnings.length ? { warnings } : {}),
+    ...(lockedMatchUpIds.length ? { lockedMatchUpIds } : {}),
+    scheduled,
+  };
 }

--- a/src/mutate/matchUps/schedule/clearMatchUpSchedule.ts
+++ b/src/mutate/matchUps/schedule/clearMatchUpSchedule.ts
@@ -1,9 +1,10 @@
 import { allTournamentMatchUps } from '@Query/matchUps/getAllTournamentMatchUps';
 import { modifyMatchUpNotice } from '@Mutate/notifications/drawNotifications';
 import { allDrawMatchUps } from '@Query/matchUps/getAllDrawMatchUps';
+import { isScheduleLocked } from '@Query/matchUp/isScheduleLocked';
 
 // constants
-import { MATCHUP_NOT_FOUND } from '@Constants/errorConditionConstants';
+import { MATCHUP_NOT_FOUND, SCHEDULE_LOCKED } from '@Constants/errorConditionConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 import {
   ALLOCATE_COURTS,
@@ -54,9 +55,16 @@ export function clearMatchUpSchedule({
     RESUME_TIME,
     STOP_TIME,
   ],
+  overrideScheduleLock,
   tournamentRecord,
   drawDefinition,
   matchUpId,
+}: {
+  overrideScheduleLock?: boolean;
+  scheduleAttributes?: string[];
+  tournamentRecord?: any;
+  drawDefinition?: any;
+  matchUpId: string;
 }) {
   const stack = 'clearMatchUpSchedule';
   const matchUp = drawDefinition
@@ -72,6 +80,11 @@ export function clearMatchUpSchedule({
       }).matchUps?.[0];
 
   if (!matchUp) return { error: MATCHUP_NOT_FOUND };
+
+  // A pinned placement is not cleared by a single-matchUp clear either. Callers
+  // that have confirmed the intent with the operator pass `overrideScheduleLock`
+  // (the lock itself survives — only setMatchUpScheduleLock removes it).
+  if (!overrideScheduleLock && isScheduleLocked({ matchUp })) return { error: SCHEDULE_LOCKED };
 
   const newTimeItems = (matchUp.timeItems ?? []).filter(
     (timeItem) => timeItem?.itemType && !scheduleAttributes.includes(timeItem?.itemType),

--- a/src/mutate/matchUps/schedule/clearScheduledMatchUps.ts
+++ b/src/mutate/matchUps/schedule/clearScheduledMatchUps.ts
@@ -1,6 +1,7 @@
 import { resolveTournamentRecords } from '@Helpers/parameters/resolveTournamentRecords';
 import { allTournamentMatchUps } from '@Query/matchUps/getAllTournamentMatchUps';
 import { modifyMatchUpNotice } from '@Mutate/notifications/drawNotifications';
+import { isScheduleLocked } from '@Query/matchUp/isScheduleLocked';
 import { allDrawMatchUps } from '@Query/matchUps/getAllDrawMatchUps';
 import { hasSchedule } from '@Query/matchUp/hasSchedule';
 import { findEvent } from '@Acquire/findEvent';
@@ -56,17 +57,20 @@ const SCHEDULE_FIRST_CLASS_ATTRIBUTES = [
 type ClearScheduledMatchUpsArgs = {
   ignoreMatchUpStatuses?: MatchUpStatusUnion[];
   tournamentRecords?: TournamentRecords;
+  overrideScheduleLock?: boolean;
   tournamentRecord?: Tournament;
   scheduleAttributes?: string[];
   scheduledDates: string[];
   venueIds?: string[];
 };
 export function clearScheduledMatchUps(params: ClearScheduledMatchUpsArgs): ResultType & {
+  lockedMatchUpIds?: string[];
   clearedScheduleCount?: number;
 } {
   const {
     scheduleAttributes = ['scheduledDate', 'scheduledTime', 'courtOrder'],
     ignoreMatchUpStatuses = completedMatchUpStatuses,
+    overrideScheduleLock,
     scheduledDates,
     venueIds,
   } = params;
@@ -80,10 +84,12 @@ export function clearScheduledMatchUps(params: ClearScheduledMatchUpsArgs): Resu
     : [];
   if (!tournamentIds?.length) return { error: MISSING_TOURNAMENT_RECORDS };
 
+  const lockedMatchUpIds: string[] = [];
   let clearedScheduleCount = 0;
   for (const tournamentId of tournamentIds) {
     const tournamentRecord = tournamentRecords[tournamentId];
     const result = clearSchedules({
+      overrideScheduleLock,
       ignoreMatchUpStatuses,
       scheduleAttributes,
       tournamentRecord,
@@ -91,20 +97,25 @@ export function clearScheduledMatchUps(params: ClearScheduledMatchUpsArgs): Resu
       venueIds,
     });
     if (result.error) return result;
+    if (result.lockedMatchUpIds?.length) lockedMatchUpIds.push(...result.lockedMatchUpIds);
     clearedScheduleCount += result.clearedScheduleCount ?? 0;
   }
 
-  return { ...SUCCESS, clearedScheduleCount };
+  return lockedMatchUpIds.length
+    ? { ...SUCCESS, clearedScheduleCount, lockedMatchUpIds }
+    : { ...SUCCESS, clearedScheduleCount };
 }
 
 function clearSchedules({
   scheduleAttributes = ['scheduledDate', 'scheduledTime', 'courtOrder'],
   ignoreMatchUpStatuses = completedMatchUpStatuses,
+  overrideScheduleLock,
   tournamentRecord,
   scheduledDates,
   venueIds = [],
 }: ClearScheduledMatchUpsArgs): {
   clearedScheduleCount?: number;
+  lockedMatchUpIds?: string[];
   success?: boolean;
   error?: ErrorType;
 } {
@@ -135,6 +146,7 @@ function clearSchedules({
   });
 
   const tournamentId = tournamentRecord.tournamentId;
+  const lockedMatchUpIds: string[] = [];
   let clearedScheduleCount = 0;
 
   for (const drawId in drawMatchUpIds) {
@@ -143,6 +155,12 @@ function clearSchedules({
       allDrawMatchUps({ drawDefinition, matchUpFilters: { matchUpIds: drawMatchUpIds[drawId] } }).matchUps ?? [];
 
     for (const matchUp of drawMatchUps) {
+      // A director's lock survives a date/venue-scoped clear — the whole point
+      // of pinning the marquee match before rebuilding the day around it.
+      if (!overrideScheduleLock && isScheduleLocked({ matchUp })) {
+        lockedMatchUpIds.push(matchUp.matchUpId);
+        continue;
+      }
       let modified = false;
       // LEGACY / DUAL records store schedule data as timeItems — strip them.
       matchUp.timeItems = (matchUp.timeItems ?? []).filter((timeItem) => {
@@ -175,5 +193,7 @@ function clearSchedules({
     }
   }
 
-  return { ...SUCCESS, clearedScheduleCount };
+  return lockedMatchUpIds.length
+    ? { ...SUCCESS, clearedScheduleCount, lockedMatchUpIds }
+    : { ...SUCCESS, clearedScheduleCount };
 }

--- a/src/mutate/matchUps/schedule/scheduleItems/scheduleItems.ts
+++ b/src/mutate/matchUps/schedule/scheduleItems/scheduleItems.ts
@@ -8,6 +8,7 @@ import {
   validTimeValue,
 } from '@Tools/dateTime';
 import { getMatchUpOfficialConflicts } from '@Query/officiating/getMatchUpOfficialConflicts';
+import { scheduleLockConflicts } from '@Query/matchUp/isScheduleLocked';
 import { setMatchUpHomeParticipantId } from '@Mutate/matchUps/schedule/scheduleItems/setMatchUpHomeParticipantId';
 import { setMatchUpFirstClassOrTimeItem } from '@Mutate/timeItems/matchUps/setMatchUpFirstClassOrTimeItem';
 import { addMatchUpScheduledTime, addMatchUpTimeModifiers } from '@Mutate/matchUps/schedule/scheduledTime';
@@ -52,6 +53,7 @@ import type { OfficialRecord } from '@Types/officiatingTypes';
 import { HydratedMatchUp } from '@Types/hydrated';
 import {
   SCHEDULE_CONFLICT_DOUBLE_BOOKING,
+  SCHEDULE_LOCKED,
   MISSING_MATCHUP_ID,
   INVALID_RESUME_TIME,
   INVALID_START_TIME,
@@ -296,6 +298,7 @@ function unassignGridPosition({ tournamentRecords, tournamentRecord, drawDefinit
 type AddMatchUpScheduleItemsArgs = {
   inContextMatchUps?: HydratedMatchUp[];
   drawMatchUps?: HydratedMatchUp[];
+  overrideScheduleLock?: boolean;
   proConflictDetection?: boolean;
   drawDefinition: DrawDefinition;
   errorOnAnachronism?: boolean;
@@ -333,6 +336,7 @@ export function addMatchUpScheduleItems(params: AddMatchUpScheduleItemsArgs): {
     proConflictDetection = false,
     errorOnAnachronism = false,
     checkChronology = true,
+    overrideScheduleLock,
     removePriorValues,
     tournamentRecords,
     tournamentRecord,
@@ -351,6 +355,21 @@ export function addMatchUpScheduleItems(params: AddMatchUpScheduleItemsArgs): {
     const result = findDrawMatchUp({ drawDefinition, event, matchUpId });
     if (result.error) return result;
     matchUp = result.matchUp;
+  }
+
+  // A director's schedule lock pins PLACEMENT. Actual-play attributes
+  // (startTime / stopTime / resumeTime / endTime) are never guarded, so a
+  // locked matchUp can still be started, suspended and completed. Callers that
+  // have confirmed the move with the operator pass `overrideScheduleLock`.
+  if (!overrideScheduleLock) {
+    const lockedAttributes = scheduleLockConflicts({ matchUp, schedule });
+    if (lockedAttributes.length) {
+      return decorateResult({
+        info: `schedule locked: ${lockedAttributes.join(', ')}`,
+        result: { error: SCHEDULE_LOCKED },
+        stack,
+      });
+    }
   }
 
   const {

--- a/src/mutate/matchUps/schedule/setMatchUpScheduleLock.ts
+++ b/src/mutate/matchUps/schedule/setMatchUpScheduleLock.ts
@@ -1,0 +1,102 @@
+import { SCHEDULE_LOCK_ATTRIBUTES } from '@Query/matchUp/isScheduleLocked';
+import { modifyMatchUpNotice } from '@Mutate/notifications/drawNotifications';
+import { decorateResult } from '@Functions/global/decorateResult';
+import { findDrawMatchUp } from '@Acquire/findDrawMatchUp';
+import { isObject } from '@Tools/objects';
+
+// constants and types
+import { DrawDefinition, Event, ScheduleLock, Tournament } from '@Types/tournamentTypes';
+import { SUCCESS } from '@Constants/resultConstants';
+import {
+  INVALID_VALUES,
+  MATCHUP_NOT_FOUND,
+  MISSING_DRAW_DEFINITION,
+  MISSING_MATCHUP_ID,
+} from '@Constants/errorConditionConstants';
+
+type SetMatchUpScheduleLockArgs = {
+  // the lock to apply; null or undefined removes an existing lock
+  lock?: ScheduleLock | null;
+  tournamentRecord?: Tournament;
+  drawDefinition: DrawDefinition;
+  disableNotice?: boolean;
+  matchUpId: string;
+  event?: Event;
+};
+
+const LOCKABLE_ATTRIBUTES = new Set<string>(SCHEDULE_LOCK_ATTRIBUTES);
+
+/**
+ * Set or clear `matchUp.schedule.lock` — a director's declaration that this
+ * placement is deliberate and must not be moved by bulk or automated
+ * scheduling. The marquee match promised centre court at 19:00 survives a
+ * Clear, a re-schedule, or a scenario apply of the rest of the day.
+ *
+ * Semantics:
+ *  - Pass a {@link ScheduleLock} object to lock. `{}` pins the whole placement;
+ *    `{ attributes: [...] }` pins only those placement fields.
+ *  - Pass `null` or `undefined` to unlock (explicit removal).
+ *  - Subsequent calls overwrite the prior lock.
+ *  - `lockedAt` / `lockedBy` / `reason` are caller-supplied metadata — the
+ *    factory never stamps wall-clock (the `calledAt` / ScheduleScenario idiom).
+ *  - The lock guards PLACEMENT only: `startTime`, `stopTime`, `resumeTime` and
+ *    `endTime` stay writable so a locked matchUp can still be played.
+ *  - It becomes inert once the matchUp reaches a completed status — see
+ *    `isScheduleLocked`. Nothing is unwritten on completion.
+ *  - Locking a matchUp that has no placement is permitted but inert: a lock
+ *    guards a placement, and an unscheduled matchUp has none. It takes effect
+ *    as soon as the matchUp is placed.
+ *  - Unrelated to `tournamentRecord.mutationLocks`, which gate whole methods at
+ *    tournament grain.
+ *
+ * This is a CODES first-class attribute — no legacy timeItem mirror, no
+ * LEGACY/DUAL/NATIVE branching.
+ */
+export function setMatchUpScheduleLock(params: SetMatchUpScheduleLockArgs) {
+  const stack = 'setMatchUpScheduleLock';
+  const { tournamentRecord, drawDefinition, disableNotice, matchUpId, event, lock } = params;
+
+  if (!drawDefinition) return decorateResult({ result: { error: MISSING_DRAW_DEFINITION }, stack });
+  if (!matchUpId) return decorateResult({ result: { error: MISSING_MATCHUP_ID }, stack });
+
+  const removing = lock === undefined || lock === null;
+
+  if (!removing) {
+    if (!isObject(lock)) {
+      return decorateResult({ result: { error: INVALID_VALUES }, stack, info: 'lock must be an object' });
+    }
+    const { attributes } = lock;
+    if (attributes !== undefined) {
+      const valid = Array.isArray(attributes) && attributes.every((attribute) => LOCKABLE_ATTRIBUTES.has(attribute));
+      if (!valid) {
+        return decorateResult({
+          info: `lock.attributes must be an array of: ${SCHEDULE_LOCK_ATTRIBUTES.join(', ')}`,
+          result: { error: INVALID_VALUES },
+          stack,
+        });
+      }
+    }
+  }
+
+  const { matchUp } = findDrawMatchUp({ drawDefinition, event, matchUpId });
+  if (!matchUp) return decorateResult({ result: { error: MATCHUP_NOT_FOUND }, stack });
+
+  if (removing) {
+    if (matchUp.schedule) delete matchUp.schedule.lock;
+  } else {
+    if (!matchUp.schedule) matchUp.schedule = {};
+    matchUp.schedule.lock = lock as ScheduleLock;
+  }
+
+  if (!disableNotice) {
+    modifyMatchUpNotice({
+      tournamentId: tournamentRecord?.tournamentId,
+      eventId: event?.eventId,
+      context: stack,
+      drawDefinition,
+      matchUp,
+    });
+  }
+
+  return { ...SUCCESS };
+}

--- a/src/query/matchUp/getMatchUpScheduleDetails.ts
+++ b/src/query/matchUp/getMatchUpScheduleDetails.ts
@@ -116,6 +116,10 @@ export function getMatchUpScheduleDetails(params: GetMatchUpScheduleDetailsArgs)
       })
     : definedAttributes({ milliseconds, startTime, endTime, time });
 
+  // A schedule lock is an internal operations annotation — it means nothing to
+  // a published or public view, and `lock.reason` is the director's own note.
+  if (usePublishState && schedule?.lock) delete schedule.lock;
+
   const { scheduledDate } = scheduledMatchUpDate({ matchUp });
   const { scheduledTime } = scheduledMatchUpTime({ matchUp });
 
@@ -191,6 +195,10 @@ function buildFullSchedule({
   const courtOrder = firstClass.courtOrder ?? timeItemMap.get(COURT_ORDER);
   const venueId = firstClass.venueId ?? timeItemMap.get(ASSIGN_VENUE);
   const courtId = firstClass.courtId ?? timeItemMap.get(ASSIGN_COURT);
+  // First-class only — a schedule lock has no legacy timeItem mirror. Hydrated
+  // here (rather than merged in addMatchUpContext alongside calledAt) so that
+  // the embargo filter strips it with the rest of the placement.
+  const lock = firstClass.lock;
 
   const recoveryTimes = computeRecoveryTimes({
     scheduleTiming,
@@ -222,6 +230,7 @@ function buildFullSchedule({
     homeParticipantId,
     courtAnnotation,
     venueAbbreviation,
+    lock,
     allocatedCourts,
     scheduledDate,
     scheduledTime,

--- a/src/query/matchUp/isScheduleLocked.ts
+++ b/src/query/matchUp/isScheduleLocked.ts
@@ -72,6 +72,22 @@ function currentValue(matchUp: any, attribute: ScheduleLockAttribute): any {
 }
 
 /**
+ * The identity of a court allocation, order-independent.
+ *
+ * `allocatedCourts` is WRITTEN as bare courtIds but STORED as hydrated court
+ * objects (`{ courtId, courtName, venueId, venueName }`), so a structural
+ * comparison of the two sides never matches and re-writing an unchanged
+ * allocation would trip the lock. Reduce both to their courtIds; re-ordering
+ * the same courts is not a move.
+ */
+const allocationIdentity = (value: any): string =>
+  (Array.isArray(value) ? value : [value])
+    .map((entry) => (typeof entry === 'string' ? entry : entry?.courtId))
+    .filter(Boolean)
+    .toSorted((a: string, b: string) => a.localeCompare(b, 'en'))
+    .join('|');
+
+/**
  * Would writing `requested` over `current` actually move the placement?
  * Clearing an already-absent attribute is a no-op, and `3` / `'3'` are the same
  * court order — neither should trip a lock.
@@ -79,7 +95,9 @@ function currentValue(matchUp: any, attribute: ScheduleLockAttribute): any {
 function equivalent(requested: any, current: any): boolean {
   if (isEmpty(requested) && isEmpty(current)) return true;
   if (isEmpty(requested) || isEmpty(current)) return false;
-  if (Array.isArray(requested) || Array.isArray(current)) return JSON.stringify(requested) === JSON.stringify(current);
+  if (Array.isArray(requested) || Array.isArray(current)) {
+    return allocationIdentity(requested) === allocationIdentity(current);
+  }
   return String(requested) === String(current);
 }
 

--- a/src/query/matchUp/isScheduleLocked.ts
+++ b/src/query/matchUp/isScheduleLocked.ts
@@ -1,0 +1,147 @@
+import { isObject } from '@Tools/objects';
+
+// constants and types
+import { completedMatchUpStatuses } from '@Constants/matchUpStatusConstants';
+import { ScheduleLockAttribute } from '@Types/tournamentTypes';
+import {
+  ALLOCATE_COURTS,
+  ASSIGN_COURT,
+  ASSIGN_VENUE,
+  COURT_ORDER,
+  SCHEDULED_DATE,
+  SCHEDULED_TIME,
+} from '@Constants/timeItemConstants';
+
+/**
+ * Placement attributes a schedule lock guards.
+ *
+ * `startTime` / `stopTime` / `resumeTime` / `endTime` are deliberately absent:
+ * they record actual play, not placement, and a locked matchUp must still be
+ * startable, suspendable and completable. `courtAnnotation`, `timeModifiers`
+ * and the official/scorekeeper/timekeeper assignments are annotations on a
+ * placement rather than the placement itself, so they stay editable too.
+ */
+export const SCHEDULE_LOCK_ATTRIBUTES: ScheduleLockAttribute[] = [
+  'allocatedCourts',
+  'scheduledDate',
+  'scheduledTime',
+  'courtOrder',
+  'courtId',
+  'venueId',
+];
+
+// Write-side spelling → stored attribute. `addMatchUpScheduleItems` accepts
+// `schedule.courtIds` for what is stored as `schedule.allocatedCourts`.
+const REQUEST_KEY_TO_ATTRIBUTE: Record<string, ScheduleLockAttribute> = {
+  allocatedCourts: 'allocatedCourts',
+  scheduledDate: 'scheduledDate',
+  scheduledTime: 'scheduledTime',
+  courtOrder: 'courtOrder',
+  courtIds: 'allocatedCourts',
+  courtId: 'courtId',
+  venueId: 'venueId',
+};
+
+// LEGACY / DUAL records keep placement in `timeItems[]` rather than first-class
+// `schedule.*`. The predicate reads BOTH surfaces so a lock behaves identically
+// in every schemaWriteMode — a first-class-only read would make locks silently
+// inert in LEGACY, which is the exact divergence that made unscheduling a no-op
+// in NATIVE before `clearScheduledMatchUps` was taught both surfaces.
+const ATTRIBUTE_ITEM_TYPE: Record<ScheduleLockAttribute, string> = {
+  allocatedCourts: ALLOCATE_COURTS,
+  scheduledDate: SCHEDULED_DATE,
+  scheduledTime: SCHEDULED_TIME,
+  courtOrder: COURT_ORDER,
+  courtId: ASSIGN_COURT,
+  venueId: ASSIGN_VENUE,
+};
+
+const COMPLETED_STATUSES = new Set<string>(completedMatchUpStatuses);
+
+const isEmpty = (value: any): boolean =>
+  value === undefined || value === null || value === '' || (Array.isArray(value) && !value.length);
+
+/** Current placement value, first-class preferred, legacy timeItem as fallback. */
+function currentValue(matchUp: any, attribute: ScheduleLockAttribute): any {
+  const firstClass = matchUp?.schedule?.[attribute];
+  if (!isEmpty(firstClass)) return firstClass;
+
+  const itemType = ATTRIBUTE_ITEM_TYPE[attribute];
+  const timeItems = (matchUp?.timeItems ?? []).filter((timeItem) => timeItem?.itemType === itemType);
+  return timeItems.at(-1)?.itemValue;
+}
+
+/**
+ * Would writing `requested` over `current` actually move the placement?
+ * Clearing an already-absent attribute is a no-op, and `3` / `'3'` are the same
+ * court order — neither should trip a lock.
+ */
+function equivalent(requested: any, current: any): boolean {
+  if (isEmpty(requested) && isEmpty(current)) return true;
+  if (isEmpty(requested) || isEmpty(current)) return false;
+  if (Array.isArray(requested) || Array.isArray(current)) return JSON.stringify(requested) === JSON.stringify(current);
+  return String(requested) === String(current);
+}
+
+/**
+ * Is this matchUp's placement pinned by a director?
+ *
+ * Two conditions make an existing lock **inert** rather than removing it —
+ * nothing is ever unwritten:
+ *
+ *  1. The matchUp has reached a completed status. Completed-status protection
+ *     already keeps bulk scheduling away, so the lock has nothing left to do.
+ *     This is the whole of the "release on completion" behaviour.
+ *  2. There is no placement to protect. A matchUp that has been unscheduled
+ *     (or was never placed) must stay freely schedulable — otherwise a lock
+ *     left behind by an overridden clear would silently make the matchUp
+ *     invisible to every bulk scheduling path, with no symptom to trace.
+ *
+ * Pass `attributes` to ask about specific placement fields; a lock with no
+ * `attributes` of its own pins the entire placement.
+ */
+export function isScheduleLocked({
+  attributes,
+  matchUp,
+}: {
+  attributes?: ScheduleLockAttribute[];
+  matchUp?: any;
+}): boolean {
+  const lock = matchUp?.schedule?.lock;
+  if (!isObject(lock)) return false;
+  if (matchUp?.matchUpStatus && COMPLETED_STATUSES.has(matchUp.matchUpStatus)) return false;
+  if (SCHEDULE_LOCK_ATTRIBUTES.every((attribute) => isEmpty(currentValue(matchUp, attribute)))) return false;
+  if (!attributes?.length) return true;
+
+  const lockedAttributes = lock.attributes;
+  if (!Array.isArray(lockedAttributes) || !lockedAttributes.length) return true;
+
+  const lockedSet = new Set<string>(lockedAttributes);
+  return attributes.some((attribute) => lockedSet.has(attribute));
+}
+
+/**
+ * Which locked placement attributes a requested `schedule` write would change.
+ * Empty ⇒ the write is permitted: either nothing is locked, or the call only
+ * touches unlocked/actual-play attributes, or it rewrites the same values.
+ */
+export function scheduleLockConflicts({
+  matchUp,
+  schedule,
+}: {
+  matchUp?: any;
+  schedule?: any;
+}): ScheduleLockAttribute[] {
+  if (!isObject(schedule) || !isScheduleLocked({ matchUp })) return [];
+
+  const conflicts = new Set<ScheduleLockAttribute>();
+
+  for (const key of Object.keys(schedule)) {
+    const attribute = REQUEST_KEY_TO_ATTRIBUTE[key];
+    if (!attribute || !isScheduleLocked({ matchUp, attributes: [attribute] })) continue;
+    if (equivalent(schedule[key], currentValue(matchUp, attribute))) continue;
+    conflicts.add(attribute);
+  }
+
+  return [...conflicts];
+}

--- a/src/tests/mutations/scheduling/scheduleLocks.test.ts
+++ b/src/tests/mutations/scheduling/scheduleLocks.test.ts
@@ -3,9 +3,18 @@ import mocksEngine from '@Assemblies/engines/mock';
 import tournamentEngine from '@Engines/syncEngine';
 import { afterEach, expect, it } from 'vitest';
 
+// constants and types
+import { OFFICIAL_CONFLICT_OF_INTEREST } from '@Constants/officiatingConstants';
 import { LEGACY, NATIVE } from '@Constants/schemaWriteModeConstants';
 import { SCHEDULE_LOCKED } from '@Constants/errorConditionConstants';
 import { COMPLETED } from '@Constants/matchUpStatusConstants';
+import { INDIVIDUAL } from '@Constants/participantConstants';
+import { DOMINANT_DUO } from '@Constants/tieFormatConstants';
+import { OFFICIAL } from '@Constants/participantRoles';
+import { TEAM } from '@Constants/eventConstants';
+
+// Fixtures
+import { POLICY_OFFICIATING_CONFLICT_OF_INTEREST } from '@Fixtures/policies/POLICY_OFFICIATING_CONFLICT_OF_INTEREST';
 
 /**
  * Schedule locks — a director pins a marquee matchUp's placement so bulk and
@@ -52,8 +61,40 @@ function seed() {
   place(matchUps[0].matchUpId, 0, '19:00');
   place(matchUps[1].matchUpId, 1, '10:00');
 
-  return { lockedId: matchUps[0].matchUpId, otherId: matchUps[1].matchUpId, courts };
+  return {
+    sides: matchUps[0].sides,
+    lockedId: matchUps[0].matchUpId,
+    otherId: matchUps[1].matchUpId,
+    courts,
+  };
 }
+
+/** An OFFICIAL participant, plus an officialRecord declaring a FAMILY tie to `participantId`. */
+function addOfficial() {
+  const { participant } = tournamentEngine.addParticipant({
+    participant: {
+      person: { standardFamilyName: 'Umpire', standardGivenName: 'Chair' },
+      participantType: INDIVIDUAL,
+      participantRole: OFFICIAL,
+    },
+    returnParticipant: true,
+  });
+  return participant.participantId;
+}
+
+const conflictedRecord = (participantId: string): any => ({
+  conflictDeclarations: [{ declarationId: 'dec-1', participantId, relationship: 'FAMILY' }],
+  certificationRequirements: [],
+  officialRecordId: 'rec-001',
+  personId: 'person-official',
+  evaluationPolicies: [],
+  certifications: [],
+  createdAt: '2025-01-01',
+  updatedAt: '2025-01-01',
+  evaluations: [],
+  assignments: [],
+  suspensions: [],
+});
 
 const lock = (matchUpId: string, lockValue: any = { reason: 'featured' }) =>
   tournamentEngine.setMatchUpScheduleLock({ matchUpId, drawId: DRAW_ID, lock: lockValue });
@@ -72,7 +113,7 @@ it('preserves a locked placement through a bulk clear and reports what it kept',
   const { lockedId, otherId } = seed();
   lock(lockedId);
 
-  const result: any = clearAll({ matchUpIds: [lockedId, otherId] });
+  let result: any = clearAll({ matchUpIds: [lockedId, otherId] });
   expect(result.success).toEqual(true);
   expect(result.lockedMatchUpIds).toEqual([lockedId]);
 
@@ -87,7 +128,7 @@ it('a locked matchUp never aborts the clear of its neighbours', () => {
   const { lockedId, otherId } = seed();
   lock(lockedId);
 
-  const result: any = clearAll({ matchUpIds: [lockedId, otherId] });
+  let result: any = clearAll({ matchUpIds: [lockedId, otherId] });
   // one skipped, one cleared — not an error result
   expect(result.error).toBeUndefined();
   expect(result.scheduled).toEqual(1);
@@ -97,7 +138,7 @@ it('clears a locked placement when the caller overrides, and the lock survives t
   const { lockedId } = seed();
   lock(lockedId);
 
-  const result: any = clearAll({ matchUpIds: [lockedId], overrideScheduleLock: true });
+  let result: any = clearAll({ matchUpIds: [lockedId], overrideScheduleLock: true });
   expect(result.success).toEqual(true);
   expect(result.lockedMatchUpIds).toBeUndefined();
   expect(scheduleOf(lockedId)?.scheduledTime).toBeUndefined();
@@ -109,7 +150,7 @@ it('refuses a single-matchUp placement change, naming the locked attributes', ()
   const { lockedId, courts } = seed();
   lock(lockedId);
 
-  const result: any = tournamentEngine.addMatchUpScheduleItems({
+  let result: any = tournamentEngine.addMatchUpScheduleItems({
     schedule: { scheduledTime: '11:00', courtId: courts[3].courtId },
     matchUpId: lockedId,
     drawId: DRAW_ID,
@@ -123,7 +164,7 @@ it('permits actual-play attributes on a locked matchUp — a pinned match must s
   const { lockedId } = seed();
   lock(lockedId);
 
-  const result: any = tournamentEngine.addMatchUpScheduleItems({
+  let result: any = tournamentEngine.addMatchUpScheduleItems({
     schedule: { startTime: '2026-06-22T19:04:00.000Z' },
     matchUpId: lockedId,
     drawId: DRAW_ID,
@@ -136,7 +177,7 @@ it('permits a no-op rewrite of the same placement values', () => {
   const { lockedId, courts } = seed();
   lock(lockedId);
 
-  const result: any = tournamentEngine.addMatchUpScheduleItems({
+  let result: any = tournamentEngine.addMatchUpScheduleItems({
     schedule: { scheduledDate: SCHEDULED_DATE, scheduledTime: '19:00', courtId: courts[0].courtId },
     matchUpId: lockedId,
     drawId: DRAW_ID,
@@ -153,13 +194,13 @@ it('releases the lock lazily once the matchUp reaches a completed status', () =>
     scoreString: '6-1 6-1',
     winningSide: 1,
   });
-  const completion: any = tournamentEngine.setMatchUpStatus({ outcome, matchUpId: lockedId, drawId: DRAW_ID });
+  let completion: any = tournamentEngine.setMatchUpStatus({ outcome, matchUpId: lockedId, drawId: DRAW_ID });
   // guard the guard: a rejected outcome would leave the matchUp TO_BE_PLAYED and
   // make the assertions below pass for the wrong reason
   expect(completion.success).toEqual(true);
   expect(scheduleOf(lockedId)?.lock).not.toBeUndefined();
 
-  const result: any = clearAll({ matchUpIds: [lockedId], scheduleCompletedMatchUps: true });
+  let result: any = clearAll({ matchUpIds: [lockedId], scheduleCompletedMatchUps: true });
   expect(result.lockedMatchUpIds).toBeUndefined();
   expect(scheduleOf(lockedId)?.scheduledTime).toBeUndefined();
 });
@@ -172,7 +213,7 @@ it('an unscheduled matchUp is not made unschedulable by a leftover lock', () => 
   // the lock object is still on the record, but with no placement to guard it
   // must not silently block the matchUp from being scheduled again
   expect(scheduleOf(lockedId)?.lock).not.toBeUndefined();
-  const result: any = tournamentEngine.addMatchUpScheduleItems({
+  let result: any = tournamentEngine.addMatchUpScheduleItems({
     schedule: { scheduledDate: SCHEDULED_DATE, scheduledTime: '14:00', courtId: courts[2].courtId },
     matchUpId: lockedId,
     drawId: DRAW_ID,
@@ -185,7 +226,7 @@ it('survives clearScheduledMatchUps, the date-scoped clear the schedulers use', 
   const { lockedId, otherId } = seed();
   lock(lockedId);
 
-  const result: any = tournamentEngine.clearScheduledMatchUps({ scheduledDates: [SCHEDULED_DATE] });
+  let result: any = tournamentEngine.clearScheduledMatchUps({ scheduledDates: [SCHEDULED_DATE] });
   expect(result.lockedMatchUpIds).toEqual([lockedId]);
   expect(scheduleOf(lockedId)?.scheduledTime).toEqual('19:00');
   expect(scheduleOf(otherId)?.scheduledTime).toBeUndefined();
@@ -195,10 +236,10 @@ it('survives clearMatchUpSchedule unless overridden', () => {
   const { lockedId } = seed();
   lock(lockedId);
 
-  const blocked: any = tournamentEngine.clearMatchUpSchedule({ matchUpId: lockedId, drawId: DRAW_ID });
+  let blocked: any = tournamentEngine.clearMatchUpSchedule({ matchUpId: lockedId, drawId: DRAW_ID });
   expect(blocked.error).toEqual(SCHEDULE_LOCKED);
 
-  const allowed: any = tournamentEngine.clearMatchUpSchedule({
+  let allowed: any = tournamentEngine.clearMatchUpSchedule({
     overrideScheduleLock: true,
     matchUpId: lockedId,
     drawId: DRAW_ID,
@@ -211,7 +252,7 @@ it('a partial lock guards only the attributes it names', () => {
   lock(lockedId, { attributes: ['scheduledTime'] });
 
   // court is not pinned — reassigning it is permitted
-  const courtChange: any = tournamentEngine.addMatchUpScheduleItems({
+  let courtChange: any = tournamentEngine.addMatchUpScheduleItems({
     schedule: { courtId: courts[3].courtId },
     matchUpId: lockedId,
     drawId: DRAW_ID,
@@ -219,7 +260,7 @@ it('a partial lock guards only the attributes it names', () => {
   expect(courtChange.error).toBeUndefined();
 
   // time is pinned
-  const timeChange: any = tournamentEngine.addMatchUpScheduleItems({
+  let timeChange: any = tournamentEngine.addMatchUpScheduleItems({
     schedule: { scheduledTime: '08:30' },
     matchUpId: lockedId,
     drawId: DRAW_ID,
@@ -241,7 +282,7 @@ it('unlocks with a null lock', () => {
   tournamentEngine.setMatchUpScheduleLock({ matchUpId: lockedId, drawId: DRAW_ID, lock: null });
   expect(scheduleOf(lockedId)?.lock).toBeUndefined();
 
-  const result: any = clearAll({ matchUpIds: [lockedId] });
+  let result: any = clearAll({ matchUpIds: [lockedId] });
   expect(result.lockedMatchUpIds).toBeUndefined();
   expect(scheduleOf(lockedId)?.scheduledTime).toBeUndefined();
 });
@@ -251,7 +292,7 @@ it('behaves identically in NATIVE, where placement is first-class', () => {
   const { lockedId, otherId } = seed();
   lock(lockedId);
 
-  const result: any = clearAll({ matchUpIds: [lockedId, otherId] });
+  let result: any = clearAll({ matchUpIds: [lockedId, otherId] });
   expect(result.lockedMatchUpIds).toEqual([lockedId]);
   expect(scheduleOf(lockedId)?.scheduledTime).toEqual('19:00');
   expect(scheduleOf(otherId)?.scheduledTime).toBeUndefined();
@@ -261,10 +302,126 @@ it('keeps the lock out of published views', () => {
   const { lockedId } = seed();
   lock(lockedId);
 
-  const publishedSchedule = tournamentEngine
+  let publishedSchedule = tournamentEngine
     .allTournamentMatchUps({ usePublishState: true })
     .matchUps.find((m: any) => m.matchUpId === lockedId)?.schedule;
   expect(publishedSchedule?.lock).toBeUndefined();
   // …while the operational view still carries it
+  expect(scheduleOf(lockedId)?.lock).not.toBeUndefined();
+});
+
+it('assigns an official to a locked matchUp — an official is not a placement', () => {
+  const { lockedId } = seed();
+  lock(lockedId);
+
+  let result: any = tournamentEngine.addMatchUpOfficial({
+    participantId: addOfficial(),
+    matchUpId: lockedId,
+    drawId: DRAW_ID,
+  });
+  expect(result.error).toBeUndefined();
+  expect(result.success).toEqual(true);
+  expect(scheduleOf(lockedId)?.official).not.toBeUndefined();
+  // the placement is untouched by the assignment
+  expect(scheduleOf(lockedId)?.scheduledTime).toEqual('19:00');
+});
+
+it('reports an officiating conflict on a locked matchUp — the lock must not mask it', () => {
+  // The conflict gate lives in addMatchUpOfficial, the lock guard in
+  // addMatchUpScheduleItems. If a refactor ever merges those paths, a lock
+  // refusal would return first and hide the conflict from a director who then
+  // unlocks, retries, and meets a second refusal they were never warned about.
+  const { lockedId, sides } = seed();
+  lock(lockedId);
+
+  let result: any = tournamentEngine.addMatchUpOfficial({
+    policyDefinitions: POLICY_OFFICIATING_CONFLICT_OF_INTEREST,
+    officialRecord: conflictedRecord(sides[0].participantId),
+    participantId: addOfficial(),
+    matchUpId: lockedId,
+    drawId: DRAW_ID,
+  });
+
+  expect(result.error).toEqual(OFFICIAL_CONFLICT_OF_INTEREST);
+  expect(result.error).not.toEqual(SCHEDULE_LOCKED);
+  expect(result.conflicts).toHaveLength(1);
+  // the conflict refusal wrote nothing, and the lock is unaffected
+  expect(scheduleOf(lockedId)?.official).toBeUndefined();
+  expect(scheduleOf(lockedId)?.lock).not.toBeUndefined();
+});
+
+it('pins allocated courts, comparing the allocation rather than the reference', () => {
+  // Only TEAM matchUps carry `allocatedCourts` (the write-side spelling is
+  // `courtIds`); a singles matchUp silently holds none. This is the one path
+  // where the lock compares arrays, so it needs a TEAM draw to be real.
+  const {
+    drawIds: [teamDrawId],
+  } = mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ drawSize: 2, eventType: TEAM, tieFormatName: DOMINANT_DUO }],
+    venueProfiles: [{ courtsCount: 4, startTime: '08:00', endTime: '21:00', venueId: VENUE_ID }],
+    startDate: SCHEDULED_DATE,
+    endDate: '2026-06-28',
+    setState: true,
+  });
+
+  const courts = tournamentEngine.getVenuesAndCourts().courts;
+  const teamMatchUpId = tournamentEngine
+    .allTournamentMatchUps()
+    .matchUps.find((m: any) => m.matchUpType === TEAM)?.matchUpId;
+  const courtIds = [courts[0].courtId, courts[1].courtId];
+
+  tournamentEngine.addMatchUpScheduleItems({
+    schedule: { scheduledDate: SCHEDULED_DATE, courtIds },
+    matchUpId: teamMatchUpId,
+    drawId: teamDrawId,
+  });
+  // guard the guard: without a stored allocation the comparison below is vacuous
+  expect(scheduleOf(teamMatchUpId)?.allocatedCourts?.length).toEqual(2);
+
+  tournamentEngine.setMatchUpScheduleLock({ matchUpId: teamMatchUpId, drawId: teamDrawId, lock: {} });
+
+  // the same allocation rewritten is not a move
+  let unchanged: any = tournamentEngine.addMatchUpScheduleItems({
+    schedule: { courtIds },
+    matchUpId: teamMatchUpId,
+    drawId: teamDrawId,
+  });
+  expect(unchanged.error).toBeUndefined();
+
+  // a different allocation is
+  let moved: any = tournamentEngine.addMatchUpScheduleItems({
+    schedule: { courtIds: [courts[2].courtId] },
+    matchUpId: teamMatchUpId,
+    drawId: teamDrawId,
+  });
+  expect(moved.error).toEqual(SCHEDULE_LOCKED);
+  expect(moved.info).toContain('allocatedCourts');
+});
+
+it('rejects a lock request that names no matchUp', () => {
+  seed();
+  let result: any = tournamentEngine.setMatchUpScheduleLock({ drawId: DRAW_ID, lock: {} });
+  expect(result.error).not.toBeUndefined();
+});
+
+it('rejects a lock request for a matchUp that is not in the draw', () => {
+  seed();
+  let result: any = tournamentEngine.setMatchUpScheduleLock({
+    matchUpId: 'no-such-matchUp',
+    drawId: DRAW_ID,
+    lock: {},
+  });
+  expect(result.error).not.toBeUndefined();
+});
+
+it('locks silently when notices are disabled', () => {
+  const { lockedId } = seed();
+  let result: any = tournamentEngine.setMatchUpScheduleLock({
+    matchUpId: lockedId,
+    disableNotice: true,
+    drawId: DRAW_ID,
+    lock: {},
+  });
+  expect(result.success).toEqual(true);
   expect(scheduleOf(lockedId)?.lock).not.toBeUndefined();
 });

--- a/src/tests/mutations/scheduling/scheduleLocks.test.ts
+++ b/src/tests/mutations/scheduling/scheduleLocks.test.ts
@@ -1,0 +1,270 @@
+import { setSchemaWriteMode } from '@Global/state/globalState';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { afterEach, expect, it } from 'vitest';
+
+import { LEGACY, NATIVE } from '@Constants/schemaWriteModeConstants';
+import { SCHEDULE_LOCKED } from '@Constants/errorConditionConstants';
+import { COMPLETED } from '@Constants/matchUpStatusConstants';
+
+/**
+ * Schedule locks — a director pins a marquee matchUp's placement so bulk and
+ * automated scheduling cannot move it.
+ *
+ * The suite-wide setup hook pins LEGACY (placement in `timeItems[]`); production
+ * runs NATIVE (first-class `matchUp.schedule.*`). The lock predicate reads both
+ * surfaces, so the mode-parity test below is the one that would catch a
+ * first-class-only regression.
+ */
+
+afterEach(() => setSchemaWriteMode(LEGACY));
+
+const DRAW_ID = 'drawId';
+const SCHEDULED_DATE = '2026-06-22';
+const VENUE_ID = 'venueId';
+
+function seed() {
+  mocksEngine.generateTournamentRecord({
+    venueProfiles: [{ courtsCount: 4, startTime: '08:00', endTime: '21:00', venueId: VENUE_ID }],
+    drawProfiles: [{ drawId: DRAW_ID, drawSize: 8 }],
+    startDate: SCHEDULED_DATE,
+    endDate: '2026-06-28',
+    setState: true,
+  });
+
+  const courts = tournamentEngine.getVenuesAndCourts().courts;
+  const matchUps = tournamentEngine
+    .allTournamentMatchUps()
+    .matchUps.filter((m: any) => m.roundNumber === 1 && m.sides?.every((s: any) => s.participant));
+
+  const place = (matchUpId: string, courtIndex: number, scheduledTime: string) =>
+    tournamentEngine.addMatchUpScheduleItems({
+      schedule: {
+        scheduledDate: SCHEDULED_DATE,
+        scheduledTime,
+        venueId: VENUE_ID,
+        courtId: courts[courtIndex].courtId,
+      },
+      matchUpId,
+      drawId: DRAW_ID,
+    });
+
+  place(matchUps[0].matchUpId, 0, '19:00');
+  place(matchUps[1].matchUpId, 1, '10:00');
+
+  return { lockedId: matchUps[0].matchUpId, otherId: matchUps[1].matchUpId, courts };
+}
+
+const lock = (matchUpId: string, lockValue: any = { reason: 'featured' }) =>
+  tournamentEngine.setMatchUpScheduleLock({ matchUpId, drawId: DRAW_ID, lock: lockValue });
+
+const scheduleOf = (matchUpId: string) =>
+  tournamentEngine.allTournamentMatchUps().matchUps.find((m: any) => m.matchUpId === matchUpId)?.schedule;
+
+const clearAll = (params: any = {}) =>
+  tournamentEngine.bulkScheduleMatchUps({
+    schedule: { courtId: '', scheduledDate: '', courtOrder: '', scheduledTime: '', venueId: '' },
+    removePriorValues: true,
+    ...params,
+  });
+
+it('preserves a locked placement through a bulk clear and reports what it kept', () => {
+  const { lockedId, otherId } = seed();
+  lock(lockedId);
+
+  const result: any = clearAll({ matchUpIds: [lockedId, otherId] });
+  expect(result.success).toEqual(true);
+  expect(result.lockedMatchUpIds).toEqual([lockedId]);
+
+  // the locked matchUp keeps its placement; the unlocked one is cleared
+  expect(scheduleOf(lockedId)?.scheduledTime).toEqual('19:00');
+  expect(scheduleOf(lockedId)?.courtId).not.toBeUndefined();
+  expect(scheduleOf(otherId)?.scheduledTime).toBeUndefined();
+  expect(scheduleOf(otherId)?.courtId).toBeUndefined();
+});
+
+it('a locked matchUp never aborts the clear of its neighbours', () => {
+  const { lockedId, otherId } = seed();
+  lock(lockedId);
+
+  const result: any = clearAll({ matchUpIds: [lockedId, otherId] });
+  // one skipped, one cleared — not an error result
+  expect(result.error).toBeUndefined();
+  expect(result.scheduled).toEqual(1);
+});
+
+it('clears a locked placement when the caller overrides, and the lock survives the move', () => {
+  const { lockedId } = seed();
+  lock(lockedId);
+
+  const result: any = clearAll({ matchUpIds: [lockedId], overrideScheduleLock: true });
+  expect(result.success).toEqual(true);
+  expect(result.lockedMatchUpIds).toBeUndefined();
+  expect(scheduleOf(lockedId)?.scheduledTime).toBeUndefined();
+  // the lock is not unwritten by an override — only setMatchUpScheduleLock removes it
+  expect(scheduleOf(lockedId)?.lock).not.toBeUndefined();
+});
+
+it('refuses a single-matchUp placement change, naming the locked attributes', () => {
+  const { lockedId, courts } = seed();
+  lock(lockedId);
+
+  const result: any = tournamentEngine.addMatchUpScheduleItems({
+    schedule: { scheduledTime: '11:00', courtId: courts[3].courtId },
+    matchUpId: lockedId,
+    drawId: DRAW_ID,
+  });
+  expect(result.error).toEqual(SCHEDULE_LOCKED);
+  expect(result.info).toContain('scheduledTime');
+  expect(scheduleOf(lockedId)?.scheduledTime).toEqual('19:00');
+});
+
+it('permits actual-play attributes on a locked matchUp — a pinned match must still be playable', () => {
+  const { lockedId } = seed();
+  lock(lockedId);
+
+  const result: any = tournamentEngine.addMatchUpScheduleItems({
+    schedule: { startTime: '2026-06-22T19:04:00.000Z' },
+    matchUpId: lockedId,
+    drawId: DRAW_ID,
+  });
+  expect(result.error).toBeUndefined();
+  expect(result.success).toEqual(true);
+});
+
+it('permits a no-op rewrite of the same placement values', () => {
+  const { lockedId, courts } = seed();
+  lock(lockedId);
+
+  const result: any = tournamentEngine.addMatchUpScheduleItems({
+    schedule: { scheduledDate: SCHEDULED_DATE, scheduledTime: '19:00', courtId: courts[0].courtId },
+    matchUpId: lockedId,
+    drawId: DRAW_ID,
+  });
+  expect(result.error).toBeUndefined();
+});
+
+it('releases the lock lazily once the matchUp reaches a completed status', () => {
+  const { lockedId } = seed();
+  lock(lockedId);
+
+  const { outcome } = mocksEngine.generateOutcomeFromScoreString({
+    matchUpStatus: COMPLETED,
+    scoreString: '6-1 6-1',
+    winningSide: 1,
+  });
+  const completion: any = tournamentEngine.setMatchUpStatus({ outcome, matchUpId: lockedId, drawId: DRAW_ID });
+  // guard the guard: a rejected outcome would leave the matchUp TO_BE_PLAYED and
+  // make the assertions below pass for the wrong reason
+  expect(completion.success).toEqual(true);
+  expect(scheduleOf(lockedId)?.lock).not.toBeUndefined();
+
+  const result: any = clearAll({ matchUpIds: [lockedId], scheduleCompletedMatchUps: true });
+  expect(result.lockedMatchUpIds).toBeUndefined();
+  expect(scheduleOf(lockedId)?.scheduledTime).toBeUndefined();
+});
+
+it('an unscheduled matchUp is not made unschedulable by a leftover lock', () => {
+  const { lockedId, courts } = seed();
+  lock(lockedId);
+  clearAll({ matchUpIds: [lockedId], overrideScheduleLock: true });
+
+  // the lock object is still on the record, but with no placement to guard it
+  // must not silently block the matchUp from being scheduled again
+  expect(scheduleOf(lockedId)?.lock).not.toBeUndefined();
+  const result: any = tournamentEngine.addMatchUpScheduleItems({
+    schedule: { scheduledDate: SCHEDULED_DATE, scheduledTime: '14:00', courtId: courts[2].courtId },
+    matchUpId: lockedId,
+    drawId: DRAW_ID,
+  });
+  expect(result.error).toBeUndefined();
+  expect(scheduleOf(lockedId)?.scheduledTime).toEqual('14:00');
+});
+
+it('survives clearScheduledMatchUps, the date-scoped clear the schedulers use', () => {
+  const { lockedId, otherId } = seed();
+  lock(lockedId);
+
+  const result: any = tournamentEngine.clearScheduledMatchUps({ scheduledDates: [SCHEDULED_DATE] });
+  expect(result.lockedMatchUpIds).toEqual([lockedId]);
+  expect(scheduleOf(lockedId)?.scheduledTime).toEqual('19:00');
+  expect(scheduleOf(otherId)?.scheduledTime).toBeUndefined();
+});
+
+it('survives clearMatchUpSchedule unless overridden', () => {
+  const { lockedId } = seed();
+  lock(lockedId);
+
+  const blocked: any = tournamentEngine.clearMatchUpSchedule({ matchUpId: lockedId, drawId: DRAW_ID });
+  expect(blocked.error).toEqual(SCHEDULE_LOCKED);
+
+  const allowed: any = tournamentEngine.clearMatchUpSchedule({
+    overrideScheduleLock: true,
+    matchUpId: lockedId,
+    drawId: DRAW_ID,
+  });
+  expect(allowed.success).toEqual(true);
+});
+
+it('a partial lock guards only the attributes it names', () => {
+  const { lockedId, courts } = seed();
+  lock(lockedId, { attributes: ['scheduledTime'] });
+
+  // court is not pinned — reassigning it is permitted
+  const courtChange: any = tournamentEngine.addMatchUpScheduleItems({
+    schedule: { courtId: courts[3].courtId },
+    matchUpId: lockedId,
+    drawId: DRAW_ID,
+  });
+  expect(courtChange.error).toBeUndefined();
+
+  // time is pinned
+  const timeChange: any = tournamentEngine.addMatchUpScheduleItems({
+    schedule: { scheduledTime: '08:30' },
+    matchUpId: lockedId,
+    drawId: DRAW_ID,
+  });
+  expect(timeChange.error).toEqual(SCHEDULE_LOCKED);
+});
+
+it('rejects an invalid lock shape', () => {
+  const { lockedId } = seed();
+  expect(lock(lockedId, { attributes: ['courtId', 'nonsense'] }).error).not.toBeUndefined();
+  expect(lock(lockedId, 'yes').error).not.toBeUndefined();
+});
+
+it('unlocks with a null lock', () => {
+  const { lockedId } = seed();
+  lock(lockedId);
+  expect(scheduleOf(lockedId)?.lock).not.toBeUndefined();
+
+  tournamentEngine.setMatchUpScheduleLock({ matchUpId: lockedId, drawId: DRAW_ID, lock: null });
+  expect(scheduleOf(lockedId)?.lock).toBeUndefined();
+
+  const result: any = clearAll({ matchUpIds: [lockedId] });
+  expect(result.lockedMatchUpIds).toBeUndefined();
+  expect(scheduleOf(lockedId)?.scheduledTime).toBeUndefined();
+});
+
+it('behaves identically in NATIVE, where placement is first-class', () => {
+  setSchemaWriteMode(NATIVE);
+  const { lockedId, otherId } = seed();
+  lock(lockedId);
+
+  const result: any = clearAll({ matchUpIds: [lockedId, otherId] });
+  expect(result.lockedMatchUpIds).toEqual([lockedId]);
+  expect(scheduleOf(lockedId)?.scheduledTime).toEqual('19:00');
+  expect(scheduleOf(otherId)?.scheduledTime).toBeUndefined();
+});
+
+it('keeps the lock out of published views', () => {
+  const { lockedId } = seed();
+  lock(lockedId);
+
+  const publishedSchedule = tournamentEngine
+    .allTournamentMatchUps({ usePublishState: true })
+    .matchUps.find((m: any) => m.matchUpId === lockedId)?.schedule;
+  expect(publishedSchedule?.lock).toBeUndefined();
+  // …while the operational view still carries it
+  expect(scheduleOf(lockedId)?.lock).not.toBeUndefined();
+});

--- a/src/types/factoryEngineMethods.ts
+++ b/src/types/factoryEngineMethods.ts
@@ -580,6 +580,7 @@ export type FactoryEngineMethod =
   | 'setMatchUpDailyLimits'
   | 'setMatchUpFormat'
   | 'setMatchUpHomeParticipantId'
+  | 'setMatchUpScheduleLock'
   | 'setMatchUpState'
   | 'setMatchUpStatus'
   | 'setOrderOfFinish'
@@ -1240,6 +1241,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'setMatchUpDailyLimits',
   'setMatchUpFormat',
   'setMatchUpHomeParticipantId',
+  'setMatchUpScheduleLock',
   'setMatchUpState',
   'setMatchUpStatus',
   'setOrderOfFinish',

--- a/src/types/methodSignatures.ts
+++ b/src/types/methodSignatures.ts
@@ -161,6 +161,7 @@ import type { deleteFlightProfileAndFlightDraws } from '@Mutate/events/deleteFli
 import type { generateOutcomeFromScoreString } from '@Generators/mocks/generateOutcomeFromScoreString';
 import type { qualifierDrawPositionAssignment } from '@Mutate/matchUps/drawPositions/positionQualifier';
 import type { resetQualifyingStructure } from '@Mutate/drawDefinitions/resetQualifyingStructure';
+import type { setMatchUpScheduleLock } from '@Mutate/matchUps/schedule/setMatchUpScheduleLock';
 import type { addCertificationRequirement } from '@Mutate/officiating/addCertificationRequirement';
 import type { applyScheduleScenario } from '@Mutate/matchUps/schedule/applyScheduleScenario';
 import type { getAssignedParticipantIds } from '@Query/drawDefinition/getAssignedParticipantIds';
@@ -1111,6 +1112,7 @@ export interface MethodSignatures {
   setMatchUpDailyLimits: EngineMethod<typeof setMatchUpDailyLimits>;
   setMatchUpFormat: EngineMethod<typeof setMatchUpFormat>;
   setMatchUpHomeParticipantId: EngineMethod<typeof setMatchUpHomeParticipantId>;
+  setMatchUpScheduleLock: EngineMethod<typeof setMatchUpScheduleLock>;
   setMatchUpState: EngineMethod<typeof setMatchUpState>;
   setMatchUpStatus: EngineMethod<typeof setMatchUpStatus>;
   setOrderOfFinish: EngineMethod<typeof setOrderOfFinish>;

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -439,6 +439,35 @@ export enum EventTypeEnum {
 }
 export type EventTypeUnion = `${EventTypeEnum}`;
 
+/** Placement attributes a {@link ScheduleLock} can pin. */
+export type ScheduleLockAttribute =
+  'allocatedCourts' | 'courtId' | 'courtOrder' | 'scheduledDate' | 'scheduledTime' | 'venueId';
+
+/**
+ * CODES first-class: a director's declaration that a matchUp's placement is
+ * deliberate and must not be moved by bulk or automated scheduling — the
+ * marquee match promised centre court at 19:00 surviving a Clear or a
+ * re-schedule of the rest of the day.
+ *
+ * The lock guards PLACEMENT only. `startTime` / `stopTime` / `resumeTime` /
+ * `endTime` record actual play and stay writable, or a locked matchUp could
+ * never be played. It is also inert once the matchUp reaches a completed
+ * status, where completed-status protection already applies.
+ *
+ * Presence of the object is the lock; `attributes` narrows it to specific
+ * placement fields (absent ⇒ the whole placement). Timestamps are
+ * caller-supplied — the factory never stamps wall-clock.
+ *
+ * Unrelated to `tournamentRecord.mutationLocks`, which gate whole methods at
+ * tournament grain.
+ */
+export interface ScheduleLock {
+  attributes?: ScheduleLockAttribute[];
+  lockedAt?: string;
+  lockedBy?: string;
+  reason?: string;
+}
+
 /**
  * CODES first-class schedule attributes on a matchUp. Each field was
  * historically stored as a `timeItem` of the corresponding `itemType`
@@ -461,6 +490,9 @@ export interface MatchUpSchedule {
   courtId?: string;
   courtOrder?: number;
   homeParticipantId?: string;
+  // CODES 5.0.0 first-class: pins this placement against bulk clears and
+  // automated scheduling. See {@link ScheduleLock}. No legacy timeItem mirror.
+  lock?: ScheduleLock;
   official?: any;
   // participantId of a nominated scorekeeper for this matchUp (crowd-scoring Phase D).
   // SCHEDULE.ASSIGNMENT.SCOREKEEPER first-class value; not cleared by rescheduling.


### PR DESCRIPTION
Phase 1 of `Mentat/planning/SCHEDULE_LOCKS.md`. A tournament director can pin a marquee matchUp's placement so bulk and automated scheduling cannot move it — the match promised centre court at 19:00 survives a Clear, a re-schedule, or a committed scenario.

## The finding that shaped the design

TMX's "Clear schedule" does **not** call `clearScheduledMatchUps` — it calls `bulkScheduleMatchUps` with empty values + `removePriorValues`. A lock enforced only in `clearScheduledMatchUps` would have passed factory tests and done nothing for the button. The predicate therefore lands at `addMatchUpScheduleItems`, the shared trunk of drag/drop *and* every bulk write, plus the two direct-delete clears.

## Model

`matchUp.schedule.lock` — CODES first-class, no legacy timeItem mirror. `setMatchUpScheduleLock` mirrors `setMatchUpCalledAt` (`null` unlocks). Presence is the lock; `attributes` narrows it to specific placement fields.

| Mutation | Behaviour on a locked matchUp |
| --- | --- |
| `addMatchUpScheduleItems` | `SCHEDULE_LOCKED`; `info` names the locked attributes |
| `bulkScheduleMatchUps` / `bulkScheduleTournamentMatchUps` | **skips**, continues, returns `lockedMatchUpIds` |
| `clearScheduledMatchUps` | skips, returns `lockedMatchUpIds` |
| `clearMatchUpSchedule` | `SCHEDULE_LOCKED` |
| `applyScheduleScenario` | skips (hand-off to `bulkScheduleMatchUps`) |

All accept `overrideScheduleLock: true`. An override moves the placement but never removes the lock.

## Four things worth reviewing

1. **Placement only.** `startTime` / `stopTime` / `resumeTime` / `endTime` are never guarded, or a pinned matchUp could not be played.
2. **Skip, don't fail, in bulk.** One pinned matchUp must not abort the clear of the other 200.
3. **Inert, never unwritten.** A lock stops applying once the matchUp completes (completed-status protection already covers it) and while it has no placement to guard — otherwise a lock left by an overridden clear would silently make the matchUp unschedulable with no symptom to trace.
4. **Write-mode parity.** The predicate reads first-class *and* `timeItems[]`, so locks are not silently inert in LEGACY (the suite's default mode).

Locks are stripped from published views (`usePublishState` + the embargo filter), and hydrated in `buildFullSchedule` rather than merged in `addMatchUpContext` precisely so embargo redaction strips them with the rest of the placement.

`deleteCourt` / `deleteVenue` and `resetDrawDefinition` deliberately ignore locks — a lock cannot survive deletion of the court it pins to.

## Officiating interaction

The conflict-of-interest gate lives in `addMatchUpOfficial`, the lock guard in `addMatchUpScheduleItems`, so a lock cannot mask a conflict refusal. Pinned with regression tests that fail if a lock guard is ever added to the official-assignment path.

Also fixes a defect found while writing those tests: `allocatedCourts` is written as bare courtIds but stored as hydrated court objects, so re-writing an unchanged allocation tripped the lock. Now compared by court identity.

## Verification

- Full suite **10963 passed / 1 skipped**
- `pnpm lint` clean (`--max-warnings 0`), `check-types` clean, `verify:generated` OK
- Coverage: global statements 95.09 / branches 86.87 / functions 97.99 / lines 97.64 — thresholds hold
- 21 new tests; **falsified** — neutering the predicate fails 7, adding a lock guard to `addMatchUpOfficial` fails the 2 officiating cases
- Docs: `concepts/schedule-locks.mdx` + `schedule-governor` entry