### PR TITLE
feat(notifications): thread event to 20 more matchUp notice emitters

### DIFF
--- a/src/mutate/drawDefinitions/luckyDrawAdvancement.ts
+++ b/src/mutate/drawDefinitions/luckyDrawAdvancement.ts
@@ -161,6 +161,7 @@ export function luckyDrawAdvancement({
     tournamentId,
     structureId,
     structure,
+    event,
   });
 
   modifyPositionAssignmentsNotice({
@@ -561,6 +562,7 @@ function assignNextRoundPositions({
   tournamentId,
   structureId,
   structure,
+  event,
 }) {
   const allAssignedPositions = new Set(positionAssignments.map((a) => a.drawPosition));
   const allMatchUpPositions = (structure.matchUps ?? []).flatMap((m) => m.drawPositions ?? []).filter(Boolean);
@@ -597,6 +599,7 @@ function assignNextRoundPositions({
       tournamentId,
       structureId,
       matchUp,
+      event,
     });
   }
 

--- a/src/mutate/drawDefinitions/matchUpGovernor/attemptToSetMatchUpStatus.ts
+++ b/src/mutate/drawDefinitions/matchUpGovernor/attemptToSetMatchUpStatus.ts
@@ -19,7 +19,7 @@ import {
 } from '@Constants/matchUpStatusConstants';
 
 export function attemptToSetMatchUpStatus(params) {
-  const { tournamentRecord, drawDefinition, matchUpStatus, structure, matchUp } = params;
+  const { tournamentRecord, drawDefinition, matchUpStatus, structure, matchUp, event } = params;
 
   const teamRoundRobinContext = !!(
     matchUp.tieMatchUps &&
@@ -102,6 +102,7 @@ export function attemptToSetMatchUpStatus(params) {
         drawDefinition,
         structure,
         matchUp,
+        event,
       })) ||
     (!directing && { error: UNRECOGNIZED_MATCHUP_STATUS }) ||
     (isDoubleExit && modifyScoreAndAdvanceDoubleExit(params)) ||

--- a/src/mutate/drawDefinitions/matchUpGovernor/setOrderOfFinish.ts
+++ b/src/mutate/drawDefinitions/matchUpGovernor/setOrderOfFinish.ts
@@ -13,12 +13,14 @@ import { DrawDefinition, Tournament } from '@Types/tournamentTypes';
 import { SUCCESS } from '@Constants/resultConstants';
 
 type SetOrderOfFinishArgs = {
+  /** Supplied so notices can carry the sanctioning origin; resolved by paramsMiddleware. */
+  event?: any;
   finishingOrder: { matchUpId: string; orderOfFinish: number }[];
   tournamentRecord: Tournament;
   drawDefinition: DrawDefinition;
 };
 
-export function setOrderOfFinish({ tournamentRecord, drawDefinition, finishingOrder }: SetOrderOfFinishArgs) {
+export function setOrderOfFinish({ tournamentRecord, drawDefinition, finishingOrder, event }: SetOrderOfFinishArgs) {
   if (!drawDefinition) return { error: MISSING_DRAW_DEFINITION };
   const stack = 'setOrderOfFinish';
 
@@ -147,6 +149,7 @@ export function setOrderOfFinish({ tournamentRecord, drawDefinition, finishingOr
         context: 'setOrderOfFinish',
         drawDefinition,
         matchUp,
+        event,
       });
     });
   }

--- a/src/mutate/drawDefinitions/resetDrawDefinition.ts
+++ b/src/mutate/drawDefinitions/resetDrawDefinition.ts
@@ -23,7 +23,7 @@ import {
   COURT_ORDER,
 } from '@Constants/timeItemConstants';
 
-export function resetDrawDefinition({ tournamentRecord, removeScheduling, removeAssignments, drawDefinition }) {
+export function resetDrawDefinition({ tournamentRecord, removeScheduling, removeAssignments, drawDefinition, event }) {
   if (!drawDefinition) return { error: MISSING_DRAW_DEFINITION };
 
   const isLuckyDraw = isLuckyBasedDraw(drawDefinition.drawType);
@@ -50,6 +50,7 @@ export function resetDrawDefinition({ tournamentRecord, removeScheduling, remove
       matchUpsMap,
       structure,
       removeAssignments,
+      event,
     });
   }
 
@@ -135,6 +136,7 @@ function resetStructureMatchUps({
   isLuckyDraw,
   matchUpsMap,
   structure,
+  event,
 }) {
   const { matchUps: inContextMatchUps, isRoundRobin } = getAllStructureMatchUps({
     afterRecoveryTimes: false,
@@ -160,6 +162,7 @@ function resetStructureMatchUps({
       context: 'resetDrawDefinition',
       drawDefinition,
       matchUp,
+      event,
     });
   }
 }

--- a/src/mutate/matchUps/drawPositions/assignDrawPositionBye.ts
+++ b/src/mutate/matchUps/drawPositions/assignDrawPositionBye.ts
@@ -301,6 +301,7 @@ function setMatchUpStatusBYE({ tournamentRecord, drawDefinition, eventId, matchU
     context: 'setMatchUpStatusBye',
     drawDefinition,
     matchUp,
+    event,
   });
 }
 

--- a/src/mutate/matchUps/drawPositions/assignMatchUpDrawPosition.ts
+++ b/src/mutate/matchUps/drawPositions/assignMatchUpDrawPosition.ts
@@ -148,6 +148,7 @@ export function assignMatchUpDrawPosition({
       matchUpId,
       matchUp,
       stack,
+      event,
     });
   } else if (matchUp && positionAssigned && slotNewlyOccupied) {
     modifyMatchUpNotice({
@@ -156,6 +157,7 @@ export function assignMatchUpDrawPosition({
       context: stack,
       drawDefinition,
       matchUp,
+      event,
     });
   }
 
@@ -256,6 +258,7 @@ function applyPositionToMatchUp({
   matchUpId,
   matchUp,
   stack,
+  event,
 }) {
   // necessary to refresh inContextDrawMatchUps after mutation
   const refreshedMatchUps =
@@ -318,6 +321,7 @@ function applyPositionToMatchUp({
     context: stack,
     drawDefinition,
     matchUp,
+    event,
   });
 }
 

--- a/src/mutate/matchUps/drawPositions/directLoser.ts
+++ b/src/mutate/matchUps/drawPositions/directLoser.ts
@@ -158,6 +158,7 @@ export function directLoser(params): ResultType {
     dualMatchUp,
     matchUpsMap,
     stack,
+    event,
   });
 
   return decorateResult({ result: { ...SUCCESS }, stack, context });
@@ -289,6 +290,7 @@ function propagateLoserLineUp({
   dualMatchUp,
   matchUpsMap,
   stack,
+  event,
 }) {
   if (!dualMatchUp || !projectedWinningSide) return;
 
@@ -318,6 +320,7 @@ function propagateLoserLineUp({
       context: stack,
       drawDefinition,
       eventId,
+      event,
     });
   }
 }

--- a/src/mutate/matchUps/drawPositions/directWinner.ts
+++ b/src/mutate/matchUps/drawPositions/directWinner.ts
@@ -67,6 +67,7 @@ export function directWinner({
       dualMatchUp,
       matchUpsMap,
       stack,
+      event,
     });
   }
 
@@ -170,9 +171,7 @@ function directWinnerViaLink({
   }
 
   if (structure?.seedAssignments && structure.structureId !== targetStructureId) {
-    const seedAssignment = structure.seedAssignments.find(
-      ({ participantId }) => participantId === winnerParticipantId,
-    );
+    const seedAssignment = structure.seedAssignments.find(({ participantId }) => participantId === winnerParticipantId);
     const participantId = seedAssignment?.participantId;
     if (seedAssignment && participantId) {
       assignSeed({
@@ -197,6 +196,7 @@ function propagateLineUp({
   dualMatchUp,
   matchUpsMap,
   stack,
+  event,
 }) {
   const side = dualMatchUp.sides?.find((s) => s.sideNumber === projectedWinningSide);
   if (!side?.lineUp) return;
@@ -226,6 +226,7 @@ function propagateLineUp({
       matchUp: targetMatchUp,
       context: stack,
       drawDefinition,
+      event,
     });
   }
 }

--- a/src/mutate/matchUps/drawPositions/positionClear.ts
+++ b/src/mutate/matchUps/drawPositions/positionClear.ts
@@ -465,6 +465,7 @@ function handleTeamPositionRemoval({
       eventId: event?.eventId,
       matchUp: targetMatchUp,
       drawDefinition,
+      event,
     });
   }
 }
@@ -520,6 +521,7 @@ function updateMatchUpStatusAfterRemoval({
       eventId: event?.eventId,
       matchUp: targetMatchUp,
       drawDefinition,
+      event,
     });
   }
 

--- a/src/mutate/matchUps/drawPositions/removeSubsequentRoundsParticipant.ts
+++ b/src/mutate/matchUps/drawPositions/removeSubsequentRoundsParticipant.ts
@@ -141,6 +141,7 @@ function removeDrawPosition({
     context: `${stack}-${targetDrawPosition}`,
     drawDefinition,
     matchUp,
+    event,
   });
 
   return { ...SUCCESS };

--- a/src/mutate/matchUps/lineUps/assignTieMatchUpParticipant.ts
+++ b/src/mutate/matchUps/lineUps/assignTieMatchUpParticipant.ts
@@ -212,6 +212,7 @@ export function assignTieMatchUpParticipantId(
       collectionId,
       tieFormat,
       stack,
+      event,
     });
     if (doublesResult.error) return doublesResult;
     deletedParticipantId = doublesResult.deletedParticipantId;
@@ -367,6 +368,7 @@ function handleDoublesAssignment({
   collectionId,
   tieFormat,
   stack,
+  event,
 }) {
   let deletedParticipantId;
 
@@ -397,6 +399,7 @@ function handleDoublesAssignment({
         matchUp: dualMatchUp,
         context: stack,
         drawDefinition,
+        event,
       });
     }
   } else {

--- a/src/mutate/matchUps/lineUps/ensureSideLineUps.ts
+++ b/src/mutate/matchUps/lineUps/ensureSideLineUps.ts
@@ -67,6 +67,7 @@ export function ensureSideLineUps({
       drawDefinition,
       tournamentId,
       eventId,
+      event,
     });
   }
 }

--- a/src/mutate/matchUps/lineUps/removeTieMatchUpParticipant.ts
+++ b/src/mutate/matchUps/lineUps/removeTieMatchUpParticipant.ts
@@ -38,6 +38,7 @@ function removeSubstitutionProcessCodes({
   tieMatchUp,
   stack,
   side,
+  event,
 }) {
   const otherSide: any = inContextTieMatchUp?.sides?.find((s) => s.sideNumber !== side.sideNumber);
   if (!otherSide?.substitutions?.length && tieMatchUp?.processCodes?.length) {
@@ -51,6 +52,7 @@ function removeSubstitutionProcessCodes({
       matchUp: tieMatchUp,
       context: stack,
       drawDefinition,
+      event,
     });
   }
 }
@@ -318,6 +320,7 @@ export function removeTieMatchUpParticipantId(
       tieMatchUp,
       stack,
       side,
+      event,
     });
   }
 

--- a/src/mutate/matchUps/lineUps/replaceTieMatchUpParticipant.ts
+++ b/src/mutate/matchUps/lineUps/replaceTieMatchUpParticipant.ts
@@ -194,6 +194,7 @@ export function replaceTieMatchUpParticipantId(params: ReplaceTieMatchUpParticip
     tieMatchUp,
     stack,
     side,
+    event,
   });
 
   if (dualMatchUp) {
@@ -385,6 +386,7 @@ function handleProcessCodes({
   tieMatchUp,
   stack,
   side,
+  event,
 }) {
   if (substitution || side.substitutions?.length === 1) {
     if (substitution) {
@@ -406,6 +408,7 @@ function handleProcessCodes({
         matchUp: tieMatchUp,
         context: stack,
         drawDefinition,
+        event,
       });
     }
   }

--- a/src/mutate/matchUps/matchUpStatus/attemptToSetMatchUpStatusBYE.ts
+++ b/src/mutate/matchUps/matchUpStatus/attemptToSetMatchUpStatusBYE.ts
@@ -6,7 +6,7 @@ import { BYE } from '@Constants/matchUpStatusConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 import { INVALID_MATCHUP_STATUS, INVALID_MATCHUP_STATUS_BYE } from '@Constants/errorConditionConstants';
 
-export function attemptToSetMatchUpStatusBYE({ tournamentRecord, drawDefinition, structure, matchUp }) {
+export function attemptToSetMatchUpStatusBYE({ tournamentRecord, drawDefinition, structure, matchUp, event }) {
   const stack = 'attemptToSetMatchUpStatusBYE';
   if (matchUp?.winningSide) {
     return decorateResult({
@@ -36,6 +36,7 @@ export function attemptToSetMatchUpStatusBYE({ tournamentRecord, drawDefinition,
       context: stack,
       drawDefinition,
       matchUp,
+      event,
     });
     return { ...SUCCESS };
   } else {

--- a/src/mutate/matchUps/matchUpStatus/modifyRoundRobinMatchUpsStatus.ts
+++ b/src/mutate/matchUps/matchUpStatus/modifyRoundRobinMatchUpsStatus.ts
@@ -45,6 +45,7 @@ export function modifyRoundRobinMatchUpsStatus({
         eventId: event?.eventId,
         drawDefinition,
         matchUp,
+        event,
       });
     }
   });

--- a/src/mutate/matchUps/schedule/removeCourtAssignment.ts
+++ b/src/mutate/matchUps/schedule/removeCourtAssignment.ts
@@ -17,6 +17,8 @@ import {
 import { DrawDefinition, Tournament } from '@Types/tournamentTypes';
 
 type RemoveCourtAssignmentArgs = {
+  /** Supplied so notices can carry the sanctioning origin; resolved by paramsMiddleware. */
+  event?: any;
   drawDefinition?: DrawDefinition;
   tournamentRecord?: Tournament;
   matchUpId: string;
@@ -27,6 +29,7 @@ export function removeCourtAssignment({
   drawDefinition,
   matchUpId,
   drawId,
+  event,
 }: RemoveCourtAssignmentArgs) {
   const stack = 'removeCourtAssignment';
   if (!matchUpId) return { error: MISSING_MATCHUP_ID };
@@ -82,6 +85,7 @@ export function removeCourtAssignment({
       context: stack,
       drawDefinition,
       matchUp,
+      event,
     });
   }
 

--- a/src/mutate/participants/removeIndividualParticipantIds.ts
+++ b/src/mutate/participants/removeIndividualParticipantIds.ts
@@ -213,7 +213,7 @@ function purgeParticipantFromLineUps({ groupingParticipantId, tournamentRecord, 
   for (const event of tournamentRecord.events ?? []) {
     for (const drawDefinition of event.drawDefinitions ?? []) {
       purgeFromDrawLineUp({ drawDefinition, groupingParticipantId, participantId });
-      purgeFromMatchUpLineUps({ drawDefinition, tournamentRecord, participantId });
+      purgeFromMatchUpLineUps({ drawDefinition, tournamentRecord, participantId, event });
     }
   }
 }
@@ -228,7 +228,7 @@ function purgeFromDrawLineUp({ drawDefinition, groupingParticipantId, participan
   }
 }
 
-function purgeFromMatchUpLineUps({ drawDefinition, tournamentRecord, participantId }) {
+function purgeFromMatchUpLineUps({ drawDefinition, tournamentRecord, participantId, event }) {
   const matchUps = allDrawMatchUps({ drawDefinition, inContext: false }).matchUps ?? [];
 
   for (const matchUp of matchUps) {
@@ -241,6 +241,7 @@ function purgeFromMatchUpLineUps({ drawDefinition, tournamentRecord, participant
           tournamentId: tournamentRecord?.tournamentId,
           drawDefinition,
           matchUp,
+          event,
         });
       }
     }

--- a/src/mutate/tieFormat/addCollectionDefinition.ts
+++ b/src/mutate/tieFormat/addCollectionDefinition.ts
@@ -445,6 +445,8 @@ function updateStructureMatchUps({ updateInProgressMatchUps, collectionDefinitio
 }
 
 type QueueNotificationsArgs = {
+  /** Supplied so notices can carry the sanctioning origin; resolved by paramsMiddleware. */
+  event?: any;
   modifiedStructureIds?: string[];
   tournamentRecord?: Tournament;
   drawDefinition: DrawDefinition;
@@ -461,6 +463,7 @@ function queueNoficiations({
   addedMatchUps,
   eventId,
   stack,
+  event,
 }: QueueNotificationsArgs) {
   addMatchUpsNotice({
     tournamentId: tournamentRecord?.tournamentId,
@@ -475,6 +478,7 @@ function queueNoficiations({
       context: stack,
       matchUp,
       eventId,
+      event,
     });
   });
   modifyDrawNotice({

--- a/src/mutate/tieFormat/orderCollectionDefinitions.ts
+++ b/src/mutate/tieFormat/orderCollectionDefinitions.ts
@@ -100,6 +100,7 @@ export function orderCollectionDefinitions({
         drawDefinition,
         structure,
         orderMap,
+        event,
       });
       modifyDrawNotice({
         drawDefinition,
@@ -204,13 +205,14 @@ function updateDrawTieFormat({
       drawDefinition,
       structure,
       orderMap,
+      event,
     });
     modifiedStructureIds.push(structure.structureId);
   }
   modifyDrawNotice({ drawDefinition, structureIds: modifiedStructureIds });
 }
 
-function updateStructureMatchUps({ tournamentRecord, drawDefinition, structure, orderMap, eventId }) {
+function updateStructureMatchUps({ tournamentRecord, drawDefinition, structure, orderMap, eventId, event }) {
   const matchUps = getAllStructureMatchUps({
     matchUpFilters: { matchUpTypes: [TEAM] },
     structure,
@@ -227,6 +229,7 @@ function updateStructureMatchUps({ tournamentRecord, drawDefinition, structure, 
         drawDefinition,
         eventId,
         matchUp,
+        event,
       });
     }
   }

--- a/src/mutate/tieFormat/updateTieFormat.ts
+++ b/src/mutate/tieFormat/updateTieFormat.ts
@@ -318,6 +318,7 @@ export function updateTieFormat({
           context: stack,
           eventId,
           matchUp,
+          event,
         });
       }
     }


### PR DESCRIPTION
Continues the sanctioning-origin work from #4632. **46 of 62** `modifyMatchUpNotice` call sites now pass the event, so the notice carries `originOrganisationId` / `originTournamentId` / `originEventId`.

Most were a destructure away — `paramsMiddleware` resolves `drawId` (or `matchUp.drawId`) into `params.event`, so engine-entry methods already receive it. Internal helpers needed one level of threading from their caller, which is where the signature changes come from.

## ⚠️ A trap worth knowing about

Passing shorthand `event,` from a function that never received it **type-checks clean** — TypeScript's DOM lib declares `var event: Event | undefined` — and then throws `event is not defined` at runtime in Node.

An intermediate state of this change did exactly that: `tsc` was silent and **21 tests failed** with an engine error. Every such site is now bound, and the full suite is what caught it.

I wrote a static guard for that class and then **removed it**: regex scope analysis could not reliably distinguish positional params, closures and shadowed loop variables, and kept reporting false positives (17 of them, all benign). A guard that has to be baselined is worse than none, and the test suite already catches this loudly.

## Also corrected

`removeIndividualParticipantIds` already binds the correct `event` as a loop variable over `tournamentRecord.events`. The parameter I initially added there was redundant and shadowed nothing useful — removed.

## Verification

lint 0, types 0, full suite **10,966 tests**.

## Remaining

16 call sites, of which 7 sit in schedule files that were claimed by another workstream for most of this session. Those are now free and are the obvious next batch.