### PR TITLE
feat(notifications): thread event to the remaining schedule and tie notice emitters

### DIFF
--- a/src/mutate/drawDefinitions/luckyDrawAdvancement.ts
+++ b/src/mutate/drawDefinitions/luckyDrawAdvancement.ts
@@ -279,6 +279,7 @@ function placeDiscardedLosers({
         tournamentId,
         structureId: targetStructureId,
         matchUp,
+        event,
       });
     }
   }

--- a/src/mutate/matchUps/drawPositions/assignMatchUpSideParticipant.ts
+++ b/src/mutate/matchUps/drawPositions/assignMatchUpSideParticipant.ts
@@ -97,6 +97,7 @@ export function assignMatchUpSideParticipant({
       context: 'assignSideParticipant',
       drawDefinition,
       matchUp,
+      event,
     });
   }
 

--- a/src/mutate/matchUps/schedule/clearMatchUpSchedule.ts
+++ b/src/mutate/matchUps/schedule/clearMatchUpSchedule.ts
@@ -59,12 +59,14 @@ export function clearMatchUpSchedule({
   tournamentRecord,
   drawDefinition,
   matchUpId,
+  event,
 }: {
   overrideScheduleLock?: boolean;
   scheduleAttributes?: string[];
   tournamentRecord?: any;
   drawDefinition?: any;
   matchUpId: string;
+  event?: any;
 }) {
   const stack = 'clearMatchUpSchedule';
   const matchUp = drawDefinition
@@ -106,6 +108,7 @@ export function clearMatchUpSchedule({
     context: stack,
     drawDefinition,
     matchUp,
+    event,
   });
 
   return { ...SUCCESS };

--- a/src/mutate/matchUps/schedule/clearScheduledMatchUps.ts
+++ b/src/mutate/matchUps/schedule/clearScheduledMatchUps.ts
@@ -187,6 +187,7 @@ function clearSchedules({
           drawDefinition,
           tournamentId,
           matchUp,
+          event,
         });
         clearedScheduleCount += 1;
       }

--- a/src/mutate/structures/removeRoundMatchUps.ts
+++ b/src/mutate/structures/removeRoundMatchUps.ts
@@ -58,6 +58,7 @@ export function removeRoundMatchUps({
       drawDefinition,
       roundNumber,
       structure,
+      event,
     });
   } else {
     console.log('not implemented');
@@ -73,6 +74,7 @@ function removeAdHocRound({
   roundNumber,
   structure,
   eventId,
+  event,
 }): ResultType & { deletedMatchUpsCount?: number; roundRemoved?: boolean } {
   const matchUps = structure?.matchUps ?? [];
   const deletedTieMatchUpIds: string[] = [];
@@ -121,6 +123,7 @@ function removeAdHocRound({
               tournamentId,
               eventId,
               matchUp,
+              event,
             });
           }
         });

--- a/src/mutate/tieFormat/aggregateTieFormats.ts
+++ b/src/mutate/tieFormat/aggregateTieFormats.ts
@@ -69,6 +69,7 @@ export function aggregateTieFormats({
           tournamentId: tournamentRecord?.tournamentId,
           eventId: event.eventId,
           matchUp,
+          event,
         });
       }
     };


### PR DESCRIPTION
Completes the practical part of the sanctioning-origin threading. **52 of 62** `modifyMatchUpNotice` call sites (**83%**) now carry the event, so notices can attribute a change to its sanctioning origin.

This batch covers the schedule files that were held by another workstream for most of the session, plus the adHoc, tieFormat and lineUp emitters.

## Three functions did NOT need a parameter

They already bind the correct event locally, and adding one **shadowed it**:

| function | how it already gets the event |
|---|---|
| `clearSchedules` | `findEvent({ tournamentRecord, drawId })` — resolved per draw |
| `aggregateTieFormats` | iterates `tournamentRecord.events` |
| `removeIndividualParticipantIds` | same loop pattern |

In each case the **locally-resolved event is more correct** than anything a caller could pass, because it is the event for *that matchUp* rather than the one the mutation was entered through. Prefer the local binding — I reverted my own additions in all three.

## Verification

lint 0, types 0, full suite **10,966 tests**.

## Remaining 10

Genuinely event-less entry points that would each need a signature change rippling to their callers (`setMatchUpCalledAt`, `setMatchUpScheduleLock`, `addMatchUpScheduleItems`, `applyLineUps`, the tie participant mutators, `swapWinnerLoser`, `attachStructures`). Worth doing deliberately rather than mechanically — several are schedule-grain where the origin question is less pressing than on score entry, which is already covered.