### PR TITLE
feat(codes): implement the tournament and draw grains of the Unified*ID family

### DIFF
--- a/documentation/docs/concepts/events/event-origin.mdx
+++ b/documentation/docs/concepts/events/event-origin.mdx
@@ -17,8 +17,15 @@ origin cannot be inferred from the record that carries it.
 ## Shape
 
 `UnifiedEventID` is the event-grain member of the `Unified*ID` family, alongside
-`UnifiedTournamentID` (`tournament.tournamentOtherIds`), `UnifiedPersonID`
-(`person.personOtherIds`) and `UnifiedVenueID` (`venue.venueOtherIds`).
+`UnifiedTournamentID` (`tournament.tournamentOtherIds`), `UnifiedDrawID`
+(`drawDefinition.drawOtherIds`), `UnifiedParticipantID`
+(`participant.participantOtherIds`), `UnifiedPersonID` (`person.personOtherIds`) and
+`UnifiedVenueID` (`venue.venueOtherIds`).
+
+See [Unified Identity](../unified-identity.md) for the rules shared across the whole
+family, and for the tournament and draw grains in particular — the tournament grain
+answers "where did this whole record come from?", which is the natural question for an
+ingested record, and is independent of the per-event sanctioning origin described here.
 
 ```js
 event.eventOtherIds = [

--- a/documentation/docs/concepts/unified-identity.md
+++ b/documentation/docs/concepts/unified-identity.md
@@ -1,0 +1,187 @@
+---
+title: Unified Identity — Other IDs
+---
+
+## The family
+
+A CODES record frequently is not the only place a competition exists. It may have been
+acquired wholesale from a federation site, sanctioned by an outside governing body, or
+copied back out to one after the fact. The `Unified*ID` family records **what each element
+is called in other organisations' systems**, so results stay addressable back to them.
+
+| grain       | array                             | type                   |
+| ----------- | --------------------------------- | ---------------------- |
+| tournament  | `tournament.tournamentOtherIds`   | `UnifiedTournamentID`  |
+| event       | `event.eventOtherIds`             | `UnifiedEventID`       |
+| draw        | `drawDefinition.drawOtherIds`     | `UnifiedDrawID`        |
+| participant | `participant.participantOtherIds` | `UnifiedParticipantID` |
+| person      | `person.personOtherIds`           | `UnifiedPersonID`      |
+| venue       | `venue.venueOtherIds`             | `UnifiedVenueID`       |
+
+Three rules hold across every member:
+
+1. **`organisationId` is the upsert key.** One entry per organisation.
+2. **At most one entry carries `isOrigin`** — the system the element came from. Everything
+   else in the array is a system the element is merely _also_ known to, typically acquired
+   by copy-back.
+3. **Every id belongs to `organisationId`, never to the carrying record.** Reading one for
+   the other is the mistake this concept exists to prevent.
+
+The factory is deliberately neutral about what `organisationId` denotes and never
+validates a foreign id. The obligation is identity, not replication — see
+[Event Origin](./events/event-origin.mdx).
+
+## Tournament grain
+
+`UnifiedTournamentID` answers "where did this whole record come from?" — the natural
+question for an ingested record, where every event, draw and participant arrived together
+from one source.
+
+```js
+tournamentRecord.tournamentOtherIds = [
+  { organisationId: 'UTR', tournamentId: '306618', uniqueOrganisationName: 'Universal Tennis', isOrigin: true },
+];
+```
+
+`tournamentId` is **required** here, unlike `UnifiedEventID`'s optional one. `eventId` is
+optional at event grain because the origin may not hold the event yet; at tournament grain
+the id is the entire payload, and an entry without one carries no identity at all.
+
+**Independent of the event grain.** A record acquired wholesale from one organisation can
+still carry events sanctioned by others, so neither flag can be inferred from the other.
+
+### Writing
+
+```js
+// upsert — the copy-back case, where an id is acquired after the record exists
+engine.addTournamentOtherId({
+  organisationId: 'UTR',
+  otherTournamentId: '306618', // theirs
+  uniqueOrganisationName: 'Universal Tennis',
+  isOrigin: true,
+});
+
+// wholesale — the reconciliation case, and the only way to RE-POINT isOrigin
+engine.setTournamentOtherIds({
+  tournamentOtherIds: [{ organisationId: 'ITA', tournamentId: 'ita-4471', isOrigin: true }],
+});
+engine.setTournamentOtherIds({ tournamentOtherIds: null }); // clear
+```
+
+`otherTournamentId` is named distinctly from the record's own `tournamentId` for the same
+reason `addParticipantOtherId` names `otherParticipantId` that way: both are tournament
+ids, and silently transposing them would stamp a record with its own id and still look
+like it worked.
+
+Both dispatch `MODIFY_TOURNAMENT_DETAIL`. An idempotent re-apply is a no-op and emits
+nothing.
+
+## Draw grain
+
+`UnifiedDrawID` exists because an outside organisation's draw-grain object is frequently
+the **only** grain that carries identity worth addressing.
+
+UTR is the motivating case. A UTR "flight" is a real remote object with its own GUID, its
+own `drawSize`, and its own UTR-band bounds, and it maps 1:1 to a CODES `drawDefinition`.
+But UTR has **no event-grain object at all** — the CODES event above it is a synthetic
+gender × matchUpType grouping with no counterpart to record.
+
+```js
+drawDefinition.drawOtherIds = [
+  {
+    organisationId: 'UTR',
+    tournamentId: '306618', // UTR's "event"
+    drawId: '77f3990b-83c8-4d2b-8bd9-8ca3c646d879', // the flight GUID
+    isOrigin: true,
+    // no eventId — UTR has no event grain
+  },
+];
+```
+
+Every id attribute is independently optional for exactly that reason: populate only the
+grains the origin actually models. An origin that does model events supplies `eventId`
+too.
+
+### Writing
+
+```js
+engine.addDrawOtherId({
+  drawId, // OURS — the engine resolves the drawDefinition
+  organisationId: 'UTR',
+  otherTournamentId: '306618',
+  otherDrawId: '77f3990b-83c8-4d2b-8bd9-8ca3c646d879',
+  isOrigin: true,
+});
+
+engine.setDrawOtherIds({ drawId, drawOtherIds: [...] });
+engine.setDrawOtherIds({ drawId, drawOtherIds: null }); // clear
+```
+
+Requires at least one of `otherDrawId` / `otherEventId` / `otherTournamentId`. Both
+dispatch `MODIFY_DRAW_DEFINITION`.
+
+## The single-origin invariant
+
+Setting `isOrigin` through an **upsert** is refused when a different organisation already
+holds it:
+
+```js
+engine.addTournamentOtherId({ organisationId: 'UTR', otherTournamentId: '306618', isOrigin: true });
+engine.addTournamentOtherId({ organisationId: 'ITA', otherTournamentId: 'ita-4471', isOrigin: true });
+// → { error: INVALID_VALUES, info: "isOrigin is already held by organisationId 'UTR'; …" }
+```
+
+An upsert that quietly unflagged the other entry would change which system results are
+addressed back to, invisibly. Re-pointing the origin is a deliberate act, so it belongs in
+a wholesale `set*OtherIds` call — which validates that the supplied array carries at most
+one `isOrigin` entry and that every entry has an `organisationId`.
+
+Readers stay **tolerant**: `tournamentOrigin` / `eventOrigin` / `drawOrigin` `find` the
+first flagged entry, so a malformed record already in storage projects deterministically
+rather than throwing on a read. Write-side strict, read-side stable.
+
+:::note
+`modifyEvent`'s `eventOtherIds` handling predates this validation and still stores the
+array as supplied. The readers behave identically either way; only the write-side
+strictness differs.
+:::
+
+## Reading
+
+```js
+import { readModel } from 'tods-competition-factory';
+
+readModel.tournamentOrigin(tournamentRecord); // the isOrigin entry, or undefined
+readModel.eventOrigin(event);
+readModel.drawOrigin(drawDefinition);
+```
+
+## In the read model
+
+Each grain flattens its flagged entry onto its own row. The `origin_*` columns are always
+independent of the carrying ids beside them.
+
+**`tournaments`**
+
+| column                   | source                                    |
+| ------------------------ | ----------------------------------------- |
+| `tournament_id`          | the record's own id                       |
+| `origin_organisation_id` | `tournamentOrigin(record).organisationId` |
+| `origin_tournament_id`   | `tournamentOrigin(record).tournamentId`   |
+
+**`draws`**
+
+| column                   | source                            |
+| ------------------------ | --------------------------------- |
+| `draw_id`                | the draw's own id                 |
+| `origin_organisation_id` | `drawOrigin(draw).organisationId` |
+| `origin_tournament_id`   | `drawOrigin(draw).tournamentId`   |
+| `origin_event_id`        | `drawOrigin(draw).eventId`        |
+| `origin_draw_id`         | `drawOrigin(draw).drawId`         |
+
+Each column is independently nullable: a UTR flight populates
+`origin_tournament_id` + `origin_draw_id` and leaves `origin_event_id` null.
+
+As with the events table, `origin_tournament_id` **cannot** carry a foreign key — a
+constraint satisfiable for a link into this ecosystem is impossible for an external one.
+Resolution is a read-time `LEFT JOIN`, never a write-time constraint.

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -149,6 +149,7 @@ module.exports = {
             'concepts/timeItems',
             'concepts/extensions',
             'concepts/caller-supplied-identity',
+            'concepts/unified-identity',
           ],
         },
         {

--- a/src/assemblies/governors/drawsGovernor/mutate.ts
+++ b/src/assemblies/governors/drawsGovernor/mutate.ts
@@ -20,6 +20,7 @@ export { attachQualifyingStructure } from '@Mutate/drawDefinitions/attachQualify
 export { renameStructures } from '@Mutate/drawDefinitions/structureGovernor/renameStructures';
 export { assignDrawPositionBye } from '@Mutate/matchUps/drawPositions/assignDrawPositionBye';
 export { addDrawDefinitionTimeItem } from '@Mutate/drawDefinitions/addDrawDefinitionTimeItem';
+export { addDrawOtherId, setDrawOtherIds } from '@Mutate/drawDefinitions/drawOtherIds';
 export { resolveDraftPositions } from '@Mutate/drawDefinitions/draft/resolveDraftPositions';
 
 export { resetQualifyingStructure } from '@Mutate/drawDefinitions/resetQualifyingStructure';

--- a/src/assemblies/governors/tournamentGovernor/mutate.ts
+++ b/src/assemblies/governors/tournamentGovernor/mutate.ts
@@ -9,6 +9,8 @@ export { addNotes, removeNotes } from '@Mutate/base/addRemoveNotes';
 export { addOnlineResource } from '@Mutate/base/addOnlineResource';
 export { addExtension } from '@Mutate/extensions/addExtension';
 
+export { addTournamentOtherId, setTournamentOtherIds } from '@Mutate/tournaments/tournamentOtherIds';
+
 export {
   setRegistrationProfile,
   setTournamentName,

--- a/src/constants/mutationLockScopeMap.ts
+++ b/src/constants/mutationLockScopeMap.ts
@@ -72,6 +72,8 @@ export const methodScopeMap: Record<string, MutationLockScope> = {
   renameStructures: 'DRAWS',
   assignDrawPositionBye: 'DRAWS',
   addDrawDefinitionTimeItem: 'DRAWS',
+  addDrawOtherId: 'DRAWS',
+  setDrawOtherIds: 'DRAWS',
   removeStructure: 'DRAWS',
   resetQualifyingStructure: 'DRAWS',
   swapDrawPositionAssignments: 'DRAWS',
@@ -256,6 +258,8 @@ export const methodScopeMap: Record<string, MutationLockScope> = {
   setTournamentStartDate: 'TOURNAMENT',
   addTournamentExtension: 'TOURNAMENT',
   removeTournamentExtension: 'TOURNAMENT',
+  addTournamentOtherId: 'TOURNAMENT',
+  setTournamentOtherIds: 'TOURNAMENT',
 
   // TIE_FORMAT — tieFormatGovernor/mutate
   modifyCollectionDefinition: 'TIE_FORMAT',

--- a/src/mutate/base/unifiedIds.ts
+++ b/src/mutate/base/unifiedIds.ts
@@ -1,0 +1,116 @@
+import { INVALID_VALUES, MISSING_VALUE } from '@Constants/errorConditionConstants';
+
+/**
+ * Shared write-side mechanics for the `Unified*ID` family — the arrays that record an
+ * element's identity in OTHER organisations' systems (`tournamentOtherIds`,
+ * `eventOtherIds`, `drawOtherIds`, `participantOtherIds`, `personOtherIds`).
+ *
+ * Every member of the family shares three properties, so they are enforced in one place
+ * rather than re-implemented per grain:
+ *
+ * 1. `organisationId` is the UPSERT KEY. One entry per organisation.
+ * 2. At most ONE entry may carry `isOrigin` — the system the element came from.
+ * 3. The factory is deliberately neutral about what `organisationId` denotes and never
+ *    validates a foreign id. Carrying identity is the whole obligation; the outside body
+ *    is not expected to hold a CODES record.
+ */
+
+/** The id attributes belonging to the OTHER organisation, keyed by attribute name. */
+type OriginValues = Record<string, string | undefined>;
+
+/**
+ * Rejects an array carrying more than one `isOrigin` entry.
+ *
+ * Readers (`eventOrigin`, `tournamentOrigin`, `drawOrigin`) deliberately stay tolerant and
+ * `find` the first flagged entry, so a malformed record read from storage projects
+ * deterministically rather than throwing. This is the write-side counterpart: a caller
+ * cannot CREATE that ambiguity through a factory mutation.
+ */
+export function checkSingleOrigin(entries: any[] | undefined): { error?: any; info?: string } | undefined {
+  if (!Array.isArray(entries)) return undefined;
+  const flagged = entries.filter((entry: any) => entry?.isOrigin);
+  if (flagged.length > 1) {
+    const organisations = flagged.map((entry: any) => entry?.organisationId).join(', ');
+    return {
+      error: INVALID_VALUES,
+      info: `At most one entry may carry isOrigin; found ${flagged.length}: ${organisations}`,
+    };
+  }
+  return undefined;
+}
+
+/** Rejects an array whose entries do not each carry an `organisationId` — the upsert key. */
+export function checkOrganisationIds(entries: any[] | undefined): { error?: any; info?: string } | undefined {
+  if (!Array.isArray(entries)) return undefined;
+  const missing = entries.filter((entry: any) => !entry?.organisationId).length;
+  if (missing) return { error: MISSING_VALUE, info: `Every entry requires an organisationId; ${missing} missing` };
+  return undefined;
+}
+
+/**
+ * Validates a wholesale replacement array for any `Unified*ID` grain.
+ * Returns an error result, or undefined when the array is acceptable.
+ */
+export function checkUnifiedIds(entries: any[] | undefined): { error?: any; info?: string } | undefined {
+  if (entries !== undefined && !Array.isArray(entries)) return { error: INVALID_VALUES, info: 'Expected an array' };
+  return checkOrganisationIds(entries) ?? checkSingleOrigin(entries);
+}
+
+/**
+ * Upsert one entry into a `Unified*ID` array, keyed on `organisationId`.
+ *
+ * Setting `isOrigin` is REFUSED when a different organisation already holds the flag,
+ * rather than silently moving it. Re-pointing the origin is a deliberate act and belongs
+ * in a wholesale `set*OtherIds` call — an upsert that quietly unflagged another entry
+ * would change which system results are addressed back to, invisibly.
+ *
+ * Returns `{ changed: false }` when the entry already matches, so callers can skip firing
+ * a notice for a genuine no-op.
+ */
+export function upsertUnifiedId({
+  uniqueOrganisationName,
+  organisationId,
+  isOrigin,
+  entries,
+  values,
+}: {
+  uniqueOrganisationName?: string;
+  organisationId: string;
+  isOrigin?: boolean;
+  entries: any[];
+  values: OriginValues;
+}): { error?: any; info?: string; changed?: boolean } {
+  const conflicting = entries.find((entry: any) => entry?.isOrigin && entry.organisationId !== organisationId);
+  if (isOrigin && conflicting) {
+    return {
+      error: INVALID_VALUES,
+      info: `isOrigin is already held by organisationId '${conflicting.organisationId}'; replace the array wholesale to re-point the origin`,
+    };
+  }
+
+  const supplied = Object.entries(values).filter(([, value]) => value !== undefined);
+  const existing = entries.find((entry: any) => entry?.organisationId === organisationId);
+
+  if (!existing) {
+    entries.push({
+      organisationId,
+      ...Object.fromEntries(supplied),
+      ...(uniqueOrganisationName ? { uniqueOrganisationName } : {}),
+      ...(isOrigin ? { isOrigin: true } : {}),
+      createdAt: new Date().toISOString(),
+    });
+    return { changed: true };
+  }
+
+  const nameChanges = !!uniqueOrganisationName && existing.uniqueOrganisationName !== uniqueOrganisationName;
+  const originChanges = !!isOrigin && !existing.isOrigin;
+  const valueChanges = supplied.some(([attribute, value]) => existing[attribute] !== value);
+  if (!nameChanges && !originChanges && !valueChanges) return { changed: false }; // idempotent no-op
+
+  for (const [attribute, value] of supplied) existing[attribute] = value;
+  if (nameChanges) existing.uniqueOrganisationName = uniqueOrganisationName;
+  if (originChanges) existing.isOrigin = true;
+  existing.updatedAt = new Date().toISOString();
+
+  return { changed: true };
+}

--- a/src/mutate/base/unifiedIds.ts
+++ b/src/mutate/base/unifiedIds.ts
@@ -18,6 +18,8 @@ import { INVALID_VALUES, MISSING_VALUE } from '@Constants/errorConditionConstant
 /** The id attributes belonging to the OTHER organisation, keyed by attribute name. */
 type OriginValues = Record<string, string | undefined>;
 
+type CheckResult = { error?: any; info?: string } | undefined;
+
 /**
  * Rejects an array carrying more than one `isOrigin` entry.
  *
@@ -25,9 +27,11 @@ type OriginValues = Record<string, string | undefined>;
  * `find` the first flagged entry, so a malformed record read from storage projects
  * deterministically rather than throwing. This is the write-side counterpart: a caller
  * cannot CREATE that ambiguity through a factory mutation.
+ *
+ * Not exported — `checkUnifiedIds` is the only entry point, and it has already established
+ * that `entries` is an array by the time this runs.
  */
-export function checkSingleOrigin(entries: any[] | undefined): { error?: any; info?: string } | undefined {
-  if (!Array.isArray(entries)) return undefined;
+function checkSingleOrigin(entries: any[]): CheckResult {
   const flagged = entries.filter((entry: any) => entry?.isOrigin);
   if (flagged.length > 1) {
     const organisations = flagged.map((entry: any) => entry?.organisationId).join(', ');
@@ -40,8 +44,7 @@ export function checkSingleOrigin(entries: any[] | undefined): { error?: any; in
 }
 
 /** Rejects an array whose entries do not each carry an `organisationId` — the upsert key. */
-export function checkOrganisationIds(entries: any[] | undefined): { error?: any; info?: string } | undefined {
-  if (!Array.isArray(entries)) return undefined;
+function checkOrganisationIds(entries: any[]): CheckResult {
   const missing = entries.filter((entry: any) => !entry?.organisationId).length;
   if (missing) return { error: MISSING_VALUE, info: `Every entry requires an organisationId; ${missing} missing` };
   return undefined;
@@ -50,9 +53,13 @@ export function checkOrganisationIds(entries: any[] | undefined): { error?: any;
 /**
  * Validates a wholesale replacement array for any `Unified*ID` grain.
  * Returns an error result, or undefined when the array is acceptable.
+ *
+ * Requires a real array. Callers handle `null` (the clear) before reaching here, so anything
+ * else — `undefined`, an object, a string — is a caller mistake rather than an intent, and
+ * accepting it would silently write a non-array into the record.
  */
-export function checkUnifiedIds(entries: any[] | undefined): { error?: any; info?: string } | undefined {
-  if (entries !== undefined && !Array.isArray(entries)) return { error: INVALID_VALUES, info: 'Expected an array' };
+export function checkUnifiedIds(entries: any): CheckResult {
+  if (!Array.isArray(entries)) return { error: INVALID_VALUES, info: 'Expected an array of Unified*ID entries' };
   return checkOrganisationIds(entries) ?? checkSingleOrigin(entries);
 }
 

--- a/src/mutate/drawDefinitions/drawOtherIds.ts
+++ b/src/mutate/drawDefinitions/drawOtherIds.ts
@@ -1,0 +1,100 @@
+import { modifyDrawNotice } from '@Mutate/notifications/drawNotifications';
+import { checkUnifiedIds, upsertUnifiedId } from '@Mutate/base/unifiedIds';
+
+// constants and types
+import { DRAW_DEFINITION_NOT_FOUND, MISSING_VALUE } from '@Constants/errorConditionConstants';
+import { UnifiedDrawID } from '@Types/tournamentTypes';
+import { SUCCESS } from '@Constants/resultConstants';
+
+/**
+ * Upsert a `UnifiedDrawID` entry into `drawDefinition.drawOtherIds[]` — the draw-grain
+ * member of the `Unified*ID` write family.
+ *
+ * `organisationId` is the upsert key. Only the id attributes actually supplied are
+ * written, because an origin system rarely has all of them: UTR carries a tournament
+ * (its "event") and a draw (its "flight" GUID) but has **no event-grain object at all**,
+ * so `eventId` is legitimately absent rather than unknown.
+ *
+ * Idempotent — re-applying the same values is a no-op and fires no notice. Setting
+ * `isOrigin` is refused when a different organisation already holds it; re-point it with
+ * {@link setDrawOtherIds}.
+ */
+export function addDrawOtherId({
+  uniqueOrganisationName,
+  otherTournamentId,
+  drawDefinition,
+  organisationId,
+  otherEventId,
+  otherDrawId,
+  tournamentId,
+  isOrigin,
+  event,
+}: {
+  uniqueOrganisationName?: string;
+  // every id below belongs to `organisationId`, never to the carrying record
+  otherTournamentId?: string;
+  drawDefinition: any;
+  organisationId: string;
+  otherEventId?: string;
+  otherDrawId?: string;
+  tournamentId?: string;
+  isOrigin?: boolean;
+  event?: any;
+}) {
+  if (!drawDefinition) return { error: DRAW_DEFINITION_NOT_FOUND };
+  if (!organisationId) return { error: MISSING_VALUE, info: 'Missing organisationId' };
+  if (!otherDrawId && !otherEventId && !otherTournamentId) {
+    return { error: MISSING_VALUE, info: 'Requires at least one of otherDrawId, otherEventId, otherTournamentId' };
+  }
+
+  drawDefinition.drawOtherIds ??= [];
+
+  const result = upsertUnifiedId({
+    values: { tournamentId: otherTournamentId, eventId: otherEventId, drawId: otherDrawId },
+    entries: drawDefinition.drawOtherIds,
+    uniqueOrganisationName,
+    organisationId,
+    isOrigin,
+  });
+  if (result.error) return result;
+
+  if (result.changed) modifyDrawNotice({ eventId: event?.eventId, drawDefinition, tournamentId });
+
+  return { ...SUCCESS };
+}
+
+/**
+ * Replace `drawDefinition.drawOtherIds[]` wholesale. Pass `null` to clear.
+ *
+ * The reconciliation grain — a caller diffing a draw against its origin system holds the
+ * full list — and the only way to re-point `isOrigin`. Validates that at most one entry
+ * carries `isOrigin` and that every entry carries an `organisationId`.
+ */
+export function setDrawOtherIds({
+  drawOtherIds,
+  drawDefinition,
+  tournamentId,
+  event,
+}: {
+  drawOtherIds: UnifiedDrawID[] | null;
+  drawDefinition: any;
+  tournamentId?: string;
+  event?: any;
+}) {
+  if (!drawDefinition) return { error: DRAW_DEFINITION_NOT_FOUND };
+
+  if (drawOtherIds === null) {
+    if (drawDefinition.drawOtherIds === undefined) return { ...SUCCESS };
+    delete drawDefinition.drawOtherIds;
+    modifyDrawNotice({ eventId: event?.eventId, drawDefinition, tournamentId });
+    return { ...SUCCESS };
+  }
+
+  const check = checkUnifiedIds(drawOtherIds as any[]);
+  if (check?.error) return check;
+
+  drawDefinition.drawOtherIds = drawOtherIds;
+  modifyDrawNotice({ eventId: event?.eventId, drawDefinition, tournamentId });
+
+  return { ...SUCCESS };
+}

--- a/src/mutate/tournaments/tournamentOtherIds.ts
+++ b/src/mutate/tournaments/tournamentOtherIds.ts
@@ -1,0 +1,122 @@
+import { checkUnifiedIds, upsertUnifiedId } from '@Mutate/base/unifiedIds';
+import { requireParams } from '@Helpers/parameters/requireParams';
+import { addNotice } from '@Global/state/globalState';
+
+// constants and types
+import { MODIFY_TOURNAMENT_DETAIL } from '@Constants/topicConstants';
+import { MISSING_VALUE } from '@Constants/errorConditionConstants';
+import { TOURNAMENT_RECORD } from '@Constants/attributeConstants';
+import { UnifiedTournamentID } from '@Types/tournamentTypes';
+import { SUCCESS } from '@Constants/resultConstants';
+
+/**
+ * Upsert a `UnifiedTournamentID` entry into `tournamentRecord.tournamentOtherIds[]` — the
+ * tournament-grain sibling of {@link addParticipantOtherId} and {@link addPersonOtherId}.
+ *
+ * `organisationId` is the upsert key: an existing entry for that organisation has its
+ * `tournamentId` replaced; otherwise a new entry is appended with a `createdAt` timestamp.
+ * Idempotent — re-applying the same `(organisationId, tournamentId)` is a no-op and fires
+ * no notice.
+ *
+ * **Why this exists.** `tournamentOtherIds` was declared on the `Tournament` type and had
+ * no write path, no reader, and no read-model column, while the event grain
+ * (`eventOtherIds`) had all three. A record acquired wholesale from an outside system —
+ * every `courthive-ingest` adapter produces exactly that — could therefore only record
+ * where it came from by convention (prefixing its `tournamentId` with `utr-`, `cts-`, …),
+ * which is not queryable and does not survive a re-id.
+ *
+ * `otherTournamentId` is named distinctly from the record's own `tournamentId` for the
+ * same reason `addParticipantOtherId` names `otherParticipantId` that way: both are
+ * tournament ids, and silently transposing them would stamp a record with its own id and
+ * still look like it worked.
+ *
+ * Setting `isOrigin` is refused when a different organisation already holds it — see
+ * {@link upsertUnifiedId}.
+ */
+export function addTournamentOtherId({
+  uniqueOrganisationName,
+  otherTournamentId,
+  tournamentRecord,
+  organisationId,
+  isOrigin,
+}: {
+  uniqueOrganisationName?: string;
+  // the OTHER organisation's id for this tournament — NOT the carrying record's
+  otherTournamentId: string;
+  tournamentRecord: any;
+  organisationId: string;
+  isOrigin?: boolean;
+}) {
+  const paramsCheck = requireParams({ tournamentRecord }, [TOURNAMENT_RECORD]);
+  if (paramsCheck.error) return paramsCheck;
+
+  if (!organisationId) return { error: MISSING_VALUE, info: 'Missing organisationId' };
+  if (!otherTournamentId) return { error: MISSING_VALUE, info: 'Missing otherTournamentId' };
+
+  tournamentRecord.tournamentOtherIds ??= [];
+
+  const result = upsertUnifiedId({
+    entries: tournamentRecord.tournamentOtherIds,
+    values: { tournamentId: otherTournamentId },
+    uniqueOrganisationName,
+    organisationId,
+    isOrigin,
+  });
+  if (result.error) return result;
+
+  if (result.changed) notifyTournamentOtherIds(tournamentRecord);
+
+  return { ...SUCCESS };
+}
+
+/**
+ * Replace `tournamentRecord.tournamentOtherIds[]` wholesale — the tournament-grain
+ * equivalent of passing `eventOtherIds` through `modifyEvent`.
+ *
+ * Wholesale is the natural grain for reconciliation: a caller diffing against a
+ * sanctioning body or an ingest source holds the full list. It is also the only way to
+ * RE-POINT `isOrigin` at a different organisation, which {@link addTournamentOtherId}
+ * deliberately refuses to do implicitly.
+ *
+ * Pass `null` to clear.
+ *
+ * Unlike `modifyEvent`'s `eventOtherIds` handling, this validates: an array carrying two
+ * `isOrigin` entries, or an entry with no `organisationId`, is rejected rather than
+ * stored. The readers stay tolerant either way.
+ */
+export function setTournamentOtherIds({
+  tournamentOtherIds,
+  tournamentRecord,
+}: {
+  tournamentOtherIds: UnifiedTournamentID[] | null;
+  tournamentRecord: any;
+}) {
+  const paramsCheck = requireParams({ tournamentRecord }, [TOURNAMENT_RECORD]);
+  if (paramsCheck.error) return paramsCheck;
+
+  if (tournamentOtherIds === null) {
+    if (tournamentRecord.tournamentOtherIds === undefined) return { ...SUCCESS };
+    delete tournamentRecord.tournamentOtherIds;
+    notifyTournamentOtherIds(tournamentRecord);
+    return { ...SUCCESS };
+  }
+
+  const check = checkUnifiedIds(tournamentOtherIds as any[]);
+  if (check?.error) return check;
+
+  tournamentRecord.tournamentOtherIds = tournamentOtherIds;
+  notifyTournamentOtherIds(tournamentRecord);
+
+  return { ...SUCCESS };
+}
+
+function notifyTournamentOtherIds(tournamentRecord: any) {
+  addNotice({
+    topic: MODIFY_TOURNAMENT_DETAIL,
+    payload: {
+      parentOrganisation: tournamentRecord.parentOrganisation,
+      tournamentOtherIds: tournamentRecord.tournamentOtherIds ?? [],
+      tournamentId: tournamentRecord.tournamentId,
+    },
+  });
+}

--- a/src/query/readModel/index.ts
+++ b/src/query/readModel/index.ts
@@ -13,9 +13,11 @@ export { isFactoryUuid, resolvePersonLink, LINK_PROVIDER_ID, LINK_UNRESOLVED } f
 export type { PersonLink } from './personRule';
 export {
   tournamentRow,
+  tournamentOrigin,
   eventRow,
   eventOrigin,
   drawRow,
+  drawOrigin,
   structureRow,
   seedRow,
   venueRow,

--- a/src/query/readModel/readModelRows.ts
+++ b/src/query/readModel/readModelRows.ts
@@ -4,7 +4,7 @@ import { LINK_UNRESOLVED, resolvePersonLink } from './personRule';
 import { findExtension } from '@Acquire/findExtension';
 
 // types
-import { UnifiedEventID } from '@Types/tournamentTypes';
+import { UnifiedDrawID, UnifiedEventID, UnifiedTournamentID } from '@Types/tournamentTypes';
 import {
   ReadModelTournamentRow,
   ReadModelCompetitorRow,
@@ -46,6 +46,7 @@ export function tournamentRow(record: any): ReadModelTournamentRow {
   // aggregate publish flag: the tournament is "published" when its order of play OR
   // its participant list is published (the same condition that drives UNPUBLISH_TOURNAMENT).
   const pubStatus: any = getTournamentPublishStatus({ tournamentRecord: record });
+  const origin = tournamentOrigin(record);
   return {
     tournament_id: record?.tournamentId,
     tournament_name: record?.tournamentName ?? null,
@@ -54,7 +55,22 @@ export function tournamentRow(record: any): ReadModelTournamentRow {
     end_date: record?.endDate ?? null,
     city: record?.tournamentContacts?.[0]?.city ?? record?.city ?? null,
     published: !!(pubStatus?.orderOfPlay?.published || pubStatus?.participants?.published),
+    origin_organisation_id: origin?.organisationId ?? null,
+    origin_tournament_id: origin?.tournamentId ?? null,
   };
+}
+
+/**
+ * The `tournamentOtherIds[]` entry flagged `isOrigin` — the system the whole RECORD was
+ * acquired from (an ingest source, or a sanctioning body that handed the record over).
+ *
+ * Independent of {@link eventOrigin} one grain down: a record acquired wholesale from one
+ * organisation can still carry events sanctioned by others, so neither can be inferred
+ * from the other. Tolerant of a malformed record for the same reason `eventOrigin` is —
+ * see the note there.
+ */
+export function tournamentOrigin(record: any): UnifiedTournamentID | undefined {
+  return (record?.tournamentOtherIds ?? []).find((otherId: UnifiedTournamentID) => otherId?.isOrigin);
 }
 
 // ── participant-list publication state ──────────────────────────────────────────
@@ -125,6 +141,7 @@ export function drawRow(
   eventId: string | null,
   providerId: string | undefined,
 ): ReadModelDrawRow {
+  const origin = drawOrigin(draw);
   return {
     draw_id: draw?.drawId,
     tournament_id: tournamentId,
@@ -133,7 +150,23 @@ export function drawRow(
     draw_name: draw?.drawName ?? null,
     draw_type: draw?.drawType ?? null,
     match_up_format: draw?.matchUpFormat ?? null,
+    origin_organisation_id: origin?.organisationId ?? null,
+    origin_tournament_id: origin?.tournamentId ?? null,
+    origin_event_id: origin?.eventId ?? null,
+    origin_draw_id: origin?.drawId ?? null,
   };
+}
+
+/**
+ * The `drawOtherIds[]` entry flagged `isOrigin` — the system this draw came from.
+ *
+ * All four projected columns are independently nullable because an origin system supplies
+ * only the grains it actually models: a UTR flight yields `origin_tournament_id` (UTR's
+ * event id) and `origin_draw_id` (the flight GUID) with `origin_event_id` NULL, since UTR
+ * has no event-grain object.
+ */
+export function drawOrigin(draw: any): UnifiedDrawID | undefined {
+  return (draw?.drawOtherIds ?? []).find((otherId: UnifiedDrawID) => otherId?.isOrigin);
 }
 
 export interface StructureRowContext {

--- a/src/tests/mutations/drawDefinitions/drawOtherIds.test.ts
+++ b/src/tests/mutations/drawDefinitions/drawOtherIds.test.ts
@@ -161,6 +161,23 @@ describe('setDrawOtherIds', () => {
     expect(drawOf(drawId).drawOtherIds).toBeUndefined();
   });
 
+  // Asserted at tournament grain from the start; the draw grain had the same behaviour and no
+  // test, which is an asymmetry in the tests rather than in the code.
+  it('clearing when nothing is set is a silent no-op rather than an error', () => {
+    const drawId = seed();
+    const result: any = tournamentEngine.setDrawOtherIds({ drawOtherIds: null, drawId });
+    expect(result.success).toEqual(true);
+    expect(drawOf(drawId).drawOtherIds).toBeUndefined();
+  });
+
+  it('REJECTS a non-array rather than storing it', () => {
+    const drawId = seed();
+    const result: any = tournamentEngine.setDrawOtherIds({ drawOtherIds: 'nope' as any, drawId });
+    expect(result.error).toBeDefined();
+    expect(result.info).toContain('array');
+    expect(drawOf(drawId).drawOtherIds).toBeUndefined();
+  });
+
   it('REJECTS two isOrigin entries and leaves the draw untouched', () => {
     const drawId = seed();
 

--- a/src/tests/mutations/drawDefinitions/drawOtherIds.test.ts
+++ b/src/tests/mutations/drawDefinitions/drawOtherIds.test.ts
@@ -1,12 +1,12 @@
 import { setSubscriptions } from '@Global/state/globalState';
-import * as readModel from '@Query/readModel';
 import mocksEngine from '@Assemblies/engines/mock';
 import tournamentEngine from '@Engines/syncEngine';
+import * as readModel from '@Query/readModel';
 import { describe, expect, it } from 'vitest';
 
 // constants and types
-import { MODIFY_DRAW_DEFINITION } from '@Constants/topicConstants';
 import { SINGLE_ELIMINATION } from '@Constants/drawDefinitionConstants';
+import { MODIFY_DRAW_DEFINITION } from '@Constants/topicConstants';
 
 /**
  * `drawOtherIds` is the draw-grain member of the `Unified*ID` family, added because an

--- a/src/tests/mutations/drawDefinitions/drawOtherIds.test.ts
+++ b/src/tests/mutations/drawDefinitions/drawOtherIds.test.ts
@@ -1,0 +1,223 @@
+import { setSubscriptions } from '@Global/state/globalState';
+import * as readModel from '@Query/readModel';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+// constants and types
+import { MODIFY_DRAW_DEFINITION } from '@Constants/topicConstants';
+import { SINGLE_ELIMINATION } from '@Constants/drawDefinitionConstants';
+
+/**
+ * `drawOtherIds` is the draw-grain member of the `Unified*ID` family, added because an
+ * outside organisation's draw-grain object is often the only grain that carries identity
+ * worth addressing.
+ *
+ * UTR is the motivating case and drives the shape: a UTR "flight" is a real remote object
+ * with its own GUID, and UTR has **no event-grain object at all** — the CODES event above
+ * it is a synthetic gender × matchUpType grouping. So `eventId` must be legitimately
+ * absent rather than unknown, which is why every id attribute is independently optional.
+ */
+describe('addDrawOtherId', () => {
+  function seed() {
+    const {
+      drawIds: [drawId],
+      eventIds: [eventId],
+    } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 8, drawType: SINGLE_ELIMINATION }],
+      participantsProfile: { nonRandom: 1 },
+      setState: true,
+    });
+    return { drawId, eventId };
+  }
+
+  const drawOf = (drawId: string) => tournamentEngine.getEvent({ drawId }).drawDefinition;
+
+  it('records the UTR shape — tournament + draw, NO event, because UTR has no event grain', () => {
+    const { drawId } = seed();
+
+    const result: any = tournamentEngine.addDrawOtherId({
+      uniqueOrganisationName: 'Universal Tennis',
+      otherDrawId: '77f3990b-83c8-4d2b-8bd9-8ca3c646d879',
+      otherTournamentId: '306618',
+      organisationId: 'UTR',
+      isOrigin: true,
+      drawId,
+    });
+    expect(result.success).toEqual(true);
+
+    const [entry] = drawOf(drawId).drawOtherIds;
+    expect(entry.organisationId).toEqual('UTR');
+    expect(entry.tournamentId).toEqual('306618');
+    expect(entry.drawId).toEqual('77f3990b-83c8-4d2b-8bd9-8ca3c646d879');
+    expect(entry.isOrigin).toEqual(true);
+    expect(entry.createdAt).toBeDefined();
+    // absent, not null — the attribute is omitted when the origin does not model it
+    expect('eventId' in entry).toEqual(false);
+    // theirs, never ours
+    expect(entry.drawId).not.toEqual(drawId);
+  });
+
+  it('carries eventId when the origin DOES model events', () => {
+    const { drawId } = seed();
+
+    tournamentEngine.addDrawOtherId({
+      otherTournamentId: 'ita-4471',
+      otherEventId: 'ita-ev-9',
+      otherDrawId: 'ita-draw-3',
+      organisationId: 'ITA',
+      drawId,
+    });
+
+    const [entry] = drawOf(drawId).drawOtherIds;
+    expect(entry.eventId).toEqual('ita-ev-9');
+  });
+
+  it('upserts on organisationId and is idempotent', () => {
+    const { drawId } = seed();
+
+    tournamentEngine.addDrawOtherId({ organisationId: 'UTR', otherDrawId: 'flight-1', drawId });
+    const result: any = tournamentEngine.addDrawOtherId({ organisationId: 'UTR', otherDrawId: 'flight-1', drawId });
+    expect(result.success).toEqual(true);
+    expect(drawOf(drawId).drawOtherIds).toHaveLength(1);
+    expect(drawOf(drawId).drawOtherIds[0].updatedAt).toBeUndefined();
+
+    tournamentEngine.addDrawOtherId({ organisationId: 'UTR', otherDrawId: 'flight-2', drawId });
+    expect(drawOf(drawId).drawOtherIds).toHaveLength(1);
+    expect(drawOf(drawId).drawOtherIds[0].drawId).toEqual('flight-2');
+    expect(drawOf(drawId).drawOtherIds[0].updatedAt).toBeDefined();
+  });
+
+  it('REFUSES to move isOrigin to a second organisation', () => {
+    const { drawId } = seed();
+
+    tournamentEngine.addDrawOtherId({ organisationId: 'UTR', otherDrawId: 'flight-1', isOrigin: true, drawId });
+    const result: any = tournamentEngine.addDrawOtherId({
+      organisationId: 'ITA',
+      otherDrawId: 'ita-draw-3',
+      isOrigin: true,
+      drawId,
+    });
+    expect(result.error).toBeDefined();
+    expect(result.info).toContain('UTR');
+    expect(readModel.drawOrigin(drawOf(drawId))?.organisationId).toEqual('UTR');
+  });
+
+  it('requires organisationId and at least one origin-side id', () => {
+    const { drawId } = seed();
+    expect(tournamentEngine.addDrawOtherId({ otherDrawId: 'x', drawId }).error).toBeDefined();
+    expect(tournamentEngine.addDrawOtherId({ organisationId: 'UTR', drawId }).error).toBeDefined();
+  });
+
+  it('fires MODIFY_DRAW_DEFINITION on a real change and stays silent on a no-op', () => {
+    const { drawId } = seed();
+
+    const notices: any[] = [];
+    setSubscriptions({ subscriptions: { [MODIFY_DRAW_DEFINITION]: (n: any[]) => notices.push(...n) } });
+
+    tournamentEngine.addDrawOtherId({ organisationId: 'UTR', otherDrawId: 'flight-1', drawId });
+    const afterFirst = notices.length;
+    expect(afterFirst).toBeGreaterThan(0);
+
+    tournamentEngine.addDrawOtherId({ organisationId: 'UTR', otherDrawId: 'flight-1', drawId });
+    expect(notices.length).toEqual(afterFirst); // idempotent re-apply emitted nothing
+
+    setSubscriptions({ subscriptions: {} });
+  });
+});
+
+describe('setDrawOtherIds', () => {
+  function seed() {
+    const {
+      drawIds: [drawId],
+    } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 8, drawType: SINGLE_ELIMINATION }],
+      participantsProfile: { nonRandom: 1 },
+      setState: true,
+    });
+    return drawId;
+  }
+
+  const drawOf = (drawId: string) => tournamentEngine.getEvent({ drawId }).drawDefinition;
+
+  it('replaces wholesale, which is how the origin is re-pointed', () => {
+    const drawId = seed();
+    tournamentEngine.addDrawOtherId({ organisationId: 'UTR', otherDrawId: 'flight-1', isOrigin: true, drawId });
+
+    const result: any = tournamentEngine.setDrawOtherIds({
+      drawOtherIds: [{ organisationId: 'ITA', drawId: 'ita-draw-3', isOrigin: true }],
+      drawId,
+    });
+    expect(result.success).toEqual(true);
+    expect(readModel.drawOrigin(drawOf(drawId))?.organisationId).toEqual('ITA');
+  });
+
+  it('clears on null', () => {
+    const drawId = seed();
+    tournamentEngine.addDrawOtherId({ organisationId: 'UTR', otherDrawId: 'flight-1', drawId });
+
+    const result: any = tournamentEngine.setDrawOtherIds({ drawOtherIds: null, drawId });
+    expect(result.success).toEqual(true);
+    expect(drawOf(drawId).drawOtherIds).toBeUndefined();
+  });
+
+  it('REJECTS two isOrigin entries and leaves the draw untouched', () => {
+    const drawId = seed();
+
+    const result: any = tournamentEngine.setDrawOtherIds({
+      drawOtherIds: [
+        { organisationId: 'UTR', drawId: 'flight-1', isOrigin: true },
+        { organisationId: 'ITA', drawId: 'ita-draw-3', isOrigin: true },
+      ],
+      drawId,
+    });
+    expect(result.error).toBeDefined();
+    expect(drawOf(drawId).drawOtherIds).toBeUndefined();
+  });
+});
+
+describe('drawOrigin + the draws read-model row', () => {
+  it('projects each grain independently — UTR leaves origin_event_id null', () => {
+    const {
+      drawIds: [drawId],
+      eventIds: [eventId],
+    } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 8, drawType: SINGLE_ELIMINATION }],
+      participantsProfile: { nonRandom: 1 },
+      setState: true,
+    });
+    tournamentEngine.addDrawOtherId({
+      otherDrawId: '77f3990b-83c8-4d2b-8bd9-8ca3c646d879',
+      otherTournamentId: '306618',
+      organisationId: 'UTR',
+      isOrigin: true,
+      drawId,
+    });
+
+    const { tournamentRecord } = tournamentEngine.getTournament();
+    const draw = tournamentEngine.getEvent({ drawId }).drawDefinition;
+    const row = readModel.drawRow(draw, tournamentRecord.tournamentId, eventId, 'PROV');
+
+    expect(row.origin_organisation_id).toEqual('UTR');
+    expect(row.origin_tournament_id).toEqual('306618');
+    expect(row.origin_draw_id).toEqual('77f3990b-83c8-4d2b-8bd9-8ca3c646d879');
+    expect(row.origin_event_id).toBeNull(); // UTR has no event grain
+    expect(row.origin_draw_id).not.toEqual(row.draw_id);
+    expect(row.origin_tournament_id).not.toEqual(row.tournament_id);
+  });
+
+  it('is undefined / null when nothing is flagged', () => {
+    expect(readModel.drawOrigin({ drawOtherIds: [{ organisationId: 'UTR', drawId: 'x' }] })).toBeUndefined();
+    expect(readModel.drawOrigin({})).toBeUndefined();
+    expect(readModel.drawOrigin(undefined)).toBeUndefined();
+
+    const row = readModel.drawRow(
+      { drawId: 'd1', drawOtherIds: [{ organisationId: 'UTR', drawId: 'x' }] },
+      't1',
+      null,
+      undefined,
+    );
+    expect(row.origin_organisation_id).toBeNull();
+    expect(row.origin_draw_id).toBeNull();
+  });
+});

--- a/src/tests/mutations/tournaments/tournamentOtherIds.test.ts
+++ b/src/tests/mutations/tournaments/tournamentOtherIds.test.ts
@@ -215,6 +215,19 @@ describe('setTournamentOtherIds', () => {
     expect(tournamentEngine.getTournament().tournamentRecord.tournamentOtherIds).toBeUndefined();
   });
 
+  // `null` clears. Anything else that is not an array is a caller mistake, and accepting it
+  // would write a non-array into the record where every reader expects `.find()` to work.
+  it('REJECTS a non-array, including undefined, rather than storing it', () => {
+    seed();
+
+    for (const tournamentOtherIds of ['nope', 42, {}, undefined] as any[]) {
+      const result: any = tournamentEngine.setTournamentOtherIds({ tournamentOtherIds });
+      expect(result.error).toBeDefined();
+      expect(result.info).toContain('array');
+    }
+    expect(tournamentEngine.getTournament().tournamentRecord.tournamentOtherIds).toBeUndefined();
+  });
+
   it('REJECTS an entry with no organisationId — the upsert key', () => {
     seed();
 

--- a/src/tests/mutations/tournaments/tournamentOtherIds.test.ts
+++ b/src/tests/mutations/tournaments/tournamentOtherIds.test.ts
@@ -1,0 +1,248 @@
+import { setSubscriptions } from '@Global/state/globalState';
+import * as readModel from '@Query/readModel';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+// constants and types
+import { MODIFY_TOURNAMENT_DETAIL } from '@Constants/topicConstants';
+import { UnifiedTournamentID } from '@Types/tournamentTypes';
+
+/**
+ * `tournamentOtherIds` was declared on the `Tournament` type with NO write path, no
+ * reader, and no read-model column, while the event grain had all three. A record
+ * acquired wholesale from an outside system — every `courthive-ingest` adapter produces
+ * exactly that — could only record its origin by prefixing its own `tournamentId`, a
+ * convention that is not queryable and does not survive a re-id.
+ *
+ * These cover the whole tier: upsert, wholesale replace, the single-origin invariant, the
+ * reader, and the projection.
+ */
+describe('addTournamentOtherId', () => {
+  const utrId: UnifiedTournamentID = {
+    uniqueOrganisationName: 'Universal Tennis',
+    organisationId: 'UTR',
+    tournamentId: '306618',
+  };
+
+  function seed() {
+    mocksEngine.generateTournamentRecord({ participantsProfile: { nonRandom: 1 }, setState: true });
+    return tournamentEngine.getTournament().tournamentRecord;
+  }
+
+  it('appends an entry keyed on organisationId, with the ORIGIN organisation id — not ours', () => {
+    const record = seed();
+
+    const result: any = tournamentEngine.addTournamentOtherId({
+      uniqueOrganisationName: 'Universal Tennis',
+      otherTournamentId: '306618',
+      organisationId: 'UTR',
+    });
+    expect(result.success).toEqual(true);
+
+    const { tournamentRecord } = tournamentEngine.getTournament();
+    expect(tournamentRecord.tournamentOtherIds).toHaveLength(1);
+    const [entry] = tournamentRecord.tournamentOtherIds;
+    expect(entry.organisationId).toEqual('UTR');
+    expect(entry.uniqueOrganisationName).toEqual('Universal Tennis');
+    expect(entry.createdAt).toBeDefined();
+    // the whole point of the field: this is THEIR id, and it is not the carrying record's
+    expect(entry.tournamentId).toEqual('306618');
+    expect(entry.tournamentId).not.toEqual(record.tournamentId);
+  });
+
+  it('upserts on organisationId rather than appending a duplicate, and is idempotent', () => {
+    seed();
+
+    tournamentEngine.addTournamentOtherId({ organisationId: 'UTR', otherTournamentId: '306618' });
+    let result: any = tournamentEngine.addTournamentOtherId({ organisationId: 'UTR', otherTournamentId: '306618' });
+    expect(result.success).toEqual(true);
+
+    let { tournamentRecord } = tournamentEngine.getTournament();
+    expect(tournamentRecord.tournamentOtherIds).toHaveLength(1);
+    expect(tournamentRecord.tournamentOtherIds[0].updatedAt).toBeUndefined(); // no-op did not touch it
+
+    result = tournamentEngine.addTournamentOtherId({ organisationId: 'UTR', otherTournamentId: '999999' });
+    expect(result.success).toEqual(true);
+
+    ({ tournamentRecord } = tournamentEngine.getTournament());
+    expect(tournamentRecord.tournamentOtherIds).toHaveLength(1);
+    expect(tournamentRecord.tournamentOtherIds[0].tournamentId).toEqual('999999');
+    expect(tournamentRecord.tournamentOtherIds[0].updatedAt).toBeDefined();
+  });
+
+  it('keeps several organisations side by side', () => {
+    seed();
+
+    tournamentEngine.addTournamentOtherId({ organisationId: 'UTR', otherTournamentId: '306618', isOrigin: true });
+    tournamentEngine.addTournamentOtherId({ organisationId: 'ITA', otherTournamentId: 'ita-4471' });
+
+    const { tournamentRecord } = tournamentEngine.getTournament();
+    expect(tournamentRecord.tournamentOtherIds).toHaveLength(2);
+    expect(readModel.tournamentOrigin(tournamentRecord)?.organisationId).toEqual('UTR');
+  });
+
+  it('REFUSES to move isOrigin to a second organisation — that would silently re-address results', () => {
+    seed();
+
+    tournamentEngine.addTournamentOtherId({ organisationId: 'UTR', otherTournamentId: '306618', isOrigin: true });
+    const result: any = tournamentEngine.addTournamentOtherId({
+      otherTournamentId: 'ita-4471',
+      organisationId: 'ITA',
+      isOrigin: true,
+    });
+    expect(result.error).toBeDefined();
+    expect(result.info).toContain('UTR');
+
+    const { tournamentRecord } = tournamentEngine.getTournament();
+    expect(readModel.tournamentOrigin(tournamentRecord)?.organisationId).toEqual('UTR');
+  });
+
+  it('requires organisationId and otherTournamentId', () => {
+    seed();
+    expect(tournamentEngine.addTournamentOtherId({ otherTournamentId: 'x' }).error).toBeDefined();
+    expect(tournamentEngine.addTournamentOtherId({ organisationId: 'UTR' }).error).toBeDefined();
+  });
+
+  it('fires MODIFY_TOURNAMENT_DETAIL on a real change and stays silent on a no-op', () => {
+    seed();
+
+    const notices: any[] = [];
+    setSubscriptions({ subscriptions: { [MODIFY_TOURNAMENT_DETAIL]: (n: any[]) => notices.push(...n) } });
+
+    tournamentEngine.addTournamentOtherId({ organisationId: 'UTR', otherTournamentId: '306618' });
+    expect(notices.length).toEqual(1);
+    expect(notices[0].tournamentOtherIds).toHaveLength(1);
+
+    tournamentEngine.addTournamentOtherId({ organisationId: 'UTR', otherTournamentId: '306618' });
+    expect(notices.length).toEqual(1); // idempotent re-apply emitted nothing
+
+    setSubscriptions({ subscriptions: {} });
+  });
+
+  it('round-trips a fully-formed entry supplied at record creation', () => {
+    const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+      participantsProfile: { nonRandom: 1 },
+    });
+    tournamentRecord.tournamentOtherIds = [{ ...utrId, isOrigin: true }];
+    tournamentEngine.setState(tournamentRecord);
+
+    const stored = tournamentEngine.getTournament().tournamentRecord;
+    expect(stored.tournamentOtherIds).toEqual([{ ...utrId, isOrigin: true }]);
+  });
+});
+
+describe('setTournamentOtherIds', () => {
+  function seed() {
+    mocksEngine.generateTournamentRecord({ participantsProfile: { nonRandom: 1 }, setState: true });
+  }
+
+  it('replaces the array wholesale, which is how the origin is re-pointed', () => {
+    seed();
+    tournamentEngine.addTournamentOtherId({ organisationId: 'UTR', otherTournamentId: '306618', isOrigin: true });
+
+    const result: any = tournamentEngine.setTournamentOtherIds({
+      tournamentOtherIds: [{ organisationId: 'ITA', tournamentId: 'ita-4471', isOrigin: true }],
+    });
+    expect(result.success).toEqual(true);
+
+    const { tournamentRecord } = tournamentEngine.getTournament();
+    expect(tournamentRecord.tournamentOtherIds).toHaveLength(1);
+    expect(readModel.tournamentOrigin(tournamentRecord)?.organisationId).toEqual('ITA');
+  });
+
+  it('clears on null', () => {
+    seed();
+    tournamentEngine.addTournamentOtherId({ organisationId: 'UTR', otherTournamentId: '306618' });
+
+    const result: any = tournamentEngine.setTournamentOtherIds({ tournamentOtherIds: null });
+    expect(result.success).toEqual(true);
+    expect(tournamentEngine.getTournament().tournamentRecord.tournamentOtherIds).toBeUndefined();
+  });
+
+  it('REJECTS an array carrying two isOrigin entries', () => {
+    seed();
+
+    const result: any = tournamentEngine.setTournamentOtherIds({
+      tournamentOtherIds: [
+        { organisationId: 'UTR', tournamentId: '306618', isOrigin: true },
+        { organisationId: 'ITA', tournamentId: 'ita-4471', isOrigin: true },
+      ],
+    });
+    expect(result.error).toBeDefined();
+    expect(result.info).toContain('isOrigin');
+    expect(tournamentEngine.getTournament().tournamentRecord.tournamentOtherIds).toBeUndefined();
+  });
+
+  it('REJECTS an entry with no organisationId — the upsert key', () => {
+    seed();
+
+    const result: any = tournamentEngine.setTournamentOtherIds({
+      tournamentOtherIds: [{ tournamentId: '306618' } as any],
+    });
+    expect(result.error).toBeDefined();
+    expect(tournamentEngine.getTournament().tournamentRecord.tournamentOtherIds).toBeUndefined();
+  });
+});
+
+describe('tournamentOrigin + the tournaments read-model row', () => {
+  it('projects the flagged entry, independently of the record’s own tournamentId', () => {
+    mocksEngine.generateTournamentRecord({ participantsProfile: { nonRandom: 1 }, setState: true });
+    tournamentEngine.addTournamentOtherId({ organisationId: 'UTR', otherTournamentId: '306618', isOrigin: true });
+
+    const { tournamentRecord } = tournamentEngine.getTournament();
+    const row = readModel.tournamentRow(tournamentRecord);
+
+    expect(row.origin_organisation_id).toEqual('UTR');
+    expect(row.origin_tournament_id).toEqual('306618');
+    // the distinction the columns exist to preserve
+    expect(row.origin_tournament_id).not.toEqual(row.tournament_id);
+  });
+
+  // The unit assertions above prove the row BUILDERS project the columns. This proves the
+  // whole rebuild path does — cast() is what the server calls, and the CFS incremental
+  // producer shares these same builders so both emit byte-identical rows.
+  it('survives cast(), at both grains, in one pass', () => {
+    const {
+      drawIds: [drawId],
+    } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 4 }],
+      participantsProfile: { nonRandom: 1 },
+      setState: true,
+    });
+    tournamentEngine.addTournamentOtherId({ organisationId: 'UTR', otherTournamentId: '306618', isOrigin: true });
+    tournamentEngine.addDrawOtherId({
+      otherDrawId: '77f3990b-83c8-4d2b-8bd9-8ca3c646d879',
+      otherTournamentId: '306618',
+      organisationId: 'UTR',
+      isOrigin: true,
+      drawId,
+    });
+
+    const { rows }: any = tournamentEngine.cast();
+
+    expect(rows.tournaments[0].origin_organisation_id).toEqual('UTR');
+    expect(rows.tournaments[0].origin_tournament_id).toEqual('306618');
+    expect(rows.draws[0].origin_organisation_id).toEqual('UTR');
+    expect(rows.draws[0].origin_draw_id).toEqual('77f3990b-83c8-4d2b-8bd9-8ca3c646d879');
+    expect(rows.draws[0].origin_event_id).toBeNull();
+    // both origin ids point at UTR's namespace, neither at ours
+    expect(rows.tournaments[0].origin_tournament_id).not.toEqual(rows.tournaments[0].tournament_id);
+    expect(rows.draws[0].origin_draw_id).not.toEqual(rows.draws[0].draw_id);
+  });
+
+  it('is undefined / null when nothing is flagged, so an unflagged entry is never mistaken for an origin', () => {
+    expect(
+      readModel.tournamentOrigin({ tournamentOtherIds: [{ organisationId: 'UTR', tournamentId: 'x' }] }),
+    ).toBeUndefined();
+    expect(readModel.tournamentOrigin({})).toBeUndefined();
+    expect(readModel.tournamentOrigin(undefined)).toBeUndefined();
+
+    const row = readModel.tournamentRow({
+      tournamentId: 't',
+      tournamentOtherIds: [{ organisationId: 'UTR', tournamentId: 'x' }],
+    });
+    expect(row.origin_organisation_id).toBeNull();
+    expect(row.origin_tournament_id).toBeNull();
+  });
+});

--- a/src/tests/mutations/tournaments/tournamentOtherIds.test.ts
+++ b/src/tests/mutations/tournaments/tournamentOtherIds.test.ts
@@ -1,7 +1,7 @@
 import { setSubscriptions } from '@Global/state/globalState';
-import * as readModel from '@Query/readModel';
 import mocksEngine from '@Assemblies/engines/mock';
 import tournamentEngine from '@Engines/syncEngine';
+import * as readModel from '@Query/readModel';
 import { describe, expect, it } from 'vitest';
 
 // constants and types
@@ -96,6 +96,47 @@ describe('addTournamentOtherId', () => {
 
     const { tournamentRecord } = tournamentEngine.getTournament();
     expect(readModel.tournamentOrigin(tournamentRecord)?.organisationId).toEqual('UTR');
+  });
+
+  // The upsert refuses to MOVE isOrigin to a different organisation, but promoting the entry
+  // that already holds the slot is the ordinary copy-back case and must work.
+  it('promotes an existing entry to origin, and updates a changed organisation name', () => {
+    seed();
+    tournamentEngine.addTournamentOtherId({ organisationId: 'UTR', otherTournamentId: '306618' });
+
+    let stored = tournamentEngine.getTournament().tournamentRecord.tournamentOtherIds[0];
+    expect(stored.isOrigin).toBeUndefined();
+
+    let result: any = tournamentEngine.addTournamentOtherId({
+      uniqueOrganisationName: 'Universal Tennis',
+      otherTournamentId: '306618',
+      organisationId: 'UTR',
+      isOrigin: true,
+    });
+    expect(result.success).toEqual(true);
+
+    stored = tournamentEngine.getTournament().tournamentRecord.tournamentOtherIds[0];
+    expect(stored.isOrigin).toEqual(true);
+    expect(stored.uniqueOrganisationName).toEqual('Universal Tennis');
+    expect(stored.updatedAt).toBeDefined();
+
+    // a name-only change is still a change — it must not be swallowed as a no-op
+    result = tournamentEngine.addTournamentOtherId({
+      uniqueOrganisationName: 'Universal Tennis (UTR)',
+      otherTournamentId: '306618',
+      organisationId: 'UTR',
+    });
+    expect(result.success).toEqual(true);
+    stored = tournamentEngine.getTournament().tournamentRecord.tournamentOtherIds[0];
+    expect(stored.uniqueOrganisationName).toEqual('Universal Tennis (UTR)');
+    expect(stored.isOrigin).toEqual(true); // promotion is not undone by an unrelated update
+  });
+
+  it('clearing when nothing is set is a silent no-op rather than an error', () => {
+    seed();
+    const result: any = tournamentEngine.setTournamentOtherIds({ tournamentOtherIds: null });
+    expect(result.success).toEqual(true);
+    expect(tournamentEngine.getTournament().tournamentRecord.tournamentOtherIds).toBeUndefined();
   });
 
   it('requires organisationId and otherTournamentId', () => {

--- a/src/tests/queries/readModel/readModelRows.test.ts
+++ b/src/tests/queries/readModel/readModelRows.test.ts
@@ -150,6 +150,8 @@ describe('tournamentRow', () => {
       end_date: null,
       city: null,
       published: false,
+      origin_organisation_id: null,
+      origin_tournament_id: null,
     });
   });
 
@@ -199,6 +201,10 @@ describe('drawRow', () => {
       draw_name: 'Main',
       draw_type: 'SINGLE_ELIMINATION',
       match_up_format: 'SET3-S:6/TB7',
+      origin_organisation_id: null,
+      origin_tournament_id: null,
+      origin_event_id: null,
+      origin_draw_id: null,
     });
     expect(drawRow({ drawId: 'd2' }, 't1', null, undefined)).toMatchObject({
       draw_id: 'd2',

--- a/src/types/factoryEngineMethods.ts
+++ b/src/types/factoryEngineMethods.ts
@@ -19,6 +19,7 @@ export type FactoryEngineMethod =
   | 'addDrawDefinitionExtension'
   | 'addDrawDefinitionTimeItem'
   | 'addDrawEntries'
+  | 'addDrawOtherId'
   | 'addDynamicRatings'
   | 'addEvaluation'
   | 'addEvaluationPolicy'
@@ -63,6 +64,7 @@ export type FactoryEngineMethod =
   | 'addSuspension'
   | 'addTimeItem'
   | 'addTournamentExtension'
+  | 'addTournamentOtherId'
   | 'addTournamentTimeItem'
   | 'addVenue'
   | 'addVenueOtherId'
@@ -570,6 +572,7 @@ export type FactoryEngineMethod =
   | 'ScoringEngine'
   | 'seedWithdrawalCascade'
   | 'setDelegatedOutcome'
+  | 'setDrawOtherIds'
   | 'setDrawParticipantRepresentativeIds'
   | 'setDrawPositionPreferences'
   | 'setEntryPosition'
@@ -602,6 +605,7 @@ export type FactoryEngineMethod =
   | 'setTournamentLocalTimeZone'
   | 'setTournamentName'
   | 'setTournamentNotes'
+  | 'setTournamentOtherIds'
   | 'setTournamentRecord'
   | 'setTournamentStartDate'
   | 'setTournamentStatus'
@@ -682,6 +686,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'addDrawDefinitionExtension',
   'addDrawDefinitionTimeItem',
   'addDrawEntries',
+  'addDrawOtherId',
   'addDynamicRatings',
   'addEvaluation',
   'addEvaluationPolicy',
@@ -726,6 +731,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'addSuspension',
   'addTimeItem',
   'addTournamentExtension',
+  'addTournamentOtherId',
   'addTournamentTimeItem',
   'addVenue',
   'addVenueOtherId',
@@ -1233,6 +1239,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'ScoringEngine',
   'seedWithdrawalCascade',
   'setDelegatedOutcome',
+  'setDrawOtherIds',
   'setDrawParticipantRepresentativeIds',
   'setDrawPositionPreferences',
   'setEntryPosition',
@@ -1265,6 +1272,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'setTournamentLocalTimeZone',
   'setTournamentName',
   'setTournamentNotes',
+  'setTournamentOtherIds',
   'setTournamentRecord',
   'setTournamentStartDate',
   'setTournamentStatus',

--- a/src/types/methodSignatures.ts
+++ b/src/types/methodSignatures.ts
@@ -337,6 +337,7 @@ import type {
   removeTournamentExtension,
 } from '@Mutate/extensions/addRemoveExtensions';
 import type { addDrawEntries } from '@Mutate/drawDefinitions/addDrawEntries';
+import type { addTournamentOtherId, setTournamentOtherIds } from '@Mutate/tournaments/tournamentOtherIds';
 import type { allPlayoffPositionsFilled, isCompletedStructure } from '@Query/drawDefinition/structureActions';
 import type { bulkMatchUpStatusUpdate } from '@Mutate/events/bulkMatchUpStatusUpdate';
 import type { completeDrawMatchUps } from '@Generators/mocks/completeDrawMatchUps';
@@ -392,6 +393,7 @@ import type { tournamentMatchUps } from '@Query/matchUps/getTournamentMatchUps';
 import type { validateSchedulingProfile } from '@Validators/validateSchedulingProfile';
 import type { addCertification } from '@Mutate/officiating/addCertification';
 import type { addCollectionGroup } from '@Mutate/tieFormat/addCollectionGroup';
+import type { addDrawOtherId, setDrawOtherIds } from '@Mutate/drawDefinitions/drawOtherIds';
 import type { addParticipants } from '@Mutate/participants/addParticipants';
 import type { analyzeTournament } from '@Query/tournaments/analyzeTournament';
 import type { calculateMatchStatistics, enrichPointHistory, getQuickStats } from '@Query/scoring/statistics/standalone';
@@ -613,6 +615,7 @@ export interface MethodSignatures {
   addDrawDefinitionExtension: EngineMethod<typeof addDrawDefinitionExtension>;
   addDrawDefinitionTimeItem: EngineMethod<typeof addDrawDefinitionTimeItem>;
   addDrawEntries: EngineMethod<typeof addDrawEntries>;
+  addDrawOtherId: EngineMethod<typeof addDrawOtherId>;
   addDynamicRatings: EngineMethod<typeof addDynamicRatings>;
   addEvaluation: EngineMethod<typeof addEvaluation>;
   addEvaluationPolicy: EngineMethod<typeof addEvaluationPolicy>;
@@ -657,6 +660,7 @@ export interface MethodSignatures {
   addSuspension: EngineMethod<typeof addSuspension>;
   addTimeItem: EngineMethod<typeof addTimeItem>;
   addTournamentExtension: EngineMethod<typeof addTournamentExtension>;
+  addTournamentOtherId: EngineMethod<typeof addTournamentOtherId>;
   addTournamentTimeItem: EngineMethod<typeof addTournamentTimeItem>;
   addVenue: EngineMethod<typeof addVenue>;
   addVenueOtherId: EngineMethod<typeof addVenueOtherId>;
@@ -1103,6 +1107,7 @@ export interface MethodSignatures {
   ScoringEngine: EngineMethod<typeof ScoringEngine>;
   seedWithdrawalCascade: EngineMethod<typeof seedWithdrawalCascade>;
   setDelegatedOutcome: EngineMethod<typeof setDelegatedOutcome>;
+  setDrawOtherIds: EngineMethod<typeof setDrawOtherIds>;
   setDrawParticipantRepresentativeIds: EngineMethod<typeof setDrawParticipantRepresentativeIds>;
   setDrawPositionPreferences: EngineMethod<typeof setDrawPositionPreferences>;
   setEntryPosition: EngineMethod<typeof setEntryPosition>;
@@ -1133,6 +1138,7 @@ export interface MethodSignatures {
   setTournamentLocalTimeZone: EngineMethod<typeof setTournamentLocalTimeZone>;
   setTournamentName: EngineMethod<typeof setTournamentName>;
   setTournamentNotes: EngineMethod<typeof setTournamentNotes>;
+  setTournamentOtherIds: EngineMethod<typeof setTournamentOtherIds>;
   setTournamentStartDate: EngineMethod<typeof setTournamentStartDate>;
   setTournamentStatus: EngineMethod<typeof setTournamentStatus>;
   setTournamentTier: EngineMethod<typeof setTournamentTier>;

--- a/src/types/readModelTypes.ts
+++ b/src/types/readModelTypes.ts
@@ -19,6 +19,13 @@ export interface ReadModelTournamentRow {
   end_date: string | null;
   city: string | null;
   published: boolean; // aggregate: order-of-play OR participants published
+  // The system the RECORD was acquired from — the `tournamentOtherIds[]` entry flagged
+  // `isOrigin`, flattened. `origin_tournament_id` is the ORIGIN organisation's id and is
+  // deliberately independent of `tournament_id` above. Independent, too, of the events
+  // table's origin columns: a record acquired wholesale from one organisation can carry
+  // events sanctioned by others. Both null when no origin is declared.
+  origin_organisation_id: string | null;
+  origin_tournament_id: string | null;
 }
 
 export interface ReadModelParticipantPublishRow {
@@ -120,6 +127,15 @@ export interface ReadModelDrawRow {
   draw_name: string | null;
   draw_type: string | null;
   match_up_format: string | null;
+  // The system this DRAW came from — the `drawOtherIds[]` entry flagged `isOrigin`,
+  // flattened. Each column is independently nullable because an origin supplies only the
+  // grains it models: a UTR flight yields origin_tournament_id (UTR's event id) +
+  // origin_draw_id (the flight GUID) and leaves origin_event_id null, UTR having no
+  // event-grain object at all.
+  origin_organisation_id: string | null;
+  origin_tournament_id: string | null;
+  origin_event_id: string | null;
+  origin_draw_id: string | null;
 }
 
 export interface ReadModelStructureRow {

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -245,6 +245,9 @@ export interface DrawDefinition {
   drawId: string;
   drawName?: string;
   drawOrder?: number;
+  // CODES first-class: this draw's identity in OTHER organisations' systems. The entry
+  // flagged `isOrigin` is the system the draw came from. See {@link UnifiedDrawID}.
+  drawOtherIds?: UnifiedDrawID[];
   drawRepresentativeIds?: string[];
   drawStatus?: DrawStatusUnion;
   drawType?: DrawTypeUnion;
@@ -1781,10 +1784,63 @@ export interface UnifiedTournamentID {
   createdAt?: Date | string;
   extensions?: Extension[];
   isMock?: boolean;
+  /** marks this entry as the source the RECORD originated from — the ingest or
+   *  sanctioning system the whole tournament was acquired from. At most one entry per
+   *  tournament should carry it; every other entry is a system the tournament is merely
+   *  also known to (typically acquired by copy-back).
+   *
+   *  Mirrors {@link UnifiedEventID.isOrigin} one grain up. The two are independent: a
+   *  record acquired wholesale from one organisation can still carry events sanctioned
+   *  by others, so neither flag can be inferred from the other.
+   *
+   *  Unlike `UnifiedEventID`, `tournamentId` here stays REQUIRED. `eventId` is optional
+   *  at event grain because the origin may not hold the event yet; at tournament grain
+   *  the id is the entire payload, and an entry without one carries no identity at all. */
+  isOrigin?: boolean;
   notes?: string;
   organisationId: string;
   timeItems?: TimeItem[];
   tournamentId: string;
+  uniqueOrganisationName?: string;
+  updatedAt?: Date | string;
+}
+
+/**
+ * CODES first-class: a DRAW's identity in another organisation's system — the
+ * draw-grain member of the `Unified*ID` family ({@link UnifiedTournamentID},
+ * {@link UnifiedEventID}, {@link UnifiedParticipantID}, {@link UnifiedPersonID},
+ * {@link UnifiedVenueID}).
+ *
+ * Carried on `DrawDefinition.drawOtherIds[]`. It exists because an outside organisation's
+ * draw-grain object is frequently the ONLY grain that carries the identity and the
+ * metadata worth addressing. UTR is the motivating case: a UTR "flight" is a real remote
+ * object with its own GUID, its own `drawSize`, and its own UTR-band bounds, and it maps
+ * 1:1 to a CODES `drawDefinition` — while UTR has no event-grain object at all, so the
+ * CODES event above it is a synthetic gender × matchUpType grouping with no counterpart
+ * to record.
+ *
+ * Every id attribute is OPTIONAL and belongs to `organisationId`, never to the carrying
+ * record. Populate only the ones the origin system actually has: UTR supplies
+ * `tournamentId` (its event id) + `drawId` (the flight GUID) and no `eventId`, and an
+ * origin that models events supplies `eventId` too. `drawId` is absent until the draw
+ * exists there, which is the copy-back case — see {@link UnifiedEventID}.
+ */
+export interface UnifiedDrawID {
+  createdAt?: Date | string;
+  /** that organisation's id for this draw */
+  drawId?: string;
+  /** that organisation's id for the event carrying this draw, when it models events */
+  eventId?: string;
+  extensions?: Extension[];
+  isMock?: boolean;
+  /** marks this entry as the source the draw originated from. At most one entry per draw
+   *  should carry it. */
+  isOrigin?: boolean;
+  notes?: string;
+  organisationId: string;
+  timeItems?: TimeItem[];
+  /** **that organisation's** tournamentId — never the carrying record's */
+  tournamentId?: string;
   uniqueOrganisationName?: string;
   updatedAt?: Date | string;
 }


### PR DESCRIPTION
Two grains of the `Unified*ID` identity family were unusable, which left an ingested record unable to say where it came from as *data* rather than as *convention*.

Found while auditing why `courthive-ingest` carries external identity by string prefix.

## What was missing

**Tournament grain was a type slot and nothing else.** `tournamentOtherIds` appeared **exactly once** in the entire factory — its declaration at `types/tournamentTypes.ts:54`. Compare the event grain:

| | `eventOtherIds` | `tournamentOtherIds` (before) |
|---|---|---|
| type | ✅ | ✅ |
| `isOrigin` flag | ✅ | ❌ |
| write path | ✅ `modifyEvent` | ❌ |
| reader | ✅ `readModel.eventOrigin()` | ❌ |
| read-model columns | ✅ | ❌ |

Every `courthive-ingest` adapter produces a record acquired wholesale from an outside system, and could only record that by prefixing its own `tournamentId` with `utr-` / `cts-` — not queryable, and gone the moment an id is remapped.

**Draw grain did not exist at all.** It is the grain that matters most for a source like UTR: a UTR "flight" is a real remote object with its own GUID, `drawSize` and rating bounds, mapping 1:1 to a `drawDefinition` — while UTR has **no event-grain object**, so the CODES event above it is a synthetic gender × matchUpType grouping with nothing to record.

## What this adds

- `UnifiedTournamentID.isOrigin`
- `UnifiedDrawID` + `DrawDefinition.drawOtherIds`
- `addTournamentOtherId` / `setTournamentOtherIds` / `addDrawOtherId` / `setDrawOtherIds`
- `readModel.tournamentOrigin()` / `readModel.drawOrigin()`
- origin columns on the `tournaments` and `draws` read-model rows
- shared write mechanics in `mutate/base/unifiedIds.ts`, so the family's three invariants are enforced once rather than per grain
- a concept doc covering the whole family

## Design decisions worth reviewing

**Every `UnifiedDrawID` id attribute is independently optional.** An origin populates only the grains it actually models: a UTR flight yields `tournamentId` + `drawId` and **omits** `eventId` rather than nulling or fabricating it.

**`tournamentId` stays REQUIRED on `UnifiedTournamentID`,** deliberately unlike the event grain's optional one. `eventId` is optional at event grain because the origin may not hold the event yet; at tournament grain the id is the entire payload, and an entry without one carries no identity at all.

**The single-origin rule is enforced on write for the first time.** An upsert **refuses** to move `isOrigin` to a second organisation rather than silently unflagging the first — that would change which system results are addressed back to, invisibly. Re-pointing an origin therefore requires a deliberate wholesale `set*OtherIds` call, which validates the supplied array. Readers stay **tolerant** and `find` the flagged entry, so a malformed record already in storage still projects deterministically instead of throwing on a read.

**`modifyEvent`'s `eventOtherIds` path is deliberately unchanged.** It still stores its array unvalidated, so event grain is laxer on write than the two new grains. Tightening shipped behaviour is a separate decision; the divergence is documented in the concept doc rather than silently introduced. Happy to fold it in if wanted.

## Verification

Full 14-step `pnpm verify` gate, exit 0.

- suite **10,990 passed** / 1 skipped (baseline 10,965 → **+25**, exactly the new tests)
- `verify:surface` — additions only, **no exports removed**
- the `cast()` test proves the columns survive the whole rebuild path, not just the row builders

The single-origin guard was **falsified**, not just asserted: disabling it turns exactly the two `REFUSES to move isOrigin` tests red and nothing else — feature on → green, feature off → red.

Two existing exhaustive `toEqual` shape contracts in `readModelRows.test.ts` were **extended** with the new null columns, not weakened — they still fail on any unexpected key.

## Downstream follow-up (not blocking)

The new columns are inert in `courthive-query` until a migration adds them and `src/modules/projection/tableMeta.ts` allow-lists them. The consumer filters delta keys against `TABLE_META[].columns`, so extra keys are **silently dropped rather than breaking** — producer-first is safe, and is exactly how event origin shipped (migration 017).

Needs: `tournaments.origin_{organisation,tournament}_id` and `draws.origin_{organisation,tournament,event,draw}_id`.

`courthive-ingest` stamping is the consumer this was built for and lands separately — it needs this published first.
