### PR TITLE
fix(tsconfig): drop the DOM lib — factory is not a DOM consumer

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,7 +10,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
-    "lib": ["dom", "esnext"],
+    "lib": ["esnext"],
     "module": "esnext",
     "moduleResolution": "bundler",
     "noEmit": true,


### PR DESCRIPTION
`tsconfig.base.json` declared `"lib": ["dom", "esnext"]`. Factory is a pure library with **no runtime DOM dependency** — consumers supply their own lib. Nothing in `src/` needs it: type-checking without it produces **zero errors**.

## The cost of having it

The DOM lib declares `var event: Event | undefined`. So a function passing a shorthand `event,` it never received **type-checks clean** and throws `event is not defined` at runtime in Node.

That is not hypothetical — during the notice-origin threading it cost **21 test failures with `tsc` silent throughout**, and a static guard I wrote for the same class had to be abandoned as unreliable (regex scope analysis could not handle positional params, closures or shadowed loop variables).

## Falsified both directions

A planted function passing an unbound `event`:

| config | result |
|---|---|
| **with** `"dom"` | 0 errors — the bug is invisible |
| **without** `"dom"` | `TS2552: Cannot find name 'event'. Did you mean 'Event'?` |

The compiler now does, properly and for free, what the regex guard could not.

## Note for future edits

`tsconfig.base.json` is `JSON.parse`'d by `rollup.config.mjs`, so it is **strict JSON and cannot carry comments** — my first attempt added explanatory comments and broke the build with `SyntaxError: Expected double-quoted property name`. The rationale lives in the commit message instead.

## Verification

lint 0, types 0, **build ✓**, full suite **10,966 tests**.