### PR TITLE
feat(scheduling): isScheduleLocked as a query, by ids or by matchUp

### DIFF
--- a/documentation/docs/concepts/schedule-locks.mdx
+++ b/documentation/docs/concepts/schedule-locks.mdx
@@ -48,6 +48,22 @@ engine.setMatchUpScheduleLock({ lock: { attributes: ['scheduledTime'] }, matchUp
 engine.setMatchUpScheduleLock({ lock: null, matchUpId, drawId });
 ```
 
+## Asking whether a matchUp is locked
+
+```js
+// ids — drawId resolves to drawDefinition through the engine
+engine.isScheduleLocked({ matchUpId, drawId });
+// → { success: true, scheduleLocked: true, lock: { reason: 'featured', … } }
+
+// a matchUp already in hand — the cheap form; a table of hundreds of rows
+// should not resolve each one by id
+engine.isScheduleLocked({ matchUp });
+```
+
+The lock object comes back alongside the verdict so a caller can show **why** a matchUp is pinned without a second lookup. `scheduleLocked` is `false` — with the lock still returned — when a lock exists but is inert (the matchUp completed, or there is no placement to guard).
+
+`scheduleGovernor.matchUpScheduleLocked({ matchUp })` is the bare predicate behind it, returning a boolean with no result envelope. Enforcement inside the factory uses that; consumers should prefer `isScheduleLocked`.
+
 ## What a lock stops
 
 The predicate is enforced at every mutation that writes or wipes placement, so there is no path that quietly bypasses it:

--- a/documentation/docs/governors/schedule-governor.md
+++ b/documentation/docs/governors/schedule-governor.md
@@ -802,6 +802,32 @@ const { times } = engine.calculateScheduleTimes({
 
 ---
 
+### isScheduleLocked
+
+Whether a matchUp's placement is pinned by a director. Accepts the matchUp
+either way round — `{ matchUpId, drawId }` when only ids are in hand, or
+`{ matchUp }` when it isn't (the cheap form: a table rendering hundreds of rows
+should not resolve each one by id).
+
+Returns the lock alongside the verdict so a caller can show _why_ a matchUp is
+pinned without a second lookup. `scheduleLocked` is `false` — with `lock` still
+returned — when a lock exists but is inert: the matchUp completed, or there is
+no placement left to guard. See [Schedule Locks](../concepts/schedule-locks.mdx).
+
+```js
+engine.isScheduleLocked({ matchUpId, drawId });
+// → { success: true, scheduleLocked: true, lock: { reason: 'featured' } }
+
+engine.isScheduleLocked({ matchUp });
+engine.isScheduleLocked({ matchUp, attributes: ['courtId'] }); // narrow to one placement field
+```
+
+`scheduleGovernor.matchUpScheduleLocked({ matchUp })` is the bare predicate
+behind it — a plain boolean with no result envelope, used by the factory's own
+enforcement. Consumers should prefer `isScheduleLocked`.
+
+---
+
 ### courtGridRows
 
 Returns court grid data for pro scheduling visualization.

--- a/src/assemblies/governors/scheduleGovernor/query.ts
+++ b/src/assemblies/governors/scheduleGovernor/query.ts
@@ -1,3 +1,4 @@
+export { isScheduleLocked, matchUpScheduleLocked } from '@Query/matchUp/isScheduleLocked';
 export { getMatchUpsToSchedule } from '@Mutate/matchUps/schedule/scheduleMatchUps/getMatchUpsToSchedule';
 export { getScheduledRoundsDetails } from '@Query/matchUps/scheduling/getScheduledRoundsDetails';
 export { getSchedulingProfileIssues } from '@Query/matchUps/scheduling/getSchedulingProfileIssues';

--- a/src/mutate/matchUps/schedule/clearMatchUpSchedule.ts
+++ b/src/mutate/matchUps/schedule/clearMatchUpSchedule.ts
@@ -1,7 +1,7 @@
 import { allTournamentMatchUps } from '@Query/matchUps/getAllTournamentMatchUps';
 import { modifyMatchUpNotice } from '@Mutate/notifications/drawNotifications';
 import { allDrawMatchUps } from '@Query/matchUps/getAllDrawMatchUps';
-import { isScheduleLocked } from '@Query/matchUp/isScheduleLocked';
+import { matchUpScheduleLocked } from '@Query/matchUp/isScheduleLocked';
 
 // constants
 import { MATCHUP_NOT_FOUND, SCHEDULE_LOCKED } from '@Constants/errorConditionConstants';
@@ -86,7 +86,7 @@ export function clearMatchUpSchedule({
   // A pinned placement is not cleared by a single-matchUp clear either. Callers
   // that have confirmed the intent with the operator pass `overrideScheduleLock`
   // (the lock itself survives — only setMatchUpScheduleLock removes it).
-  if (!overrideScheduleLock && isScheduleLocked({ matchUp })) return { error: SCHEDULE_LOCKED };
+  if (!overrideScheduleLock && matchUpScheduleLocked({ matchUp })) return { error: SCHEDULE_LOCKED };
 
   const newTimeItems = (matchUp.timeItems ?? []).filter(
     (timeItem) => timeItem?.itemType && !scheduleAttributes.includes(timeItem?.itemType),

--- a/src/mutate/matchUps/schedule/clearScheduledMatchUps.ts
+++ b/src/mutate/matchUps/schedule/clearScheduledMatchUps.ts
@@ -1,7 +1,7 @@
 import { resolveTournamentRecords } from '@Helpers/parameters/resolveTournamentRecords';
 import { allTournamentMatchUps } from '@Query/matchUps/getAllTournamentMatchUps';
 import { modifyMatchUpNotice } from '@Mutate/notifications/drawNotifications';
-import { isScheduleLocked } from '@Query/matchUp/isScheduleLocked';
+import { matchUpScheduleLocked } from '@Query/matchUp/isScheduleLocked';
 import { allDrawMatchUps } from '@Query/matchUps/getAllDrawMatchUps';
 import { hasSchedule } from '@Query/matchUp/hasSchedule';
 import { findEvent } from '@Acquire/findEvent';
@@ -157,7 +157,7 @@ function clearSchedules({
     for (const matchUp of drawMatchUps) {
       // A director's lock survives a date/venue-scoped clear — the whole point
       // of pinning the marquee match before rebuilding the day around it.
-      if (!overrideScheduleLock && isScheduleLocked({ matchUp })) {
+      if (!overrideScheduleLock && matchUpScheduleLocked({ matchUp })) {
         lockedMatchUpIds.push(matchUp.matchUpId);
         continue;
       }

--- a/src/query/matchUp/isScheduleLocked.ts
+++ b/src/query/matchUp/isScheduleLocked.ts
@@ -1,8 +1,13 @@
+import { decorateResult } from '@Functions/global/decorateResult';
+import { findDrawMatchUp } from '@Acquire/findDrawMatchUp';
 import { isObject } from '@Tools/objects';
 
 // constants and types
+import { MATCHUP_NOT_FOUND, MISSING_DRAW_DEFINITION, MISSING_MATCHUP_ID } from '@Constants/errorConditionConstants';
+import { DrawDefinition, Event, ScheduleLock, ScheduleLockAttribute } from '@Types/tournamentTypes';
 import { completedMatchUpStatuses } from '@Constants/matchUpStatusConstants';
-import { ScheduleLockAttribute } from '@Types/tournamentTypes';
+import { SUCCESS } from '@Constants/resultConstants';
+import { ResultType } from '@Types/factoryTypes';
 import {
   ALLOCATE_COURTS,
   ASSIGN_COURT,
@@ -118,7 +123,7 @@ function equivalent(requested: any, current: any): boolean {
  * Pass `attributes` to ask about specific placement fields; a lock with no
  * `attributes` of its own pins the entire placement.
  */
-export function isScheduleLocked({
+export function matchUpScheduleLocked({
   attributes,
   matchUp,
 }: {
@@ -139,6 +144,49 @@ export function isScheduleLocked({
 }
 
 /**
+ * Public query: is this matchUp's placement pinned?
+ *
+ * Accepts the matchUp either way round, because callers arrive from both
+ * directions:
+ *
+ *  - `{ matchUp }` — a hydrated matchUp already in hand. This is the cheap form:
+ *    a table rendering hundreds of rows should not resolve each one by id.
+ *  - `{ drawId, matchUpId }` — ids only. `drawId` resolves to `drawDefinition`
+ *    through the engine's params middleware; a `drawDefinition` passed directly
+ *    also works.
+ *
+ * Returns the lock itself alongside the verdict so a caller can show *why* a
+ * matchUp is pinned (`lock.reason`) without a second lookup. `scheduleLocked`
+ * is false — with the lock still returned — when the lock exists but is inert
+ * (matchUp completed, or nothing placed to guard).
+ */
+export function isScheduleLocked(params: {
+  attributes?: ScheduleLockAttribute[];
+  drawDefinition?: DrawDefinition;
+  matchUpId?: string;
+  matchUp?: any;
+  event?: Event;
+}): ResultType & { scheduleLocked?: boolean; lock?: ScheduleLock } {
+  const stack = 'isScheduleLocked';
+  const { attributes, drawDefinition, matchUpId, event } = params;
+
+  let matchUp = params.matchUp;
+  if (!matchUp) {
+    if (!matchUpId) return decorateResult({ result: { error: MISSING_MATCHUP_ID }, stack });
+    if (!drawDefinition) return decorateResult({ result: { error: MISSING_DRAW_DEFINITION }, stack });
+    matchUp = findDrawMatchUp({ drawDefinition, event, matchUpId }).matchUp;
+    if (!matchUp) return decorateResult({ result: { error: MATCHUP_NOT_FOUND }, stack });
+  }
+
+  const lock = matchUp?.schedule?.lock;
+  return {
+    ...SUCCESS,
+    scheduleLocked: matchUpScheduleLocked({ matchUp, attributes }),
+    ...(isObject(lock) ? { lock } : {}),
+  };
+}
+
+/**
  * Which locked placement attributes a requested `schedule` write would change.
  * Empty ⇒ the write is permitted: either nothing is locked, or the call only
  * touches unlocked/actual-play attributes, or it rewrites the same values.
@@ -150,13 +198,13 @@ export function scheduleLockConflicts({
   matchUp?: any;
   schedule?: any;
 }): ScheduleLockAttribute[] {
-  if (!isObject(schedule) || !isScheduleLocked({ matchUp })) return [];
+  if (!isObject(schedule) || !matchUpScheduleLocked({ matchUp })) return [];
 
   const conflicts = new Set<ScheduleLockAttribute>();
 
   for (const key of Object.keys(schedule)) {
     const attribute = REQUEST_KEY_TO_ATTRIBUTE[key];
-    if (!attribute || !isScheduleLocked({ matchUp, attributes: [attribute] })) continue;
+    if (!attribute || !matchUpScheduleLocked({ matchUp, attributes: [attribute] })) continue;
     if (equivalent(schedule[key], currentValue(matchUp, attribute))) continue;
     conflicts.add(attribute);
   }

--- a/src/tests/mutations/scheduling/scheduleLocks.test.ts
+++ b/src/tests/mutations/scheduling/scheduleLocks.test.ts
@@ -425,3 +425,48 @@ it('locks silently when notices are disabled', () => {
   expect(result.success).toEqual(true);
   expect(scheduleOf(lockedId)?.lock).not.toBeUndefined();
 });
+
+it('answers isScheduleLocked from ids, and returns the lock so a caller can say why', () => {
+  const { lockedId, otherId } = seed();
+  lock(lockedId, { reason: 'broadcast' });
+
+  let byIds: any = tournamentEngine.isScheduleLocked({ matchUpId: lockedId, drawId: DRAW_ID });
+  expect(byIds.scheduleLocked).toEqual(true);
+  expect(byIds.lock.reason).toEqual('broadcast');
+
+  let unlocked: any = tournamentEngine.isScheduleLocked({ matchUpId: otherId, drawId: DRAW_ID });
+  expect(unlocked.scheduleLocked).toEqual(false);
+  expect(unlocked.lock).toBeUndefined();
+});
+
+it('answers isScheduleLocked from a matchUp object — the cheap form for a table of rows', () => {
+  const { lockedId } = seed();
+  lock(lockedId);
+
+  const matchUp = tournamentEngine.allTournamentMatchUps().matchUps.find((m: any) => m.matchUpId === lockedId);
+  let result: any = tournamentEngine.isScheduleLocked({ matchUp });
+  expect(result.scheduleLocked).toEqual(true);
+});
+
+it('reports a lock that exists but is inert, rather than hiding it', () => {
+  // Completed ⇒ the lock stops applying, but a caller asking "why is this
+  // pinned?" should still see the record rather than a bare false.
+  const { lockedId } = seed();
+  lock(lockedId, { reason: 'featured' });
+  const { outcome } = mocksEngine.generateOutcomeFromScoreString({
+    matchUpStatus: COMPLETED,
+    scoreString: '6-1 6-1',
+    winningSide: 1,
+  });
+  expect(tournamentEngine.setMatchUpStatus({ outcome, matchUpId: lockedId, drawId: DRAW_ID }).success).toEqual(true);
+
+  let result: any = tournamentEngine.isScheduleLocked({ matchUpId: lockedId, drawId: DRAW_ID });
+  expect(result.scheduleLocked).toEqual(false);
+  expect(result.lock.reason).toEqual('featured');
+});
+
+it('errors rather than guessing when neither a matchUp nor a resolvable id is given', () => {
+  seed();
+  expect(tournamentEngine.isScheduleLocked({ drawId: DRAW_ID }).error).not.toBeUndefined();
+  expect(tournamentEngine.isScheduleLocked({ matchUpId: 'nope', drawId: DRAW_ID }).error).not.toBeUndefined();
+});

--- a/src/types/factoryEngineMethods.ts
+++ b/src/types/factoryEngineMethods.ts
@@ -411,6 +411,7 @@ export type FactoryEngineMethod =
   | 'isComplete'
   | 'isCompletedStructure'
   | 'isEmbargoed'
+  | 'isScheduleLocked'
   | 'isValid'
   | 'isValidForQualifying'
   | 'isValidMatchUpFormat'
@@ -422,6 +423,7 @@ export type FactoryEngineMethod =
   | 'luckyLoserDrawPositionAssignment'
   | 'matchUpActions'
   | 'matchUpScheduleChange'
+  | 'matchUpScheduleLocked'
   | 'mcpValidator'
   | 'mergeAdjacentSegments'
   | 'mergeFacilitySchedule'
@@ -1072,6 +1074,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'isComplete',
   'isCompletedStructure',
   'isEmbargoed',
+  'isScheduleLocked',
   'isValid',
   'isValidForQualifying',
   'isValidMatchUpFormat',
@@ -1083,6 +1086,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'luckyLoserDrawPositionAssignment',
   'matchUpActions',
   'matchUpScheduleChange',
+  'matchUpScheduleLocked',
   'mcpValidator',
   'mergeAdjacentSegments',
   'mergeFacilitySchedule',

--- a/src/types/methodSignatures.ts
+++ b/src/types/methodSignatures.ts
@@ -500,6 +500,7 @@ import type { drawMatchUps } from '@Query/matchUps/getDrawMatchUps';
 import type { getAllowedDrawTypes, getAllowedMatchUpFormats } from '@Query/tournaments/allowedTypes';
 import type { getEventProperties } from '@Query/event/getEventProperties';
 import type { getParticipantSignInStatus } from '@Query/participant/signInStatus';
+import type { isScheduleLocked, matchUpScheduleLocked } from '@Query/matchUp/isScheduleLocked';
 import type { publishEvent } from '@Mutate/publishing/publishEvent';
 import type { publishEventSeeding, unPublishEventSeeding } from '@Mutate/publishing/eventSeeding';
 import type { resetScorecard } from '@Mutate/matchUps/resetScorecard';
@@ -964,6 +965,7 @@ export interface MethodSignatures {
   isComplete: EngineMethod<typeof isComplete>;
   isCompletedStructure: EngineMethod<typeof isCompletedStructure>;
   isEmbargoed: EngineMethod<typeof isEmbargoed>;
+  isScheduleLocked: EngineMethod<typeof isScheduleLocked>;
   isValid: EngineMethod<typeof isValidMatchUpFormat>;
   isValidForQualifying: EngineMethod<typeof isValidForQualifying>;
   isValidMatchUpFormat: EngineMethod<typeof isValidMatchUpFormat>;
@@ -974,6 +976,7 @@ export interface MethodSignatures {
   luckyLoserDrawPositionAssignment: EngineMethod<typeof luckyLoserDrawPositionAssignment>;
   matchUpActions: EngineMethod<typeof matchUpActions>;
   matchUpScheduleChange: EngineMethod<typeof matchUpScheduleChange>;
+  matchUpScheduleLocked: EngineMethod<typeof matchUpScheduleLocked>;
   mcpValidator: EngineMethod<typeof mcpValidator>;
   mergeFacilitySchedule: EngineMethod<typeof mergeFacilitySchedule>;
   mergeParticipants: EngineMethod<typeof mergeParticipants>;


### PR DESCRIPTION
Phase 3 item from `Mentat/planning/SCHEDULE_LOCKS.md`. TMX was mirroring the lock predicate to drive its grid affordance ([TMX #1285](https://github.com/CourtHive/TMX/pull/1285)) because the predicate was internal — duplicated business logic across a repo boundary. Export it instead.

## The surface

```js
engine.isScheduleLocked({ matchUpId, drawId });   // ids — drawId resolves via params middleware
engine.isScheduleLocked({ matchUp });             // a matchUp already in hand
engine.isScheduleLocked({ matchUp, attributes: ['courtId'] });
// → { success: true, scheduleLocked: true, lock: { reason: 'featured', … } }
```

**Both shapes because callers arrive from both directions.** A cell menu has ids; a table rendering hundreds of rows has the matchUps already and must not resolve each one by id.

**It returns the lock, not just a boolean**, so a caller can answer "*why* is this pinned?" without a second lookup. `scheduleLocked: false` with `lock` still present is the inert case — matchUp completed, or no placement left to guard — which is exactly the state a UI wants to explain rather than hide.

## The rename

The bare predicate becomes `matchUpScheduleLocked` — a plain boolean, no result envelope — and stays the internal enforcement path in `clearScheduledMatchUps` / `clearMatchUpSchedule` / `scheduleLockConflicts`. Both are exported from `scheduleGovernor`, so a consumer can call the pure form directly the way TMX already calls `scoreGovernor.checkScoreHasValue(matchUp)`.

That rename caught a live bug mid-change: `scheduleLockConflicts` was still calling the old name, which now resolved to the object-returning function — always truthy. 13 tests went red until the internal calls were pointed at the pure predicate. Worth knowing if anyone else renames across this boundary.

## Verification

- `pnpm verify` run **in full locally** — all 14 steps, exit 0 (including `attr-audit`, `coverage`, `build`, `pack`)
- Schedule-lock suite **25 passing**, +4 covering: ids form, matchUp form, an inert lock still reporting its record, and erroring rather than guessing when neither a matchUp nor a resolvable id is supplied
- Registries regenerated (`661 methods`); docs updated in `concepts/schedule-locks.mdx` and `governors/schedule-governor.md`

## Note for the concurrent factory session

`factory-unified-identity-tiers` also lists `factoryEngineMethods.ts` / `methodSignatures.ts` in its claim. Both are **generated** — a conflict there is mechanical, and whoever merges second just regenerates. No behavioural overlap; that workstream is types / otherIds / readModel, this is `query/matchUp` + the schedule governor.