### PR TITLE
style(scheduling): longest-first ordering for the schedule-lock imports

### DIFF
--- a/src/assemblies/governors/scheduleGovernor/query.ts
+++ b/src/assemblies/governors/scheduleGovernor/query.ts
@@ -1,7 +1,7 @@
-export { isScheduleLocked, matchUpScheduleLocked } from '@Query/matchUp/isScheduleLocked';
 export { getMatchUpsToSchedule } from '@Mutate/matchUps/schedule/scheduleMatchUps/getMatchUpsToSchedule';
 export { getScheduledRoundsDetails } from '@Query/matchUps/scheduling/getScheduledRoundsDetails';
 export { getSchedulingProfileIssues } from '@Query/matchUps/scheduling/getSchedulingProfileIssues';
+export { isScheduleLocked, matchUpScheduleLocked } from '@Query/matchUp/isScheduleLocked';
 export { getScheduleProjection } from '@Query/facilitySchedule/getScheduleProjection';
 export { mergeFacilitySchedule } from '@Query/facilitySchedule/mergeFacilitySchedule';
 export { getPersonRequests } from '@Query/matchUps/scheduling/getPersonRequests';

--- a/src/mutate/matchUps/schedule/clearMatchUpSchedule.ts
+++ b/src/mutate/matchUps/schedule/clearMatchUpSchedule.ts
@@ -1,7 +1,7 @@
 import { allTournamentMatchUps } from '@Query/matchUps/getAllTournamentMatchUps';
 import { modifyMatchUpNotice } from '@Mutate/notifications/drawNotifications';
-import { allDrawMatchUps } from '@Query/matchUps/getAllDrawMatchUps';
 import { matchUpScheduleLocked } from '@Query/matchUp/isScheduleLocked';
+import { allDrawMatchUps } from '@Query/matchUps/getAllDrawMatchUps';
 
 // constants
 import { MATCHUP_NOT_FOUND, SCHEDULE_LOCKED } from '@Constants/errorConditionConstants';


### PR DESCRIPTION
Two longest-first ordering violations I introduced in #4638.

| file | length | was placed after | correct |
|---|---|---|---|
| `clearMatchUpSchedule.ts` | 72 | `allDrawMatchUps` (69) | before it |
| `scheduleGovernor/query.ts` | 90 | first in the block | below the 97/99 exports |

**Worth noting how these survived:** `eslint --max-warnings 0`, `tsc`, the full 10,900-test suite and all 14 `pnpm verify` steps passed clean over both. The longest-first rule in `Mentat/standards/coding-standards.md` has no enforcement anywhere in CI — it is only ever caught by looking. Found by measuring the import lines by hand after the unified-identity session reported three of the same class on their own branch.

Pre-existing disorder in `scheduleGovernor/query.ts` (97 before 99) is **left alone** — reordering lines I did not touch would add diff noise and obscure a two-line fix.

Verified: `pnpm lint` clean, `pnpm check-types` clean, schedule-lock suite 25 passing.