### PR TITLE
feat(notifications): resolve notice origin at the draw grain

### DIFF
--- a/src/mutate/drawDefinitions/attachStructures.ts
+++ b/src/mutate/drawDefinitions/attachStructures.ts
@@ -150,7 +150,9 @@ export function attachStructures({
             matchUp.tieMatchUps.forEach((tm) => Object.assign(tm, modifiedTieMatchUpsMap[tm.matchUpId]));
           }
           modifiedMatchUpMap[matchUp.matchUpId].matchUp = matchUp;
-          modifyMatchUpNotice(modifiedMatchUpMap[matchUp.matchUpId]);
+          // The payload is pre-built from `matchUpModifications`, so `event` has to be merged in
+          // here rather than at an inline call — it is what lets the notice carry the origin.
+          modifyMatchUpNotice({ ...modifiedMatchUpMap[matchUp.matchUpId], event });
         }
       });
     };

--- a/src/mutate/matchUps/drawPositions/swapWinnerLoser.ts
+++ b/src/mutate/matchUps/drawPositions/swapWinnerLoser.ts
@@ -8,7 +8,7 @@ import { getDevContext } from '@Global/state/globalState';
  * for FMLC 2nd round matchUps test whether it works if a first loss for both participants
  */
 export function swapWinnerLoser(params) {
-  const { tournamentRecord, inContextMatchUp, structure, drawDefinition } = params;
+  const { tournamentRecord, inContextMatchUp, structure, drawDefinition, event } = params;
   const matchUpRoundNumber = inContextMatchUp.roundNumber;
 
   const existingWinnerSide = inContextMatchUp.sides.find((side) => side.sideNumber === inContextMatchUp.winningSide);
@@ -39,6 +39,7 @@ export function swapWinnerLoser(params) {
       context: stack,
       drawDefinition,
       matchUp,
+      event,
     });
   });
 

--- a/src/mutate/matchUps/lineUps/applyLineUps.ts
+++ b/src/mutate/matchUps/lineUps/applyLineUps.ts
@@ -124,6 +124,7 @@ export function applyLineUps(params: ApplyLineUps) {
     context: stack,
     drawDefinition,
     matchUp,
+    event,
   });
 
   return { ...SUCCESS };

--- a/src/mutate/matchUps/lineUps/assignTieMatchUpParticipant.ts
+++ b/src/mutate/matchUps/lineUps/assignTieMatchUpParticipant.ts
@@ -236,6 +236,7 @@ export function assignTieMatchUpParticipantId(
       matchUp: dualMatchUp,
       context: stack,
       drawDefinition,
+      event,
     });
 
   if (deletedParticipantId) {

--- a/src/mutate/matchUps/lineUps/removeTieMatchUpParticipant.ts
+++ b/src/mutate/matchUps/lineUps/removeTieMatchUpParticipant.ts
@@ -329,6 +329,7 @@ export function removeTieMatchUpParticipantId(
     matchUp: dualMatchUp,
     context: stack,
     drawDefinition,
+    event,
   });
 
   return { ...SUCCESS, modifiedLineUp };

--- a/src/mutate/matchUps/lineUps/replaceTieMatchUpParticipant.ts
+++ b/src/mutate/matchUps/lineUps/replaceTieMatchUpParticipant.ts
@@ -203,6 +203,7 @@ export function replaceTieMatchUpParticipantId(params: ReplaceTieMatchUpParticip
       matchUp: dualMatchUp,
       context: stack,
       drawDefinition,
+      event,
     });
   }
 

--- a/src/mutate/matchUps/schedule/scheduleItems/scheduleItems.ts
+++ b/src/mutate/matchUps/schedule/scheduleItems/scheduleItems.ts
@@ -488,6 +488,7 @@ export function addMatchUpScheduleItems(params: AddMatchUpScheduleItemsArgs): {
       context: stack,
       drawDefinition,
       matchUp,
+      event,
     });
   }
 

--- a/src/mutate/matchUps/schedule/setMatchUpCalledAt.ts
+++ b/src/mutate/matchUps/schedule/setMatchUpCalledAt.ts
@@ -67,6 +67,7 @@ export function setMatchUpCalledAt(params: SetMatchUpCalledAtArgs) {
       tournamentId: tournamentRecord?.tournamentId,
       context: stack,
       matchUp,
+      event,
     });
   }
 

--- a/src/mutate/matchUps/schedule/setMatchUpScheduleLock.ts
+++ b/src/mutate/matchUps/schedule/setMatchUpScheduleLock.ts
@@ -95,6 +95,7 @@ export function setMatchUpScheduleLock(params: SetMatchUpScheduleLockArgs) {
       context: stack,
       drawDefinition,
       matchUp,
+      event,
     });
   }
 

--- a/src/mutate/matchUps/sides/removeMatchUpSideParticipant.ts
+++ b/src/mutate/matchUps/sides/removeMatchUpSideParticipant.ts
@@ -45,6 +45,7 @@ export function removeMatchUpSideParticipant(params: RemoveMatchUpSideParticipan
     context: 'assignSideParticipant',
     drawDefinition,
     matchUp,
+    event,
   });
 
   return { ...SUCCESS };

--- a/src/mutate/notifications/drawNotifications.ts
+++ b/src/mutate/notifications/drawNotifications.ts
@@ -1,7 +1,7 @@
 import { getPositionAssignments } from '@Query/drawDefinition/positionsGetter';
 import { addNotice, deleteNotice } from '@Global/state/globalState';
 import { requireParams } from '@Helpers/parameters/requireParams';
-import { eventOrigin } from '@Query/readModel/readModelRows';
+import { drawOrigin, eventOrigin } from '@Query/readModel/readModelRows';
 
 // Constants and types
 import { ErrorType, MISSING_DRAW_DEFINITION, MISSING_MATCHUP } from '@Constants/errorConditionConstants';
@@ -155,7 +155,12 @@ export function modifyMatchUpNotice({
   // was just touched (complements the drawDefinition + structure
   // timestamps written above via `modifyDrawNotice`).
   stampMatchUpUpdatedAt(matchUp);
-  const origin = eventOrigin(event);
+  // Most-specific grain wins. A matchUp lives in a DRAW, and an origin system supplies only the grains
+  // it actually models — a UTR flight carries tournament + draw ids with NO event grain at all
+  // (see drawOrigin in readModelRows). Resolving only the event origin would leave those notices with
+  // no attribution whatsoever, which is the case fan-out most needs. One coherent origin per notice
+  // rather than two organisationIds that could disagree.
+  const origin = drawOrigin(drawDefinition) ?? eventOrigin(event);
   addNotice({
     topic: MODIFY_MATCHUP,
     // eventId/drawId/structureId ride the ENVELOPE, not just the entity. A subscriber that only needs
@@ -173,6 +178,7 @@ export function modifyMatchUpNotice({
       originOrganisationId: origin?.organisationId,
       originTournamentId: origin?.tournamentId,
       originEventId: origin?.eventId,
+      originDrawId: (origin as any)?.drawId,
       context,
     },
     key: matchUp.matchUpId,

--- a/src/tests/mutations/notifications/noticeOrigin.test.ts
+++ b/src/tests/mutations/notifications/noticeOrigin.test.ts
@@ -76,4 +76,70 @@ describe('MODIFY_MATCHUP carries the sanctioning origin', () => {
     expect(notices[0].originOrganisationId).toBeUndefined();
     expect(notices[0].originTournamentId).toBeUndefined();
   });
+
+  it('prefers the DRAW grain, which can carry an origin the event grain cannot', () => {
+    // #4636's case: a UTR flight yields tournament + draw ids with NO event grain at all. A notice
+    // resolving only eventOrigin would carry nothing for exactly the records fan-out most needs.
+    const { drawId, eventId } = seed();
+
+    // Use the dedicated mutation added by #4636 rather than writing drawOtherIds by hand.
+    let result: any = tournamentEngine.addDrawOtherId({
+      drawId,
+      organisationId: 'UTR',
+      otherTournamentId: 'UTR-EVENT-77',
+      otherDrawId: 'UTR-FLIGHT-GUID',
+      isOrigin: true,
+    });
+    expect(result.success).toEqual(true);
+
+    const notices: any[] = [];
+    setSubscriptions({ subscriptions: { [MODIFY_MATCHUP]: (n: any[]) => notices.push(...n) } });
+    result = scoreOne(drawId);
+    expect(result.success).toEqual(true);
+    setSubscriptions({ subscriptions: {} });
+
+    expect(notices.length).toBeGreaterThan(0);
+    const payload = notices[0];
+    expect(payload.originOrganisationId).toEqual('UTR');
+    expect(payload.originTournamentId).toEqual('UTR-EVENT-77');
+    expect(payload.originDrawId).toEqual('UTR-FLIGHT-GUID');
+    // UTR has no event-grain object, so this is legitimately absent
+    expect(payload.originEventId).toBeUndefined();
+    // local identity unaffected
+    expect(payload.eventId).toEqual(eventId);
+  });
+
+  it('when BOTH grains declare an origin, the DRAW wins — a matchUp lives in a draw', () => {
+    // The ordering test. Without both present and DIFFERENT, `draw ?? event` and `event ?? draw`
+    // are indistinguishable, and an earlier version of this suite could not tell them apart.
+    const { drawId } = seed();
+
+    let result: any = tournamentEngine.modifyEvent({
+      eventId: tournamentEngine.getTournament().tournamentRecord.events[0].eventId,
+      eventUpdates: {
+        eventOtherIds: [{ organisationId: 'EVENT-ORG', tournamentId: 'E-TID', eventId: 'E-EID', isOrigin: true }],
+      },
+    });
+    expect(result.success).toEqual(true);
+
+    result = tournamentEngine.addDrawOtherId({
+      drawId,
+      organisationId: 'DRAW-ORG',
+      otherTournamentId: 'D-TID',
+      otherDrawId: 'D-DID',
+      isOrigin: true,
+    });
+    expect(result.success).toEqual(true);
+
+    const notices: any[] = [];
+    setSubscriptions({ subscriptions: { [MODIFY_MATCHUP]: (n: any[]) => notices.push(...n) } });
+    result = scoreOne(drawId);
+    expect(result.success).toEqual(true);
+    setSubscriptions({ subscriptions: {} });
+
+    const payload = notices[0];
+    expect(payload.originOrganisationId).toEqual('DRAW-ORG');
+    expect(payload.originTournamentId).toEqual('D-TID');
+    expect(payload.originDrawId).toEqual('D-DID');
+  });
 });


### PR DESCRIPTION
#4636 added the **draw grain** of the `Unified*ID` family — `drawOrigin()` plus an `origin_draw_id` column on the read-model draw row. `NoticeIdentity` carried only the **event** grain, so the notice surface had fallen behind the read-model: two vocabularies for one concept, which is exactly what the design set out to avoid.

## The gap is not cosmetic

Quoting #4636's own doc:

> *an origin system supplies only the grains it actually models: a UTR flight yields `origin_tournament_id` (UTR's event id) and `origin_draw_id` (the flight GUID) with `origin_event_id` NULL, since UTR has no event-grain object.*

A matchUp lives in a **draw**. So a notice resolving only `eventOrigin` carried **nothing at all** for exactly the ingested records that fan-out most needs to attribute.

## Change

MatchUp notices resolve **most-specific-first**:

```ts
const origin = drawOrigin(drawDefinition) ?? eventOrigin(event);
```

and `NoticeIdentity` gains `originDrawId`. One coherent origin per notice, rather than two `organisationId`s that could disagree.

**Safe to change now** — every notice-identity PR is merged but **unpublished**, so nothing consumes the old shape.

## A test that wasn't testing what it claimed

My first ordering test set only a *draw* origin. With the event grain absent, `draw ?? event` and `event ?? draw` produce identical results — so inverting the preference **passed**, and the falsification silently proved nothing.

Added a case where both grains declare **different** origins. That one fails correctly when the preference is inverted, which is what makes the ordering actually verified.

## Verification

lint 0, types 0, full suite **11,002 tests**. Falsified two ways: reverting to event-only fails the UTR case; inverting the preference fails the both-grains case.