### PR TITLE
fix(scheduling): accept allocatedCourts as an alias for courtIds

### DIFF
--- a/documentation/docs/governors/schedule-governor.md
+++ b/documentation/docs/governors/schedule-governor.md
@@ -1457,6 +1457,7 @@ engine.addMatchUpScheduleItems({
     courtOrder, // optional — order on court
     homeParticipantId, // optional — home team participant
     courtIds, // optional — for TEAM matchUps, allocate courts
+    allocatedCourts, // optional — alias for courtIds; accepts the read-side shape
   },
   removePriorValues, // optional boolean — clear existing schedule timeItems first
   checkChronology, // optional boolean — defaults to true; validate time ordering
@@ -1465,6 +1466,24 @@ engine.addMatchUpScheduleItems({
   disableNotice, // optional boolean — suppress modification notices
 });
 ```
+
+### Court allocation: `courtIds` in, `allocatedCourts` out
+
+A TEAM matchUp's court allocation is **written** as bare `courtIds` and **read back** as
+`schedule.allocatedCourts` — court objects (`{ courtId, venueId }`, hydrated with `courtName` /
+`venueName`). Because the write path originally destructured only `courtIds`, a schedule object read
+off one matchUp and applied to another silently carried no allocation: the unrecognised key was
+ignored, with no error and no warning.
+
+`allocatedCourts` is now accepted as an alias, in either shape:
+
+```js
+engine.addMatchUpScheduleItems({ matchUpId, drawId, schedule: { allocatedCourts: [courtIdA, courtIdB] } });
+engine.addMatchUpScheduleItems({ matchUpId, drawId, schedule: { ...anotherMatchUp.schedule } }); // round-trips
+```
+
+An explicit `courtIds` wins when a caller supplies both. A non-array `allocatedCourts` is ignored
+rather than treated as an error, since it cannot have come from a read.
 
 ### Grid position is cleared on a date change
 

--- a/src/mutate/matchUps/schedule/scheduleItems/scheduleItems.ts
+++ b/src/mutate/matchUps/schedule/scheduleItems/scheduleItems.ts
@@ -69,6 +69,20 @@ import {
   PARTICIPANT_NOT_FOUND,
 } from '@Constants/errorConditionConstants';
 
+/**
+ * Court identities from an `allocatedCourts` value, in the bare-string form the
+ * allocation mutation expects. Accepts what a matchUp reads back — hydrated
+ * court objects — as well as plain ids, so read → write round-trips.
+ *
+ * Returns `undefined` for a non-array (nothing to alias) and passes an empty
+ * array through unchanged, so `allocatedCourts: []` behaves exactly as
+ * `courtIds: []` does rather than acquiring new semantics here.
+ */
+function allocatedCourtIds(value: any): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.map((entry) => (typeof entry === 'string' ? entry : entry?.courtId)).filter(Boolean);
+}
+
 function timeDate(value, scheduledDate) {
   const time = validTimeString.test(value) ? value : extractTime(value);
   const date = extractDate(value) || extractDate(scheduledDate) || formatDate(new Date());
@@ -375,7 +389,6 @@ export function addMatchUpScheduleItems(params: AddMatchUpScheduleItemsArgs): {
   const {
     endTime,
     courtId,
-    courtIds,
     courtAnnotation,
     courtOrder,
     resumeTime,
@@ -387,6 +400,14 @@ export function addMatchUpScheduleItems(params: AddMatchUpScheduleItemsArgs): {
     timeModifiers,
     venueId,
   } = schedule;
+
+  // `courtIds` is the write spelling; `allocatedCourts` is what a matchUp READS
+  // back (`[{ courtId, venueId }]`, hydrated with court/venue names). Accept
+  // both so a schedule object round-trips: reading a matchUp's schedule and
+  // writing it back used to drop a TEAM court allocation silently, because this
+  // function destructured only `courtIds` and ignored the other key entirely.
+  // An explicit `courtIds` wins when a caller supplies both.
+  const courtIds = schedule.courtIds ?? allocatedCourtIds(schedule.allocatedCourts);
 
   if (checkChronology && (!matchUpDependencies || !inContextMatchUps)) {
     ({ matchUpDependencies, matchUps: inContextMatchUps } = getMatchUpDependencies({

--- a/src/tests/mutations/scheduling/allocatedCourtsAlias.test.ts
+++ b/src/tests/mutations/scheduling/allocatedCourtsAlias.test.ts
@@ -1,0 +1,116 @@
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { expect, it } from 'vitest';
+
+import { DOMINANT_DUO } from '@Constants/tieFormatConstants';
+import { TEAM } from '@Constants/eventConstants';
+
+/**
+ * `allocatedCourts` round-trip.
+ *
+ * A TEAM matchUp's court allocation is WRITTEN as `schedule.courtIds` (bare
+ * strings) and READ back as `schedule.allocatedCourts` (court objects, hydrated
+ * with names). `addMatchUpScheduleItems` used to destructure only `courtIds`,
+ * so writing back a schedule you had just read dropped the allocation with no
+ * error — the write simply ignored the key it did not recognise.
+ */
+
+const DRAW_ID = 'drawId';
+const VENUE_ID = 'venueId';
+const SCHEDULED_DATE = '2026-06-22';
+
+function seed() {
+  mocksEngine.generateTournamentRecord({
+    venueProfiles: [{ courtsCount: 4, startTime: '08:00', endTime: '21:00', venueId: VENUE_ID }],
+    drawProfiles: [{ drawId: DRAW_ID, drawSize: 4, eventType: TEAM, tieFormatName: DOMINANT_DUO }],
+    startDate: SCHEDULED_DATE,
+    endDate: '2026-06-28',
+    setState: true,
+  });
+  const courts = tournamentEngine.getVenuesAndCourts().courts;
+  const matchUpIds = tournamentEngine
+    .allTournamentMatchUps()
+    .matchUps.filter((m: any) => m.matchUpType === TEAM)
+    .map((m: any) => m.matchUpId);
+  return { matchUpId: matchUpIds[0], matchUpIds, courts };
+}
+
+const scheduleOf = (matchUpId: string) =>
+  tournamentEngine.allTournamentMatchUps().matchUps.find((m: any) => m.matchUpId === matchUpId)?.schedule;
+
+it('accepts allocatedCourts as an alias for courtIds', () => {
+  const { matchUpId, courts } = seed();
+
+  let result: any = tournamentEngine.addMatchUpScheduleItems({
+    schedule: { scheduledDate: SCHEDULED_DATE, allocatedCourts: [courts[0].courtId, courts[1].courtId] },
+    matchUpId,
+    drawId: DRAW_ID,
+  });
+  expect(result.success).toEqual(true);
+  expect(scheduleOf(matchUpId)?.allocatedCourts?.length).toEqual(2);
+});
+
+it('transfers an allocation carried on a schedule read off another matchUp', () => {
+  // The defect this closes is a write that IGNORES the key, not one that wipes
+  // it: re-writing a schedule onto the SAME matchUp passes either way, because
+  // an absent `courtIds` simply leaves the existing allocation untouched. The
+  // test therefore has to apply the read-back schedule to a DIFFERENT matchUp,
+  // where the allocation must actually be transferred to survive.
+  const { matchUpIds, courts } = seed();
+  const [source, target] = matchUpIds;
+
+  tournamentEngine.addMatchUpScheduleItems({
+    schedule: { scheduledDate: SCHEDULED_DATE, courtIds: [courts[0].courtId, courts[1].courtId] },
+    matchUpId: source,
+    drawId: DRAW_ID,
+  });
+
+  // read it back — hydrated court objects, carrying courtName / venueName
+  const readBack = scheduleOf(source);
+  expect(readBack?.allocatedCourts?.[0]?.courtName).not.toBeUndefined();
+  expect(scheduleOf(target)?.allocatedCourts).toBeUndefined();
+
+  // …and apply exactly that object to another matchUp, as a scenario placement
+  // or a copy-the-schedule caller would
+  let result: any = tournamentEngine.addMatchUpScheduleItems({
+    schedule: { ...readBack },
+    matchUpId: target,
+    drawId: DRAW_ID,
+  });
+  expect(result.error).toBeUndefined();
+
+  const allocated = scheduleOf(target)?.allocatedCourts ?? [];
+  expect(allocated.length).toEqual(2);
+  expect(allocated.map((c: any) => c.courtId).toSorted((a: string, b: string) => a.localeCompare(b))).toEqual(
+    [courts[0].courtId, courts[1].courtId].toSorted((a, b) => a.localeCompare(b)),
+  );
+});
+
+it('lets an explicit courtIds win when a caller supplies both', () => {
+  const { matchUpId, courts } = seed();
+
+  tournamentEngine.addMatchUpScheduleItems({
+    schedule: {
+      allocatedCourts: [{ courtId: courts[2].courtId }, { courtId: courts[3].courtId }],
+      courtIds: [courts[0].courtId],
+      scheduledDate: SCHEDULED_DATE,
+    },
+    matchUpId,
+    drawId: DRAW_ID,
+  });
+
+  const allocated = scheduleOf(matchUpId)?.allocatedCourts ?? [];
+  expect(allocated.length).toEqual(1);
+  expect(allocated[0].courtId).toEqual(courts[0].courtId);
+});
+
+it('ignores a non-array allocatedCourts rather than erroring', () => {
+  const { matchUpId } = seed();
+  let result: any = tournamentEngine.addMatchUpScheduleItems({
+    schedule: { scheduledDate: SCHEDULED_DATE, allocatedCourts: 'not-an-array' },
+    matchUpId,
+    drawId: DRAW_ID,
+  });
+  expect(result.error).toBeUndefined();
+  expect(scheduleOf(matchUpId)?.allocatedCourts).toBeUndefined();
+});


### PR DESCRIPTION
The open half of a defect found while building schedule locks (recorded in `Mentat/planning/SCHEDULE_LOCKS.md`).

## The bug

A TEAM matchUp's court allocation is **written** as bare `courtIds` and **read back** as `schedule.allocatedCourts` — court objects hydrated with `courtName` / `venueName`. `addMatchUpScheduleItems` destructured only `courtIds`, so a schedule object read off one matchUp and applied to another carried **no allocation at all**: the unrecognised key was ignored, with no error and no warning.

That matters most for `ScenarioPlacement`, documented as "deliberately identical to a `bulkScheduleMatchUps` `matchUpDetails` entry" — a placement built from a hydrated matchUp silently loses its allocation on apply.

## The fix

`allocatedCourts` is accepted as an alias, in either shape (bare ids or court objects). An explicit `courtIds` wins when both are supplied. A non-array `allocatedCourts` is ignored rather than erroring, since it cannot have come from a read.

## A note for whoever writes the next test here

My first regression test was **vacuous and I nearly shipped it**. Re-writing a schedule onto the *same* matchUp passes with or without the fix: an absent `courtIds` simply leaves the existing allocation untouched, so the allocation survives by not being touched rather than by transferring. I only caught it because reverting the alias failed 1 of 4 tests instead of 2.

The test now applies the read-back schedule to a **different** matchUp, where the allocation must actually transfer. Reverting the alias fails exactly the two tests that should fail.

This is the "check that your falsification actually falsifies" discipline paying for itself — a green probe can be green because it never touched the code path.

## Verification

- `pnpm verify` run **in full locally** — all 14 steps, exit 0
- 4 new tests in `src/tests/mutations/scheduling/allocatedCourtsAlias.test.ts`; falsified as above
- Docs: `schedule-governor.md` gains the alias in the parameter list plus a section on why the two spellings exist