### PR TITLE
feat(query): add getStructureData

### DIFF
--- a/documentation/docs/governors/query-governor.md
+++ b/documentation/docs/governors/query-governor.md
@@ -566,6 +566,35 @@ available on the un-hydrated matchUp — so a structure list still renders a sta
 Purely additive — omitting it is byte-identical to `FULL`, and an unrecognised value returns
 `INVALID_VALUES` rather than falling back.
 
+## getStructureData
+
+One structure's data — the drill-in tier of the payload decomposition. A client lists draws with
+[`drawsProfile: 'STUBS'`](#drawsprofile), lists structures with
+[`structuresProfile: 'STUBS'`](#structuresprofile), then fetches exactly the structure it is about to
+render.
+
+```js
+const { structure, drawInfo } = engine.getStructureData({
+  drawId,
+  structureId,
+  // ...accepts the same optional params as getDrawData
+});
+```
+
+> **This narrows the payload, not the computation.** Every draw type measured — single elimination,
+> round robin, compass, Curtis consolation, feed-in championship, and a qualifying-fed draw — resolves
+> to a **single structure group**, because `getStructureGroups` partitions by linkage and a draw's
+> structures are linked by construction. There is no independent group to skip, and assembling one
+> structure in isolation is not available cheaply: within-group values depend on siblings
+> (`sourceStructuresComplete` reads `completedStructures[sourceId]`).
+>
+> The value is a **smaller response** and a **per-structure cache entry** — cache granularity is
+> invalidation granularity, so a score in one structure need not evict another's cached payload.
+
+Returns `STRUCTURE_NOT_FOUND` when the id is not in the draw, and `MISSING_STRUCTURE_ID` when omitted. A
+structure filtered out by publish state yields `structure: undefined` with `success` — a legitimate
+empty result for a public reader rather than an error.
+
 ## getEventData
 
 Returns event information optimized for publishing: `matchUps` have context and separated into rounds for consumption by visualization libraries such as `tods-react-draws`. See examples: [Event Data Payload](../concepts/publishing/publishing-data-subscriptions.md#event-data-payload), [Event Data](../concepts/publishing/publishing-workflows.md#event-data), [Test Publish State](../concepts/publishing/publishing-workflows.md#test-publish-state).

--- a/src/assemblies/governors/publishingGovernor/query.ts
+++ b/src/assemblies/governors/publishingGovernor/query.ts
@@ -5,6 +5,7 @@ export { isEmbargoed, isVisiblyPublished } from '@Query/publishing/isEmbargoed';
 export { getEventPublishStatus } from '@Query/event/getEventPublishStatus';
 export { getPublishState } from '@Query/publishing/getPublishState';
 export { getAllEventData } from '@Query/event/getAllEventData';
+export { getStructureData } from '@Query/drawDefinition/getStructureData';
 export { getDrawData } from '@Query/drawDefinition/getDrawData';
 export { getVenueData } from '@Query/venues/getVenueData';
 export { getCourtInfo } from '@Query/venues/getCourtInfo';

--- a/src/query/drawDefinition/getStructureData.ts
+++ b/src/query/drawDefinition/getStructureData.ts
@@ -1,0 +1,56 @@
+import { getDrawData } from '@Query/drawDefinition/getDrawData';
+import { findStructure } from '@Acquire/findStructure';
+
+// constants and types
+import {
+  ErrorType,
+  MISSING_DRAW_DEFINITION,
+  MISSING_STRUCTURE_ID,
+  STRUCTURE_NOT_FOUND,
+} from '@Constants/errorConditionConstants';
+import { SUCCESS } from '@Constants/resultConstants';
+
+/**
+ * One structure's data — the drill-in tier of the payload decomposition
+ * (`Mentat/planning/PUBLISH_WARMCACHE_AND_PAYLOAD_DECOMPOSITION.md`). A client lists draws with
+ * `drawsProfile: STUBS`, lists structures with `structuresProfile: STUBS`, then fetches exactly the one
+ * structure it is about to render.
+ *
+ * ⚠️ **This narrows the PAYLOAD, not the computation.** Measured across SINGLE_ELIMINATION,
+ * ROUND_ROBIN, COMPASS, CURTIS_CONSOLATION, FEED_IN_CHAMPIONSHIP and a qualifying-fed draw, every draw
+ * resolves to a SINGLE structure group: `getStructureGroups` partitions by linkage, and a draw's
+ * structures are linked by construction. There is no independent group to skip.
+ *
+ * Assembling one structure in isolation is therefore not available cheaply — within-group values depend
+ * on siblings (`sourceStructuresComplete` reads `completedStructures[sourceId]`, which would read
+ * `undefined` for a skipped source and report a complete source as incomplete).
+ *
+ * The value is real but specific: a **smaller response** and, more importantly, a **per-structure cache
+ * entry**. Cache granularity is invalidation granularity — a score in one structure need not evict
+ * another's cached payload. That was G2's second prize and it does not depend on saving compute.
+ *
+ * Do not describe this as reducing server work; it does not, and an earlier draft of it wrongly claimed
+ * it did.
+ */
+export function getStructureData(params: any): {
+  structure?: any;
+  drawInfo?: any;
+  success?: boolean;
+  error?: ErrorType;
+} {
+  const { drawDefinition, structureId } = params ?? {};
+  if (!drawDefinition) return { error: MISSING_DRAW_DEFINITION };
+  if (!structureId) return { error: MISSING_STRUCTURE_ID };
+
+  // Fail before any assembly when the id is not in this draw.
+  const { structure: found } = findStructure({ drawDefinition, structureId });
+  if (!found) return { error: STRUCTURE_NOT_FOUND };
+
+  const result: any = getDrawData(params);
+  if (result.error) return result;
+
+  const structure = (result.structures ?? []).find((s: any) => s?.structureId === structureId);
+  // A structure can be filtered out by publish state though it exists in the draw — a legitimate empty
+  // result for a public reader, not an error.
+  return { ...SUCCESS, structure, drawInfo: result.drawInfo };
+}

--- a/src/tests/queries/drawDefinition/getStructureData.test.ts
+++ b/src/tests/queries/drawDefinition/getStructureData.test.ts
@@ -1,0 +1,102 @@
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { expect, it, describe } from 'vitest';
+
+// constants and types
+import { MISSING_STRUCTURE_ID, STRUCTURE_NOT_FOUND } from '@Constants/errorConditionConstants';
+import { SINGLE_ELIMINATION, ROUND_ROBIN } from '@Constants/drawDefinitionConstants';
+
+function seedWithQualifying() {
+  const {
+    drawIds: [drawId],
+  } = mocksEngine.generateTournamentRecord({
+    drawProfiles: [
+      {
+        drawSize: 32,
+        drawType: SINGLE_ELIMINATION,
+        qualifiersCount: 4,
+        qualifyingProfiles: [
+          { roundTarget: 1, structureProfiles: [{ stageSequence: 1, drawSize: 16, qualifyingPositions: 4 }] },
+        ],
+      },
+    ],
+    participantsProfile: { nonRandom: 1 },
+    setState: true,
+  });
+  return drawId;
+}
+
+describe('getStructureData', () => {
+  it('returns one structure, identical to that structure from getDrawData', () => {
+    const drawId = seedWithQualifying();
+    const { drawDefinition } = tournamentEngine.getEvent({ drawId });
+
+    const full: any = tournamentEngine.getDrawData({ drawDefinition });
+    const target = full.structures.find((s: any) => s.stage === 'MAIN');
+
+    const result: any = tournamentEngine.getStructureData({ drawDefinition, structureId: target.structureId });
+    expect(result.success).toEqual(true);
+    // Identical content — narrowing must not change what a structure looks like.
+    expect(JSON.stringify(result.structure)).toEqual(JSON.stringify(target));
+    expect(result.drawInfo?.drawId).toEqual(drawId);
+  });
+
+  it('narrows the PAYLOAD — one structure instead of all of them', () => {
+    // Deliberately NOT a claim about compute. Measured across SINGLE_ELIMINATION, ROUND_ROBIN, COMPASS,
+    // CURTIS_CONSOLATION, FEED_IN_CHAMPIONSHIP and a qualifying-fed draw, every draw is a SINGLE
+    // structure group, so there is no independent group to skip. The value is response size and a
+    // per-structure cache entry — cache granularity is invalidation granularity.
+    const drawId = seedWithQualifying();
+    const { drawDefinition } = tournamentEngine.getEvent({ drawId });
+
+    const full: any = tournamentEngine.getDrawData({ drawDefinition });
+    expect(full.structures.length).toBeGreaterThan(1);
+    const mainId = full.structures.find((s: any) => s.stage === 'MAIN').structureId;
+
+    const one: any = tournamentEngine.getStructureData({ drawDefinition, structureId: mainId });
+    expect(one.structure.structureId).toEqual(mainId);
+    expect(JSON.stringify(one.structure).length).toBeLessThan(JSON.stringify(full.structures).length);
+  });
+
+  it('preserves sourceStructuresComplete — it depends on siblings, so the draw is assembled whole', () => {
+    // Within-group values read completedStructures[sourceId]; skipping a sibling in the same group
+    // would make a complete source read as incomplete.
+    const drawId = seedWithQualifying();
+    const { drawDefinition } = tournamentEngine.getEvent({ drawId });
+
+    const full: any = tournamentEngine.getDrawData({ drawDefinition });
+    for (const s of full.structures) {
+      const one: any = tournamentEngine.getStructureData({ drawDefinition, structureId: s.structureId });
+      expect(one.structure?.sourceStructuresComplete).toEqual(s.sourceStructuresComplete);
+    }
+  });
+
+  it('round robin — nested structures resolve to the containing structure', () => {
+    const {
+      drawIds: [drawId],
+    } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 16, drawType: ROUND_ROBIN }],
+      participantsProfile: { nonRandom: 1 },
+      setState: true,
+    });
+    const { drawDefinition } = tournamentEngine.getEvent({ drawId });
+    const full: any = tournamentEngine.getDrawData({ drawDefinition });
+
+    const result: any = tournamentEngine.getStructureData({
+      drawDefinition,
+      structureId: full.structures[0].structureId,
+    });
+    expect(result.success).toEqual(true);
+    expect(JSON.stringify(result.structure)).toEqual(JSON.stringify(full.structures[0]));
+  });
+
+  it('errors rather than guessing', () => {
+    const drawId = seedWithQualifying();
+    const { drawDefinition } = tournamentEngine.getEvent({ drawId });
+
+    expect(tournamentEngine.getStructureData({ drawDefinition }).error).toEqual(MISSING_STRUCTURE_ID);
+    expect(tournamentEngine.getStructureData({ drawDefinition, structureId: 'nope' }).error).toEqual(
+      STRUCTURE_NOT_FOUND,
+    );
+  });
+});

--- a/src/types/factoryEngineMethods.ts
+++ b/src/types/factoryEngineMethods.ts
@@ -365,6 +365,7 @@ export type FactoryEngineMethod =
   | 'getSetScoreString'
   | 'getState'
   | 'getStructureCompleteness'
+  | 'getStructureData'
   | 'getStructureInconsistencies'
   | 'getStructureReports'
   | 'getStructureSeedAssignments'
@@ -1032,6 +1033,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'getSetScoreString',
   'getState',
   'getStructureCompleteness',
+  'getStructureData',
   'getStructureInconsistencies',
   'getStructureReports',
   'getStructureSeedAssignments',

--- a/src/types/methodSignatures.ts
+++ b/src/types/methodSignatures.ts
@@ -348,6 +348,7 @@ import type { getCompetitionMatchUps } from '@Query/matchUps/getCompetitionMatch
 import type { getEntriesAndSeedsCount } from '@Query/entries/getEntriesAndSeedsCount';
 import type { getMatchUpDependencies } from '@Query/matchUps/getMatchUpDependencies';
 import type { getParticipantStats } from '@Query/participant/getParticipantStats';
+import type { getStructureData } from '@Query/drawDefinition/getStructureData';
 import type { getTournamentPointAwards } from '@Query/scales/getTournamentPointAwards';
 import type { mergeParticipants } from '@Mutate/participants/mergeParticipants';
 import type { modifyDrawName } from '@Mutate/drawDefinitions/modifyDrawName';
@@ -928,6 +929,7 @@ export interface MethodSignatures {
   getSetComplement: EngineMethod<typeof getSetComplement>;
   getSetScoreString: EngineMethod<typeof getSetScoreString>;
   getStructureCompleteness: EngineMethod<typeof getStructureCompleteness>;
+  getStructureData: EngineMethod<typeof getStructureData>;
   getStructureInconsistencies: EngineMethod<typeof getStructureInconsistencies>;
   getStructureReports: EngineMethod<typeof getStructureReports>;
   getStructureSeedAssignments: EngineMethod<typeof getStructureSeedAssignments>;


### PR DESCRIPTION
**G2 increment 3** — the drill-in tier. A client lists draws with `drawsProfile: 'STUBS'`, lists structures with `structuresProfile: 'STUBS'`, then fetches exactly the structure it is about to render.

## ⚠️ It narrows the payload, not the computation — and my first version claimed otherwise

I built it to skip assembling other structure **groups**, assuming `getStructureGroups` partitions a draw usefully. **It does not.** Measured:

| draw type | structures | groups |
|---|---:|---:|
| SINGLE_ELIMINATION 32 | 1 | 1 |
| SE 32 + qualifying | 2 | **1** |
| COMPASS 16 | 8 | **1** |
| CURTIS_CONSOLATION 32 | 1 | 1 |
| FEED_IN_CHAMPIONSHIP 32 | 2 | **1** |
| ROUND_ROBIN 16 | 1 | 1 |

Groups partition by **linkage**, and a draw's structures are linked by construction — so there is never an independent group to skip. The filter saved nothing while adding a parameter and a misleading rationale. **Removed.**

Assembling one structure in isolation is not cheaply available either: within-group values depend on siblings, and `sourceStructuresComplete` reads `completedStructures[sourceId]` — a skipped source would report a complete source as **incomplete**. There is a test asserting that equivalence across every structure in a qualifying-fed draw.

## What the value actually is

A **smaller response**, and a **per-structure cache entry**. Cache granularity is invalidation granularity — a score in one structure need not evict another's cached payload. That was G2's second prize and it does not depend on saving compute.

The doc comment and Docusaurus page both say this plainly, so nobody inherits the assumption I started with.

## Verification

- lint 0, types 0, `verify:generated` OK
- full suite **11,012 tests**
- both guards falsified: returning the wrong structure, and dropping the `STRUCTURE_NOT_FOUND` check

## Isolation

Built in a dedicated worktree (`.claude/worktrees/structure-data`, branch cut from `master` @ `f5336d9bd`) so the session holding #4642 owns the shared checkout.