### PR TITLE
feat(notifications): populate structureId on MODIFY_MATCHUP notices

### DIFF
--- a/src/mutate/notifications/drawNotifications.ts
+++ b/src/mutate/notifications/drawNotifications.ts
@@ -129,6 +129,37 @@ type ModifyMatchUpNoticeArgs = {
   event?: any;
 };
 
+/**
+ * Resolve the structure a matchUp lives in, for notice ATTRIBUTION only.
+ *
+ * Stored matchUps carry no `structureId` — only inContext ones do — so a notice emitted from the
+ * mutation path has nothing to read. Callers that already hold a `structure` should pass
+ * `structureId` explicitly; this is the fallback that keeps the envelope populated for the 57 of 61
+ * `modifyMatchUpNotice` call sites that do not, every score path among them.
+ *
+ * Returns the id of the structure DIRECTLY holding the matchUp — for round robins that is the group
+ * (child) structure, matching what `allTournamentMatchUps` reports inContext. Conformance with that
+ * convention is asserted in noticeStructureId.test.ts; a subscriber must not have to know which of
+ * two vocabularies a given topic used.
+ */
+function resolveStructureId(drawDefinition?: DrawDefinition, matchUpId?: string): string | undefined {
+  if (!drawDefinition?.structures?.length || !matchUpId) return undefined;
+
+  const search = (structures: any[]): string | undefined => {
+    for (const structure of structures) {
+      // Depth first: the group structure owns the matchUp, not its round-robin parent.
+      if (structure?.structures?.length) {
+        const found = search(structure.structures);
+        if (found) return found;
+      }
+      if (structure?.matchUps?.some((m: any) => m?.matchUpId === matchUpId)) return structure.structureId;
+    }
+    return undefined;
+  };
+
+  return search(drawDefinition.structures);
+}
+
 export function modifyMatchUpNotice({
   drawDefinition,
   tournamentId,
@@ -143,6 +174,11 @@ export function modifyMatchUpNotice({
     return { error: MISSING_MATCHUP };
   }
   if (drawDefinition) {
+    // DELIBERATELY the caller-supplied structureId only, NOT the resolved one below. This argument
+    // decides which structures get their `updatedAt` stamped by `drawUpdatedAt`; widening it to the
+    // resolved id would narrow stamping from "every structure" to "one" at 57 call sites — a
+    // behaviour change to timestamps consumers may sync on. Notice attribution and updatedAt
+    // stamping are separate concerns and are kept separate here.
     const structureIds = structureId ? [structureId] : undefined;
     modifyDrawNotice({
       drawDefinition,
@@ -171,7 +207,9 @@ export function modifyMatchUpNotice({
       tournamentId,
       eventId: eventId ?? event?.eventId,
       drawId: drawDefinition?.drawId ?? (matchUp as any)?.drawId,
-      structureId,
+      // Best-effort, same as drawId above: an explicit caller value wins, otherwise resolve it from
+      // the drawDefinition so the envelope is populated regardless of call site.
+      structureId: structureId ?? resolveStructureId(drawDefinition, matchUp?.matchUpId),
       // The sanctioning source, flattened — same vocabulary as the read-model's
       // origin_organisation_id / origin_tournament_id / origin_event_id. Absent when the event
       // declares no origin, which is the ordinary single-sanction case.

--- a/src/tests/mutations/notifications/noticeStructureId.test.ts
+++ b/src/tests/mutations/notifications/noticeStructureId.test.ts
@@ -1,0 +1,108 @@
+import { setSubscriptions } from '@Global/state/globalState';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { expect, it, describe } from 'vitest';
+
+// constants and types
+import {
+  COMPASS,
+  ROUND_ROBIN,
+  SINGLE_ELIMINATION,
+  FIRST_MATCH_LOSER_CONSOLATION,
+} from '@Constants/drawDefinitionConstants';
+import { MODIFY_MATCHUP, MODIFY_POSITION_ASSIGNMENTS } from '@Constants/topicConstants';
+
+/**
+ * MODIFY_MATCHUP must carry the structure a change happened in, so a subscriber can route it without
+ * resolving the matchUp. CFS uses this for structure-grain cache eviction; before it was populated,
+ * a score could not name the structure it changed and the whole tier had to be swept.
+ * See Mentat/planning/FACTORY_NOTICE_IDENTITY_AUDIT.md.
+ */
+describe('MODIFY_MATCHUP structureId', () => {
+  function capture(topics: string[]) {
+    const notices: any[] = [];
+    const subscriptions: any = {};
+    for (const topic of topics)
+      subscriptions[topic] = (n: any[]) => (n ?? []).forEach((p) => notices.push({ topic, p }));
+    setSubscriptions({ subscriptions });
+    return notices;
+  }
+
+  it.each([
+    ['single elimination', { drawSize: 8, drawType: SINGLE_ELIMINATION }],
+    ['compass (loser crosses into another structure)', { drawSize: 8, drawType: COMPASS }],
+    ['first match loser consolation', { drawSize: 8, drawType: FIRST_MATCH_LOSER_CONSOLATION }],
+    ['round robin (matchUps live in NESTED structures)', { drawSize: 8, drawType: ROUND_ROBIN }],
+  ])('%s — matches the structureId allTournamentMatchUps reports', (_label, drawProfile) => {
+    const {
+      drawIds: [drawId],
+    } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [drawProfile],
+      participantsProfile: { nonRandom: 1 },
+      setState: true,
+    });
+
+    const { matchUps } = tournamentEngine.allTournamentMatchUps();
+    const target: any = matchUps.find(
+      (m: any) => !m.winningSide && (m.sides ?? []).filter((s: any) => s?.participantId).length === 2,
+    );
+    expect(target.structureId).toBeDefined(); // inContext is the reference vocabulary
+
+    const notices = capture([MODIFY_MATCHUP]);
+    const { outcome } = mocksEngine.generateOutcomeFromScoreString({
+      scoreString: '6-4 6-2',
+      matchUpStatus: 'COMPLETED',
+      winningSide: 1,
+    });
+    const result: any = tournamentEngine.setMatchUpStatus({ matchUpId: target.matchUpId, drawId, outcome });
+    expect(result.success).toEqual(true);
+
+    const emitted = notices.filter((n) => n.topic === MODIFY_MATCHUP).map((n) => n.p);
+    expect(emitted.length).toBeGreaterThan(0);
+    // EVERY notice must be attributable — one unattributed notice forces a consumer back to a
+    // wholesale sweep, which is exactly the state this change exists to leave behind.
+    expect(emitted.filter((p: any) => !p.structureId)).toEqual([]);
+
+    // The notice for the scored matchUp must name the structure it actually lives in.
+    const scored = emitted.find((p: any) => p.matchUp?.matchUpId === target.matchUpId);
+    expect(scored?.structureId).toEqual(target.structureId);
+
+    // Every emitted structureId must agree with the inContext view — no second vocabulary.
+    const byId = Object.fromEntries(matchUps.map((m: any) => [m.matchUpId, m]));
+    for (const p of emitted) {
+      const inContext = byId[p.matchUp?.matchUpId];
+      if (inContext) expect(p.structureId).toEqual(inContext.structureId);
+    }
+
+    setSubscriptions({ subscriptions: {} });
+  });
+
+  it('a caller-supplied structureId is not overwritten by the fallback', () => {
+    // The fallback must stay a fallback: call sites that know the structure remain authoritative.
+    const {
+      drawIds: [drawId],
+    } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 8, drawType: COMPASS }],
+      participantsProfile: { nonRandom: 1 },
+      setState: true,
+    });
+    const notices = capture([MODIFY_MATCHUP, MODIFY_POSITION_ASSIGNMENTS]);
+    const { matchUps } = tournamentEngine.allTournamentMatchUps();
+    const target: any = matchUps.find(
+      (m: any) => !m.winningSide && (m.sides ?? []).filter((s: any) => s?.participantId).length === 2,
+    );
+    const { outcome } = mocksEngine.generateOutcomeFromScoreString({
+      scoreString: '6-4 6-2',
+      matchUpStatus: 'COMPLETED',
+      winningSide: 1,
+    });
+    tournamentEngine.setMatchUpStatus({ matchUpId: target.matchUpId, drawId, outcome });
+
+    // A compass loser lands in a DIFFERENT structure; that topic carries the destination explicitly.
+    const positional = notices.filter((n) => n.topic === MODIFY_POSITION_ASSIGNMENTS).map((n) => n.p);
+    expect(positional.length).toBeGreaterThan(0);
+    for (const p of positional) expect(p.structureId).toBeDefined();
+
+    setSubscriptions({ subscriptions: {} });
+  });
+});


### PR DESCRIPTION
Closes the root cause behind CFS #907. Follows the notice-identity audit (`Mentat/planning/FACTORY_NOTICE_IDENTITY_AUDIT.md`) — this is the draw/structure-grain threading pass it identified as step two.

## The problem

`modifyMatchUpNotice` has declared an optional `structureId` on its envelope, but **57 of its 61 non-test call sites never pass one** — every score path included. Consumers could not attribute a matchUp change to a structure.

Downstream, CFS had to sweep its entire structure-scoped cache tier on every score rather than evicting the one structure that changed. The endpoint shipped in CFS #906 therefore delivered a smaller response but no invalidation granularity at all.

## Why not just edit the call sites

Stored matchUps carry no `structureId` (only inContext ones do), so there is nothing to read at the emission point — each site would have to thread a `structure` it may not hold. 57 edits also drift the moment a 58th call site is added.

Instead `modifyMatchUpNotice` resolves the structure from the `drawDefinition` when a caller does not supply one. **An explicit caller value still wins**, so sites that know better stay authoritative.

## Round robins

The resolver searches **depth-first**, so a round-robin matchUp reports its **group** structure — matching what `allTournamentMatchUps` reports inContext. A subscriber must not have to know which of two vocabularies a given topic used. Conformance is asserted across four draw types (single elimination, compass, FMLC, round robin), not described.

## Deliberately not changed

The `structureIds` argument handed to `modifyDrawNotice` still uses **only the caller-supplied value**. That argument decides which structures `drawUpdatedAt` stamps; widening it to the resolved id would narrow stamping from "every structure" to "one" across 57 call sites — a behaviour change to timestamps consumers may sync on.

Notice attribution and `updatedAt` stamping are separate concerns and stay separate. This is the part most likely to be "simplified" later, so the reasoning is in a comment at the site.

## Cost — measured, not assumed

A resolver on the scoring path needs evidence. A/B against `src`, scoring an entire 128 draw:

| | best of 3 |
|---|---|
| with resolver | 1773 ms |
| without | 1779 ms |

Within noise (−0.3%). Both arms scored the same 127 matchUps, asserted so the timing covers real work.

## Falsification

| Defect injected | Result |
|---|---|
| remove the fallback (pre-fix behaviour) | all four draw types fail |
| return the round-robin **parent** instead of the group | round-robin case fails specifically |

## Verification

- `tsc --noEmit` — clean
- `eslint --max-warnings 0` — clean
- `verify:generated` — enum-exports OK, engine-methods OK, method-signatures up to date
- full suite — **11020 passed**, 1 skipped, 0 failed

## Compatibility

Additive only: an optional field that was previously `undefined` is now populated. No existing shape changes, consistent with the ClubSpark constraint.

## After this lands

Needs a factory release, then a CFS bump. At that point CFS's `gsd|` tier stops being marked unattributable and structure-grain eviction becomes real. The CFS fail-safe from #907 stays regardless — it is what makes an unattributable change safe rather than silent.