### PR TITLE
fix(notifications): carry eventId on notices for PROPAGATED matchUps

### DIFF
--- a/src/mutate/matchUps/drawPositions/assignMatchUpDrawPosition.ts
+++ b/src/mutate/matchUps/drawPositions/assignMatchUpDrawPosition.ts
@@ -176,6 +176,7 @@ export function assignMatchUpDrawPosition({
   const isLuckyDraw = isLuckyBasedDraw(drawDefinition?.drawType);
 
   const advanceResult = advanceDrawPosition({
+    event,
     inContextDrawMatchUps: resolvedInContextDrawMatchUps,
     positionAssigned,
     isPropagatedExit,
@@ -340,11 +341,13 @@ function advanceDrawPosition({
   matchUpsMap,
   matchUp,
   structure,
+  event,
 }) {
   if (positionAssigned && isByeMatchUp && !isLuckyDraw) {
     if (winnerMatchUp) {
       if ([BYE, DOUBLE_WALKOVER, DOUBLE_DEFAULT].includes(matchUpStatus)) {
         const result = assignMatchUpDrawPosition({
+          event,
           matchUpId: winnerMatchUp.matchUpId,
           inContextDrawMatchUps,
           tournamentRecord,
@@ -363,6 +366,7 @@ function advanceDrawPosition({
   } else if (positionAssigned && isPropagatedExit) {
     if (winnerMatchUp) {
       const result = assignMatchUpDrawPosition({
+        event,
         matchUpId: winnerMatchUp.matchUpId,
         inContextDrawMatchUps,
         tournamentRecord,
@@ -382,6 +386,7 @@ function advanceDrawPosition({
 
     if (pairedPreviousMatchUpIsDoubleExit) {
       const result = assignMatchUpDrawPosition({
+        event,
         matchUpId: winnerMatchUp.matchUpId,
         inContextDrawMatchUps,
         tournamentRecord,

--- a/src/mutate/matchUps/drawPositions/directWinner.ts
+++ b/src/mutate/matchUps/drawPositions/directWinner.ts
@@ -54,6 +54,7 @@ export function directWinner({
       sourceMatchUpId,
       drawDefinition,
       matchUpsMap,
+      event,
     });
     if (result.error) return result;
   }
@@ -162,6 +163,7 @@ function directWinnerViaLink({
       sourceMatchUpId,
       drawDefinition,
       matchUpsMap,
+      event,
     });
     if (assignResult.error) return decorateResult({ result: assignResult, stack });
   } else if (structure?.stage !== QUALIFYING) {

--- a/src/mutate/matchUps/drawPositions/positionAssignment.ts
+++ b/src/mutate/matchUps/drawPositions/positionAssignment.ts
@@ -216,6 +216,7 @@ export function assignDrawPosition({
       participantId,
       matchUpsMap,
       structure,
+      event,
     });
   } else {
     addDrawPositionToMatchUps({
@@ -298,6 +299,7 @@ function handleContainerAssignment({
   participantId,
   matchUpsMap,
   structure,
+  event,
 }) {
   modifyRoundRobinMatchUpsStatus({
     positionAssignments,
@@ -305,6 +307,7 @@ function handleContainerAssignment({
     drawDefinition,
     matchUpsMap,
     structure,
+    event,
   });
 
   const { drawPositions, matchUps, targetMatchUps } = getTargetMatchUps({
@@ -374,6 +377,7 @@ function addDrawPositionToMatchUps({
       drawDefinition,
       drawPosition,
       matchUpsMap,
+      event,
     });
     if (result.error)
       return decorateResult({

--- a/src/mutate/matchUps/drawPositions/positionClear.ts
+++ b/src/mutate/matchUps/drawPositions/positionClear.ts
@@ -149,6 +149,7 @@ export function drawPositionRemovals({
       drawDefinition,
       matchUpsMap,
       structure,
+      event,
     });
     return { drawPositionCleared, ...SUCCESS };
   }

--- a/src/tests/mutations/notifications/noticeStructureId.test.ts
+++ b/src/tests/mutations/notifications/noticeStructureId.test.ts
@@ -77,6 +77,55 @@ describe('MODIFY_MATCHUP structureId', () => {
     setSubscriptions({ subscriptions: {} });
   });
 
+  it.each([
+    ['single elimination', 'SINGLE_ELIMINATION'],
+    ['compass', 'COMPASS'],
+    ['round robin', 'ROUND_ROBIN'],
+    ['first match loser consolation', 'FIRST_MATCH_LOSER_CONSOLATION'],
+    ['round robin with playoff', 'ROUND_ROBIN_WITH_PLAYOFF'],
+    ['feed in championship', 'FEED_IN_CHAMPIONSHIP'],
+  ])('%s — EVERY notice from a fully played draw carries an eventId', (_label, drawType) => {
+    // Advancement paths used to drop `event` on the way down (directWinner -> assignMatchUpDrawPosition,
+    // handleContainerAssignment -> modifyRoundRobinMatchUpsStatus, advanceDrawPosition), so notices for
+    // PROPAGATED matchUps arrived with no eventId. A consumer cannot route those, and one unattributable
+    // notice forces a wholesale cache sweep — it only takes one to lose the granularity for the batch.
+    // Playing the draw OUT is the point: the gap was in advancement, not in the first score.
+    const {
+      drawIds: [drawId],
+    } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 8, drawType }],
+      participantsProfile: { nonRandom: 1 },
+      setState: true,
+    });
+
+    const notices = capture([MODIFY_MATCHUP]);
+    const { outcome } = mocksEngine.generateOutcomeFromScoreString({
+      scoreString: '6-4 6-2',
+      matchUpStatus: 'COMPLETED',
+      winningSide: 1,
+    });
+    let scored = 0;
+    for (let pass = 0; pass < 14; pass++) {
+      const all: any[] = tournamentEngine.allTournamentMatchUps().matchUps ?? [];
+      const next = all.filter(
+        (m: any) => !m.winningSide && (m.sides ?? []).filter((s: any) => s?.participantId).length === 2,
+      );
+      if (!next.length) break;
+      for (const m of next) {
+        if (tournamentEngine.setMatchUpStatus({ matchUpId: m.matchUpId, drawId, outcome }).success) scored += 1;
+      }
+    }
+    expect(scored).toBeGreaterThan(0); // guard: the timing/coverage claim rests on real mutations
+
+    const emitted = notices.map((n) => n.p);
+    expect(emitted.length).toBeGreaterThan(0);
+    expect(emitted.filter((p: any) => !p.eventId)).toEqual([]);
+    expect(emitted.filter((p: any) => !p.structureId)).toEqual([]);
+    expect(emitted.filter((p: any) => !p.drawId)).toEqual([]);
+
+    setSubscriptions({ subscriptions: {} });
+  });
+
   it('a caller-supplied structureId is not overwritten by the fallback', () => {
     // The fallback must stay a fallback: call sites that know the structure remain authoritative.
     const {


### PR DESCRIPTION
Found while verifying that CFS's structure-tier cache granularity actually turned on after 6.28.0. It had not — and the reason was a second, larger identity gap.

## Why grep said this was already fine

All **61** `modifyMatchUpNotice` call sites pass an `eventId` *syntactically*. At runtime the value was `undefined` on the advancement paths, because `event` was dropped between callers:

| From | To | Was |
|---|---|---|
| `directWinner` | `assignMatchUpDrawPosition` | one branch passed `event`, the other did not |
| `directWinnerViaLink` | `assignMatchUpDrawPosition` | dropped |
| `addDrawPositionToMatchUps` | `assignMatchUpDrawPosition` | dropped |
| `assignMatchUpDrawPosition` | `advanceDrawPosition` | never accepted it |
| `handleContainerAssignment` | `modifyRoundRobinMatchUpsStatus` | dropped |

So the notice for the matchUp a winner **advances into** carried no `eventId`, while the notice for the **scored** matchUp did.

## Why one missing id costs more than it looks

A consumer cannot route the propagated notice — and a single unattributable notice costs the **whole batch** its granularity. CFS must fall back to a tournament-wide sweep of its per-event cache tier, because an unattributable change could belong to any event. Per-event narrowing was therefore defeated on every score, despite the machinery working exactly as designed.

## How it was found

An **integration test asserting on real factory notices** rather than hand-written payloads. The existing unit mocks asserted a shape the factory did not emit — which is precisely how this class of bug shipped once already (CFS #906 → #907). Mock divergence is the actual root cause here, twice over.

## Verification

Traced every `modifyMatchUpNotice` emission while playing **six draw types out to completion** — single elimination, compass, round robin, FMLC, round robin with playoff, feed-in championship:

- **before:** 229 emissions with no `eventId`
- **after:** zero notices lacking `eventId`, `structureId` or `drawId`

Playing the draw *out* is the point — the gap was in advancement, not in the first score, so a single-score test would have missed it. The new guard does exactly that, per draw type.

**Falsified:** restoring the `directWinner` omission fails four of the six draw types.

- `tsc --noEmit` — clean
- `eslint --max-warnings 0` — clean
- `verify:generated` — enum-exports, engine-methods, method-signatures all OK
- full suite — **11026 passed**, 1 skipped, 0 failed

## Compatibility

Additive only: no shape changes. A field that was intermittently `undefined` is now consistently populated.

## Follow-up

Needs a release, then a CFS bump — at which point both the event tier and structure tier narrow properly. The CFS fail-safe stays regardless; it is what made this gap visible as "coarse" rather than "silently stale".
