### PR TITLE
fix(notifications): apply the eventId fallback to the draw notice too

### DIFF
--- a/src/mutate/notifications/drawNotifications.ts
+++ b/src/mutate/notifications/drawNotifications.ts
@@ -173,6 +173,12 @@ export function modifyMatchUpNotice({
     console.log(MISSING_MATCHUP);
     return { error: MISSING_MATCHUP };
   }
+  // Resolve ONCE and use everywhere. Previously the fallback was applied to this notice's own payload
+  // but not to the drawNotice below, so a caller supplying `event` (and not `eventId`) produced a
+  // MODIFY_MATCHUP that could be attributed and a MODIFY_DRAW_DEFINITION that could not — from the
+  // same call. One unattributable notice is enough to cost a consumer the whole batch's granularity.
+  const resolvedEventId = eventId ?? event?.eventId;
+
   if (drawDefinition) {
     // DELIBERATELY the caller-supplied structureId only, NOT the resolved one below. This argument
     // decides which structures get their `updatedAt` stamped by `drawUpdatedAt`; widening it to the
@@ -184,7 +190,7 @@ export function modifyMatchUpNotice({
       drawDefinition,
       structureIds,
       tournamentId,
-      eventId,
+      eventId: resolvedEventId,
     });
   }
   // Stamp the matchUp itself so consumers can see at-a-glance that it
@@ -205,7 +211,7 @@ export function modifyMatchUpNotice({
     payload: {
       matchUp,
       tournamentId,
-      eventId: eventId ?? event?.eventId,
+      eventId: resolvedEventId,
       drawId: drawDefinition?.drawId ?? (matchUp as any)?.drawId,
       // Best-effort, same as drawId above: an explicit caller value wins, otherwise resolve it from
       // the drawDefinition so the envelope is populated regardless of call site.

--- a/src/tests/mutations/notifications/noticeStructureId.test.ts
+++ b/src/tests/mutations/notifications/noticeStructureId.test.ts
@@ -10,7 +10,7 @@ import {
   SINGLE_ELIMINATION,
   FIRST_MATCH_LOSER_CONSOLATION,
 } from '@Constants/drawDefinitionConstants';
-import { MODIFY_MATCHUP, MODIFY_POSITION_ASSIGNMENTS } from '@Constants/topicConstants';
+import { MODIFY_MATCHUP, MODIFY_POSITION_ASSIGNMENTS, MODIFY_DRAW_DEFINITION } from '@Constants/topicConstants';
 
 /**
  * MODIFY_MATCHUP must carry the structure a change happened in, so a subscriber can route it without
@@ -122,6 +122,47 @@ describe('MODIFY_MATCHUP structureId', () => {
     expect(emitted.filter((p: any) => !p.eventId)).toEqual([]);
     expect(emitted.filter((p: any) => !p.structureId)).toEqual([]);
     expect(emitted.filter((p: any) => !p.drawId)).toEqual([]);
+
+    setSubscriptions({ subscriptions: {} });
+  });
+
+  it('MODIFY_DRAW_DEFINITION emitted alongside a score carries the same eventId', () => {
+    // The two notices come from ONE call. The fallback used to be applied to the MODIFY_MATCHUP
+    // payload but not to the drawNotice, so a caller supplying `event` (and not `eventId`) produced
+    // one notice that could be attributed and one that could not — and a consumer needs only one
+    // unattributable notice to lose the whole batch's granularity.
+    const {
+      drawIds: [drawId],
+    } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 8, drawType: SINGLE_ELIMINATION }],
+      participantsProfile: { nonRandom: 1 },
+      setState: true,
+    });
+
+    const notices = capture([MODIFY_MATCHUP, MODIFY_DRAW_DEFINITION]);
+    const matchUps: any[] = tournamentEngine.allTournamentMatchUps().matchUps ?? [];
+    const { outcome } = mocksEngine.generateOutcomeFromScoreString({
+      scoreString: '6-4 6-2',
+      matchUpStatus: 'COMPLETED',
+      winningSide: 1,
+    });
+    let scored = 0;
+    for (let pass = 0; pass < 12; pass++) {
+      const all: any[] = tournamentEngine.allTournamentMatchUps().matchUps ?? [];
+      const next = all.filter(
+        (m: any) => !m.winningSide && (m.sides ?? []).filter((s: any) => s?.participantId).length === 2,
+      );
+      if (!next.length) break;
+      for (const m of next) {
+        if (tournamentEngine.setMatchUpStatus({ matchUpId: m.matchUpId, drawId, outcome }).success) scored += 1;
+      }
+    }
+    expect(scored).toBeGreaterThan(0);
+    expect(matchUps.length).toBeGreaterThan(0);
+
+    const drawNotices = notices.filter((n) => n.topic === MODIFY_DRAW_DEFINITION).map((n) => n.p);
+    expect(drawNotices.length).toBeGreaterThan(0);
+    expect(drawNotices.filter((p: any) => !p.eventId)).toEqual([]);
 
     setSubscriptions({ subscriptions: {} });
   });


### PR DESCRIPTION
Third and final increment of the notice-attribution work. Small change, but it is the one that actually closes the loop — verified end-to-end against CFS rather than by inspection.

## The bug

`modifyMatchUpNotice` resolved `eventId ?? event?.eventId` for **its own payload** but handed the **raw** `eventId` to `modifyDrawNotice`.

So a caller supplying `event` and not `eventId` produced, from a single call:

- a `MODIFY_MATCHUP` a consumer **could** attribute
- a `MODIFY_DRAW_DEFINITION` it **could not**

That asymmetry is worse than a uniform gap, because it looks fixed from whichever topic you inspect first. #4647 and #4649 both looked complete against `MODIFY_MATCHUP`.

## Why one notice matters

A consumer needs only **one** unattributable notice to lose the whole batch's granularity. CFS must fall back to a tournament-wide sweep of its per-event cache tier, because an unattributed change could belong to any event. So the event tier stayed fully swept on every score even after the previous two fixes.

## How it was verified

Not by reading. CFS has an integration spec that drives **real** factory notices through its eviction handlers. Against this build it went from

    unnarrowablePrefixes: ['ged|']     →     unnarrowablePrefixes: []

with per-event, per-draw and per-structure keys all evicted precisely. That spec lands with the CFS bump, once this is released.

## Verification

- `tsc --noEmit` — clean
- `eslint --max-warnings 0` — clean
- full suite — **11026 passed**, 1 skipped, 0 failed
- guard falsified: restoring the raw hand-off fails the new test

## Note on the remaining surface

Many other `modifyDrawNotice` call sites pass no `eventId` at all — `addAdHocMatchUps`, `setSubOrder`, `updateParticipantResults`, `setMatchUpFormat` and others. Those are **not** on the scoring path and are not touched here. They remain correctly handled by the CFS fail-safe (sweep the tier rather than spare it), and are worth a follow-up pass if per-event granularity matters for those operations too. I have not claimed they are fixed.