### PR TITLE
refactor(matchUps): rename setMatchUpMatchUpFormat to applyMatchUpFormat

### DIFF
--- a/src/assemblies/generators/drawDefinitions/generateDrawDefinition/checkFormatScopeEquivalence.ts
+++ b/src/assemblies/generators/drawDefinitions/generateDrawDefinition/checkFormatScopeEquivalence.ts
@@ -1,4 +1,4 @@
-import { setMatchUpMatchUpFormat } from '@Mutate/matchUps/matchUpFormat/setMatchUpMatchUpFormat';
+import { applyMatchUpFormat } from '@Mutate/matchUps/matchUpFormat/applyMatchUpFormat';
 import { checkTieFormat } from '@Mutate/tieFormat/checkTieFormat';
 import { makeDeepCopy } from '@Tools/makeDeepCopy';
 
@@ -34,7 +34,7 @@ export function checkFormatScopeEquivalence({
           drawDefinition.tieFormat = result.tieFormat ?? tieFormat;
         }
       } else if (matchUpFormat) {
-        const result = setMatchUpMatchUpFormat({
+        const result = applyMatchUpFormat({
           tournamentRecord,
           drawDefinition,
           matchUpFormat,

--- a/src/mutate/matchUps/matchUpFormat/applyMatchUpFormat.ts
+++ b/src/mutate/matchUps/matchUpFormat/applyMatchUpFormat.ts
@@ -16,7 +16,7 @@ import {
   ErrorType,
 } from '@Constants/errorConditionConstants';
 
-type SetMatchUpMatchUpFormatArgs = {
+type ApplyMatchUpFormatArgs = {
   tournamentRecord?: Tournament;
   drawDefinition: DrawDefinition;
   structureIds?: string[];
@@ -28,7 +28,16 @@ type SetMatchUpMatchUpFormatArgs = {
 
 // internal use only; set matchUpFormat for a matchUp or structure
 
-export function setMatchUpMatchUpFormat(params: SetMatchUpMatchUpFormatArgs): {
+/**
+ * Writes a `matchUpFormat` onto the matchUps identified by the params — one matchUp, a structure, or
+ * a set of structures.
+ *
+ * NOT public. `setMatchUpFormat` is the exported engine method; this is the worker it delegates to,
+ * shared with `setMatchUpStatus` and `checkFormatScopeEquivalence`. It was called
+ * `setMatchUpMatchUpFormat` — `setMatchUp` + `MatchUpFormat` — which read as a typo rather than as a
+ * distinct role, and collided confusingly with the public name.
+ */
+export function applyMatchUpFormat(params: ApplyMatchUpFormatArgs): {
   success?: boolean;
   error?: ErrorType;
   info?: string;
@@ -40,6 +49,9 @@ export function setMatchUpMatchUpFormat(params: SetMatchUpMatchUpFormatArgs): {
   if (paramsCheck.error) return paramsCheck;
 
   if (!isValidMatchUpFormat({ matchUpFormat })) return { error: UNRECOGNIZED_MATCHUP_FORMAT };
+  // DELIBERATELY still the PUBLIC entry point's name, not this function's. `stack` is surfaced in
+  // decorated errors, and `setMatchUpFormat` is the only one of the two a consumer can call or
+  // recognise. Not a missed rename.
   const stack = 'setMatchUpFormat';
 
   if (matchUpId) {

--- a/src/mutate/matchUps/matchUpFormat/setMatchUpFormat.ts
+++ b/src/mutate/matchUps/matchUpFormat/setMatchUpFormat.ts
@@ -4,7 +4,7 @@ import { checkRequiredParameters } from '@Helpers/parameters/checkRequiredParame
 import { getAllStructureMatchUps } from '@Query/matchUps/getAllStructureMatchUps';
 import { modifyEventNotice } from '@Mutate/notifications/eventNotifications';
 import { isValidMatchUpFormat } from '@Validators/isValidMatchUpFormat';
-import { setMatchUpMatchUpFormat } from './setMatchUpMatchUpFormat';
+import { applyMatchUpFormat } from './applyMatchUpFormat';
 import { decorateResult } from '@Functions/global/decorateResult';
 import { getMatchUpId } from '@Functions/global/extractors';
 
@@ -94,7 +94,7 @@ export function setMatchUpFormat(params: SetMatchUpStatusArgs) {
   }
 
   if (drawId && matchUpId && drawDefinition) {
-    const result = setMatchUpMatchUpFormat({
+    const result = applyMatchUpFormat({
       tournamentRecord,
       drawDefinition,
       matchUpFormat,

--- a/src/mutate/matchUps/matchUpStatus/setMatchUpStatus.ts
+++ b/src/mutate/matchUps/matchUpStatus/setMatchUpStatus.ts
@@ -1,4 +1,4 @@
-import { setMatchUpMatchUpFormat } from '@Mutate/matchUps/matchUpFormat/setMatchUpMatchUpFormat';
+import { applyMatchUpFormat } from '@Mutate/matchUps/matchUpFormat/applyMatchUpFormat';
 import { resolveTournamentRecords } from '@Helpers/parameters/resolveTournamentRecords';
 import { checkRequiredParameters } from '@Helpers/parameters/checkRequiredParameters';
 import { setMatchUpState } from '@Mutate/matchUps/matchUpStatus/setMatchUpState';
@@ -125,7 +125,7 @@ export function setMatchUpStatus(params: SetMatchUpStatusArgs) {
   // WHY: Format affects score validation (e.g., number of sets, tiebreak rules)
   // Must be set first to ensure score is validated against correct format
   if (matchUpFormat) {
-    const result = setMatchUpMatchUpFormat({
+    const result = applyMatchUpFormat({
       tournamentRecord,
       drawDefinition,
       matchUpFormat,

--- a/src/tests/mutations/matchUps/matchUpTests.test.ts
+++ b/src/tests/mutations/matchUps/matchUpTests.test.ts
@@ -1,5 +1,5 @@
 import { generateDrawTypeAndModifyDrawDefinition } from '@Assemblies/generators/drawDefinitions/generateDrawTypeAndModifyDrawDefinition';
-import { setMatchUpMatchUpFormat } from '@Mutate/matchUps/matchUpFormat/setMatchUpMatchUpFormat';
+import { applyMatchUpFormat } from '@Mutate/matchUps/matchUpFormat/applyMatchUpFormat';
 import { newDrawDefinition } from '@Assemblies/generators/drawDefinitions/newDrawDefinition';
 import { getAllStructureMatchUps } from '@Query/matchUps/getAllStructureMatchUps';
 import { getStructureMatchUps } from '@Query/structure/getStructureMatchUps';
@@ -152,14 +152,14 @@ it('can set matchUpFormat', () => {
   expect(matchUp?.matchUpFormat).toEqual(undefined);
 
   const matchUpId = matchUp?.matchUpId as string;
-  let result = setMatchUpMatchUpFormat({
+  let result = applyMatchUpFormat({
     drawDefinition,
     matchUpFormat,
     matchUpId,
   });
   expect(result.success).toEqual(true);
 
-  result = setMatchUpMatchUpFormat({
+  result = applyMatchUpFormat({
     drawDefinition,
     matchUpFormat,
   });
@@ -173,48 +173,48 @@ it('can set matchUpFormat', () => {
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  result = setMatchUpMatchUpFormat({ drawDefinition, matchUpId });
+  result = applyMatchUpFormat({ drawDefinition, matchUpId });
   expect(result.error).toEqual(MISSING_MATCHUP_FORMAT);
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  result = setMatchUpMatchUpFormat({
+  result = applyMatchUpFormat({
     matchUpId: 'bogus matchUpId',
     matchUpFormat,
   });
   expect(result.error).toEqual(MISSING_DRAW_DEFINITION);
-  result = setMatchUpMatchUpFormat({
+  result = applyMatchUpFormat({
     matchUpId: 'bogus matchUpId',
     drawDefinition,
     matchUpFormat,
   });
   expect(result.error).toEqual(MATCHUP_NOT_FOUND);
-  result = setMatchUpMatchUpFormat({
+  result = applyMatchUpFormat({
     structureId: 'bogus structureId',
     drawDefinition,
     matchUpFormat,
   });
   expect(result.error).toEqual(STRUCTURE_NOT_FOUND);
-  result = setMatchUpMatchUpFormat({
+  result = applyMatchUpFormat({
     structureId: structure?.structureId,
     drawDefinition,
     matchUpFormat,
   });
   expect(result.success).toEqual(true);
-  result = setMatchUpMatchUpFormat({
+  result = applyMatchUpFormat({
     // @ts-expect-error possibly undefined param
     structureIds: [structure?.structureId],
     drawDefinition,
     matchUpFormat,
   });
   expect(result.success).toEqual(true);
-  result = setMatchUpMatchUpFormat({
+  result = applyMatchUpFormat({
     structureIds: ['bogus structureId'],
     drawDefinition,
     matchUpFormat,
   });
   expect(result.error).toEqual(STRUCTURE_NOT_FOUND);
-  result = setMatchUpMatchUpFormat({
+  result = applyMatchUpFormat({
     structureId: structure?.structureId,
     matchUpFormat: 'bogus format',
     drawDefinition,
@@ -222,7 +222,7 @@ it('can set matchUpFormat', () => {
   expect(result.error).toEqual(UNRECOGNIZED_MATCHUP_FORMAT);
 
   // @ts-expect-error missing params
-  result = setMatchUpMatchUpFormat({
+  result = applyMatchUpFormat({
     structureId: structure?.structureId,
     matchUpFormat,
   });
@@ -240,7 +240,7 @@ it('throws error when setting matchUpFormat on TEAM events', () => {
 
   expect(event.eventType).toEqual(TEAM_EVENT);
 
-  let result = setMatchUpMatchUpFormat({
+  let result = applyMatchUpFormat({
     matchUpFormat: FORMAT_TIMED_10_1,
     drawDefinition,
     structureId,
@@ -248,7 +248,7 @@ it('throws error when setting matchUpFormat on TEAM events', () => {
   });
   expect(result.error).toEqual(INVALID_EVENT_TYPE);
 
-  result = setMatchUpMatchUpFormat({
+  result = applyMatchUpFormat({
     matchUpFormat: FORMAT_TIMED_10_1,
     structureIds: [structureId],
     drawDefinition,
@@ -256,28 +256,28 @@ it('throws error when setting matchUpFormat on TEAM events', () => {
   });
   expect(result.error).toEqual(INVALID_EVENT_TYPE);
 
-  result = setMatchUpMatchUpFormat({
+  result = applyMatchUpFormat({
     matchUpFormat: FORMAT_TIMED_10_1,
     matchUpId: 'match-1-1',
     drawDefinition,
   });
   expect(result.error).toEqual(INVALID_MATCHUP);
 
-  result = setMatchUpMatchUpFormat({
+  result = applyMatchUpFormat({
     matchUpFormat: FORMAT_TIMED_10_1,
     matchUpId: 'match-x-y',
     drawDefinition,
   });
   expect(result.error).toEqual(MATCHUP_NOT_FOUND);
 
-  result = setMatchUpMatchUpFormat({
+  result = applyMatchUpFormat({
     structureId: 'bogusStructureId',
     matchUpFormat: FORMAT_TIMED_10_1,
     drawDefinition,
   });
   expect(result.error).toEqual(STRUCTURE_NOT_FOUND);
 
-  result = setMatchUpMatchUpFormat({
+  result = applyMatchUpFormat({
     structureIds: ['bogusStructureId'],
     matchUpFormat: FORMAT_TIMED_10_1,
     drawDefinition,


### PR DESCRIPTION
Naming cleanup CA asked for. Pure rename, no behaviour change.

## The problem with the old name

`setMatchUpMatchUpFormat` parses as `setMatchUp` + `MatchUpFormat` — mechanically correct (the entity is a matchUp, the property really is `matchUpFormat`) but it reads as a typo of the public `setMatchUpFormat` rather than as a distinct role.

The two are genuinely different things:

| | |
|---|---|
| `setMatchUpFormat` | the **exported engine method** — validates and delegates |
| `applyMatchUpFormat` | the **worker** — resolves which matchUps to write (one matchUp, a structure, or several) |

The worker is also called by `setMatchUpStatus` and `checkFormatScopeEquivalence`, so it is not merely an implementation detail of the public method.

## Why this is safe to rename

Checked against the **published** 6.28.1 package rather than the source, since that is what defines the API surface:

```
factory.competitionEngine.setMatchUpFormat
factory.competitionEngineAsync.setMatchUpFormat
factory.governors.matchUpGovernor.mutate.setMatchUpFormat
factory.governors.matchUpGovernor.setMatchUpFormat
```

`setMatchUpMatchUpFormat` appears nowhere — it reaches no governor, so it never enters the bundle. Grep across TMX, CFS, courthive-components and courthive-public finds no reference either.

## One thing deliberately NOT renamed

The internal `const stack = 'setMatchUpFormat'` stays as-is. It is surfaced in decorated errors and names the entry point a consumer can actually call; changing it would smuggle an error-payload change into a rename. It is commented so it does not read as a missed rename.

Telling detail: that label already said `setMatchUpFormat` before this change — the function's own errors never used its real name, which suggests the doubling was never deliberate.

## Verification

- `tsc --noEmit` — clean · `eslint --max-warnings 0` — clean · prettier clean
- `verify:generated` — engine-methods 666 OK, method-signatures up to date (the public method list is unchanged, as expected)
- full suite — **11027 passed**, 1 skipped, 0 failed
- the existing `matchUpTests` suite exercises this function directly through 19 call sites, so the rename is covered by real behavioural tests rather than by compilation alone