### PR TITLE
docs(matchUps): drop the rename history from applyMatchUpFormat

### DIFF
--- a/src/mutate/matchUps/matchUpFormat/applyMatchUpFormat.ts
+++ b/src/mutate/matchUps/matchUpFormat/applyMatchUpFormat.ts
@@ -26,16 +26,12 @@ type ApplyMatchUpFormatArgs = {
   event?: Event;
 };
 
-// internal use only; set matchUpFormat for a matchUp or structure
-
 /**
  * Writes a `matchUpFormat` onto the matchUps identified by the params — one matchUp, a structure, or
  * a set of structures.
  *
  * NOT public. `setMatchUpFormat` is the exported engine method; this is the worker it delegates to,
- * shared with `setMatchUpStatus` and `checkFormatScopeEquivalence`. It was called
- * `setMatchUpMatchUpFormat` — `setMatchUp` + `MatchUpFormat` — which read as a typo rather than as a
- * distinct role, and collided confusingly with the public name.
+ * shared with `setMatchUpStatus` and `checkFormatScopeEquivalence`.
  */
 export function applyMatchUpFormat(params: ApplyMatchUpFormatArgs): {
   success?: boolean;


### PR DESCRIPTION
Follow-up to #4653, on CA's call: the symbol was never external-facing, so recording what it used to be called is noise for every future reader. Git carries that history.

What stays is the part that helps: it is **not public**, and it is the worker `setMatchUpFormat` delegates to (also called by `setMatchUpStatus` and `checkFormatScopeEquivalence`).

Also drops the stale one-line comment above the block, which duplicated the doc comment's first sentence.

Comment-only — no code, no assertions.

`grep` confirms `setMatchUpMatchUpFormat` now appears nowhere in `src`.

Verified: tsc clean, eslint clean, prettier clean, `matchUpTests` + `forge` suites green.