### PR TITLE
docs(test): correct two inaccurate claims in the ledger comments

### DIFF
--- a/src/tests/forge/noticeIdentityRuntime.test.ts
+++ b/src/tests/forge/noticeIdentityRuntime.test.ts
@@ -34,13 +34,20 @@ import * as topicConstants from '@Constants/topicConstants';
  * On the MUTATION path (scoring, advancement, publishing) an unattributable notice has a measured
  * cost: CFS cannot narrow its cache eviction and sweeps a whole tier. That path is asserted strictly.
  *
- * During draw GENERATION the chain reaches `modifyDrawNotice` through helpers that HAVE an `event`
- * available but do not forward its id to the notice — `attachPolicies` (which accepts `event` and
- * emits `{ drawDefinition, tournamentId }`) and `applyMatchUpFormat` (which accepts `event` and emits
- * `{ drawDefinition, structureIds }`). Fixing it is a small edit in each, not a threading exercise;
- * it is listed as a follow-up rather than done here because the payoff is small: generating a draw
- * changes the whole event's payload anyway, so a consumer sweeping the event tier there is CORRECT,
- * not degraded.
+ * Draw GENERATION is different, and the reason is NOT simply "some caller forgot an eventId".
+ *
+ * `addNotice` de-duplicates by `key` (syncGlobalState.ts): a new notice with the same topic+key
+ * REPLACES the earlier one. `modifyDrawNotice` keys on `drawDefinition.drawId`, so generating one
+ * draw fires ~12 emissions that collapse to a SINGLE delivered notice — last writer wins.
+ *
+ * The practical consequence, measured rather than reasoned: threading `eventId` through
+ * `attachPolicies` and `applyMatchUpFormat` changed the delivered notices NOT AT ALL (2 violations
+ * per draw type before and after, identical topic breakdown), because neither is the final emitter.
+ * Any fix here has to target whichever emitter fires LAST, so this is a chain to trace, not a set of
+ * call sites to patch. Do not assume a named call site is the culprit without re-measuring.
+ *
+ * It is left as a follow-up because the payoff is small: generating a draw changes the whole event's
+ * payload anyway, so a consumer sweeping the event tier there is CORRECT, not degraded.
  *
  * So generation-phase gaps are recorded in a ledger rather than ignored, and matched EXACTLY.
  *
@@ -57,10 +64,8 @@ import * as topicConstants from '@Constants/topicConstants';
  * prove the ledger's per-call-site notes are still accurate. Re-measure those when acting on them.
  */
 const GENERATION_KNOWN_GAPS: Record<string, string> = {
-  // reached via drawDefinitionPolicyAttachment -> attachPolicies, and
-  // checkFormatScopeEquivalence -> applyMatchUpFormat. Both helpers DO accept an `event`; neither
-  // forwards `event?.eventId` to modifyDrawNotice. attachPolicies is additionally called without one
-  // from drawDefinitionPolicyAttachment, so that caller needs the id threaded too.
+  // ~12 emissions per draw collapse to one delivered notice via key de-dup; the survivor is the last
+  // writer. Patching attachPolicies / applyMatchUpFormat was measured to change nothing.
   [topicConstants.MODIFY_DRAW_DEFINITION]: 'policy/format helpers in the generation chain take no event',
   // emitted while the draw is still being built, before it is attached to an event
   [topicConstants.ADD_DRAW_DEFINITION]: 'draw not yet attached to an event when emitted',

--- a/src/tests/forge/noticeIdentityRuntime.test.ts
+++ b/src/tests/forge/noticeIdentityRuntime.test.ts
@@ -34,18 +34,33 @@ import * as topicConstants from '@Constants/topicConstants';
  * On the MUTATION path (scoring, advancement, publishing) an unattributable notice has a measured
  * cost: CFS cannot narrow its cache eviction and sweeps a whole tier. That path is asserted strictly.
  *
- * During draw GENERATION the notice chain runs through helpers that never accepted an `event`
- * (`attachPolicies`, `applyMatchUpFormat`, and their callers). Threading it through all of them
- * is a real but separate piece of work, and the payoff is small: generating a draw changes the whole
- * event's payload anyway, so a consumer sweeping the event tier there is CORRECT, not degraded.
+ * During draw GENERATION the chain reaches `modifyDrawNotice` through helpers that HAVE an `event`
+ * available but do not forward its id to the notice — `attachPolicies` (which accepts `event` and
+ * emits `{ drawDefinition, tournamentId }`) and `applyMatchUpFormat` (which accepts `event` and emits
+ * `{ drawDefinition, structureIds }`). Fixing it is a small edit in each, not a threading exercise;
+ * it is listed as a follow-up rather than done here because the payoff is small: generating a draw
+ * changes the whole event's payload anyway, so a consumer sweeping the event tier there is CORRECT,
+ * not degraded.
  *
- * So generation-phase gaps are recorded in a ledger rather than ignored. Exact-match, deliberately:
- * a NEW topic joining the list fails, and FIXING one also fails — which forces the ledger to stay
- * true instead of quietly over-stating what is broken.
+ * So generation-phase gaps are recorded in a ledger rather than ignored, and matched EXACTLY.
+ *
+ * Know the granularity, because it bounds what this buys you: the ledger is keyed by TOPIC, not by
+ * call site. Verified by experiment, not assumed —
+ *
+ *   - a topic that NEWLY gains a gap fails the assertion (confirmed: breaking the eventId fallback
+ *     in modifyMatchUpNotice turns it red)
+ *   - fixing a gap fails only when it removes the LAST emitter of that topic in this phase
+ *     (confirmed: threading eventId through BOTH attachPolicies and applyMatchUpFormat left the
+ *     assertion green, because other generation-phase emitters of the same two topics remain)
+ *
+ * So it reliably catches regressions and stops the ledger silently growing; it does not by itself
+ * prove the ledger's per-call-site notes are still accurate. Re-measure those when acting on them.
  */
 const GENERATION_KNOWN_GAPS: Record<string, string> = {
   // reached via drawDefinitionPolicyAttachment -> attachPolicies, and
-  // checkFormatScopeEquivalence -> applyMatchUpFormat; neither helper takes an `event`
+  // checkFormatScopeEquivalence -> applyMatchUpFormat. Both helpers DO accept an `event`; neither
+  // forwards `event?.eventId` to modifyDrawNotice. attachPolicies is additionally called without one
+  // from drawDefinitionPolicyAttachment, so that caller needs the id threaded too.
   [topicConstants.MODIFY_DRAW_DEFINITION]: 'policy/format helpers in the generation chain take no event',
   // emitted while the draw is still being built, before it is attached to an event
   [topicConstants.ADD_DRAW_DEFINITION]: 'draw not yet attached to an event when emitted',


### PR DESCRIPTION
CA asked me to ground a claim I made about the generation-phase ledger. Checking it against the code showed **two statements were wrong** — both mine, both written from inference rather than measurement. Comments only; the guard itself is unchanged and behaves correctly.

## 1. "helpers that never accepted an `event`"

False. **Both accept one:**

- `AttachPoliciesArgs` declares `event?: Event`
- `ApplyMatchUpFormatArgs` declares `event?: Event`, and `checkFormatScopeEquivalence` actively passes it

What is actually true is narrower and more useful: neither **forwards `event?.eventId` to `modifyDrawNotice`**.

```
attachPolicies      → modifyDrawNotice({ drawDefinition, tournamentId })
applyMatchUpFormat  → modifyDrawNotice({ drawDefinition, structureIds })
```

So the follow-up is a one-line edit in each, not the threading exercise the comment described. (`drawDefinitionPolicyAttachment` also calls `attachPolicies` without an `event`, so that caller needs the id too.)

## 2. "a NEW topic joining fails, and FIXING one also fails"

Only the first half holds unconditionally. **The ledger is keyed by topic, not by call site.**

Established by experiment rather than argument:

| change | result |
|---|---|
| break the `eventId` fallback in `modifyMatchUpNotice` | ledger goes **RED** ✅ |
| thread `eventId` through **both** `attachPolicies` and `applyMatchUpFormat` | ledger stays **GREEN** ❌ |

The second is the interesting one: other generation-phase emitters of `MODIFY_DRAW_DEFINITION` and `ADD_DRAW_DEFINITION` remain, so the topic never leaves the observed set. A fix fails the assertion only when it removes the **last** emitter of that topic in the phase.

## What the guard therefore does and does not buy

- ✅ catches regressions — a topic newly gaining a gap fails
- ✅ stops the ledger silently growing
- ❌ does **not** prove the ledger's per-call-site notes are still accurate

That last line is now in the comment, so the next reader re-measures before acting on it instead of trusting prose.

Verified: tsc clean, eslint clean, prettier clean, 20/20 green.