### PR TITLE
fix(notices): keyed de-dup no longer destroys identity it already had

### DIFF
--- a/src/forge/topicTypes.ts
+++ b/src/forge/topicTypes.ts
@@ -40,6 +40,21 @@ export interface NoticeIdentity {
   eventId?: string;
   drawId?: string;
   structureId?: string;
+
+  /**
+   * The sanctioning source, flattened — same vocabulary as the read-model's
+   * `origin_organisation_id` / `origin_tournament_id` / `origin_event_id`. `originTournamentId` is the
+   * ORIGIN organisation's id and is deliberately independent of `tournamentId` above; all are absent
+   * when the event declares no origin, which is the ordinary single-sanction case.
+   *
+   * Declared here because `modifyMatchUpNotice` has emitted them since 6.27.0 while this interface did
+   * not list them — under-declaring what is on the wire. Caught by the drift guard in
+   * `tests/global/noticeIdentityPreservation.test.ts`.
+   */
+  originOrganisationId?: string;
+  originTournamentId?: string;
+  originEventId?: string;
+  originDrawId?: string;
 }
 
 // ============================================================================

--- a/src/global/state/globalState.ts
+++ b/src/global/state/globalState.ts
@@ -1,3 +1,4 @@
+export { preserveNoticeIdentity, NOTICE_IDENTITY_FIELDS } from './noticeIdentity';
 import { isFunction, isObject } from '@Tools/objects';
 import syncGlobalState from './syncGlobalState';
 import { intersection } from '@Tools/arrays';

--- a/src/global/state/globalState.ts
+++ b/src/global/state/globalState.ts
@@ -1,4 +1,3 @@
-export { preserveNoticeIdentity, NOTICE_IDENTITY_FIELDS } from './noticeIdentity';
 import { isFunction, isObject } from '@Tools/objects';
 import syncGlobalState from './syncGlobalState';
 import { intersection } from '@Tools/arrays';
@@ -14,6 +13,10 @@ import {
   MISSING_ASYNC_STATE_PROVIDER,
   MISSING_VALUE,
 } from '@Constants/errorConditionConstants';
+
+// Re-exported so any OTHER implementation of the notice buffer — competition-factory-server supplies
+// its own provider for per-request async isolation — calls THIS merge rather than copying it.
+export { preserveNoticeIdentity, NOTICE_IDENTITY_FIELDS } from './noticeIdentity';
 
 export type Notice = {
   topic: string;

--- a/src/global/state/noticeIdentity.ts
+++ b/src/global/state/noticeIdentity.ts
@@ -1,0 +1,55 @@
+import { NoticeIdentity } from '../../forge/topicTypes';
+
+/**
+ * Identity fields carried on a notice ENVELOPE — the SINGLE definition.
+ *
+ * Any provider implementing the notice buffer (factory's `syncGlobalState`, and
+ * competition-factory-server's `asyncGlobalState`, which reimplements it for per-request async
+ * isolation) must share this, or the two drift and only one of them preserves identity.
+ *
+ * Keyed to `NoticeIdentity` so a field added to the type without being added here is a compile error
+ * rather than a silent omission.
+ */
+export const NOTICE_IDENTITY_FIELDS: (keyof NoticeIdentity)[] = [
+  'tournamentId',
+  'eventId',
+  'drawId',
+  'structureId',
+  'originOrganisationId',
+  'originTournamentId',
+  'originEventId',
+  'originDrawId',
+];
+
+/**
+ * Carry identity forward when a keyed notice supersedes an earlier one.
+ *
+ * Keyed notices coalesce — a later notice with the same topic+key replaces the earlier one, so a
+ * subscriber sees one notice per entity per mutation. That is intentional. Replacing WHOLESALE was
+ * not: a later emission often knows LESS.
+ *
+ * Measured on one generated draw: 12 `MODIFY_DRAW_DEFINITION` emissions for the same drawId, of which
+ * eight consecutive ones carried `eventId` AND `tournamentId` while the final one carried NEITHER —
+ * so the delivered notice was the only unroutable emission in the batch. Identity the system fully
+ * knew was destroyed by the transport, not by any caller omitting it.
+ *
+ * SOUND because for a given topic+key identity is INVARIANT: a matchUp does not change which
+ * structure, draw or event it belongs to, and a draw does not migrate between events. Filling a field
+ * the newer payload left `undefined` can only restore the value it would have carried — it cannot
+ * override a differing one, because a differing one cannot exist for that key.
+ *
+ * Returns the payload UNCHANGED (same reference) when nothing needs restoring, so callers that reuse
+ * a payload object are unaffected.
+ */
+export function preserveNoticeIdentity(payload: any, superseded: any): any {
+  if (!superseded || typeof payload !== 'object' || payload === null || Array.isArray(payload)) return payload;
+
+  let restored: any;
+  for (const field of NOTICE_IDENTITY_FIELDS) {
+    if (payload[field] === undefined && superseded[field] !== undefined) {
+      restored ??= { ...payload };
+      restored[field] = superseded[field];
+    }
+  }
+  return restored ?? payload;
+}

--- a/src/global/state/syncGlobalState.ts
+++ b/src/global/state/syncGlobalState.ts
@@ -1,3 +1,4 @@
+import { preserveNoticeIdentity } from './noticeIdentity';
 import {
   CallListenerArgs,
   DeleteNoticeArgs,
@@ -152,52 +153,6 @@ export function cycleMutationStatus() {
   return status;
 }
 
-/**
- * Identity fields carried on a notice ENVELOPE. Mirrors `NoticeIdentity` in `forge/topicTypes.ts`;
- * conformance is asserted in `tests/global/noticeIdentityPreservation.test.ts` so the two cannot drift.
- */
-const NOTICE_IDENTITY_FIELDS = [
-  'tournamentId',
-  'eventId',
-  'drawId',
-  'structureId',
-  'originOrganisationId',
-  'originTournamentId',
-  'originEventId',
-  'originDrawId',
-] as const;
-
-/**
- * Carry identity forward when a keyed notice supersedes an earlier one.
- *
- * WHY THIS IS SOUND: for a given topic+key, identity is INVARIANT. A matchUp does not change which
- * structure, draw or event it belongs to; a draw does not migrate between events. So filling a field
- * the newer payload left undefined can only restore the value it would have carried — never override
- * a differing one, because a differing one cannot exist.
- *
- * WHY IT IS NEEDED: de-dup keeps the LAST writer wholesale. Generating one draw fires ~12
- * `MODIFY_DRAW_DEFINITION` emissions for the same drawId; measured, eight consecutive ones carry
- * eventId and tournamentId and the final one carries NEITHER — so the delivered notice was the only
- * unroutable one in the batch. Identity the system fully knew was destroyed by the transport.
- *
- * This also removes a silent fragility: `MODIFY_MATCHUP` is keyed on matchUpId, so the identity fixes
- * in 6.28.0/6.28.1 were correct only because the last emitter happened to carry identity. A future
- * emission added later in the chain would have quietly undone them.
- */
-function preserveIdentity(payload: any, superseded: any): any {
-  if (!superseded || typeof payload !== 'object' || Array.isArray(payload)) return payload;
-
-  let restored: any;
-  for (const field of NOTICE_IDENTITY_FIELDS) {
-    if (payload[field] === undefined && superseded[field] !== undefined) {
-      // copy lazily: an unmodified payload must stay the caller's own object
-      restored ??= { ...payload };
-      restored[field] = superseded[field];
-    }
-  }
-  return restored ?? payload;
-}
-
 export function addNotice({ topic, payload, key }: Notice, isGlobalSubscription?: boolean) {
   if (typeof topic !== 'string' || typeof payload !== 'object') return;
   // if there is a notice then the state has been modified, regardless of whether there is a subscription
@@ -211,7 +166,7 @@ export function addNotice({ topic, payload, key }: Notice, isGlobalSubscription?
     for (const notice of syncGlobalState.notices) {
       if (notice.topic === topic && notice.key === key) {
         // superseded — but its identity is still true of this key, so do not discard it
-        outgoing = preserveIdentity(outgoing, notice.payload);
+        outgoing = preserveNoticeIdentity(outgoing, notice.payload);
       } else {
         retained.push(notice);
       }

--- a/src/global/state/syncGlobalState.ts
+++ b/src/global/state/syncGlobalState.ts
@@ -152,19 +152,74 @@ export function cycleMutationStatus() {
   return status;
 }
 
+/**
+ * Identity fields carried on a notice ENVELOPE. Mirrors `NoticeIdentity` in `forge/topicTypes.ts`;
+ * conformance is asserted in `tests/global/noticeIdentityPreservation.test.ts` so the two cannot drift.
+ */
+const NOTICE_IDENTITY_FIELDS = [
+  'tournamentId',
+  'eventId',
+  'drawId',
+  'structureId',
+  'originOrganisationId',
+  'originTournamentId',
+  'originEventId',
+  'originDrawId',
+] as const;
+
+/**
+ * Carry identity forward when a keyed notice supersedes an earlier one.
+ *
+ * WHY THIS IS SOUND: for a given topic+key, identity is INVARIANT. A matchUp does not change which
+ * structure, draw or event it belongs to; a draw does not migrate between events. So filling a field
+ * the newer payload left undefined can only restore the value it would have carried — never override
+ * a differing one, because a differing one cannot exist.
+ *
+ * WHY IT IS NEEDED: de-dup keeps the LAST writer wholesale. Generating one draw fires ~12
+ * `MODIFY_DRAW_DEFINITION` emissions for the same drawId; measured, eight consecutive ones carry
+ * eventId and tournamentId and the final one carries NEITHER — so the delivered notice was the only
+ * unroutable one in the batch. Identity the system fully knew was destroyed by the transport.
+ *
+ * This also removes a silent fragility: `MODIFY_MATCHUP` is keyed on matchUpId, so the identity fixes
+ * in 6.28.0/6.28.1 were correct only because the last emitter happened to carry identity. A future
+ * emission added later in the chain would have quietly undone them.
+ */
+function preserveIdentity(payload: any, superseded: any): any {
+  if (!superseded || typeof payload !== 'object' || Array.isArray(payload)) return payload;
+
+  let restored: any;
+  for (const field of NOTICE_IDENTITY_FIELDS) {
+    if (payload[field] === undefined && superseded[field] !== undefined) {
+      // copy lazily: an unmodified payload must stay the caller's own object
+      restored ??= { ...payload };
+      restored[field] = superseded[field];
+    }
+  }
+  return restored ?? payload;
+}
+
 export function addNotice({ topic, payload, key }: Notice, isGlobalSubscription?: boolean) {
   if (typeof topic !== 'string' || typeof payload !== 'object') return;
   // if there is a notice then the state has been modified, regardless of whether there is a subscription
   if (!syncGlobalState.disableNotifications) syncGlobalState.modified = true;
   if (syncGlobalState.disableNotifications || (!syncGlobalState.subscriptions[topic] && !isGlobalSubscription)) return;
 
+  let outgoing = payload;
+
   if (key) {
-    syncGlobalState.notices = syncGlobalState.notices.filter(
-      (notice) => !(notice.topic === topic && notice.key === key),
-    );
+    const retained: any[] = [];
+    for (const notice of syncGlobalState.notices) {
+      if (notice.topic === topic && notice.key === key) {
+        // superseded — but its identity is still true of this key, so do not discard it
+        outgoing = preserveIdentity(outgoing, notice.payload);
+      } else {
+        retained.push(notice);
+      }
+    }
+    syncGlobalState.notices = retained;
   }
 
-  syncGlobalState.notices.push({ topic, payload, key });
+  syncGlobalState.notices.push({ topic, payload: outgoing, key });
 
   return { ...SUCCESS };
 }

--- a/src/server/providers/factory/engines/asyncGlobalState.ts
+++ b/src/server/providers/factory/engines/asyncGlobalState.ts
@@ -1,3 +1,4 @@
+import { preserveNoticeIdentity } from '@Global/state/noticeIdentity';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import {
   CallListenerArgs,
@@ -243,13 +244,27 @@ function addNotice({ topic, payload, key }: Notice, isGlobalSubscription?: boole
   if (!instanceState.disableNotifications) instanceState.modified = true;
   if (instanceState.disableNotifications || (!instanceState.subscriptions[topic] && !isGlobalSubscription)) return;
 
+  let outgoing = payload;
+
   if (key) {
-    instanceState.notices = instanceState.notices.filter((notice) => !(notice.topic === topic && notice.key === key));
+    const retained: any[] = [];
+    for (const notice of instanceState.notices) {
+      if (notice.topic === topic && notice.key === key) {
+        // Superseded — but its identity is still true of this key, so do not discard it. A later
+        // emission often knows LESS; replacing wholesale used to deliver the only unroutable notice
+        // in a batch. Shared helper, never a local copy: this file is the reference an async provider
+        // gets copied FROM, so a divergent copy here propagates to every implementation derived from it.
+        outgoing = preserveNoticeIdentity(outgoing, notice.payload);
+      } else {
+        retained.push(notice);
+      }
+    }
+    instanceState.notices = retained;
   }
   // NOTE: when backend does not recognize undefined for updates
   // params = undefinedToNull(params) // => see object.js utils
 
-  instanceState.notices.push({ topic, payload, key });
+  instanceState.notices.push({ topic, payload: outgoing, key });
 
   return { ...SUCCESS };
 }

--- a/src/tests/forge/noticeIdentityRuntime.test.ts
+++ b/src/tests/forge/noticeIdentityRuntime.test.ts
@@ -42,7 +42,8 @@ import * as topicConstants from '@Constants/topicConstants';
  * topic+key used to REPLACE the earlier one wholesale — so of ~12 emissions per generated draw, eight
  * carrying full identity were discarded in favour of a final one carrying none. The transport was
  * destroying identity the system already had. `addNotice` now carries identity across a supersede
- * (`preserveIdentity`, syncGlobalState.ts), which closed this gap without touching a single emitter.
+ * (`preserveNoticeIdentity`, global/state/noticeIdentity.ts), which closed this gap without touching a
+ * single emitter.
  *
  * Remaining gaps are recorded in a ledger rather than ignored, matched EXACTLY: a NEW topic joining
  * fails, and so does a FIX that removes the last emitter of a listed topic — which is precisely how

--- a/src/tests/forge/noticeIdentityRuntime.test.ts
+++ b/src/tests/forge/noticeIdentityRuntime.test.ts
@@ -34,19 +34,21 @@ import * as topicConstants from '@Constants/topicConstants';
  * On the MUTATION path (scoring, advancement, publishing) an unattributable notice has a measured
  * cost: CFS cannot narrow its cache eviction and sweeps a whole tier. That path is asserted strictly.
  *
- * During draw GENERATION the notice chain runs through helpers that never accepted an `event`
- * (`attachPolicies`, `applyMatchUpFormat`, and their callers). Threading it through all of them
- * is a real but separate piece of work, and the payoff is small: generating a draw changes the whole
- * event's payload anyway, so a consumer sweeping the event tier there is CORRECT, not degraded.
+ * The one remaining generation-phase gap is `ADD_DRAW_DEFINITION`, emitted while the draw is still
+ * being built and genuinely not yet attached to an event.
  *
- * So generation-phase gaps are recorded in a ledger rather than ignored. Exact-match, deliberately:
- * a NEW topic joining the list fails, and FIXING one also fails — which forces the ledger to stay
- * true instead of quietly over-stating what is broken.
+ * `MODIFY_DRAW_DEFINITION` used to sit here too, and why it no longer does is the useful part: it was
+ * never "a caller forgot an eventId". Keyed notices de-duplicate, and a later notice with the same
+ * topic+key used to REPLACE the earlier one wholesale — so of ~12 emissions per generated draw, eight
+ * carrying full identity were discarded in favour of a final one carrying none. The transport was
+ * destroying identity the system already had. `addNotice` now carries identity across a supersede
+ * (`preserveIdentity`, syncGlobalState.ts), which closed this gap without touching a single emitter.
+ *
+ * Remaining gaps are recorded in a ledger rather than ignored, matched EXACTLY: a NEW topic joining
+ * fails, and so does a FIX that removes the last emitter of a listed topic — which is precisely how
+ * the de-dup fix above forced this list to shrink.
  */
 const GENERATION_KNOWN_GAPS: Record<string, string> = {
-  // reached via drawDefinitionPolicyAttachment -> attachPolicies, and
-  // checkFormatScopeEquivalence -> applyMatchUpFormat; neither helper takes an `event`
-  [topicConstants.MODIFY_DRAW_DEFINITION]: 'policy/format helpers in the generation chain take no event',
   // emitted while the draw is still being built, before it is attached to an event
   [topicConstants.ADD_DRAW_DEFINITION]: 'draw not yet attached to an event when emitted',
 };

--- a/src/tests/global/noticeIdentityPreservation.test.ts
+++ b/src/tests/global/noticeIdentityPreservation.test.ts
@@ -1,0 +1,114 @@
+import { setSubscriptions, addNotice, getNotices, deleteNotices } from '@Global/state/globalState';
+import mocksEngine from '@Assemblies/engines/mock';
+import { expect, it, describe } from 'vitest';
+
+// constants and types
+import { MODIFY_DRAW_DEFINITION } from '@Constants/topicConstants';
+
+/**
+ * Keyed notices de-duplicate: a later notice with the same topic+key REPLACES the earlier one, so a
+ * subscriber sees only the last writer. That coalescing is intentional — one notice per entity per
+ * mutation — but replacing wholesale meant a later, LESS-identified notice destroyed identity the
+ * system already knew.
+ *
+ * Measured before this fix: generating one draw fires ~12 MODIFY_DRAW_DEFINITION emissions for the
+ * same drawId; eight consecutive ones carried eventId + tournamentId and the FINAL one carried
+ * neither — so the only unroutable emission in the batch was the one delivered.
+ */
+describe('keyed notice de-dup preserves identity', () => {
+  it('a later notice missing identity inherits it from the one it supersedes', () => {
+    setSubscriptions({ subscriptions: { [MODIFY_DRAW_DEFINITION]: () => {} } });
+    deleteNotices();
+
+    addNotice({
+      topic: MODIFY_DRAW_DEFINITION,
+      payload: { tournamentId: 't1', eventId: 'e1', drawDefinition: { drawId: 'd1', v: 1 } },
+      key: 'd1',
+    });
+    // the shape that used to win: same entity, no identity at all
+    addNotice({
+      topic: MODIFY_DRAW_DEFINITION,
+      payload: { drawDefinition: { drawId: 'd1', v: 2 } },
+      key: 'd1',
+    });
+
+    const notices = getNotices({ topic: MODIFY_DRAW_DEFINITION });
+    expect(notices.length).toEqual(1); // coalescing still happens
+    expect(notices[0].drawDefinition.v).toEqual(2); // last writer still wins for the ENTITY
+    expect(notices[0].eventId).toEqual('e1'); // ...but identity survives
+    expect(notices[0].tournamentId).toEqual('t1');
+
+    deleteNotices();
+    setSubscriptions({ subscriptions: {} });
+  });
+
+  it('a later notice NEVER has its own identity overwritten', () => {
+    // Guards the direction of the merge: fill only what is undefined.
+    setSubscriptions({ subscriptions: { [MODIFY_DRAW_DEFINITION]: () => {} } });
+    deleteNotices();
+
+    addNotice({ topic: MODIFY_DRAW_DEFINITION, payload: { eventId: 'OLD', drawDefinition: {} }, key: 'd1' });
+    addNotice({ topic: MODIFY_DRAW_DEFINITION, payload: { eventId: 'NEW', drawDefinition: {} }, key: 'd1' });
+
+    expect(getNotices({ topic: MODIFY_DRAW_DEFINITION })[0].eventId).toEqual('NEW');
+
+    deleteNotices();
+    setSubscriptions({ subscriptions: {} });
+  });
+
+  it('different keys do not bleed identity into each other', () => {
+    setSubscriptions({ subscriptions: { [MODIFY_DRAW_DEFINITION]: () => {} } });
+    deleteNotices();
+
+    addNotice({ topic: MODIFY_DRAW_DEFINITION, payload: { eventId: 'e1', drawDefinition: {} }, key: 'd1' });
+    addNotice({ topic: MODIFY_DRAW_DEFINITION, payload: { drawDefinition: {} }, key: 'd2' });
+
+    const notices = getNotices({ topic: MODIFY_DRAW_DEFINITION });
+    expect(notices.length).toEqual(2);
+    expect(notices.find((n: any) => n.eventId === 'e1')).toBeDefined();
+    // d2 never had an eventId and must not acquire d1's
+    expect(notices.filter((n: any) => n.eventId === 'e1').length).toEqual(1);
+
+    deleteNotices();
+    setSubscriptions({ subscriptions: {} });
+  });
+
+  it('END TO END: generating a draw delivers a MODIFY_DRAW_DEFINITION that carries its eventId', () => {
+    // The bug in situ. Before this fix the delivered notice had neither eventId nor tournamentId,
+    // even though eight earlier emissions for the same drawId carried both.
+    const notices: any[] = [];
+    setSubscriptions({ subscriptions: { [MODIFY_DRAW_DEFINITION]: (n: any[]) => notices.push(...n) } });
+
+    const {
+      eventIds: [eventId],
+    } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 8, drawType: 'SINGLE_ELIMINATION' }],
+      participantsProfile: { nonRandom: 1 },
+      setState: true,
+    });
+
+    expect(notices.length).toBeGreaterThan(0);
+    expect(notices.filter((n: any) => !n.eventId)).toEqual([]);
+    expect(notices[0].eventId).toEqual(eventId);
+
+    setSubscriptions({ subscriptions: {} });
+  });
+
+  it('the identity field list matches NoticeIdentity — no drift', async () => {
+    // Same guard style as the TopicPayloadMap key check: a field added to the interface but not to
+    // the runtime list would silently stop being preserved.
+    const fs = await import('fs');
+    const path = await import('path');
+
+    const types = fs.readFileSync(path.resolve(__dirname, '../../forge/topicTypes.ts'), 'utf8');
+    const body = types.slice(types.indexOf('export interface NoticeIdentity'));
+    const declared = [...body.slice(0, body.indexOf('\n}')).matchAll(/^\s{2}(\w+)\??:/gm)].map((m) => m[1]);
+
+    const src = fs.readFileSync(path.resolve(__dirname, '../../global/state/syncGlobalState.ts'), 'utf8');
+    const listBody = src.slice(src.indexOf('const NOTICE_IDENTITY_FIELDS'));
+    const runtime = [...listBody.slice(0, listBody.indexOf(']')).matchAll(/'(\w+)'/g)].map((m) => m[1]);
+
+    expect(declared.length).toBeGreaterThan(3);
+    expect(runtime.sort()).toEqual(declared.sort());
+  });
+});

--- a/src/tests/global/noticeIdentityPreservation.test.ts
+++ b/src/tests/global/noticeIdentityPreservation.test.ts
@@ -95,8 +95,9 @@ describe('keyed notice de-dup preserves identity', () => {
   });
 
   it('the identity field list matches NoticeIdentity — no drift', async () => {
-    // Same guard style as the TopicPayloadMap key check: a field added to the interface but not to
-    // the runtime list would silently stop being preserved.
+    // The list is typed `(keyof NoticeIdentity)[]`, so a field REMOVED from the interface is already
+    // a compile error. This catches the other direction: a field ADDED to the interface and not to
+    // the list would silently stop being preserved, and types cannot see that.
     const fs = await import('fs');
     const path = await import('path');
 
@@ -104,11 +105,27 @@ describe('keyed notice de-dup preserves identity', () => {
     const body = types.slice(types.indexOf('export interface NoticeIdentity'));
     const declared = [...body.slice(0, body.indexOf('\n}')).matchAll(/^\s{2}(\w+)\??:/gm)].map((m) => m[1]);
 
-    const src = fs.readFileSync(path.resolve(__dirname, '../../global/state/syncGlobalState.ts'), 'utf8');
-    const listBody = src.slice(src.indexOf('const NOTICE_IDENTITY_FIELDS'));
-    const runtime = [...listBody.slice(0, listBody.indexOf(']')).matchAll(/'(\w+)'/g)].map((m) => m[1]);
+    const src = fs.readFileSync(path.resolve(__dirname, '../../global/state/noticeIdentity.ts'), 'utf8');
+    // slice from the ARRAY LITERAL, not the declaration: the type annotation
+    // `(keyof NoticeIdentity)[]` contains a `]` of its own and would truncate the match to nothing.
+    const decl = src.slice(src.indexOf('const NOTICE_IDENTITY_FIELDS'));
+    const listBody = decl.slice(decl.indexOf('= ['), decl.indexOf('];') + 1);
+    const runtime = [...listBody.matchAll(/'(\w+)'/g)].map((m) => m[1]);
 
     expect(declared.length).toBeGreaterThan(3);
+    expect(runtime.length).toBeGreaterThan(3); // the parser found something — not a vacuous pass
     expect(runtime.sort()).toEqual(declared.sort());
+  });
+
+  it('is exported publicly so other providers use THIS implementation, not a copy', async () => {
+    // competition-factory-server reimplements the notice buffer for per-request async isolation. It
+    // must be able to import the helper rather than hand-copy it; a copy is how the two drift.
+    const globalStateModule: any = await import('@Global/state/globalState');
+    expect(typeof globalStateModule.preserveNoticeIdentity).toEqual('function');
+    expect(Array.isArray(globalStateModule.NOTICE_IDENTITY_FIELDS)).toEqual(true);
+
+    // and it behaves through the public path, not just the internal one
+    const merged = globalStateModule.preserveNoticeIdentity({ matchUp: {} }, { eventId: 'e1' });
+    expect(merged.eventId).toEqual('e1');
   });
 });

--- a/src/tests/global/noticeIdentityPreservation.test.ts
+++ b/src/tests/global/noticeIdentityPreservation.test.ts
@@ -128,4 +128,37 @@ describe('keyed notice de-dup preserves identity', () => {
     const merged = globalStateModule.preserveNoticeIdentity({ matchUp: {} }, { eventId: 'e1' });
     expect(merged.eventId).toEqual('e1');
   });
+
+  it('every notice buffer in this repo preserves identity — no copy may skip it', async () => {
+    // The real protection. Three implementations of this de-dup existed (syncGlobalState, the
+    // reference async provider under src/server, and — outside this repo — CFS's asyncGlobalState),
+    // and only fixing them one at a time guarantees the next copy reintroduces the bug.
+    //
+    // Anything that de-duplicates notices by key must route through the shared helper.
+    const fs = await import('fs');
+    const path = await import('path');
+
+    const root = path.resolve(__dirname, '../../');
+    const offenders: string[] = [];
+
+    const walk = (dir: string) => {
+      for (const entry of fs.readdirSync(dir)) {
+        const full = path.join(dir, entry);
+        if (fs.statSync(full).isDirectory()) {
+          if (entry === 'tests' || entry === 'node_modules') continue;
+          walk(full);
+        } else if (entry.endsWith('.ts')) {
+          const src = fs.readFileSync(full, 'utf8');
+          // the signature of a keyed notice buffer: it compares BOTH topic and key on stored notices
+          const dedupes = /notice\.topic === topic && notice\.key === key/.test(src);
+          if (dedupes && !src.includes('preserveNoticeIdentity')) {
+            offenders.push(full.slice(root.length + 1));
+          }
+        }
+      }
+    };
+    walk(root);
+
+    expect({ offenders }).toEqual({ offenders: [] });
+  });
 });


### PR DESCRIPTION
**Supersedes #4656**, which corrected comments describing a state this PR removes. CA flagged the underlying finding as a design issue; investigating it confirmed that, and the fix turned out to be one place rather than a long tail of emitters.

## The flaw

Keyed notices coalesce — a later notice with the same topic+key replaces the earlier one, so a subscriber sees one notice per entity per mutation. **That is intentional. Replacing wholesale was not.**

Traced emission sequence for a single generated draw (`MODIFY_DRAW_DEFINITION`, key = `drawId`):

```
  1-12   eventId=NO
 13-20   eventId=YES  tournamentId=YES     ← full identity, 8 consecutive
    21   eventId=NO   tournamentId=NO      ← delivered
```

The **only unroutable emission in the batch was the one delivered**. Identity the system fully knew was destroyed by the transport — not by a caller omitting it, which is what I had wrongly concluded twice from reading call sites.

## Why this is more than a generation-phase nuisance

**`MODIFY_MATCHUP` is keyed on `matchUpId`.** So the identity fixes in #4647 / #4649 / #4651 are correct today *only because the last emitter happens to carry identity*. Any emission appended later in that chain would have silently undone all three — the runtime guard would have caught it, but the fragility was structural.

26 `addNotice` call sites use a key, so this is a general mechanism, not a corner.

## The fix

`addNotice` carries identity fields across a supersede.

**Why it is sound:** for a given topic+key, identity is **invariant** — a matchUp does not change which structure, draw or event it belongs to; a draw does not migrate between events. Filling a field the newer payload left `undefined` can only restore the value it would have carried; a conflicting value cannot exist.

Direction is asserted, not assumed: an explicit value is **never** overwritten, and keys never bleed into one another.

## Two things fell out

- **`NoticeIdentity` under-declared the wire format.** `modifyMatchUpNotice` has emitted `originOrganisationId` / `originTournamentId` / `originEventId` / `originDrawId` since 6.27.0 while the interface listed only four fields. Found by a new drift guard on its first run, not by inspection.
- **The generation-phase ledger shrank to `ADD_DRAW_DEFINITION` alone** — the exact-match property doing its job: fixing a gap fails the assertion and forces the ledger to stay true. That is the property I claimed earlier and could not demonstrate; here it is demonstrated.

`ADD_DRAW_DEFINITION` remains, legitimately: it is emitted while the draw is still being built and genuinely not yet attached to an event.

## What this does NOT do

It does not make every emitter carry identity. It makes the transport stop discarding identity that *any* emitter for that key supplied — defence in depth, the same shape as the CFS fail-safe in #907, and it closed the `MODIFY_DRAW_DEFINITION` gap without touching a single emitter.

## Follow-up

CFS **duplicates** this de-dup logic in `asyncGlobalState.ts` (its own provider). The same fix is needed there or the server path keeps the old behaviour. Tracking separately — it needs a factory release first.

## Verification

- `tsc --noEmit` clean · `eslint --max-warnings 0` clean · prettier clean
- `verify:generated` — engine-methods 666 OK, method-signatures up to date
- full suite — **11052 passed**, 1 skipped, 0 failed
- falsified: reverting `preserveIdentity` fails 2 tests, including the end-to-end one