### PR TITLE
feat(forge): tag dryRun dev-log lines and surface their cost

### DIFF
--- a/src/assemblies/engines/parts/executeMethod.ts
+++ b/src/assemblies/engines/parts/executeMethod.ts
@@ -19,6 +19,9 @@ export function executeFunction(
   params: { [key: string]: any } | undefined,
   methodName: string,
   engineType: string,
+  // `dryRun` only tags the dev log — it does not change dispatch. The caller
+  // that sets it (`forge/dryRun`) owns snapshotting and restoring the state.
+  options?: { dryRun?: boolean },
 ) {
   delete engine.success;
   delete engine.error;
@@ -51,7 +54,7 @@ export function executeFunction(
     method,
   });
   const elapsed = Date.now() - start;
-  engineLogging({ result, methodName, elapsed, params: paramsToLog, engineType });
+  engineLogging({ result, methodName, elapsed, params: paramsToLog, engineType, dryRun: options?.dryRun });
 
   return result;
 }

--- a/src/forge/dryRun.ts
+++ b/src/forge/dryRun.ts
@@ -4,7 +4,7 @@
  *
  * Same machinery as the real `executionQueue` (per-tournament snapshot via
  * `makeDeepCopy`, sequential method dispatch via `executeFunction`) but
- * with two contract differences:
+ * with three contract differences:
  *
  *   1. **State is always restored** at the end — both on success and on
  *      error. Callers never see persisted side effects.
@@ -13,6 +13,13 @@
  *      the buffer so the next real call starts clean. A consumer that
  *      wants to know "what would have fired" inspects the returned
  *      `willEmitNotices` array.
+ *   3. **Dev-log lines are tagged `dryRun: true`.** Dispatch goes through
+ *      the same `executeFunction` as a real mutation, so without the tag a
+ *      pre-flight and the commit that follows it print identical lines and
+ *      read as the mutation having fired twice. A single summary line —
+ *      `{ dryRun, methods, elapsed, overhead, execute, patchOps }` — is
+ *      emitted under `devContext` so the deep copies, patch walk and
+ *      restore this costs are visible rather than hidden in the caller.
  *
  * Returns the RFC 6902 JSON patch between the pre-state and the would-be
  * post-state, plus the per-method results and what topics/payloads the
@@ -35,7 +42,15 @@
  * (50+ events, full draws) it's 50–200 ms. Safe for dev/preflight callers,
  * not for hot paths — for hot-path gating use `explain` instead.
  */
-import { deleteNotices, getMethods, getNotices, getTopics, getTournamentRecords } from '@Global/state/globalState';
+import {
+  deleteNotices,
+  getDevContext,
+  getMethods,
+  getNotices,
+  getTopics,
+  getTournamentRecords,
+  globalLog,
+} from '@Global/state/globalState';
 import { executeFunction } from '@Assemblies/engines/parts/executeMethod';
 import { setState } from '@Assemblies/engines/parts/stateMethods';
 import { generatePatch, JsonPatch } from './jsonPatch';
@@ -80,7 +95,10 @@ export function dryRun(engine: FactoryEngine, directives: Directives): DryRunRes
 
   // Snapshot BEFORE any method runs. Independent deep copies so we can
   // diff `snapshot` against the post-state without aliasing surprises.
+  const snapshotStart = Date.now();
   const snapshot = makeDeepCopy(getTournamentRecords(), false, true);
+  const snapshotElapsed = Date.now() - snapshotStart;
+  const executeStart = Date.now();
 
   const results: any[] = [];
   let error: any = undefined;
@@ -111,7 +129,7 @@ export function dryRun(engine: FactoryEngine, directives: Directives): DryRunRes
       }
     }
 
-    const result = executeFunction(engine, methods[methodName], params, methodName, 'sync');
+    const result = executeFunction(engine, methods[methodName], params, methodName, 'sync', { dryRun: true });
     results.push({ ...result, methodName });
 
     if (result?.error) {
@@ -120,11 +138,15 @@ export function dryRun(engine: FactoryEngine, directives: Directives): DryRunRes
     }
   }
 
+  const executeElapsed = Date.now() - executeStart;
+
   // Capture the would-be post-state BEFORE restoring; diff snapshot vs. it.
   // The post-snapshot must also be a deep copy so the cached `tournamentRecords`
   // reference isn't shared with `snapshot` once we call `setState(snapshot)`.
+  const diffStart = Date.now();
   const postState = makeDeepCopy(getTournamentRecords(), false, true);
   const patch = generatePatch(snapshot, postState);
+  const diffElapsed = Date.now() - diffStart;
 
   // Drain the notices buffer the methods accumulated. Capture per-topic
   // payloads first, then `deleteNotices()` so the next real call starts
@@ -139,7 +161,28 @@ export function dryRun(engine: FactoryEngine, directives: Directives): DryRunRes
   deleteNotices();
 
   // Restore the snapshot. Always — dryRun's contract is "never persist".
+  const restoreStart = Date.now();
   setState(snapshot);
+  const restoreElapsed = Date.now() - restoreStart;
+
+  // Cost summary. The per-method lines carry `dryRun: true` but only account
+  // for the method's own execution — the deep copies, the patch walk and the
+  // restore are dryRun's overhead and are invisible without this. Making the
+  // price legible is the point: a caller gating a UI action on `explain` pays
+  // it on every click, and 5ms on a small state is 200ms on a large one.
+  if (typeof getDevContext() === 'object') {
+    globalLog(
+      {
+        dryRun: true,
+        methods: results.length,
+        elapsed: snapshotElapsed + executeElapsed + diffElapsed + restoreElapsed,
+        overhead: { snapshot: snapshotElapsed, diff: diffElapsed, restore: restoreElapsed },
+        execute: executeElapsed,
+        patchOps: patch.length,
+      },
+      'sync',
+    );
+  }
 
   return {
     wouldSucceed: !error,

--- a/src/global/state/engineLogging.ts
+++ b/src/global/state/engineLogging.ts
@@ -9,13 +9,19 @@ type EngineLoggingArgs = {
   engineType: string;
   methodName: string;
   elapsed: number;
+  /** True when the call came from `dryRun`/`explain` — the method ran against a
+   *  snapshot and nothing was committed. Without the tag a pre-flight and the
+   *  real mutation that follows it are indistinguishable in the dev log, which
+   *  reads as the mutation having fired twice. */
+  dryRun?: boolean;
 };
 
-export function engineLogging({ engineType, methodName, elapsed, params, result }: EngineLoggingArgs) {
+export function engineLogging({ engineType, methodName, elapsed, params, result, dryRun }: EngineLoggingArgs) {
   const devContext: DevContextType = getDevContext();
   if (typeof devContext !== 'object') return;
 
   const log: any = { method: methodName };
+  if (dryRun) log.dryRun = true;
   const logError =
     result?.error &&
     (devContext.errors === true || (Array.isArray(devContext.errors) && devContext.errors.includes(methodName)));
@@ -50,5 +56,8 @@ export function engineLogging({ engineType, methodName, elapsed, params, result 
     log.result = result;
   }
 
-  if (Object.keys(log).length > 1) globalLog(log, engineType);
+  // `method` and `dryRun` are labels, not content — neither on its own is a
+  // reason to emit a line. Only elapsed/params/result make a log worth printing.
+  const hasContent = Object.keys(log).some((key) => key !== 'method' && key !== 'dryRun');
+  if (hasContent) globalLog(log, engineType);
 }

--- a/src/tests/forge/dryRunLogging.test.ts
+++ b/src/tests/forge/dryRunLogging.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { setGlobalLog } from '@Global/state/globalState';
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+
+/**
+ * `dryRun`/`explain` dispatch through the same `executeFunction` path as a real
+ * mutation, so under `devContext` a pre-flight and the commit that follows it
+ * printed two identical lines — indistinguishable, and read by callers as the
+ * mutation having fired twice. The pre-flight lines now carry `dryRun: true`,
+ * and `dryRun` emits one summary line so its own overhead (deep copy, patch
+ * walk, restore) is visible rather than hidden inside the caller's click.
+ */
+
+const SET_TOURNAMENT_DATES = 'setTournamentDates';
+
+type Captured = { log: any; engine?: string };
+
+function captureLogs(): { captured: Captured[] } {
+  const captured: Captured[] = [];
+  setGlobalLog(({ log, engine }: Captured) => captured.push({ log, engine }));
+  return { captured };
+}
+
+afterEach(() => {
+  setGlobalLog();
+  tournamentEngine.devContext(false);
+  tournamentEngine.reset();
+});
+
+describe('dryRun dev logging', () => {
+  it('tags pre-flight method lines with dryRun and leaves the real call untagged', () => {
+    mocksEngine.generateTournamentRecord({
+      nonRandom: 1,
+      setState: true,
+      startDate: '2026-08-01',
+      endDate: '2026-08-05',
+    });
+
+    tournamentEngine.devContext({ params: true, result: true });
+    const { captured } = captureLogs();
+
+    tournamentEngine.explain(SET_TOURNAMENT_DATES, { startDate: '2026-08-02', endDate: '2026-08-06' });
+
+    const preflight = captured.filter((c) => c.log?.method === SET_TOURNAMENT_DATES);
+    expect(preflight).toHaveLength(1);
+    expect(preflight[0].log.dryRun).toEqual(true);
+
+    captured.length = 0;
+    tournamentEngine.setTournamentDates({ startDate: '2026-08-02', endDate: '2026-08-06' });
+
+    const committed = captured.filter((c) => c.log?.method === SET_TOURNAMENT_DATES);
+    expect(committed).toHaveLength(1);
+    // The real mutation must NOT be tagged — otherwise the tag distinguishes
+    // nothing, which is the bug this guards.
+    expect(committed[0].log.dryRun).toBeUndefined();
+  });
+
+  it('emits a cost summary carrying the overhead dryRun adds on top of execution', () => {
+    mocksEngine.generateTournamentRecord({
+      nonRandom: 1,
+      setState: true,
+      startDate: '2026-08-01',
+      endDate: '2026-08-05',
+    });
+
+    tournamentEngine.devContext({ params: true, result: true });
+    const { captured } = captureLogs();
+
+    tournamentEngine.explain(SET_TOURNAMENT_DATES, { startDate: '2026-08-02', endDate: '2026-08-06' });
+
+    const summary = captured.find((c) => c.log?.dryRun === true && c.log?.method === undefined);
+    expect(summary).toBeDefined();
+    expect(summary?.log.methods).toEqual(1);
+    expect(summary?.log.overhead).toEqual(
+      expect.objectContaining({
+        snapshot: expect.any(Number),
+        restore: expect.any(Number),
+        diff: expect.any(Number),
+      }),
+    );
+    expect(typeof summary?.log.elapsed).toEqual('number');
+    // A date change that shifts start + end must show up as patch operations —
+    // a zero here would mean the summary is reporting on a run that did nothing.
+    expect(summary?.log.patchOps).toBeGreaterThan(0);
+  });
+
+  it('logs nothing at all when devContext is off', () => {
+    mocksEngine.generateTournamentRecord({
+      nonRandom: 1,
+      setState: true,
+      startDate: '2026-08-01',
+      endDate: '2026-08-05',
+    });
+
+    tournamentEngine.devContext(false);
+    const { captured } = captureLogs();
+
+    tournamentEngine.explain(SET_TOURNAMENT_DATES, { startDate: '2026-08-02', endDate: '2026-08-06' });
+
+    expect(captured).toEqual([]);
+  });
+});


### PR DESCRIPTION
A pre-flight and the mutation that follows it printed two identical `sync {method: …}` lines under `devContext`, which reads from a console as the mutation having fired twice. Reported from a TMX session watching `setTournamentDates`.

`dryRun`/`explain` dispatch through the same `executeFunction` as a real mutation, hence the identical lines. Nothing was actually firing twice.

## What changed

- pre-flight lines carry `dryRun: true`; the real mutation stays untagged
- `executeMethod` takes an optional `options?: { dryRun?: boolean }` — log-only, dispatch unchanged
- `dryRun` emits one summary line so its own overhead is legible instead of hidden inside the caller's click:
  `{ dryRun, methods, elapsed, overhead: { snapshot, diff, restore }, execute, patchOps }`
- `method` and `dryRun` are labels, not content — neither on its own causes a line to print that would not have printed before

The cost matters because `explain` is documented as the hot-path option but v1 is built on `dryRun`, so a UI gating an action on it pays a full `makeDeepCopy` plus a JSON-patch diff on every click. TMX's Edit Dates modal is the only `explain` call site in the ecosystem today.

## Verification

`src/tests/forge/dryRunLogging.test.ts` — 3 tests, each falsified individually: removing the tag fails only the tag test, removing the summary fails only the summary test.

Local on the rebased tree: `tsc --noEmit` 0 · `eslint src --max-warnings 0` 0 · full vitest **11,057 passed / 1 skipped**.