### PR TITLE
feat(venues): add discipline to Court

### DIFF
--- a/src/assemblies/generators/templates/courtTemplate.ts
+++ b/src/assemblies/generators/templates/courtTemplate.ts
@@ -1,8 +1,12 @@
+// NOTE: this template doubles as the ATTRIBUTE WHITELIST — `modifyCourt` derives
+// `validAttributes` from `Object.keys(courtTemplate())`, so an attribute missing here is
+// silently dropped from a modification rather than rejected. Any new Court field belongs here.
 export const courtTemplate = () => ({
   altitude: undefined,
   courtId: undefined,
   courtName: '',
   courtDimensions: undefined,
+  discipline: undefined,
   latitude: undefined,
   longitude: undefined,
   surfaceCategory: undefined,

--- a/src/global/schema/tournament.schema.json
+++ b/src/global/schema/tournament.schema.json
@@ -3410,6 +3410,7 @@
       "type": "object",
       "properties": {
         "disabled": { "type": "boolean" },
+        "discipline": { "$ref": "#/definitions/DisciplineEnum" },
         "createdAt": {
           "type": ["string", "object"],
           "format": "date-time"

--- a/src/tests/mutations/venues/courtDiscipline.test.ts
+++ b/src/tests/mutations/venues/courtDiscipline.test.ts
@@ -1,0 +1,99 @@
+import tournamentEngine from '@Engines/syncEngine';
+import { expect, it } from 'vitest';
+
+// constants
+import { PICKLEBALL, TENNIS } from '@Constants/disciplineConstants';
+import { NO_VALID_ATTRIBUTES } from '@Constants/errorConditionConstants';
+
+/**
+ * `Court.discipline` — which sport a court IS.
+ *
+ * Added so a dedicated pickleball court is distinguishable from a tennis court by DATA rather
+ * than by a naming convention. The facility registry's court load would otherwise have to encode
+ * it in the court name ("Pickleball 1"), which is unqueryable and lost on a rename.
+ *
+ * The `modifyCourt` case is the one that matters. `modifyCourt` derives its whitelist from
+ * `Object.keys(courtTemplate())`, and an attribute missing from that template is **silently
+ * dropped** rather than rejected — so a type-and-schema-only change would type-check, pass a
+ * round-trip test through `addCourt`, and still lose the value on every modification. Deleting
+ * `discipline: undefined` from courtTemplate must redden "modifyCourt persists discipline".
+ */
+
+function setupVenueWithCourt(court: any = { courtName: 'Court 1' }) {
+  tournamentEngine.reset();
+  let result: any = tournamentEngine.newTournamentRecord({
+    startDate: '2024-01-01',
+    endDate: '2024-01-07',
+  });
+  expect(result.success).toEqual(true);
+
+  result = tournamentEngine.addVenue({ venue: { venueName: 'Test Venue' } });
+  expect(result.success).toEqual(true);
+  const venueId = result.venue.venueId;
+
+  result = tournamentEngine.addCourt({ venueId, court });
+  expect(result.success).toEqual(true);
+
+  return { venueId, courtId: result.court.courtId };
+}
+
+function findCourt(venueId: string, courtId: string) {
+  const { venue } = tournamentEngine.findVenue({ venueId });
+  return venue.courts.find((c: any) => c.courtId === courtId);
+}
+
+it('addCourt persists discipline', () => {
+  const { venueId, courtId } = setupVenueWithCourt({ courtName: 'Pickleball 1', discipline: PICKLEBALL });
+
+  expect(findCourt(venueId, courtId).discipline).toEqual(PICKLEBALL);
+});
+
+it('modifyCourt persists discipline', () => {
+  const { venueId, courtId } = setupVenueWithCourt();
+
+  // Absent, not defaulted: a court nobody has declared a discipline for is not evidence that it
+  // is a tennis court.
+  expect(findCourt(venueId, courtId).discipline).toBeUndefined();
+
+  const result: any = tournamentEngine.modifyCourt({ courtId, modifications: { discipline: TENNIS } });
+  expect(result.success).toEqual(true);
+  expect(findCourt(venueId, courtId).discipline).toEqual(TENNIS);
+
+  // And it can be corrected, not merely set once.
+  tournamentEngine.modifyCourt({ courtId, modifications: { discipline: PICKLEBALL } });
+  expect(findCourt(venueId, courtId).discipline).toEqual(PICKLEBALL);
+});
+
+it('accepts a discipline outside the known vocabulary', () => {
+  // The vocabulary is deliberately OPEN (DISCIPLINE_EXTENSIBILITY.md) — a new sport must not need
+  // a factory release. This guards the openness, which an enum-shaped schema change would break.
+  const { venueId, courtId } = setupVenueWithCourt({ courtName: 'Court 1', discipline: 'SQUASH' });
+
+  expect(findCourt(venueId, courtId).discipline).toEqual('SQUASH');
+});
+
+it('does not treat discipline as the only modifiable attribute', () => {
+  // Guards against a whitelist edit that adds `discipline` by REPLACING the template rather than
+  // extending it — the other attributes must still be modifiable.
+  const { venueId, courtId } = setupVenueWithCourt();
+
+  const result: any = tournamentEngine.modifyCourt({
+    courtId,
+    modifications: { discipline: PICKLEBALL, courtName: 'Pickleball 1' },
+  });
+  expect(result.success).toEqual(true);
+
+  const court = findCourt(venueId, courtId);
+  expect(court.discipline).toEqual(PICKLEBALL);
+  expect(court.courtName).toEqual('Pickleball 1');
+});
+
+it('rejects a modification containing no valid attributes', () => {
+  // Falsifies the "everything is now valid" reading of the whitelist change: an unknown
+  // attribute must still be refused, so `discipline` was added to the whitelist rather than the
+  // whitelist being bypassed.
+  const { courtId } = setupVenueWithCourt();
+
+  const result: any = tournamentEngine.modifyCourt({ courtId, modifications: { notACourtAttribute: true } });
+  expect(result.error).toEqual(NO_VALID_ATTRIBUTES);
+});

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -1949,6 +1949,21 @@ export interface Court {
   dateAvailability?: Availability[];
   // CODES first-class: previously stored as `disabled` extension
   disabled?: boolean | { dates?: string[] };
+  /**
+   * The sport this court is for. Absent means unspecified, NOT tennis — a court nobody has
+   * declared a discipline for is not evidence that it is a tennis court, and defaulting it
+   * would invent data.
+   *
+   * A physical surface can serve more than one sport (a tennis court with pickleball lines, or a
+   * portable net dropped on it). That is a court CAPABILITY and is deliberately NOT modelled
+   * here: this field says what the court IS, so a dedicated pickleball court is distinguishable
+   * from a tennis court. Do not repurpose it to mean "can also host" — that turns one physical
+   * slab into two schedulable courts.
+   *
+   * Open vocabulary, like `Event.discipline`: normalize with `normalizeDiscipline` and constrain
+   * with the `allowedDisciplines` policy where a fixed list is required.
+   */
+  discipline?: DisciplineUnion;
   extensions?: Extension[];
   floodlit?: boolean;
   indoorOutdoor?: IndoorOutdoorUnion;


### PR DESCRIPTION
A `Court` has no way to say which sport it is for. `discipline` exists on `Event` — open vocabulary, already including `PICKLEBALL` — but not on `Court`, so the facility registry's court load has to encode it in the court **name** (`Pickleball 1`): unqueryable, and lost the moment anyone renames the court.

CODES is a superset of TODS, so this is a canonical field on the type and the schema rather than an extension. `{ "$ref": "#/definitions/DisciplineEnum" }` is `type: string` with examples, so the vocabulary stays open and a new sport still needs no factory release.

## Two deliberate semantics

**Absent means unspecified, not tennis.** A court nobody has declared a discipline for is not evidence that it is a tennis court; defaulting would invent data.

**It says what the court IS, not what it can host.** A physical surface can serve more than one sport (pickleball lines on a tennis court, a portable net dropped on it). That is a *capability* and is deliberately not modelled here — modelling "can also host" on this field turns one slab into two schedulable courts, which is precisely the double-booking error the ALTA court load exists to avoid. Documented on the field so it does not get repurposed later.

## `courtTemplate` is the part worth reviewing

`modifyCourt` derives its whitelist from `Object.keys(courtTemplate())`, so an attribute missing there is **silently dropped** from a modification rather than rejected. A type-and-schema-only change would type-check, pass a round-trip through `addCourt`, and still lose the value on every edit. Added, with a note on the template explaining why any new `Court` field belongs there.

## Falsified, not assumed

Deleting `discipline: undefined` from the template reddens **4 of the 5** new tests — both the add and modify paths. The 5th (unknown attributes still rejected with `NO_VALID_ATTRIBUTES`) stays green, which is what demonstrates the whitelist was *extended* rather than bypassed. Also covered: a discipline outside the known vocabulary round-trips, and `discipline` is not the only modifiable attribute.

## Verification

Full suite **11,059 passed / 1 skipped**, `lint` 0, `tsc --noEmit` 0, `verify:generated` OK (666 methods, signatures up to date), `attr-audit` 0, prettier clean. Baseline before the change was identical.

## Follow-on

Downstream, after this publishes: `facility_courts.discipline` in courthive-facilities, `toTodsCourt` passthrough, and the court resolve input. Plan: `Mentat/planning/FACILITY_COURTS_SYNTHESIS.md` (D2).