### PR TITLE
fix(verify): audit every lockfile, not just the package's

### DIFF
--- a/scripts/verify/README.md
+++ b/scripts/verify/README.md
@@ -6,19 +6,19 @@ A 12th check, `verify:ecosystem`, runs downstream consumer tests against the in-
 
 ## What each check catches
 
-| Step                 | Catches                                                                                                                                                                   | Cost   |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
-| `verify:types`       | type errors anywhere in `src`                                                                                                                                             | ~3 s   |
-| `verify:lint`        | style + cognitive-complexity violations; zero-warnings rule                                                                                                               | ~5 s   |
-| `verify:coverage`    | regressions below `95/95/85/95` statements/functions/branches/lines                                                                                                       | ~100 s |
-| `verify:server`      | NestJS-style server tests (`pnpm test:server` alias for `jest`)                                                                                                           | ~12 s  |
-| `verify:audit`       | high or critical `pnpm audit` advisories                                                                                                                                  | ~5 s   |
-| `verify:build`       | the full prod build produces `dist/` (run after the above so a tiny lint/type fix re-runs the cheap stuff first)                                                          | ~13 s  |
-| `verify:publint`     | `publint --strict --level warning` — package.json `exports` correctness, per-format type declarations, `sideEffects` / `type` hints, tarball contents match `files` field | ~6 s   |
-| `verify:runtime`     | "compiles but doesn't run" — CJS + ESM smoke against the built dist                                                                                                       | ~3 s   |
-| `verify:bundle-size` | a file in `dist/` grew beyond +10 % vs baseline                                                                                                                           | ~1 s   |
-| `verify:surface`     | a public export was removed (breaking) or signature drifted                                                                                                               | ~1 s   |
-| `verify:pack`        | the published `.d.ts` references an internal path that didn't get packed; runtime `require()` smoke after `npm install` of the tarball                                    | ~30 s  |
+| Step                 | Catches                                                                                                                                                                           | Cost   |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `verify:types`       | type errors anywhere in `src`                                                                                                                                                     | ~3 s   |
+| `verify:lint`        | style + cognitive-complexity violations; zero-warnings rule                                                                                                                       | ~5 s   |
+| `verify:coverage`    | regressions below `95/95/85/95` statements/functions/branches/lines                                                                                                               | ~100 s |
+| `verify:server`      | NestJS-style server tests (`pnpm test:server` alias for `jest`)                                                                                                                   | ~12 s  |
+| `verify:audit`       | high or critical `pnpm audit` advisories in **every** lockfile (package + `documentation/`), minus entries in `audit-waivers.json`; a waiver matching no open advisory also fails | ~10 s  |
+| `verify:build`       | the full prod build produces `dist/` (run after the above so a tiny lint/type fix re-runs the cheap stuff first)                                                                  | ~13 s  |
+| `verify:publint`     | `publint --strict --level warning` — package.json `exports` correctness, per-format type declarations, `sideEffects` / `type` hints, tarball contents match `files` field         | ~6 s   |
+| `verify:runtime`     | "compiles but doesn't run" — CJS + ESM smoke against the built dist                                                                                                               | ~3 s   |
+| `verify:bundle-size` | a file in `dist/` grew beyond +10 % vs baseline                                                                                                                                   | ~1 s   |
+| `verify:surface`     | a public export was removed (breaking) or signature drifted                                                                                                                       | ~1 s   |
+| `verify:pack`        | the published `.d.ts` references an internal path that didn't get packed; runtime `require()` smoke after `npm install` of the tarball                                            | ~30 s  |
 
 Total: ~3 minutes warm. The chain is ordered so cheap fail-fast checks run first.
 

--- a/scripts/verify/audit-waivers.json
+++ b/scripts/verify/audit-waivers.json
@@ -1,0 +1,30 @@
+{
+  "$comment": [
+    "Advisories verify:audit will not fail on. Every waiver is printed on every run,",
+    "so a waived advisory stays visible rather than becoming a silent exception.",
+    "A waiver that no longer matches an open advisory is a FAILURE, not a no-op —",
+    "stale waivers must be deleted, otherwise the list only ever grows and quietly",
+    "widens what the gate ignores.",
+    "",
+    "Waive only when there is no action available. 'We will get to it' is not a",
+    "waiver; a version bump is."
+  ],
+  "waivers": [
+    {
+      "ghsa": "GHSA-w3rx-r6r6-pgpr",
+      "module": "image-size",
+      "tree": "documentation",
+      "reason": "Transitive via @docusaurus/mdx-loader; build-time image parsing for the docs site only. Not in the package lockfile (package.json ships files:[dist]), so it cannot reach a consumer of tods-competition-factory.",
+      "noFixAvailable": "The advisory names patched_versions >=2.0.3, but image-size has never published 2.0.3 — npm latest is 2.0.2, the vulnerable version. There is nothing to bump to.",
+      "recheck": "Drop this waiver as soon as image-size publishes a release above 2.0.2, or Docusaurus stops depending on it."
+    },
+    {
+      "ghsa": "GHSA-5p2g-fcmc-qvqq",
+      "module": "image-size",
+      "tree": "documentation",
+      "reason": "Same package, same path, same reasoning as GHSA-w3rx-r6r6-pgpr.",
+      "noFixAvailable": "The advisory names patched_versions >=2.0.3, but image-size has never published 2.0.3 — npm latest is 2.0.2, the vulnerable version. There is nothing to bump to.",
+      "recheck": "Drop this waiver as soon as image-size publishes a release above 2.0.2, or Docusaurus stops depending on it."
+    }
+  ]
+}

--- a/scripts/verify/audit.mjs
+++ b/scripts/verify/audit.mjs
@@ -5,51 +5,127 @@
  * Factory has zero runtime deps, so this is almost entirely about dev-tree
  * awareness. We only fail on `high` or `critical` advisories; moderate/low
  * are surfaced for visibility but don't gate publish.
+ *
+ * SCOPE — audits every lockfile in the repo, not just the package's.
+ * `documentation/` carries its own lockfile and is not a pnpm workspace member,
+ * so an audit run only at FACTORY_ROOT never saw it. That reported "no
+ * high/critical advisories" for the repo while two high advisories sat open in
+ * the docs tree — a check whose scope silently excluded where the finding was,
+ * which is worse than no check because it settles the question.
+ *
+ * WAIVERS — `audit-waivers.json` lists advisories this gate will not fail on.
+ * The alternative was leaving `documentation/` unaudited, which is the bug this
+ * fixes, or a permanently-red gate that every PR has to be merged around, which
+ * trains people to ignore it. Every waiver is printed on every run, and a waiver
+ * that no longer matches an open advisory FAILS — so the list cannot quietly
+ * accumulate exceptions after the advisories behind them are resolved.
  */
 import { execSync } from 'node:child_process';
-import { dirname, resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FACTORY_ROOT = resolve(__dirname, '../..');
+const WAIVERS_PATH = join(__dirname, 'audit-waivers.json');
+
+/** Every tree with its own lockfile. `name` is what a waiver's `tree` matches. */
+const TREES = [
+  { name: 'package', cwd: FACTORY_ROOT },
+  { name: 'documentation', cwd: join(FACTORY_ROOT, 'documentation') },
+];
+
+const BLOCKING = new Set(['high', 'critical']);
 
 function log(msg) {
   process.stdout.write(`[verify:audit] ${msg}\n`);
 }
 
-let json;
-try {
-  json = execSync('pnpm audit --json', { cwd: FACTORY_ROOT, encoding: 'utf8' });
-} catch (err) {
-  // pnpm audit exits non-zero when ANY advisory is found; the JSON is still
-  // on stdout for parsing.
-  json = err.stdout || '';
-  if (!json) {
-    process.stderr.write(`[verify:audit] could not parse pnpm audit output: ${err.message}\n`);
-    process.exit(1);
+function fail(msg) {
+  process.stderr.write(`[verify:audit] ${msg}\n`);
+  process.exit(1);
+}
+
+/** Run `pnpm audit --json` in one tree and return its parsed report. */
+function auditTree(cwd) {
+  let json;
+  try {
+    json = execSync('pnpm audit --json', { cwd, encoding: 'utf8' });
+  } catch (err) {
+    // pnpm audit exits non-zero when ANY advisory is found; the JSON is still
+    // on stdout for parsing.
+    json = err.stdout || '';
+    if (!json) fail(`could not run pnpm audit in ${cwd}: ${err.message}`);
+  }
+  try {
+    return JSON.parse(json);
+  } catch {
+    return fail(`pnpm audit produced non-JSON output in ${cwd}:\n${json}`);
   }
 }
 
-let report;
-try {
-  report = JSON.parse(json);
-} catch (err) {
-  process.stderr.write(`[verify:audit] pnpm audit produced non-JSON output:\n${json}\n`);
-  process.exit(1);
+const waiverFile = existsSync(WAIVERS_PATH) ? JSON.parse(readFileSync(WAIVERS_PATH, 'utf8')) : { waivers: [] };
+const waivers = waiverFile.waivers ?? [];
+const matchedWaivers = new Set();
+
+const blocking = [];
+const waived = [];
+const counts = { critical: 0, high: 0, moderate: 0, low: 0, info: 0 };
+
+for (const tree of TREES) {
+  if (!existsSync(join(tree.cwd, 'pnpm-lock.yaml'))) {
+    log(`skipping ${tree.name} — no pnpm-lock.yaml`);
+    continue;
+  }
+
+  const report = auditTree(tree.cwd);
+  const meta = report.metadata?.vulnerabilities ?? {};
+  for (const key of Object.keys(counts)) counts[key] += meta[key] ?? 0;
+
+  for (const advisory of Object.values(report.advisories ?? {})) {
+    if (!BLOCKING.has(advisory.severity)) continue;
+
+    const ghsa = advisory.github_advisory_id;
+    const waiver = waivers.find((w) => w.ghsa === ghsa && w.module === advisory.module_name && w.tree === tree.name);
+
+    const entry = { tree: tree.name, ghsa, module: advisory.module_name, title: advisory.title, url: advisory.url };
+    if (waiver) {
+      matchedWaivers.add(waiver.ghsa);
+      waived.push({ ...entry, reason: waiver.reason });
+    } else {
+      blocking.push(entry);
+    }
+  }
 }
 
-const meta = report.metadata?.vulnerabilities ?? {};
-const high = (meta.high ?? 0) + (meta.critical ?? 0);
-const moderate = meta.moderate ?? 0;
-const low = meta.low ?? 0;
-const info = meta.info ?? 0;
+log(
+  `advisories across ${TREES.map((t) => t.name).join(' + ')} — ` +
+    `critical: ${counts.critical}, high: ${counts.high}, moderate: ${counts.moderate}, ` +
+    `low: ${counts.low}, info: ${counts.info}`,
+);
 
-log(`advisories — critical+high: ${high}, moderate: ${moderate}, low: ${low}, info: ${info}`);
-
-if (high > 0) {
-  process.stderr.write(`[verify:audit] FAIL — ${high} high/critical advisory(ies).\n`);
-  process.stderr.write('Inspect with `pnpm audit` and resolve before publish.\n');
-  process.exit(1);
+// Print waived advisories every run. A waiver that stops being visible is a
+// waiver nobody revisits.
+for (const w of waived) {
+  log(`WAIVED ${w.ghsa} — ${w.module} (${w.tree}): ${w.title}`);
+  log(`        ${w.reason}`);
 }
 
-log('OK — no high/critical advisories');
+// A waiver matching nothing means the advisory was resolved (or the entry was
+// wrong). Either way it must go, or the list only ever widens what is ignored.
+const stale = waivers.filter((w) => !matchedWaivers.has(w.ghsa));
+if (stale.length) {
+  for (const w of stale) {
+    process.stderr.write(`[verify:audit] STALE WAIVER ${w.ghsa} (${w.module}, ${w.tree}) matches no open advisory.\n`);
+  }
+  fail(`FAIL — ${stale.length} stale waiver(s) in scripts/verify/audit-waivers.json. Delete them.`);
+}
+
+if (blocking.length) {
+  for (const b of blocking) {
+    process.stderr.write(`[verify:audit] ${b.ghsa} — ${b.module} (${b.tree}): ${b.title}\n${b.url}\n`);
+  }
+  fail(`FAIL — ${blocking.length} unwaived high/critical advisory(ies). Resolve before publish.`);
+}
+
+log(`OK — no unwaived high/critical advisories${waived.length ? ` (${waived.length} waived)` : ''}`);


### PR DESCRIPTION
`verify:audit` ran `pnpm audit` only at `FACTORY_ROOT`. `documentation/` carries its **own** lockfile and is not a pnpm workspace member (`workspaces: undefined`), so it was never audited.

The result: the step reported *"OK — no high/critical advisories"* for the repo while **two high advisories sat open** in the docs tree. A check whose scope silently excludes where the finding is, is worse than no check — it settles the question.

Surfaced by a push warning, not by CI.

## The advisories

| GHSA | package | issue |
|---|---|---|
| `GHSA-w3rx-r6r6-pgpr` | `image-size@2.0.2` | ICNS parser — DoS via infinite loop |
| `GHSA-5p2g-fcmc-qvqq` | `image-size@2.0.2` | JXL/HEIF parsers — DoS via infinite loops |

Transitive, one hop: `@docusaurus/mdx-loader@3.10.2` → `image-size`. Build-time image parsing for the docs site. **It cannot reach a consumer** — `package.json` ships `files: ["dist"]`, and `grep -c image-size pnpm-lock.yaml` is `0`.

**There is nothing to bump to.** Both advisories name `patched_versions: ">=2.0.3"`, but `image-size` has never published 2.0.3 — npm latest is **2.0.2**, the vulnerable version. GitHub's own alert data agrees: `first_patched_version: null`. Dependabot cannot open a bump PR.

## Why waivers rather than just widening the scope

Auditing both trees alone leaves the gate permanently red, and a red gate every PR must be merged around trains people to ignore it. So advisories can be waived explicitly in `audit-waivers.json`, with two properties that stop a waiver becoming a silent exception:

- **every waiver prints on every run** — a waiver that stops being visible is one nobody revisits
- **a waiver matching no open advisory FAILS** — so the list cannot accumulate entries after the advisories behind them are resolved

Each entry records why it is waived, that no fix exists, and what should trigger its removal.

## Falsified in three directions

| probe | result |
|---|---|
| remove a waiver | FAILS as unwaived (exit 1, names the GHSA) |
| add a bogus waiver | FAILS as stale (exit 1, names the entry to delete) |
| drop `documentation/` from the tree list | reports **0 high** — confirming the docs tree carries them and the old scope genuinely could not see them |

That third one matters most: it proves the *scope change* is what surfaces these, not something incidental.

## Cost

~5 s → ~10 s (one extra `pnpm audit`). README updated to state the scope, since a reader would otherwise reasonably conclude the whole repo was already audited.