### PR TITLE
feat(query): participantsVersion handshake on getEventData

### DIFF
--- a/src/query/event/getEventData.ts
+++ b/src/query/event/getEventData.ts
@@ -2,6 +2,7 @@ import { checkRequiredParameters } from '@Helpers/parameters/checkRequiredParame
 import { getEventPublishStatus } from '@Query/event/getEventPublishStatus';
 import { getDrawIsPublished } from '@Query/publishing/getDrawIsPublished';
 import { getTournamentInfo } from '@Query/tournaments/getTournamentInfo';
+import { participantsVersion as computeParticipantsVersion } from '@Query/participants/participantsVersion';
 import { getParticipants } from '@Query/participants/getParticipants';
 import { getPublishState } from '@Query/publishing/getPublishState';
 import { isVisiblyPublished } from '@Query/publishing/isEmbargoed';
@@ -38,6 +39,7 @@ type GetEventDataArgs = {
   pressureRating?: boolean;
   drawsProfile?: PayloadProfileUnion;
   participantFilters?: any;
+  participantsVersion?: string;
   contextProfile?: any;
   eventId?: string;
   status?: string;
@@ -46,6 +48,7 @@ type GetEventDataArgs = {
 
 export function getEventData(params: GetEventDataArgs): {
   participants?: HydratedParticipant[];
+  participantsVersion?: string;
   error?: ErrorType;
   success?: boolean;
   eventData?: any;
@@ -304,5 +307,18 @@ export function getEventData(params: GetEventDataArgs): {
   eventData.eventInfo.publishState = eventPublishState;
   eventData.eventInfo.published = eventPublishState?.status?.published;
 
-  return { ...SUCCESS, eventData, participants: tournamentParticipants };
+  // ADDITIVE: the stamp always rides the response; omission happens only when the caller PROVES it
+  // already holds this exact set. `participantsVersion` absent from params → unchanged behaviour,
+  // which is the ClubSpark constraint (their deployed pattern must not move).
+  const version = computeParticipantsVersion(tournamentParticipants);
+  const clientHoldsCurrentSet = !!params.participantsVersion && params.participantsVersion === version;
+
+  return {
+    ...SUCCESS,
+    eventData,
+    // A mismatch or absence sends participants, exactly as today. Only an EXACT match omits them, so
+    // the failure direction is "sent bytes that were not needed" rather than a blank bracket.
+    participants: clientHoldsCurrentSet ? undefined : tournamentParticipants,
+    participantsVersion: version,
+  };
 }

--- a/src/query/participants/participantsVersion.ts
+++ b/src/query/participants/participantsVersion.ts
@@ -1,0 +1,59 @@
+/**
+ * A version stamp for a participant set, used by the payload-decomposition handshake.
+ *
+ * WHY A HANDSHAKE AND NOT A CLIENT ASSERTION. A client saying "I already have these participants" is
+ * a claim the server cannot check, and when it is wrong the failure is SILENT — every bracket side
+ * renders TBD. That is not hypothetical: it is the documented reason competition-factory-server
+ * invalidates its cache rather than seeding it. With a version stamp the client PROVES what it holds;
+ * a mismatch simply sends bytes that were not needed. Loud and self-correcting beats silent.
+ *
+ * WHY A HAND-ROLLED HASH. The factory has no runtime dependencies and runs in browsers as well as
+ * Node, so `node:crypto` is unavailable. This is a cache-validity check, not a security primitive.
+ *
+ * COLLISION SAFETY MATTERS HERE, because a false MATCH is the dangerous direction — it would omit
+ * participants that actually differ, reproducing the silent-blank-bracket failure this design exists
+ * to prevent. So the stamp is deliberately over-specified: participant COUNT plus two independent
+ * 32-bit hashes with different primes. Two sets must collide on all three to be confused.
+ *
+ * A false MISMATCH is harmless — the server sends participants, exactly as it does today.
+ */
+
+/** FNV-1a, 32-bit, parameterised so two independent digests can be taken over the same input. */
+function fnv1a(input: string, offsetBasis: number, prime: number): number {
+  let hash = offsetBasis;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, prime);
+  }
+  // >>> 0 keeps it an unsigned 32-bit value; Math.imul can produce negatives
+  return hash >>> 0;
+}
+
+/**
+ * Canonical serialization: participants sorted by their serialized form so an ordering change in an
+ * upstream query does not present as a content change. Order-independence is the point — a false
+ * mismatch is safe but pointless, and it would make the handshake never fire.
+ */
+function canonicalize(participants: any[]): string {
+  return participants
+    .map((participant) => JSON.stringify(participant))
+    .sort()
+    .join(' ');
+}
+
+/**
+ * Stable stamp for a participant set. Same participants (in any order) produce the same stamp.
+ *
+ * Format: `p1-<count>-<hashA><hashB>`. The `p1` prefix names the scheme so it can change without a
+ * client mistaking an old stamp for a new one — a scheme change makes every stamp mismatch, which
+ * degrades to today's behaviour rather than to a wrong match.
+ */
+export function participantsVersion(participants?: any[]): string | undefined {
+  if (!Array.isArray(participants)) return undefined;
+
+  const canonical = canonicalize(participants);
+  const hashA = fnv1a(canonical, 0x811c9dc5, 0x01000193).toString(36);
+  const hashB = fnv1a(canonical, 0x9e3779b1, 0x85ebca77).toString(36);
+
+  return `p1-${participants.length}-${hashA}${hashB}`;
+}

--- a/src/tests/queries/participants/participantsVersion.test.ts
+++ b/src/tests/queries/participants/participantsVersion.test.ts
@@ -1,0 +1,165 @@
+import { participantsVersion } from '@Query/participants/participantsVersion';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { expect, it, describe } from 'vitest';
+
+// constants and types
+import { SINGLE_ELIMINATION } from '@Constants/drawDefinitionConstants';
+
+/**
+ * `participantsVersion` handshake — G2 / D2.
+ *
+ * Measured motivation: participants are 52%–78.6% of an event payload, the same 412 KB block is
+ * byte-identical across all five events of a slam-shaped tournament (5x duplication), and
+ * `getEventData` returns ALL tournament participants regardless of event — 86.4% of them irrelevant
+ * to the smallest event. See Mentat/planning/PUBLISH_WARMCACHE_AND_PAYLOAD_DECOMPOSITION.md.
+ *
+ * The handshake exists so a client can PROVE what it holds rather than ASSERT it. Assertion fails
+ * silently — every bracket side renders TBD.
+ */
+describe('participantsVersion', () => {
+  function loadTournament() {
+    return mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 16, drawType: SINGLE_ELIMINATION }],
+      participantsProfile: { nonRandom: 1 },
+      setState: true,
+    });
+  }
+
+  describe('the stamp itself', () => {
+    it('is stable across calls and independent of ordering', () => {
+      const participants = [{ participantId: 'a', participantName: 'A' }, { participantId: 'b' }];
+      const reversed = [...participants].reverse();
+
+      expect(participantsVersion(participants)).toEqual(participantsVersion(participants));
+      // ordering is not a content change; treating it as one would mean the handshake never fires
+      expect(participantsVersion(reversed)).toEqual(participantsVersion(participants));
+    });
+
+    it('changes when content changes, not merely when length does', () => {
+      const base = [{ participantId: 'a', participantName: 'A' }];
+      const renamed = [{ participantId: 'a', participantName: 'CHANGED' }];
+      const added = [...base, { participantId: 'b' }];
+
+      expect(participantsVersion(renamed)).not.toEqual(participantsVersion(base));
+      expect(participantsVersion(added)).not.toEqual(participantsVersion(base));
+    });
+
+    it('encodes the count, so sets of different size can never collide', () => {
+      // The count is the cheap discriminator that makes a false MATCH — the dangerous direction —
+      // require a collision on count AND two independent hashes.
+      const version = participantsVersion([{ participantId: 'a' }, { participantId: 'b' }]);
+      expect(version?.startsWith('p1-2-')).toEqual(true);
+    });
+
+    it('returns undefined for a non-array rather than a stamp that means nothing', () => {
+      expect(participantsVersion(undefined)).toBeUndefined();
+      expect(participantsVersion(null as any)).toBeUndefined();
+    });
+  });
+
+  describe('getEventData integration', () => {
+    it('ADDITIVE — omitting participantsVersion is byte-identical to today, apart from the new field', () => {
+      // The load-bearing guarantee. ClubSpark runs the existing pattern at scale for USTA and ITA;
+      // default output must not move. Asserted mechanically rather than promised in review.
+      const {
+        eventIds: [eventId],
+      } = loadTournament();
+
+      const result: any = tournamentEngine.getEventData({ eventId });
+      const { participantsVersion: version, ...withoutNewField } = result;
+
+      expect(version).toBeDefined();
+      expect(withoutNewField.participants?.length).toBeGreaterThan(0);
+      expect(withoutNewField.eventData).toBeDefined();
+      expect(withoutNewField.success).toEqual(true);
+      // nothing else appeared
+      expect(Object.keys(withoutNewField).sort()).toEqual(['eventData', 'participants', 'success']);
+    });
+
+    it('omits participants ONLY on an exact version match', () => {
+      const {
+        eventIds: [eventId],
+      } = loadTournament();
+
+      const first: any = tournamentEngine.getEventData({ eventId });
+      const version = first.participantsVersion;
+      expect(first.participants.length).toBeGreaterThan(0);
+
+      const second: any = tournamentEngine.getEventData({ eventId, participantsVersion: version });
+      expect(second.participants).toBeUndefined();
+      // the stamp still rides the response, so the client can detect a later change
+      expect(second.participantsVersion).toEqual(version);
+      // and the rest of the payload is untouched
+      expect(second.eventData).toBeDefined();
+    });
+
+    it.each([
+      ['a stale version', 'p1-1-aaaabbbb'],
+      ['a malformed version', 'nonsense'],
+      ['an empty string', ''],
+    ])('INCLUDES participants on %s — the safe direction', (_label, supplied) => {
+      const {
+        eventIds: [eventId],
+      } = loadTournament();
+
+      const result: any = tournamentEngine.getEventData({ eventId, participantsVersion: supplied });
+      expect(result.participants?.length).toBeGreaterThan(0);
+    });
+
+    it('a participant change invalidates the stamp, so a stale client is re-sent the set', () => {
+      // Proves the stamp tracks real mutations rather than agreeing with itself forever.
+      //
+      // Uses ADDITION deliberately. An earlier version of this test renamed a participant via
+      // `modifyParticipant`, which returns success:true while leaving `participantName` untouched —
+      // for an INDIVIDUAL the name is derived from `person`, so a direct edit is recomputed away.
+      // That made the test look like a stamp defect when the mutation had simply not happened.
+      const {
+        eventIds: [eventId],
+      } = loadTournament();
+
+      const before: any = tournamentEngine.getEventData({ eventId });
+      const staleVersion = before.participantsVersion;
+
+      const { participants: additions } = mocksEngine.generateParticipants({
+        participantsCount: 1,
+        participantType: 'INDIVIDUAL',
+        nonRandom: 2,
+      });
+      const result: any = tournamentEngine.addParticipants({ participants: additions });
+      expect(result.success).toEqual(true);
+
+      const after: any = tournamentEngine.getEventData({ eventId, participantsVersion: staleVersion });
+      expect(after.participantsVersion).not.toEqual(staleVersion);
+      // the whole point: a client holding the old set is NOT left with a silently stale one
+      expect(after.participants?.length).toBeGreaterThan(0);
+    });
+
+    it('a SCORE does not invalidate the stamp — participants and results change at different rates', () => {
+      // This is the premise the whole tier rests on. If scoring moved the stamp, the handshake would
+      // never fire during play and the optimization would be worthless. Verified, not assumed.
+      const {
+        eventIds: [eventId],
+        drawIds: [drawId],
+      } = loadTournament();
+
+      const before: any = tournamentEngine.getEventData({ eventId });
+
+      const { outcome } = mocksEngine.generateOutcomeFromScoreString({
+        scoreString: '6-4 6-2',
+        matchUpStatus: 'COMPLETED',
+        winningSide: 1,
+      });
+      const matchUps: any[] = tournamentEngine.allTournamentMatchUps().matchUps ?? [];
+      const target = matchUps.find(
+        (m: any) => !m.winningSide && (m.sides ?? []).filter((s: any) => s?.participantId).length === 2,
+      );
+      const scored: any = tournamentEngine.setMatchUpStatus({ matchUpId: target.matchUpId, drawId, outcome });
+      expect(scored.success).toEqual(true);
+
+      const after: any = tournamentEngine.getEventData({ eventId, participantsVersion: before.participantsVersion });
+      expect(after.participantsVersion).toEqual(before.participantsVersion);
+      expect(after.participants).toBeUndefined(); // still omitted — the saving survives play
+    });
+  });
+});


### PR DESCRIPTION
G2 / D2 — the participants tier. Participants are the largest remaining slice of an event payload, and they are duplicated wholesale across events.

## Re-measured before building, because the recorded figures understated it

| | plan recorded | actually measured |
|---|---|---|
| participants share of payload | 52% | **61.7%** aggregate, up to **78.6%** per event |
| duplication across events | 1.7× | **5×** — byte-identical 412 KB block per event |
| participants in >1 event | 46% | **100%** |

**And a finding the plan missed entirely:** `getEventData` returns **all 704 tournament participants at the top level regardless of event**. An event with 32 entries carries 704 people — **86.4% irrelevant to it**.

| event | entries | returned | needed | irrelevant |
|---|---|---|---|---|
| SINGLES | 256 | 704 | 256 | 63.6% |
| SINGLES | 256 | 704 | 256 | 63.6% |
| DOUBLES | 64 | 704 | 192 | 72.7% |
| DOUBLES | 64 | 704 | 192 | 72.7% |
| DOUBLES | 32 | 704 | 96 | **86.4%** |

## The design: prove, don't assert

The response always carries a `participantsVersion`. Participants are omitted **only** when the caller supplies a version matching exactly.

A client asserting *"I already have these"* is a claim the server cannot check, and when it is wrong the failure is **silent** — every bracket side renders TBD. That is the documented reason CFS invalidates its cache rather than seeding it (`getMutationEngine.ts:136`). With a stamp, mismatch or absence sends participants exactly as today, so the failure direction is *"sent bytes that were not needed"*.

**Collision safety runs one way on purpose.** A false *match* is the dangerous direction — it would omit participants that differ. So the stamp is over-specified: participant **count** plus **two** independent 32-bit hashes with different primes. A false *mismatch* is harmless.

## Measured payoff, end to end

| | |
|---|---|
| cold (no version held) | 3,342 KB |
| warm (version held) | **1,281 KB** |
| saved | **2,061 KB — 61.7%** |

The stamp is **identical across all five events**, so a client that fetches one event can use that version for the rest and have participants omitted from all of them.

## Cost, stated plainly

Hashing adds **~18 ms to an ~89 ms** five-event build — about 20%. A cheaper stamp over only identity fields would miss content changes, which is the dangerous direction, so the full hash is deliberate.

**This is a bandwidth win bought with CPU, not a free one.**

## Premise verified, not assumed

The whole tier rests on participants and results having different change rates. Tested: a score leaves the participant block **byte-identical** and the stamp unchanged, so the handshake keeps firing during play. Had that been false, the optimization would have been worthless.

## Additive

Omitting the parameter leaves behaviour unchanged apart from the new field — asserted mechanically (`Object.keys` of the result equals `['eventData','participants','success']`), not promised in review. ClubSpark runs the existing pattern at scale for USTA and ITA.

## Falsification

| defect injected | tests failed |
|---|---|
| trust the client's assertion, skip the match check | 3 |
| never omit — handshake does nothing | 2 |
| count-only stamp — content changes unnoticed | 2 |
| order-dependent stamp — handshake rarely fires | 1 |

## Verification

- `tsc --noEmit` clean · `eslint --max-warnings 0` clean · prettier clean
- `verify:generated` — engine-methods and method-signatures up to date
- full suite — **11065 passed**, 1 skipped, 0 failed

Built in a worktree (A8): `facility-courts-2026-08-18` is building in the shared factory checkout.

## Not in this PR

The tournament-scoped shared participants block (the follow-on to D2) and CFS/consumer wiring. This is the factory half.