### PR TITLE
perf(query): make participantsVersion opt-in

### DIFF
--- a/src/query/event/getEventData.ts
+++ b/src/query/event/getEventData.ts
@@ -40,6 +40,7 @@ type GetEventDataArgs = {
   drawsProfile?: PayloadProfileUnion;
   participantFilters?: any;
   participantsVersion?: string;
+  withParticipantsVersion?: boolean;
   contextProfile?: any;
   eventId?: string;
   status?: string;
@@ -307,10 +308,15 @@ export function getEventData(params: GetEventDataArgs): {
   eventData.eventInfo.publishState = eventPublishState;
   eventData.eventInfo.published = eventPublishState?.status?.published;
 
-  // ADDITIVE: the stamp always rides the response; omission happens only when the caller PROVES it
-  // already holds this exact set. `participantsVersion` absent from params → unchanged behaviour,
-  // which is the ClubSpark constraint (their deployed pattern must not move).
-  const version = computeParticipantsVersion(tournamentParticipants);
+  // OPT-IN. Hashing the participant set costs ~18 ms of an ~89 ms five-event build (~20%), and every
+  // caller would pay it for a handshake almost none of them use. So the stamp is computed only when
+  // it can actually be used: the caller either supplied a version to check, or asked for one.
+  //
+  // Deliberately NOT a separate "enable the feature" flag divorced from the parameters — supplying a
+  // version implies wanting the comparison, and a caller that had to set two things to get one
+  // behaviour would eventually set only one and silently get the slow-and-useless combination.
+  const versionRequested = params.withParticipantsVersion || params.participantsVersion !== undefined;
+  const version = versionRequested ? computeParticipantsVersion(tournamentParticipants) : undefined;
   const clientHoldsCurrentSet = !!params.participantsVersion && params.participantsVersion === version;
 
   return {
@@ -319,6 +325,9 @@ export function getEventData(params: GetEventDataArgs): {
     // A mismatch or absence sends participants, exactly as today. Only an EXACT match omits them, so
     // the failure direction is "sent bytes that were not needed" rather than a blank bracket.
     participants: clientHoldsCurrentSet ? undefined : tournamentParticipants,
-    participantsVersion: version,
+    // Conditional spread, not `participantsVersion: version`. An explicitly-undefined key still shows
+    // up in Object.keys, so the unasked-for case would carry a key it never had before — a shape
+    // change, however invisible to JSON.stringify.
+    ...(version !== undefined && { participantsVersion: version }),
   };
 }

--- a/src/tests/queries/participants/participantsVersion.test.ts
+++ b/src/tests/queries/participants/participantsVersion.test.ts
@@ -67,14 +67,42 @@ describe('participantsVersion', () => {
       } = loadTournament();
 
       const result: any = tournamentEngine.getEventData({ eventId });
-      const { participantsVersion: version, ...withoutNewField } = result;
 
-      expect(version).toBeDefined();
-      expect(withoutNewField.participants?.length).toBeGreaterThan(0);
-      expect(withoutNewField.eventData).toBeDefined();
-      expect(withoutNewField.success).toEqual(true);
-      // nothing else appeared
-      expect(Object.keys(withoutNewField).sort()).toEqual(['eventData', 'participants', 'success']);
+      // NOTHING is added by default — not even the stamp. Hashing costs ~20% of the build, so a
+      // caller that never uses the handshake must not pay for it.
+      expect(result.participantsVersion).toBeUndefined();
+      expect(result.participants?.length).toBeGreaterThan(0);
+      expect(result.eventData).toBeDefined();
+      expect(result.success).toEqual(true);
+      expect(Object.keys(result).sort()).toEqual(['eventData', 'participants', 'success']);
+    });
+
+    it('withParticipantsVersion returns the stamp WITHOUT omitting anything', () => {
+      // Asking for the stamp is not asking to skip participants — a first-time caller needs both.
+      const {
+        eventIds: [eventId],
+      } = loadTournament();
+
+      const result: any = tournamentEngine.getEventData({ eventId, withParticipantsVersion: true });
+      expect(result.participantsVersion).toBeDefined();
+      expect(result.participants?.length).toBeGreaterThan(0);
+    });
+
+    it('supplying a version implies wanting the comparison — no second flag needed', () => {
+      // Requiring BOTH a flag and a version to get one behaviour is how a caller ends up setting one
+      // of them and silently getting the slow-and-useless combination.
+      const {
+        eventIds: [eventId],
+      } = loadTournament();
+
+      const { participantsVersion: version }: any = tournamentEngine.getEventData({
+        eventId,
+        withParticipantsVersion: true,
+      });
+      // note: no withParticipantsVersion here
+      const result: any = tournamentEngine.getEventData({ eventId, participantsVersion: version });
+      expect(result.participants).toBeUndefined();
+      expect(result.participantsVersion).toEqual(version);
     });
 
     it('omits participants ONLY on an exact version match', () => {
@@ -82,7 +110,7 @@ describe('participantsVersion', () => {
         eventIds: [eventId],
       } = loadTournament();
 
-      const first: any = tournamentEngine.getEventData({ eventId });
+      const first: any = tournamentEngine.getEventData({ eventId, withParticipantsVersion: true });
       const version = first.participantsVersion;
       expect(first.participants.length).toBeGreaterThan(0);
 
@@ -118,7 +146,7 @@ describe('participantsVersion', () => {
         eventIds: [eventId],
       } = loadTournament();
 
-      const before: any = tournamentEngine.getEventData({ eventId });
+      const before: any = tournamentEngine.getEventData({ eventId, withParticipantsVersion: true });
       const staleVersion = before.participantsVersion;
 
       const { participants: additions } = mocksEngine.generateParticipants({
@@ -143,7 +171,7 @@ describe('participantsVersion', () => {
         drawIds: [drawId],
       } = loadTournament();
 
-      const before: any = tournamentEngine.getEventData({ eventId });
+      const before: any = tournamentEngine.getEventData({ eventId, withParticipantsVersion: true });
 
       const { outcome } = mocksEngine.generateOutcomeFromScoreString({
         scoreString: '6-4 6-2',


### PR DESCRIPTION
Answers CA's question — *"should the hashing be behind a boolean, used only when a consumer wants this capability?"* Yes. Nothing uses the handshake yet, so **100% of callers were paying for it**.

## The change

The stamp is computed only when it can be used:

- the caller supplied a `participantsVersion` to check, **or**
- the caller asked for one with `withParticipantsVersion: true`

**Supplying a version implies wanting the comparison.** Requiring two settings for one behaviour is how a caller ends up setting only one and silently getting the slow-and-useless combination — hashing performed, nothing omitted.

## Measured

Single-run A/B on the slam corpus:

| | |
|---|---|
| default callers | **87.1 ms** |
| opted in (stamp) | 94.6 ms |
| opted in (handshake) | 95.8 ms |
| **hash cost avoided by default** | **7.5 ms (~8.6%)** |

## ⚠️ Correcting my own figure

**#4664 reported this cost as ~18 ms / ~20%. That was wrong** — it subtracted across two separate benchmark runs instead of comparing within one, overstating by more than double. The real figure is 7.5 ms / 8.6%.

Still worth making opt-in, but the trade was not as stark as I described it.

## A shape leak from #4664, also fixed

`participantsVersion: version` put the key on the response **even when undefined**. `JSON.stringify` drops it, but `Object.keys` does not — so the default response carried a key it never had before. That is a shape change, however invisible on the wire, and it undercuts the additive guarantee I claimed.

Now a conditional spread. The default result is exactly `['eventData','participants','success']` again, asserted.

## Falsification

| defect injected | tests failed |
|---|---|
| always hash, ignore opt-in | 1 (default-shape) |
| require both flag *and* version | 3 |
| restore the unconditional `participantsVersion` key | 1 (shape) |

## Verification

- `tsc --noEmit` clean · `eslint --max-warnings 0` clean · prettier clean
- full suite — **11114 passed**, 1 skipped, 0 failed

Built in a worktree (A8).