### PR TITLE
feat(participants): surface when participantName is superseded by the derived name

### DIFF
--- a/src/constants/infoConstants.ts
+++ b/src/constants/infoConstants.ts
@@ -1,2 +1,11 @@
 export const ELEMENT_REQUIRED = 'element required';
 export const MISSING_NAME = 'missing name';
+
+/**
+ * A supplied `participantName` was replaced by a name derived from `person`.
+ *
+ * Not an error: for an INDIVIDUAL the derived name is canonical, and `updateParticipantName: false`
+ * opts out. But discarding a value the caller explicitly supplied while returning success is exactly
+ * the silence that makes a no-op look like a success, so it is surfaced.
+ */
+export const PARTICIPANT_NAME_DERIVED_FROM_PERSON = 'participantName derived from person; supplied value not used';

--- a/src/mutate/participants/modifyParticipant.ts
+++ b/src/mutate/participants/modifyParticipant.ts
@@ -16,6 +16,7 @@ import { isString } from '@Tools/objects';
 // constants
 import { CANNOT_MODIFY_PARTICIPANT_TYPE, INVALID_DATE } from '@Constants/errorConditionConstants';
 import { GROUP, INDIVIDUAL, PAIR, participantTypes } from '@Constants/participantConstants';
+import { PARTICIPANT_NAME_DERIVED_FROM_PERSON } from '@Constants/infoConstants';
 import { TOURNAMENT_RECORD, PARTICIPANT } from '@Constants/attributeConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 import { TEAM } from '@Constants/matchUpTypes';
@@ -63,7 +64,8 @@ export function modifyParticipant(params) {
   if (onlineResources) newValues.onlineResources = onlineResources;
 
   if (participantOtherName !== undefined) newValues.participantOtherName = participantOtherName || undefined;
-  if (participantName && isString(participantName)) newValues.participantName = participantName;
+  const suppliedParticipantName = participantName && isString(participantName) ? participantName : undefined;
+  if (suppliedParticipantName) newValues.participantName = suppliedParticipantName;
 
   if (Array.isArray(individualParticipantIds)) {
     updateIndividualParticipantIds({
@@ -92,6 +94,12 @@ export function modifyParticipant(params) {
     if (personResult?.error) return personResult;
   }
 
+  // A supplied participantName can be superseded by a derived one — from `person` for an INDIVIDUAL,
+  // or from the individuals of a PAIR. That is intended precedence, but returning success while
+  // silently dropping a value the caller passed makes a partial no-op indistinguishable from a full
+  // success. Surface it instead. See PARTICIPANT_NAME_DERIVED_FROM_PERSON.
+  const participantNameSuperseded = !!suppliedParticipantName && newValues.participantName !== suppliedParticipantName;
+
   Object.assign(existingParticipant, definedAttributes(newValues));
 
   if (groupingParticipantId) {
@@ -111,6 +119,8 @@ export function modifyParticipant(params) {
   return {
     participant: makeDeepCopy(existingParticipant),
     ...SUCCESS,
+    // conditional: callers that did not hit the precedence see the response shape they always have
+    ...(participantNameSuperseded && { info: PARTICIPANT_NAME_DERIVED_FROM_PERSON }),
   };
 }
 

--- a/src/tests/mutations/participants/modifyParticipantNameInfo.test.ts
+++ b/src/tests/mutations/participants/modifyParticipantNameInfo.test.ts
@@ -1,0 +1,95 @@
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { expect, it, describe } from 'vitest';
+
+// constants and types
+import { PARTICIPANT_NAME_DERIVED_FROM_PERSON } from '@Constants/infoConstants';
+
+/**
+ * `modifyParticipant` derives `participantName` from `person` for an INDIVIDUAL when person names are
+ * supplied and `updateParticipantName` is left at its default of true. That precedence is intended —
+ * the derived name is canonical.
+ *
+ * What was not intended is the SILENCE. A caller passing both a `person` block and an explicit
+ * `participantName` got `success: true` and no indication that its name had been discarded, so a
+ * partial no-op was indistinguishable from a full success. This was mistaken for a stamp defect while
+ * building the participantsVersion handshake — the mutation had simply not done what it appeared to.
+ */
+describe('modifyParticipant — participantName precedence is surfaced', () => {
+  function loadParticipant() {
+    const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 8 }],
+      participantsProfile: { nonRandom: 1 },
+      setState: true,
+    });
+    const participant = (tournamentRecord.participants ?? []).find((p: any) => p.participantType === 'INDIVIDUAL');
+    return { participant, tournamentRecord };
+  }
+
+  function currentName(participantId: string) {
+    const state: any = tournamentEngine.getState();
+    const record = state.tournamentRecords ? Object.values(state.tournamentRecords)[0] : state.tournamentRecord;
+    return (record as any).participants.find((p: any) => p.participantId === participantId)?.participantName;
+  }
+
+  it('reports info when a supplied participantName is superseded by the person-derived name', () => {
+    const { participant } = loadParticipant();
+
+    const result: any = tournamentEngine.modifyParticipant({
+      participant: { ...participant, participantName: 'SUPPLIED NAME' },
+      participantId: participant.participantId,
+    });
+
+    expect(result.success).toEqual(true);
+    // the precedence itself is unchanged — the derived name still wins
+    expect(currentName(participant.participantId)).not.toEqual('SUPPLIED NAME');
+    // ...but it is no longer silent
+    expect(result.info).toEqual(PARTICIPANT_NAME_DERIVED_FROM_PERSON);
+  });
+
+  it('applies a supplied participantName when no person block competes with it', () => {
+    // Guards the direction: this must stay a report of a real supersede, not a blanket warning.
+    const { participant } = loadParticipant();
+
+    const result: any = tournamentEngine.modifyParticipant({
+      participant: {
+        participantId: participant.participantId,
+        participantType: participant.participantType,
+        participantRole: participant.participantRole,
+        participantName: 'ACCEPTED NAME',
+      },
+      participantId: participant.participantId,
+    });
+
+    expect(result.success).toEqual(true);
+    expect(currentName(participant.participantId)).toEqual('ACCEPTED NAME');
+    expect(result.info).toBeUndefined();
+  });
+
+  it('adds nothing to the response when no participantName was supplied at all', () => {
+    // The ordinary case must keep the exact shape it has always had.
+    const { participant } = loadParticipant();
+
+    const result: any = tournamentEngine.modifyParticipant({
+      participant: { ...participant },
+      participantId: participant.participantId,
+    });
+
+    expect(result.success).toEqual(true);
+    expect(Object.keys(result).sort()).toEqual(['participant', 'success']);
+  });
+
+  it('updateParticipantName: false lets a supplied name win — the documented opt-out', () => {
+    const { participant } = loadParticipant();
+
+    const result: any = tournamentEngine.modifyParticipant({
+      participant: { ...participant, participantName: 'EXPLICIT WINS' },
+      participantId: participant.participantId,
+      updateParticipantName: false,
+    });
+
+    expect(result.success).toEqual(true);
+    expect(currentName(participant.participantId)).toEqual('EXPLICIT WINS');
+    expect(result.info).toBeUndefined();
+  });
+});


### PR DESCRIPTION
CA asked for this after we established the behaviour was **not a bug** but was silent.

## What was measured

| call | result |
|---|---|
| `participantName` alone | ✅ applied |
| `participantName` + `person` block | ❌ discarded, person-derived name wins |
| `participantName` + `person` + `updateParticipantName: false` | ✅ applied |

`updateParticipantName` defaults to `true`, so a supplied `person` recomputes the name from `standardGivenName`/`standardFamilyName`. **That precedence is intended** — the derived name is canonical and there is a documented opt-out.

**The silence was not.** A caller passing both got `success: true` with no indication its value had been dropped, making a partial no-op indistinguishable from a full success.

This cost real time: while building #4664 I read it as a defect in the `participantsVersion` stamp — the stamp was correct, the mutation simply had not done what it appeared to.

## The change

`PARTICIPANT_NAME_DERIVED_FROM_PERSON` is returned as `info` **only when a supplied name was actually superseded**. No behaviour change; the response is now honest about a partial application.

**Conditional spread, not `info: x ? y : undefined`.** An explicitly-undefined key still appears in `Object.keys`, which would put a field on every reply that never had one. That exact leak shipped in #4664 and is guarded here by a test asserting the ordinary response is still `['participant','success']`.

## Falsification

| defect injected | tests failed |
|---|---|
| remove the info — silent again | 1 |
| report whenever a name was supplied, not when superseded | 3 |
| `info: … : undefined` — key leaks into every reply | 1 |

## Verification

- `tsc --noEmit` clean · `eslint --max-warnings 0` clean · prettier clean
- `verify:generated` up to date
- full suite — **11142 passed**, 1 skipped, 0 failed
- import placed in the `// constants` section in correct longest-first position

Built in a worktree (A8).