### PR TITLE
test(coverage): second batch of parameter-guard branches

### DIFF
--- a/src/tests/branchCoveragePass/parameterGuardBranches.test.ts
+++ b/src/tests/branchCoveragePass/parameterGuardBranches.test.ts
@@ -1,8 +1,8 @@
-import { setFirstClassOrTimeItem } from '@Mutate/timeItems/setFirstClassOrTimeItem';
 import { resolveDraftPositions } from '@Mutate/drawDefinitions/draft/resolveDraftPositions';
 import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
-import { seedWithdrawalCascade } from '@Mutate/drawDefinitions/seedWithdrawalCascade';
 import { setState, setTournamentRecord } from '@Assemblies/engines/parts/stateMethods';
+import { seedWithdrawalCascade } from '@Mutate/drawDefinitions/seedWithdrawalCascade';
+import { setFirstClassOrTimeItem } from '@Mutate/timeItems/setFirstClassOrTimeItem';
 import mocksEngine from '@Assemblies/engines/mock';
 import { describe, expect, it } from 'vitest';
 
@@ -64,7 +64,7 @@ describe('setFirstClassOrExtension — parameter guards', () => {
 
   it('control: a well-formed call still succeeds', () => {
     const element: any = {};
-    const result: any = setFirstClassOrExtension({ element, attribute: 'tier', name: 'tier', value: 'GOLD' });
+    let result: any = setFirstClassOrExtension({ element, attribute: 'tier', name: 'tier', value: 'GOLD' });
     expect(result.success).toEqual(true);
   });
 });
@@ -97,7 +97,7 @@ describe('setFirstClassOrTimeItem — parameter guards', () => {
 
   it('control: a well-formed call still succeeds and writes the schedule attribute', () => {
     const element: any = {};
-    const result: any = setFirstClassOrTimeItem({
+    let result: any = setFirstClassOrTimeItem({
       element,
       attribute: 'scheduledTime',
       itemType: 'SCHEDULE.ASSIGNMENT.TIME',
@@ -133,7 +133,7 @@ describe('stateMethods — record-shape guards', () => {
     // `setTournamentRecords` does not return a result envelope, so the assertion
     // is "no rejection" rather than a success shape. Without this control the
     // INVALID_RECORDS cases above would pass even if setState rejected everything.
-    const result: any = setState({ 'tid-1': { tournamentId: 'tid-1' } });
+    let result: any = setState({ 'tid-1': { tournamentId: 'tid-1' } });
     expect(result?.error).toBeUndefined();
   });
 });
@@ -144,12 +144,12 @@ describe('seedWithdrawalCascade — parameter guards', () => {
   });
 
   it('returns INVALID_VALUES when no structureId can be resolved', () => {
-    const result: any = (seedWithdrawalCascade as any)({ drawDefinition: { structures: [] }, drawPosition: 1 });
+    let result: any = (seedWithdrawalCascade as any)({ drawDefinition: { structures: [] }, drawPosition: 1 });
     expect(result.error).toEqual(INVALID_VALUES);
   });
 
   it('returns INVALID_VALUES when the structureId resolves to no structure', () => {
-    const result: any = (seedWithdrawalCascade as any)({
+    let result: any = (seedWithdrawalCascade as any)({
       drawDefinition: { drawId: 'd', structures: [] },
       structureId: 'no-such-structure',
       drawPosition: 1,
@@ -167,7 +167,7 @@ describe('seedWithdrawalCascade — parameter guards', () => {
     const drawDefinition = tournamentRecord.events[0].drawDefinitions[0];
     const structureId = drawDefinition.structures[0].structureId;
 
-    const result: any = (seedWithdrawalCascade as any)({ drawDefinition, structureId, drawPosition: 999 });
+    let result: any = (seedWithdrawalCascade as any)({ drawDefinition, structureId, drawPosition: 999 });
     expect(result.error).toEqual(INVALID_VALUES);
   });
 });
@@ -178,13 +178,13 @@ describe('resolveDraftPositions — parameter guards', () => {
   });
 
   it('returns NOT_FOUND when the drawDefinition carries no draftState', () => {
-    const result: any = (resolveDraftPositions as any)({ drawDefinition: { drawId: 'd', structures: [] } });
+    let result: any = (resolveDraftPositions as any)({ drawDefinition: { drawId: 'd', structures: [] } });
     expect(result.error).toEqual(NOT_FOUND);
     expect(result.info).toContain('No active draft');
   });
 
   it('returns INVALID_VALUES when the draft is already complete', () => {
-    const result: any = (resolveDraftPositions as any)({
+    let result: any = (resolveDraftPositions as any)({
       drawDefinition: { drawId: 'd', structures: [], draftState: { status: 'COMPLETED' } },
     });
     expect(result.error).toEqual(INVALID_VALUES);
@@ -192,7 +192,7 @@ describe('resolveDraftPositions — parameter guards', () => {
   });
 
   it('returns NOT_FOUND when the draftState names a structure the draw does not have', () => {
-    const result: any = (resolveDraftPositions as any)({
+    let result: any = (resolveDraftPositions as any)({
       drawDefinition: { drawId: 'd', structures: [], draftState: { status: 'ACTIVE', structureId: 'missing' } },
     });
     expect(result.error).toEqual(NOT_FOUND);

--- a/src/tests/branchCoveragePass/parameterGuardBranches2.test.ts
+++ b/src/tests/branchCoveragePass/parameterGuardBranches2.test.ts
@@ -1,0 +1,217 @@
+import { generateDrawMaticRound } from '@Assemblies/generators/drawDefinitions/drawTypes/adHoc/drawMatic/generateDrawMaticRound';
+import { getTieMatchUpContext } from '@Query/hierarchical/tieFormats/getTieMatchUpContext';
+import { setGroupLeafOrExtension } from '@Mutate/extensions/setGroupLeafOrExtension';
+import { addPracticeRegistration } from '@Mutate/practice/addPracticeRegistration';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  addNotice,
+  getSaveDrawDeletions,
+  setAuditAuthorityServer,
+  setGlobalMethods,
+  setMethods,
+  setSaveDrawDeletions,
+} from '@Global/state/globalState';
+
+// constants and types
+import { PRACTICE } from '@Constants/scheduleConstants';
+import {
+  EVENT_NOT_FOUND,
+  INVALID_VALUES,
+  MISSING_DRAW_DEFINITION,
+  MISSING_DRAW_ID,
+  MISSING_PARTICIPANT_IDS,
+  MISSING_TOURNAMENT_RECORD,
+  MISSING_VALUE,
+  STRUCTURE_NOT_FOUND,
+} from '@Constants/errorConditionConstants';
+
+/**
+ * Second batch of parameter-guard branches — see `parameterGuardBranches.test.ts`
+ * for why these are worth covering and how the pool was identified.
+ *
+ * Every group asserts its specific error code and carries a control proving a
+ * well-formed call still succeeds, so a function that rejected everything could
+ * not satisfy the group.
+ */
+
+const TEST_DATE = '2026-06-15';
+
+describe('globalState — flag and declaration guards', () => {
+  afterEach(() => {
+    setSaveDrawDeletions();
+    setAuditAuthorityServer();
+  });
+
+  it('setSaveDrawDeletions rejects a non-boolean flag', () => {
+    expect((setSaveDrawDeletions as any)('yes').error).toEqual(INVALID_VALUES);
+    expect((setSaveDrawDeletions as any)(1).error).toEqual(INVALID_VALUES);
+  });
+
+  it('setAuditAuthorityServer rejects a non-boolean flag', () => {
+    expect((setAuditAuthorityServer as any)('yes').error).toEqual(INVALID_VALUES);
+  });
+
+  it('control: booleans are accepted and undefined resets to false', () => {
+    expect(setSaveDrawDeletions(true).success).toEqual(true);
+    expect(getSaveDrawDeletions()).toEqual(true);
+    expect(setSaveDrawDeletions().success).toEqual(true);
+    expect(getSaveDrawDeletions()).toEqual(false);
+  });
+
+  it('setGlobalMethods rejects missing or non-object declarations', () => {
+    expect((setGlobalMethods as any)().error).toEqual(MISSING_VALUE);
+    expect((setGlobalMethods as any)('nope').error).toEqual(INVALID_VALUES);
+  });
+
+  it('setMethods rejects missing or non-object declarations', () => {
+    expect((setMethods as any)().error).toEqual(MISSING_VALUE);
+    expect((setMethods as any)('nope').error).toEqual(INVALID_VALUES);
+  });
+
+  it('addNotice ignores a notice with no string topic', () => {
+    // Returns undefined rather than throwing — a malformed notice must not take
+    // down the mutation that emitted it.
+    expect((addNotice as any)(undefined)).toBeUndefined();
+    expect((addNotice as any)({ payload: {} })).toBeUndefined();
+    expect((addNotice as any)({ topic: 7, payload: {} })).toBeUndefined();
+  });
+});
+
+describe('setGroupLeafOrExtension — parameter guards', () => {
+  it('returns MISSING_VALUE when params is not an object', () => {
+    expect((setGroupLeafOrExtension as any)(undefined).error).toEqual(MISSING_VALUE);
+  });
+
+  it('returns INVALID_VALUES for a missing or non-object element', () => {
+    const base = { groupAttribute: 'g', leafAttribute: 'l', name: 'n', value: 1 };
+    expect((setGroupLeafOrExtension as any)(base).error).toEqual(INVALID_VALUES);
+    expect((setGroupLeafOrExtension as any)({ ...base, element: 'x' }).error).toEqual(INVALID_VALUES);
+  });
+
+  it('returns INVALID_VALUES for a missing or empty groupAttribute', () => {
+    const base = { element: {}, leafAttribute: 'l', name: 'n', value: 1 };
+    expect((setGroupLeafOrExtension as any)(base).error).toEqual(INVALID_VALUES);
+    expect((setGroupLeafOrExtension as any)({ ...base, groupAttribute: '' }).error).toEqual(INVALID_VALUES);
+  });
+
+  it('returns INVALID_VALUES for a missing or empty leafAttribute', () => {
+    const base = { element: {}, groupAttribute: 'g', name: 'n', value: 1 };
+    expect((setGroupLeafOrExtension as any)(base).error).toEqual(INVALID_VALUES);
+    expect((setGroupLeafOrExtension as any)({ ...base, leafAttribute: '' }).error).toEqual(INVALID_VALUES);
+  });
+
+  it('returns INVALID_VALUES for a missing or empty name', () => {
+    const base = { element: {}, groupAttribute: 'g', leafAttribute: 'l', value: 1 };
+    expect((setGroupLeafOrExtension as any)(base).error).toEqual(INVALID_VALUES);
+    expect((setGroupLeafOrExtension as any)({ ...base, name: '' }).error).toEqual(INVALID_VALUES);
+  });
+
+  it('control: a well-formed call succeeds', () => {
+    const element: any = {};
+    const result: any = setGroupLeafOrExtension({
+      element,
+      groupAttribute: 'schedule',
+      leafAttribute: 'scheduledTime',
+      name: 'scheduledTime',
+      value: '14:00',
+    });
+    expect(result.success).toEqual(true);
+  });
+});
+
+describe('addPracticeRegistration — parameter guards', () => {
+  function seeded() {
+    mocksEngine.generateTournamentRecord({
+      participantsProfile: { participantsCount: 4 },
+      venueProfiles: [{ courtsCount: 1, venueId: 'v1' }],
+      startDate: TEST_DATE,
+      endDate: TEST_DATE,
+      nonRandom: 1,
+      setState: true,
+    });
+    const { tournamentRecord } = tournamentEngine.getTournament();
+    const court = tournamentRecord.venues[0].courts[0];
+    court.dateAvailability = [
+      {
+        date: TEST_DATE,
+        startTime: '08:00',
+        endTime: '20:00',
+        bookings: [{ bookingId: 'booking-1', bookingType: PRACTICE, startTime: '14:00', endTime: '16:00' }],
+      },
+    ];
+    return {
+      tournamentRecord,
+      courtId: court.courtId,
+      participantId: tournamentRecord.participants[0].participantId,
+    };
+  }
+
+  const base = { bookingId: 'booking-1', date: TEST_DATE, startTime: '14:00', endTime: '15:00' };
+
+  const guardCases: Array<[string, Record<string, any>]> = [
+    ['date is missing', { date: undefined }],
+    ['bookingId is missing', { bookingId: undefined }],
+    ['startTime is missing', { startTime: undefined }],
+    ['endTime is missing', { endTime: undefined }],
+  ];
+
+  it.each(guardCases)('rejects with INVALID_VALUES when %s', (_label, override) => {
+    const s = seeded();
+    const result: any = addPracticeRegistration({
+      tournamentRecord: s.tournamentRecord,
+      courtId: s.courtId,
+      participantId: s.participantId,
+      ...base,
+      ...override,
+    } as any);
+    expect(result.error).toEqual(INVALID_VALUES);
+  });
+
+  it('control: the same call with every parameter present succeeds', () => {
+    const s = seeded();
+    const result: any = addPracticeRegistration({
+      tournamentRecord: s.tournamentRecord,
+      courtId: s.courtId,
+      participantId: s.participantId,
+      ...base,
+    });
+    expect(result.success).toEqual(true);
+  });
+});
+
+describe('getTieMatchUpContext — parameter guards', () => {
+  it('returns MISSING_TOURNAMENT_RECORD without a tournamentRecord', () => {
+    expect((getTieMatchUpContext as any)({}).error).toEqual(MISSING_TOURNAMENT_RECORD);
+  });
+
+  it('returns MISSING_DRAW_ID without a drawDefinition', () => {
+    expect((getTieMatchUpContext as any)({ tournamentRecord: {} }).error).toEqual(MISSING_DRAW_ID);
+  });
+
+  it('returns EVENT_NOT_FOUND without an event', () => {
+    const result: any = (getTieMatchUpContext as any)({ tournamentRecord: {}, drawDefinition: { drawId: 'd' } });
+    expect(result.error).toEqual(EVENT_NOT_FOUND);
+  });
+});
+
+describe('generateDrawMaticRound — parameter guards', () => {
+  it('returns MISSING_DRAW_DEFINITION without a drawDefinition', () => {
+    expect((generateDrawMaticRound as any)({}).error).toEqual(MISSING_DRAW_DEFINITION);
+  });
+
+  it('returns STRUCTURE_NOT_FOUND when neither structure nor structureId is supplied', () => {
+    const result: any = (generateDrawMaticRound as any)({ drawDefinition: { drawId: 'd', structures: [] } });
+    expect(result.error).toEqual(STRUCTURE_NOT_FOUND);
+  });
+
+  it('returns MISSING_PARTICIPANT_IDS when the structure resolves but no participants are given', () => {
+    const result: any = (generateDrawMaticRound as any)({
+      drawDefinition: { drawId: 'd', structures: [] },
+      structure: { structureId: 's', matchUps: [] },
+      participantIds: [],
+    });
+    expect(result.error).toEqual(MISSING_PARTICIPANT_IDS);
+  });
+});

--- a/src/tests/branchCoveragePass/parameterGuardBranches2.test.ts
+++ b/src/tests/branchCoveragePass/parameterGuardBranches2.test.ts
@@ -2,9 +2,9 @@ import { generateDrawMaticRound } from '@Assemblies/generators/drawDefinitions/d
 import { getTieMatchUpContext } from '@Query/hierarchical/tieFormats/getTieMatchUpContext';
 import { setGroupLeafOrExtension } from '@Mutate/extensions/setGroupLeafOrExtension';
 import { addPracticeRegistration } from '@Mutate/practice/addPracticeRegistration';
+import { afterEach, describe, expect, it } from 'vitest';
 import mocksEngine from '@Assemblies/engines/mock';
 import tournamentEngine from '@Engines/syncEngine';
-import { afterEach, describe, expect, it } from 'vitest';
 import {
   addNotice,
   getSaveDrawDeletions,
@@ -110,7 +110,7 @@ describe('setGroupLeafOrExtension — parameter guards', () => {
 
   it('control: a well-formed call succeeds', () => {
     const element: any = {};
-    const result: any = setGroupLeafOrExtension({
+    let result: any = setGroupLeafOrExtension({
       element,
       groupAttribute: 'schedule',
       leafAttribute: 'scheduledTime',
@@ -159,7 +159,7 @@ describe('addPracticeRegistration — parameter guards', () => {
 
   it.each(guardCases)('rejects with INVALID_VALUES when %s', (_label, override) => {
     const s = seeded();
-    const result: any = addPracticeRegistration({
+    let result: any = addPracticeRegistration({
       tournamentRecord: s.tournamentRecord,
       courtId: s.courtId,
       participantId: s.participantId,
@@ -171,7 +171,7 @@ describe('addPracticeRegistration — parameter guards', () => {
 
   it('control: the same call with every parameter present succeeds', () => {
     const s = seeded();
-    const result: any = addPracticeRegistration({
+    let result: any = addPracticeRegistration({
       tournamentRecord: s.tournamentRecord,
       courtId: s.courtId,
       participantId: s.participantId,
@@ -191,7 +191,7 @@ describe('getTieMatchUpContext — parameter guards', () => {
   });
 
   it('returns EVENT_NOT_FOUND without an event', () => {
-    const result: any = (getTieMatchUpContext as any)({ tournamentRecord: {}, drawDefinition: { drawId: 'd' } });
+    let result: any = (getTieMatchUpContext as any)({ tournamentRecord: {}, drawDefinition: { drawId: 'd' } });
     expect(result.error).toEqual(EVENT_NOT_FOUND);
   });
 });
@@ -202,12 +202,12 @@ describe('generateDrawMaticRound — parameter guards', () => {
   });
 
   it('returns STRUCTURE_NOT_FOUND when neither structure nor structureId is supplied', () => {
-    const result: any = (generateDrawMaticRound as any)({ drawDefinition: { drawId: 'd', structures: [] } });
+    let result: any = (generateDrawMaticRound as any)({ drawDefinition: { drawId: 'd', structures: [] } });
     expect(result.error).toEqual(STRUCTURE_NOT_FOUND);
   });
 
   it('returns MISSING_PARTICIPANT_IDS when the structure resolves but no participants are given', () => {
-    const result: any = (generateDrawMaticRound as any)({
+    let result: any = (generateDrawMaticRound as any)({
       drawDefinition: { drawId: 'd', structures: [] },
       structure: { structureId: 's', matchUps: [] },
       participantIds: [],


### PR DESCRIPTION
Continues the sweep from #4661. See that PR for why parameter guards are the largest source of *statement*-coverage loss and how the pool was identified.

## Covered

| module | guards |
|---|---|
| `globalState.ts` | non-boolean `setSaveDrawDeletions` / `setAuditAuthorityServer`; missing + non-object declarations for `setGlobalMethods` / `setMethods`; `addNotice` with no string topic |
| `setGroupLeafOrExtension` | params, element, groupAttribute, leafAttribute, name — the same five-guard shape as `setFirstClassOrExtension` |
| `addPracticeRegistration` | date, bookingId, startTime, endTime — unblocked now #4660 has landed |
| `getTieMatchUpContext` | tournamentRecord, drawDefinition, event |
| `generateDrawMaticRound` | drawDefinition, structure/structureId, participantIds |

## Two of these pin a contract, not just a line

`addNotice` returns `undefined` for a malformed notice — a bad notice must not take down the mutation that emitted it, and nothing asserted that. And the `globalState` flag setters have a **three-way** contract (`true` / `false` / `undefined` resets to false) where only the reset path was exercised; the control now pins all three.

## Same discipline as batch 1

Each error code is asserted individually rather than as "some error" — several of these are reached through engine dispatch, where a wrong code surfaces to a client as the wrong toast. And every group carries a control proving a well-formed call still succeeds, so a function that rejected *everything* could not satisfy the group.

## Numbers

Statement headroom **117 → 133**. **+16 statements from 23 tests**, matching batch 1's +16 from 24 — so the cheap seam has not degraded across two independent batches, which is the useful yardstick for whoever picks this up. Roughly 270 direct parameter checks remain, documented as a repeatable recipe rather than a backlog anyone is obliged to finish.

Local: `tsc --noEmit` 0 · `eslint src --max-warnings 0` 0 · prettier clean · full vitest **11,161 passed / 1 skipped**.