### PR TITLE
chore(verify): re-seed the coverage-headroom baseline after the guard batches

### DIFF
--- a/scripts/verify/baseline/coverage-headroom.json
+++ b/scripts/verify/baseline/coverage-headroom.json
@@ -1,6 +1,6 @@
 {
-  "statements": 117,
-  "branches": 769,
+  "statements": 135,
+  "branches": 782,
   "functions": 223,
-  "lines": 1021
+  "lines": 1024
 }


### PR DESCRIPTION
Baseline data only — no behaviour change.

`coverage-headroom.json` was seeded at **117** in #4666, before #4661 and #4668 landed. `master` now sits at **135**.

A stale-*low* baseline makes the gate **less** sensitive, not more. With the budget at 25 and actual headroom at 135, a change could spend **41** items of margin before tripping, instead of 25. Left alone, the gauge's first real use would have been quietly loose in exactly the direction it exists to catch.

```
[verify:coverage-headroom]   statements   41283/43313   95.31%  floor 95  headroom   135
[verify:coverage-headroom]   branches     31918/36630   87.13%  floor 85  headroom   782
[verify:coverage-headroom]   functions     7128/7268    98.07%  floor 95  headroom   223
[verify:coverage-headroom]   lines        36459/37300   97.74%  floor 95  headroom  1024
```

Measured from a full `vitest run --coverage` on `master` at `474688356` — **11,165 passed / 1 skipped, exit 0**.