### PR TITLE
fix(query): apply participant privacy policy at every emission boundary

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -50,6 +50,21 @@ export default [
       'no-unused-vars': 'off',
       'no-unassigned-vars': 'warn',
       'no-useless-assignment': 'warn',
+      // Ban `JSON.parse(JSON.stringify(x))` as a deep-copy idiom. It silently drops `undefined`,
+      // functions, `Date`/`Map`/`Set` and throws on cycles — and it was the idiom in use where a
+      // shared privacy-policy fixture needed copying, next to three call sites that copied nothing at
+      // all and mutated it in place. Machine-enforced because prose could not hold it.
+      // Genuinely testing JSON serialization (a `toJSON` round-trip) is a different thing: disable the
+      // rule on that line with a reason.
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "CallExpression[callee.object.name='JSON'][callee.property.name='parse'] > CallExpression[callee.object.name='JSON'][callee.property.name='stringify']",
+          message:
+            'Use structuredClone() to deep-copy — JSON.parse(JSON.stringify(x)) drops undefined/functions/Date/Map/Set and throws on cycles. For tournamentRecords use tools.makeDeepCopy, which carries factory extension semantics.',
+        },
+      ],
       'sonarjs/cognitive-complexity': ['warn', 30],
       'sonarjs/no-all-duplicated-branches': 'warn',
       'sonarjs/no-collapsible-if': 'warn',

--- a/src/assemblies/engines/scoring/ScoringEngine.ts
+++ b/src/assemblies/engines/scoring/ScoringEngine.ts
@@ -232,6 +232,10 @@ export class ScoringEngine {
    * framework proxy wrappers (e.g. Svelte 5 $state) that structuredClone rejects.
    */
   getState(): MatchUp {
+    // Deliberate — see the JSDoc above. structuredClone throws DataCloneError on the framework proxies
+    // this state can hold, so the JSON round-trip is the requirement here, not the default deep-copy
+    // idiom the rule exists to retire.
+    // eslint-disable-next-line no-restricted-syntax
     return JSON.parse(JSON.stringify(this.state));
   }
 
@@ -1106,9 +1110,7 @@ export class ScoringEngine {
     // matching their new positions in history.points.
     const entries = this.state.history?.entries;
     if (entries) {
-      const entryIdx = entries.findIndex(
-        (e) => e.type === 'point' && (e as any).pointIndex === pointIndex,
-      );
+      const entryIdx = entries.findIndex((e) => e.type === 'point' && (e as any).pointIndex === pointIndex);
       if (entryIdx !== -1) entries.splice(entryIdx, 1);
       for (const e of entries) {
         if (e.type === 'point' && (e as any).pointIndex > pointIndex) {

--- a/src/errors/FactoryError.test.ts
+++ b/src/errors/FactoryError.test.ts
@@ -58,6 +58,9 @@ describe('FactoryError', () => {
 
   it('serializes to the legacy envelope shape via toJSON', () => {
     const err = new MissingTournamentRecordError({ info: 'no state loaded' });
+    // A genuine JSON serialization round-trip: the point is to exercise toJSON, which structuredClone
+    // does not call.
+    // eslint-disable-next-line no-restricted-syntax
     expect(JSON.parse(JSON.stringify({ error: err }))).toEqual({
       error: {
         code: 'ERR_MISSING_TOURNAMENT',
@@ -69,6 +72,8 @@ describe('FactoryError', () => {
 
   it('omits info from JSON projection when absent', () => {
     const err = new InvalidValuesError();
+    // JSON serialization round-trip, not a deep copy.
+    // eslint-disable-next-line no-restricted-syntax
     expect(JSON.parse(JSON.stringify(err))).toEqual({
       code: 'ERR_INVALID_VALUES',
       message: 'Invalid values',

--- a/src/global/policyComposer.test.ts
+++ b/src/global/policyComposer.test.ts
@@ -54,7 +54,7 @@ describe('policyComposer.extend', () => {
   });
 
   it('does NOT mutate the inputs', () => {
-    const before = JSON.parse(JSON.stringify(stockUstaSeeding));
+    const before = structuredClone(stockUstaSeeding);
     policyComposer(POLICY_TYPE_SEEDING).extend(stockUstaSeeding).set('policyName', 'MUTATED').build();
     expect(stockUstaSeeding).toEqual(before);
   });

--- a/src/query/matchUps/addMatchUpContext.ts
+++ b/src/query/matchUps/addMatchUpContext.ts
@@ -215,6 +215,7 @@ export function addMatchUpContext({
 
   const collectionAssignmentDetail = collectionId
     ? getCollectionAssignment({
+        participantTemplate: appliedPolicies?.[POLICY_TYPE_PARTICIPANT]?.participant,
         tournamentParticipants,
         positionAssignments,
         collectionPosition,
@@ -516,16 +517,18 @@ function hydrateSides({
   event,
 }) {
   const participantAttributes = appliedPolicies?.[POLICY_TYPE_PARTICIPANT];
-  const getMappedParticipant = (participantId) => {
+  const participantTemplate = participantAttributes?.participant;
+  // A privacy policy carries a SEPARATE `individualParticipants` sub-template, which may be stricter
+  // than the top-level one. Judging nested individuals by the top-level template is invisible while
+  // the two happen to be identical — as they are in POLICY_PRIVACY_DEFAULT — and silently wrong the
+  // moment a provider tightens one of them.
+  const individualsTemplate = participantTemplate?.individualParticipants;
+  const filterWith = (template) => (participantId) => {
     const participant = participantMap?.[participantId]?.participant;
-    return (
-      participant &&
-      attributeFilter({
-        template: participantAttributes?.participant,
-        source: participant,
-      })
-    );
+    return participant && attributeFilter({ template, source: participant });
   };
+  const getMappedParticipant = filterWith(participantTemplate);
+  const getMappedIndividual = filterWith(individualsTemplate);
 
   matchUpWithContext.sides.filter(Boolean).forEach((side) => {
     hydrateSideParticipant({
@@ -540,20 +543,27 @@ function hydrateSides({
       event,
     });
 
-    if (side?.participant?.individualParticipantIds?.length && !side.participant.individualParticipants?.length) {
+    // A policy that names no `individualParticipants` sub-template denies the attribute outright —
+    // `attributeFilter` copies only what it names — so nothing may be attached here either.
+    const individualsDenied = !!participantTemplate && !individualsTemplate;
+
+    if (
+      side?.participant?.individualParticipantIds?.length &&
+      !side.participant.individualParticipants?.length &&
+      !individualsDenied
+    ) {
       const individualParticipants = side.participant.individualParticipantIds.map((participantId) => {
-        return (
-          getMappedParticipant(participantId) ||
+        const found =
+          getMappedIndividual(participantId) ||
           (tournamentParticipants
             ? findParticipant({
-                policyDefinitions: appliedPolicies,
                 tournamentParticipants,
                 internalUse: true,
                 contextProfile,
                 participantId,
               })
-            : undefined)
-        );
+            : undefined);
+        return individualsTemplate && found ? attributeFilter({ template: individualsTemplate, source: found }) : found;
       });
       if (hydrateParticipants !== false) Object.assign(side.participant, { individualParticipants });
     }

--- a/src/query/matchUps/getCollectionAssignment.ts
+++ b/src/query/matchUps/getCollectionAssignment.ts
@@ -1,6 +1,7 @@
 import { getCollectionPositionAssignments } from '@Query/hierarchical/tieFormats/getCollectionPositionAssignments';
 import { getPairedParticipant } from '@Query/participant/getPairedParticipant';
 import { getTeamLineUp } from '@Query/drawDefinition/getTeamLineUp';
+import { attributeFilter } from '@Tools/attributeFilter';
 
 // constants and types
 import { DrawDefinition, Participant, PositionAssignment } from '@Types/tournamentTypes';
@@ -10,6 +11,8 @@ import { DOUBLES } from '@Constants/matchUpTypes';
 type GetDrawPositionCollectionAssignmentArgs = {
   positionAssignments: PositionAssignment[];
   tournamentParticipants?: Participant[];
+  /** `participant` template of a supplied participant privacy policy; undefined means no filtering. */
+  participantTemplate?: any;
   participantMap?: ParticipantMap;
   drawDefinition?: DrawDefinition;
   collectionPosition?: number;
@@ -30,6 +33,7 @@ type TeamCollectionAssignment = {
 export function getCollectionAssignment({
   tournamentParticipants,
   positionAssignments,
+  participantTemplate,
   collectionPosition,
   drawPositions = [],
   participantMap,
@@ -43,7 +47,18 @@ export function getCollectionAssignment({
 } {
   if (!collectionId || !collectionPosition) return {};
 
-  const getAssignment = ({ attribute, lineUp, teamParticipant }) => {
+  // `teamParticipant` lands on `sides[].teamParticipant` of every tie matchUp. Two of the three ways
+  // it is resolved below reach straight into the RAW participant (`participantMap`, then a scan of
+  // `tournamentParticipants`), so without this it carried `penalties`, `timeItems` and everything else
+  // the policy denies — on the same hydrated matchUps whose `sides[].participant` was filtered
+  // correctly beside it.
+  const filterTeamParticipant = (teamParticipant) =>
+    participantTemplate && teamParticipant
+      ? attributeFilter({ source: teamParticipant, template: participantTemplate })
+      : teamParticipant;
+
+  const getAssignment = ({ attribute, lineUp, teamParticipant: rawTeamParticipant }) => {
+    const teamParticipant = filterTeamParticipant(rawTeamParticipant);
     const { assignedParticipantIds, substitutions } = getCollectionPositionAssignments({
       collectionPosition,
       collectionId,

--- a/src/query/matchUps/getTournamentMatchUps.ts
+++ b/src/query/matchUps/getTournamentMatchUps.ts
@@ -1,3 +1,4 @@
+import { applyParticipantPrivacy, getParticipantPrivacyTemplate } from '../participants/participantPrivacy';
 import { hydrateParticipants } from '../participants/hydrateParticipants';
 import { getAppliedPolicies } from '../extensions/getAppliedPolicies';
 import { getContextContent } from '../hierarchical/getContextContent';
@@ -100,5 +101,16 @@ export function tournamentMatchUps(params: GetMatchUpsArgs): GroupsMatchUpsResul
     { matchUpsCount: 0 },
   );
 
-  return { ...eventsDrawMatchUpsResult, groupInfo, participants };
+  // Emission boundary. `participants` above is the hydrated, UNFILTERED array that context assembly
+  // needs (scale values read `timeItems`, participant resolution reads `personId`); the copy that
+  // leaves the engine is the one a supplied privacy policy governs. `getCompetitionMatchUps` folds
+  // this array into `mappedParticipants`, which `competitionScheduleMatchUps` returns to public
+  // callers, so an unfiltered array here is an unfiltered public payload.
+  const template = getParticipantPrivacyTemplate(policyDefinitions);
+
+  return {
+    ...eventsDrawMatchUpsResult,
+    participants: applyParticipantPrivacy({ participants, template }),
+    groupInfo,
+  };
 }

--- a/src/query/participants/getParticipantSchedules.ts
+++ b/src/query/participants/getParticipantSchedules.ts
@@ -1,22 +1,32 @@
 import { getMatchUpDependencies } from '../matchUps/getMatchUpDependencies';
 import { allTournamentMatchUps } from '../matchUps/getAllTournamentMatchUps';
 
+import { INVALID_OBJECT, MISSING_TOURNAMENT_RECORD } from '@Constants/errorConditionConstants';
+import { PolicyDefinitions } from '@Types/factoryTypes';
 import { Tournament } from '@Types/tournamentTypes';
 import { SUCCESS } from '@Constants/resultConstants';
-import { INVALID_OBJECT, MISSING_TOURNAMENT_RECORD } from '@Constants/errorConditionConstants';
 
 type GetParticipantSchedulesArgs = {
+  policyDefinitions?: PolicyDefinitions;
   tournamentRecord: Tournament;
   participantFilters?: any;
 };
-export function getParticipantSchedules({ participantFilters = {}, tournamentRecord }: GetParticipantSchedulesArgs) {
+export function getParticipantSchedules({
+  participantFilters = {},
+  policyDefinitions,
+  tournamentRecord,
+}: GetParticipantSchedulesArgs) {
   if (!tournamentRecord) return { error: MISSING_TOURNAMENT_RECORD };
 
   if (typeof participantFilters !== 'object') return { error: INVALID_OBJECT, context: { participantFilters } };
 
   const contextFilters = { eventIds: participantFilters.eventIds };
+  // Every participant this surface emits is read off a hydrated `side.participant`, so threading the
+  // policy into matchUp hydration is what governs the whole response — the schedules, the matchUps
+  // they carry, and the `sides[].participant` inside those.
   const matchUps =
     allTournamentMatchUps({
+      policyDefinitions,
       tournamentRecord,
       contextFilters,
     }).matchUps ?? [];

--- a/src/query/participants/getParticipants.ts
+++ b/src/query/participants/getParticipants.ts
@@ -1,3 +1,4 @@
+import { applyParticipantPrivacyToMap } from '@Query/participants/participantPrivacy';
 import { getParticipantEntries } from '@Query/participants/getParticipantEntries';
 import { getMatchUpDependencies } from '@Query/matchUps/getMatchUpDependencies';
 import { filterParticipants } from '@Query/participants/filterParticipants';
@@ -214,8 +215,13 @@ export function getParticipants(params: GetParticipantsArgs): {
     ? filteredParticipants.map((source) => attributeFilter({ source, template }))
     : filteredParticipants;
 
+  // The map is a second emission of the same people. It was returned raw, so a caller that supplied a
+  // privacy policy and spread the whole result — as the public schedule route does — published every
+  // attribute the policy denies, while `participants` beside it was correctly filtered.
+  const emittedParticipantMap = applyParticipantPrivacyToMap({ participantMap, template });
+
   return {
-    participantMap: params.returnParticipantMap !== false ? participantMap : undefined,
+    participantMap: params.returnParticipantMap !== false ? emittedParticipantMap : undefined,
     mappedMatchUps: params.returnMatchUps !== false ? mappedMatchUps : undefined,
     matchUps: params.returnMatchUps !== false ? matchUps : undefined,
     missingParticipantIds: mapResult.missingParticipantIds,

--- a/src/query/participants/hydrateParticipants.ts
+++ b/src/query/participants/hydrateParticipants.ts
@@ -1,3 +1,4 @@
+import { applyParticipantPrivacyToGroupInfo, getParticipantPrivacyTemplate } from './participantPrivacy';
 import { addParticipantGroupings } from '@Query/drawDefinition/avoidance/addParticipantGroupings';
 import { addNationalityCode } from '@Query/participants/addNationalityCode';
 import { getScaleValues } from '../participant/getScaleValues';
@@ -9,6 +10,17 @@ import { ContextProfile, ParticipantMap, ParticipantsProfile, PolicyDefinitions 
 import { HydratedParticipant } from '@Types/hydrated';
 import { Tournament } from '@Types/tournamentTypes';
 
+/**
+ * ⚠️ `policyDefinitions` is accepted for signature parity with the query surfaces that call this, and
+ * is DELIBERATELY not applied here. Hydration must return participants whole: `getScaleValues` reads
+ * `timeItems`, participant resolution reads `person.personId`, and gender enforcement reads
+ * `person.sex` — all of which a privacy policy may deny. Filtering here would silently break context
+ * assembly for exactly the callers that asked for privacy.
+ *
+ * A participant privacy policy is applied at the EMISSION BOUNDARY instead — see
+ * `participantPrivacy.ts` and its use in `getTournamentMatchUps` / `getParticipants`. If you are
+ * adding a surface that returns participants, filter them there, not here.
+ */
 type HydrateParticipantsArgs = {
   participantsProfile?: ParticipantsProfile;
   policyDefinitions?: PolicyDefinitions;
@@ -20,6 +32,7 @@ type HydrateParticipantsArgs = {
 export function hydrateParticipants({
   participantsProfile,
   useParticipantMap,
+  policyDefinitions,
   tournamentRecord,
   contextProfile,
   inContext,
@@ -28,12 +41,21 @@ export function hydrateParticipants({
   participantMap?: ParticipantMap;
   groupInfo: any;
 } {
+  // `groupInfo` is the one thing here a policy CAN govern in place: it is built for the caller and
+  // read by nothing inside the engine, so filtering it breaks no downstream assembly. Every surface
+  // that emits `groupInfo` gets it from this function, which is why one filter here covers them all.
+  const groupInfoTemplate = getParticipantPrivacyTemplate(policyDefinitions);
+
   if (useParticipantMap) {
-    return getParticipantMap({
+    const mapResult = getParticipantMap({
       ...participantsProfile,
       ...contextProfile,
       tournamentRecord,
     });
+    return {
+      ...mapResult,
+      groupInfo: applyParticipantPrivacyToGroupInfo({ groupInfo: mapResult.groupInfo, template: groupInfoTemplate }),
+    };
   }
 
   let participants: HydratedParticipant[] = makeDeepCopy(tournamentRecord.participants, false, true) ?? [];
@@ -58,5 +80,5 @@ export function hydrateParticipants({
     }
   }
 
-  return { participants, groupInfo };
+  return { participants, groupInfo: applyParticipantPrivacyToGroupInfo({ groupInfo, template: groupInfoTemplate }) };
 }

--- a/src/query/participants/participantPrivacy.ts
+++ b/src/query/participants/participantPrivacy.ts
@@ -1,0 +1,70 @@
+import { attributeFilter } from '@Tools/attributeFilter';
+
+// constants and types
+import { POLICY_TYPE_PARTICIPANT } from '@Constants/policyConstants';
+import { PolicyDefinitions } from '@Types/factoryTypes';
+
+/**
+ * The `participant` attribute template of a supplied participant privacy policy, or `undefined` when
+ * no policy was supplied. `undefined` means "no filtering was requested" — never "filter everything".
+ */
+export function getParticipantPrivacyTemplate(policyDefinitions?: PolicyDefinitions): any {
+  return policyDefinitions?.[POLICY_TYPE_PARTICIPANT]?.participant;
+}
+
+/**
+ * Apply a participant privacy template at an EMISSION BOUNDARY — the point where participants leave
+ * the engine — rather than at hydration.
+ *
+ * Hydration deliberately keeps participants whole: `getScaleValues` reads `timeItems`, `findParticipant`
+ * resolves by `personId`, and gender enforcement reads `person.sex`. A policy that denies any of those
+ * would silently break context assembly if the filter were applied upstream, so the filter is applied
+ * to the copy that is returned and to nothing else.
+ *
+ * Returns a new array; the input participants are not mutated. Filtering ATTRIBUTES never removes a
+ * participant — the returned array has the same length and the same entities as the input, whatever
+ * the policy denies.
+ */
+export function applyParticipantPrivacy<T = any>(params: { participants?: T[]; template?: any }): T[] | undefined {
+  const { participants, template } = params;
+  if (!template || !participants?.length) return participants;
+  return participants.map((source) => attributeFilter({ source, template }));
+}
+
+/**
+ * `groupInfo` is a `{ participantId, participantName }` lookup for the TEAM / GROUP / PAIR entities an
+ * individual belongs to. It is participant data under a different shape, so a policy that denies
+ * `participantName` must deny it here too — the entry survives (an entity is never removed), stripped
+ * to what the policy permits.
+ */
+export function applyParticipantPrivacyToGroupInfo(params: { groupInfo?: any; template?: any }): any {
+  const { groupInfo, template } = params;
+  if (!template || !groupInfo) return groupInfo;
+
+  const filtered = {};
+  for (const [participantId, group] of Object.entries<any>(groupInfo)) {
+    filtered[participantId] = attributeFilter({ source: group, template });
+  }
+  return filtered;
+}
+
+/**
+ * The same boundary treatment for a `participantMap`, whose entries hold the participant alongside
+ * per-participant aggregations (matchUps, events, draws, opponents, scheduleItems).
+ *
+ * Only the `participant` is replaced — the aggregations are keyed by id and carry no participant
+ * attributes of their own. A new map is built so the caller's working copy, which the engine still
+ * reads from, is left intact.
+ */
+export function applyParticipantPrivacyToMap(params: { participantMap?: any; template?: any }): any {
+  const { participantMap, template } = params;
+  if (!template || !participantMap) return participantMap;
+
+  const filtered = {};
+  for (const [participantId, entry] of Object.entries<any>(participantMap)) {
+    filtered[participantId] = entry?.participant
+      ? { ...entry, participant: attributeFilter({ source: entry.participant, template }) }
+      : entry;
+  }
+  return filtered;
+}

--- a/src/tests/mutations/tieFormat/tieFormatForkFragmentation.test.ts
+++ b/src/tests/mutations/tieFormat/tieFormatForkFragmentation.test.ts
@@ -250,7 +250,7 @@ describe('shared tieFormat does not fragment on removeCollectionDefinition', () 
     const teamMatchUps = structure.matchUps.filter((m: any) => m.tieMatchUps);
     expect(teamMatchUps.length).toBeGreaterThan(1);
 
-    const privateFormat = JSON.parse(JSON.stringify(event.tieFormats[0]));
+    const privateFormat = structuredClone(event.tieFormats[0]);
     privateFormat.tieFormatId = 'private-tf';
     event.tieFormats.push(privateFormat);
     teamMatchUps[0].tieFormatId = 'private-tf';

--- a/src/tests/policies/privacy/detectorFalsification.test.ts
+++ b/src/tests/policies/privacy/detectorFalsification.test.ts
@@ -7,6 +7,10 @@
  * treatment: it must fail when the fixture stops holding a value for something the policy denies.
  */
 
+import { uncoveredDeniedPaths, templateDeniedPaths } from '@Tests/testHarness/privacySaturation';
+import { generatePrivacyFixture } from '@Tests/testHarness/privacyFixture';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
 import {
   collectUnpermittedAttributes,
   analysePolicyConformance,
@@ -15,11 +19,8 @@ import {
   deriveForbiddenData,
   participantTemplate,
 } from '@Tests/testHarness/privacyConformance';
-import { uncoveredDeniedPaths, templateDeniedPaths } from '@Tests/testHarness/privacySaturation';
-import { generatePrivacyFixture } from '@Tests/testHarness/privacyFixture';
-import tournamentEngine from '@Engines/syncEngine';
-import { describe, expect, it } from 'vitest';
 
+// constants and types
 import POLICY_PRIVACY_DEFAULT from '@Fixtures/policies/POLICY_PRIVACY_DEFAULT';
 import { POLICY_TYPE_PARTICIPANT } from '@Constants/policyConstants';
 

--- a/src/tests/policies/privacy/detectorFalsification.test.ts
+++ b/src/tests/policies/privacy/detectorFalsification.test.ts
@@ -1,0 +1,188 @@
+/**
+ * The check on the check.
+ *
+ * A conformance suite that cannot report "dirty" is worth exactly nothing, and looks identical to one
+ * that passes. Every detector in `privacyConformance.ts` is fed a known-bad input here and required to
+ * fire, and a known-good input and required to stay silent. The saturation control gets the same
+ * treatment: it must fail when the fixture stops holding a value for something the policy denies.
+ */
+
+import {
+  collectUnpermittedAttributes,
+  analysePolicyConformance,
+  scanForForbiddenData,
+  describeViolations,
+  deriveForbiddenData,
+  participantTemplate,
+} from '@Tests/testHarness/privacyConformance';
+import { uncoveredDeniedPaths, templateDeniedPaths } from '@Tests/testHarness/privacySaturation';
+import { generatePrivacyFixture } from '@Tests/testHarness/privacyFixture';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+import POLICY_PRIVACY_DEFAULT from '@Fixtures/policies/POLICY_PRIVACY_DEFAULT';
+import { POLICY_TYPE_PARTICIPANT } from '@Constants/policyConstants';
+
+const fixture = generatePrivacyFixture();
+const template = participantTemplate(POLICY_PRIVACY_DEFAULT);
+
+const clean = () =>
+  tournamentEngine.getParticipants({ policyDefinitions: POLICY_PRIVACY_DEFAULT, withGroupings: true }).participants;
+
+describe('deriveForbiddenData', () => {
+  it('finds what the policy removes, and nothing it permits', () => {
+    const forbidden = deriveForbiddenData({ participants: fixture.hydratedParticipants, template });
+    const attributes = new Set(forbidden.map((datum) => datum.attribute));
+
+    expect(attributes.has('sex')).toEqual(true);
+    expect(attributes.has('birthDate')).toEqual(true);
+    expect(attributes.has('personId')).toEqual(true);
+    // permitted attributes must NOT be treated as forbidden, or every response would look dirty
+    expect(attributes.has('standardFamilyName')).toEqual(false);
+    expect(attributes.has('participantId')).toEqual(false);
+    expect(attributes.has('nationalityCode')).toEqual(false);
+  });
+
+  it('returns nothing when no policy is supplied — absence of a policy is not a denial', () => {
+    expect(deriveForbiddenData({ participants: fixture.hydratedParticipants, template: undefined })).toEqual([]);
+  });
+});
+
+describe('scanForForbiddenData', () => {
+  const forbidden = deriveForbiddenData({ participants: fixture.hydratedParticipants, template });
+
+  it('stays silent on a filtered response', () => {
+    const result = scanForForbiddenData({ node: clean(), forbidden });
+    expect(result.objectsScanned).toBeGreaterThan(0);
+    expect(result.violations).toEqual([]);
+  });
+
+  it.each([
+    ['at the top level', (leak: any, participant: any) => ({ ...participant, sex: leak.person.sex })],
+    ['nested in a person', (leak: any, participant: any) => ({ ...participant, person: { sex: leak.person.sex } })],
+    [
+      'buried under an unrelated key',
+      (leak: any, participant: any) => ({ ...participant, meta: { extra: [{ sex: leak.person.sex }] } }),
+    ],
+  ])('fires on a planted value %s', (_name, plant) => {
+    const participants = clean();
+    const leakSource = fixture.hydratedParticipants.find((p: any) => p.person?.sex);
+    expect(leakSource).toBeDefined();
+    const planted = [plant(leakSource, participants[0]), ...participants.slice(1)];
+
+    const result = scanForForbiddenData({ node: planted, forbidden });
+    expect(result.violations.map((violation) => violation.attribute)).toContain('sex');
+  });
+
+  it('does not fire on a matching value under a DIFFERENT attribute name', () => {
+    const leakSource: any = fixture.hydratedParticipants.find((p: any) => p.person?.sex);
+    const decoy = [{ unrelatedAttribute: leakSource.person.sex }];
+    expect(scanForForbiddenData({ node: decoy, forbidden }).violations).toEqual([]);
+  });
+
+  it('skips a declared subtree, and reports having skipped it', () => {
+    const leakSource: any = fixture.hydratedParticipants.find((p: any) => p.person?.sex);
+    const node = { tournamentContacts: [{ sex: leakSource.person.sex }] };
+    const result = scanForForbiddenData({ node, forbidden, skipSubtrees: ['tournamentContacts'] });
+    expect(result.violations).toEqual([]);
+    expect(result.skippedSubtrees).toEqual(['tournamentContacts']);
+    // and without the declaration it fires — the skip is doing the work, not the shape of the input
+    expect(scanForForbiddenData({ node, forbidden }).violations.length).toBeGreaterThan(0);
+  });
+});
+
+describe('collectUnpermittedAttributes', () => {
+  it('stays silent on a filtered response, having examined participants', () => {
+    const result = collectUnpermittedAttributes({ node: clean(), template });
+    expect(result.participantsScanned).toBeGreaterThan(0);
+    expect(result.findings).toEqual([]);
+  });
+
+  it('fires on a COMPUTED attribute that no record holds', () => {
+    // `seedings` exists only after hydration, so the value-matching detector cannot see it. This is
+    // the case that justifies having two detectors rather than one.
+    const participants = clean();
+    const planted = [{ ...participants[0], seedings: { SINGLES: [{ seedValue: 1 }] } }, ...participants.slice(1)];
+    const result = collectUnpermittedAttributes({ node: planted, template });
+    expect(result.findings.flatMap((finding) => finding.attributes)).toContain('seedings');
+  });
+
+  it('honours declared context annotations, and reports which were seen', () => {
+    const participants = clean();
+    const planted = [{ ...participants[0], entryStatus: 'DIRECT_ACCEPTANCE' }, ...participants.slice(1)];
+
+    const withAnnotation = collectUnpermittedAttributes({
+      contextAnnotations: ['entryStatus'],
+      node: planted,
+      template,
+    });
+    expect(withAnnotation.findings).toEqual([]);
+    expect(withAnnotation.annotationsSeen).toEqual(['entryStatus']);
+
+    // without the declaration the same input is a violation — the exemption is load-bearing
+    expect(collectUnpermittedAttributes({ node: planted, template }).findings.length).toBeGreaterThan(0);
+  });
+
+  it('returns nothing when no policy is supplied', () => {
+    const result = collectUnpermittedAttributes({ node: fixture.hydratedParticipants, template: undefined });
+    expect(result.findings).toEqual([]);
+    expect(result.participantsScanned).toEqual(0);
+  });
+});
+
+describe('the saturation control', () => {
+  it('reports nothing uncovered for the fixture as built', () => {
+    expect(uncoveredDeniedPaths({ participants: fixture.hydratedParticipants, template })).toEqual([]);
+  });
+
+  it('names every denied path, at every depth', () => {
+    const denied = templateDeniedPaths(template);
+    expect(denied).toContain('person.sex');
+    expect(denied).toContain('individualParticipants.person.sex');
+    expect(denied).toContain('contacts');
+    expect(denied).not.toContain('person.standardFamilyName');
+  });
+
+  it('fires when a denied attribute has no value to leak', () => {
+    const stripped = fixture.hydratedParticipants.map((participant: any) => {
+      const { person, ...rest } = participant;
+      const { sex, ...personRest } = person ?? {};
+      return person ? { ...rest, person: personRest } : rest;
+    });
+    expect(uncoveredDeniedPaths({ participants: stripped, template })).toContain('person.sex');
+  });
+});
+
+describe('analysePolicyConformance', () => {
+  it('composes both detectors and describes violations from each', () => {
+    const participants = clean();
+    const leakSource: any = fixture.hydratedParticipants.find((p: any) => p.person?.sex);
+    const planted = [
+      { ...participants[0], person: { ...participants[0].person, sex: leakSource.person.sex } },
+      { ...participants[1], seedings: { SINGLES: [{ seedValue: 1 }] } },
+      ...participants.slice(2),
+    ];
+
+    const violations = describeViolations(
+      analysePolicyConformance({
+        participants: fixture.hydratedParticipants,
+        policyDefinitions: POLICY_PRIVACY_DEFAULT,
+        node: planted,
+      }),
+    );
+    expect(violations.some((violation) => violation.startsWith('person.sex'))).toEqual(true);
+    expect(violations.some((violation) => violation.startsWith('seedings'))).toEqual(true);
+  });
+
+  it('is silent when the policy permits what is present', () => {
+    const permissive = structuredClone(POLICY_PRIVACY_DEFAULT);
+    permissive[POLICY_TYPE_PARTICIPANT].participant = { '*': true };
+    const analysis = analysePolicyConformance({
+      participants: fixture.hydratedParticipants,
+      policyDefinitions: permissive,
+      node: fixture.hydratedParticipants,
+    });
+    expect(analysis.unpermitted.participantsScanned).toBeGreaterThan(0);
+    expect(describeViolations(analysis)).toEqual([]);
+  });
+});

--- a/src/tests/policies/privacy/participantTypeMatrix.test.ts
+++ b/src/tests/policies/privacy/participantTypeMatrix.test.ts
@@ -13,8 +13,9 @@ import { generatePrivacyFixture, GROUP_PARTICIPANT_ID } from '@Tests/testHarness
 import tournamentEngine from '@Engines/syncEngine';
 import { describe, expect, it } from 'vitest';
 
-import POLICY_PRIVACY_DEFAULT from '@Fixtures/policies/POLICY_PRIVACY_DEFAULT';
+// constants and types
 import { GROUP, INDIVIDUAL, PAIR, TEAM } from '@Constants/participantConstants';
+import POLICY_PRIVACY_DEFAULT from '@Fixtures/policies/POLICY_PRIVACY_DEFAULT';
 import { POLICY_TYPE_PARTICIPANT } from '@Constants/policyConstants';
 
 const fixture = generatePrivacyFixture();

--- a/src/tests/policies/privacy/participantTypeMatrix.test.ts
+++ b/src/tests/policies/privacy/participantTypeMatrix.test.ts
@@ -1,0 +1,141 @@
+/**
+ * The participantType matrix, and the distinction that is load-bearing and was previously untested:
+ *
+ *   filtering an ATTRIBUTE must never remove an ENTITY.
+ *
+ * `teams` is an attribute of an INDIVIDUAL participant — the teams it belongs to — and a policy may
+ * deny it. A TEAM participant is an entity, and no policy may make it disappear. The two share a
+ * word and nothing else.
+ */
+
+import { analysePolicyConformance, describeViolations } from '@Tests/testHarness/privacyConformance';
+import { generatePrivacyFixture, GROUP_PARTICIPANT_ID } from '@Tests/testHarness/privacyFixture';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+import POLICY_PRIVACY_DEFAULT from '@Fixtures/policies/POLICY_PRIVACY_DEFAULT';
+import { GROUP, INDIVIDUAL, PAIR, TEAM } from '@Constants/participantConstants';
+import { POLICY_TYPE_PARTICIPANT } from '@Constants/policyConstants';
+
+const fixture = generatePrivacyFixture();
+
+const countByType = (participants: any[]) =>
+  participants.reduce((counts, participant) => {
+    counts[participant.participantType] = (counts[participant.participantType] ?? 0) + 1;
+    return counts;
+  }, {});
+
+/** The same query with no policy at all — the yardstick for "did filtering remove anything". */
+const unfiltered = () =>
+  tournamentEngine.getParticipants({ withGroupings: true, withIndividualParticipants: true }).participants;
+
+const filtered = (policyDefinitions: any) =>
+  tournamentEngine.getParticipants({ policyDefinitions, withGroupings: true, withIndividualParticipants: true })
+    .participants;
+
+/** `teams` named explicitly as denied, rather than merely absent from the template. */
+function teamsDeniedPolicy() {
+  const policy = structuredClone(POLICY_PRIVACY_DEFAULT);
+  policy[POLICY_TYPE_PARTICIPANT].participant.teams = false;
+  policy[POLICY_TYPE_PARTICIPANT].participant.groups = false;
+  return policy;
+}
+
+describe('filtering an attribute never removes an entity', () => {
+  it.each([
+    ['teams absent from the template', POLICY_PRIVACY_DEFAULT],
+    ['teams explicitly false', teamsDeniedPolicy()],
+  ])('%s: every participantType survives, in the same numbers', (_name, policyDefinitions) => {
+    const before = unfiltered();
+    const after = filtered(policyDefinitions);
+
+    // control: the fixture actually contains all four types, so the comparison is not between two
+    // empty sets
+    expect(Object.keys(countByType(before)).sort((a, b) => a.localeCompare(b, 'en'))).toEqual([
+      GROUP,
+      INDIVIDUAL,
+      PAIR,
+      TEAM,
+    ]);
+    expect(countByType(after)).toEqual(countByType(before));
+    expect(after.map((p: any) => p.participantId).sort((a, b) => a.localeCompare(b, 'en'))).toEqual(
+      before.map((p: any) => p.participantId).sort((a, b) => a.localeCompare(b, 'en')),
+    );
+  });
+
+  it.each([
+    ['teams absent from the template', POLICY_PRIVACY_DEFAULT],
+    ['teams explicitly false', teamsDeniedPolicy()],
+  ])('%s: the `teams` / `groups` ATTRIBUTE is gone from individuals', (_name, policyDefinitions) => {
+    const before = unfiltered().filter((p: any) => p.participantType === INDIVIDUAL);
+    const after = filtered(policyDefinitions).filter((p: any) => p.participantType === INDIVIDUAL);
+
+    // control: without a policy the attribute is populated, so its absence below means something
+    expect(before.filter((p: any) => p.teams?.length).length).toBeGreaterThan(0);
+    expect(before.filter((p: any) => p.groups?.length).length).toBeGreaterThan(0);
+
+    expect(after.filter((p: any) => p.teams !== undefined)).toEqual([]);
+    expect(after.filter((p: any) => p.groups !== undefined)).toEqual([]);
+  });
+
+  it('the GROUP participant is still addressable after its members are filtered', () => {
+    const after = filtered(POLICY_PRIVACY_DEFAULT);
+    const group = after.find((p: any) => p.participantId === GROUP_PARTICIPANT_ID);
+    expect(group?.participantType).toEqual(GROUP);
+    expect(group?.individualParticipantIds?.length).toBeGreaterThan(0);
+  });
+});
+
+describe('nested individualParticipants are governed', () => {
+  /**
+   * A policy strictly stricter on `individualParticipants` than at the top level. If a surface applied
+   * the TOP-LEVEL template to nested individuals — an easy and invisible mistake — the nested people
+   * would carry a family name the policy denies them while the outer participants correctly did not.
+   */
+  function strictNestedPolicy() {
+    const policy = structuredClone(POLICY_PRIVACY_DEFAULT);
+    policy[POLICY_TYPE_PARTICIPANT].participant.individualParticipants.person.standardFamilyName = false;
+    return policy;
+  }
+
+  it.each([
+    ['getParticipants', () => filtered(strictNestedPolicy())],
+    [
+      'matchUp sides',
+      () =>
+        tournamentEngine.allTournamentMatchUps({ policyDefinitions: strictNestedPolicy(), inContext: true }).matchUps,
+    ],
+  ])('%s applies the individualParticipants sub-template, not the top-level one', (_name, invoke) => {
+    const nested: any[] = [];
+    const outer: any[] = [];
+    const walk = (node: any, insideIndividuals: boolean) => {
+      if (Array.isArray(node)) return node.forEach((member) => walk(member, insideIndividuals));
+      if (!node || typeof node !== 'object') return;
+      if (node.person && node.participantId) (insideIndividuals ? nested : outer).push(node);
+      for (const [key, value] of Object.entries(node)) {
+        walk(value, insideIndividuals || key === 'individualParticipants');
+      }
+    };
+    walk(invoke(), false);
+
+    // controls: both populations exist, and the outer one still carries the attribute
+    expect(nested.length).toBeGreaterThan(0);
+    expect(outer.length).toBeGreaterThan(0);
+    expect(outer.filter((p) => p.person?.standardFamilyName !== undefined).length).toBeGreaterThan(0);
+
+    expect(nested.filter((p) => p.person?.standardFamilyName !== undefined)).toEqual([]);
+  });
+});
+
+describe('every participantType is scanned by the general check', () => {
+  it('reports no violation for any type, having examined all of them', () => {
+    const node = filtered(POLICY_PRIVACY_DEFAULT);
+    const analysis = analysePolicyConformance({
+      participants: fixture.hydratedParticipants,
+      policyDefinitions: POLICY_PRIVACY_DEFAULT,
+      node,
+    });
+    expect(analysis.unpermitted.participantsScanned).toBeGreaterThanOrEqual(node.length);
+    expect(describeViolations(analysis)).toEqual([]);
+  });
+});

--- a/src/tests/policies/privacy/seedingsFiltering.test.ts
+++ b/src/tests/policies/privacy/seedingsFiltering.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Draw, event and structure views cannot break when `seedings` is filtered out.
+ *
+ * CA, 2026-08-21: if a view depends on a filtered attribute, the view is wrong, not the policy. So
+ * this asserts equivalence of everything a bracket needs in order to render — structures, position
+ * assignments, seed assignments, matchUps, sides — between a policy that permits `seedings` and one
+ * that denies it, while proving the attribute really did disappear.
+ *
+ * Two distinctions the assertions depend on:
+ *
+ *  - `seedings` (the participant attribute: a per-eventType scale, opt-in via `withSeeding`) is what a
+ *    privacy policy governs. `seedValue` / `seedNumber` on a SIDE, and `seedAssignments` on a
+ *    structure, are draw structure — they are not participant attributes and must survive.
+ *  - Only `getEventData` emits `seedings` at all, and only when asked. `getDrawData` and
+ *    `getStructureData` emit none under either policy; that is asserted rather than assumed, with
+ *    `getEventData`'s non-zero count proving the counter can count.
+ */
+
+import { generatePrivacyFixture, SINGLES_DRAW_ID } from '@Tests/testHarness/privacyFixture';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+import POLICY_PRIVACY_DEFAULT from '@Fixtures/policies/POLICY_PRIVACY_DEFAULT';
+import { POLICY_TYPE_PARTICIPANT } from '@Constants/policyConstants';
+
+const fixture = generatePrivacyFixture();
+
+/** `POLICY_PRIVACY_DEFAULT` names no `seedings` key, and `attributeFilter` copies only what is named. */
+const seedingsDenied = POLICY_PRIVACY_DEFAULT;
+
+function seedingsPermitted() {
+  const policy = structuredClone(POLICY_PRIVACY_DEFAULT);
+  policy[POLICY_TYPE_PARTICIPANT].participant.seedings = true;
+  policy[POLICY_TYPE_PARTICIPANT].participant.individualParticipants.seedings = true;
+  return policy;
+}
+
+const participantsProfile = { withSeeding: true, withEvents: true };
+
+function countSeedings(node: any): number {
+  if (Array.isArray(node)) return node.reduce((total, member) => total + countSeedings(member), 0);
+  if (!node || typeof node !== 'object') return 0;
+  let total = 0;
+  for (const [key, value] of Object.entries(node)) {
+    if (key === 'seedings' && value && Object.keys(value).length) total += 1;
+    else total += countSeedings(value);
+  }
+  return total;
+}
+
+/** Everything a bracket needs in order to render, reduced to comparable counts. */
+function renderShape(structures: any[] = []) {
+  const matchUps = structures.flatMap((structure) => Object.values(structure?.roundMatchUps ?? {}).flat()) as any[];
+  const sides = matchUps.flatMap((matchUp) => matchUp?.sides ?? []);
+  return {
+    structures: structures.length,
+    positionAssignments: structures.reduce((total, s) => total + (s?.positionAssignments?.length ?? 0), 0),
+    seedAssignments: structures.reduce((total, s) => total + (s?.seedAssignments?.length ?? 0), 0),
+    sidesWithParticipants: sides.filter((side) => side?.participant).length,
+    sidesWithSeedValue: sides.filter((side) => side?.seedValue !== undefined).length,
+    matchUps: matchUps.length,
+  };
+}
+
+const surfaces: [string, (policyDefinitions: any) => { node: any; structures: any[] }][] = [
+  [
+    'getEventData',
+    (policyDefinitions) => {
+      const result = tournamentEngine.getEventData({
+        eventId: fixture.eventIds[0],
+        participantsProfile,
+        policyDefinitions,
+      });
+      return { node: result, structures: result.eventData.drawsData?.flatMap((draw: any) => draw.structures ?? []) };
+    },
+  ],
+  [
+    'getDrawData',
+    (policyDefinitions) => {
+      const result = tournamentEngine.getDrawData({
+        drawId: SINGLES_DRAW_ID,
+        participantsProfile,
+        policyDefinitions,
+      });
+      return { node: result, structures: result.structures };
+    },
+  ],
+  [
+    'getStructureData',
+    (policyDefinitions) => {
+      const { drawDefinition } = tournamentEngine.getEvent({ drawId: SINGLES_DRAW_ID });
+      const result = tournamentEngine.getStructureData({
+        structureId: drawDefinition.structures[0].structureId,
+        drawId: SINGLES_DRAW_ID,
+        participantsProfile,
+        policyDefinitions,
+      });
+      return { node: result, structures: [result.structure] };
+    },
+  ],
+];
+
+describe.each(surfaces)('%s renders identically when seedings are filtered', (_name, invoke) => {
+  const permitted = invoke(seedingsPermitted());
+  const denied = invoke(seedingsDenied);
+
+  it('structures, positions, seed assignments, matchUps and sides are unchanged', () => {
+    const shape = renderShape(permitted.structures);
+    // controls, so an "identical" result is not two identical zeroes
+    expect(shape.structures).toBeGreaterThan(0);
+    expect(shape.matchUps).toBeGreaterThan(0);
+    expect(shape.sidesWithParticipants).toBeGreaterThan(0);
+    expect(shape.seedAssignments).toBeGreaterThan(0);
+    expect(shape.sidesWithSeedValue).toBeGreaterThan(0);
+
+    expect(renderShape(denied.structures)).toEqual(shape);
+  });
+
+  it('emits no seedings under the denying policy', () => {
+    expect(countSeedings(denied.node)).toEqual(0);
+  });
+});
+
+describe('the seedings counter can count', () => {
+  it('getEventData emits seedings when the policy permits them', () => {
+    const { node } = surfaces[0][1](seedingsPermitted());
+    expect(countSeedings(node)).toBeGreaterThan(0);
+  });
+
+  it('getDrawData and getStructureData emit none under either policy — a fact, not an assumption', () => {
+    for (const [, invoke] of surfaces.slice(1)) {
+      expect(countSeedings(invoke(seedingsPermitted()).node)).toEqual(0);
+    }
+  });
+});

--- a/src/tests/policies/privacy/staffContacts.test.ts
+++ b/src/tests/policies/privacy/staffContacts.test.ts
@@ -1,0 +1,77 @@
+/**
+ * `tournamentContacts` is the one participant population the caller's policy does NOT govern.
+ *
+ * `getTournamentInfo` filters it with `POLICY_PRIVACY_STAFF` and accepts no `policyDefinitions` of its
+ * own, so a caller supplying a strict competitor policy still receives contacts shaped by the staff
+ * policy. That is deliberate — a contact stripped of `participantRoleResponsibilities` is not a
+ * contact — and it is the reason the general suite excludes the subtree rather than judging it by the
+ * wrong rules.
+ *
+ * Excluding it is only defensible if it is asserted here instead, which is what this file does: the
+ * staff policy is honoured on the staff population, and the personal attributes both policies deny are
+ * absent either way. If the design changes so that the caller's policy caps the staff policy, this
+ * file is where that becomes visible.
+ */
+
+import { analysePolicyConformance, describeViolations } from '@Tests/testHarness/privacyConformance';
+import { generatePrivacyFixture, STAFF_PARTICIPANT_ID } from '@Tests/testHarness/privacyFixture';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+import POLICY_PRIVACY_DEFAULT from '@Fixtures/policies/POLICY_PRIVACY_DEFAULT';
+import POLICY_PRIVACY_STAFF from '@Fixtures/policies/POLICY_PRIVACY_STAFF';
+
+const fixture = generatePrivacyFixture();
+
+const contacts = () => tournamentEngine.getTournamentInfo().tournamentInfo.tournamentContacts;
+
+describe('tournamentContacts', () => {
+  it('exists — the control, without which every assertion below is vacuous', () => {
+    const tournamentContacts = contacts();
+    expect(tournamentContacts.length).toBeGreaterThan(0);
+    expect(tournamentContacts.some((contact: any) => contact.participantId === STAFF_PARTICIPANT_ID)).toEqual(true);
+    // the staff participant on the record really does carry the attributes asserted absent below
+    const record = fixture.participants.find((p: any) => p.participantId === STAFF_PARTICIPANT_ID);
+    expect(record.person.sex).toBeDefined();
+    expect(record.person.personId).toBeDefined();
+    expect(record.participantRoleResponsibilities?.length).toBeGreaterThan(0);
+  });
+
+  it('honours POLICY_PRIVACY_STAFF in full', () => {
+    const analysis = analysePolicyConformance({
+      participants: fixture.participants,
+      policyDefinitions: POLICY_PRIVACY_STAFF,
+      node: contacts(),
+    });
+    expect(analysis.unpermitted.participantsScanned).toBeGreaterThan(0);
+    expect(analysis.forbidden.length).toBeGreaterThan(0);
+    expect(describeViolations(analysis)).toEqual([]);
+  });
+
+  it('carries participantRoleResponsibilities, which the competitor policy denies and the staff policy permits', () => {
+    // The single, deliberate divergence between the two policies on this surface. Naming it here means
+    // a future change that removes it fails a test rather than passing silently.
+    const withResponsibilities = contacts().filter((c: any) => c.participantRoleResponsibilities !== undefined);
+    expect(withResponsibilities.length).toBeGreaterThan(0);
+
+    const analysis = analysePolicyConformance({
+      participants: fixture.participants,
+      policyDefinitions: POLICY_PRIVACY_DEFAULT,
+      node: contacts(),
+    });
+    expect(new Set(describeViolations(analysis).map((violation) => violation.split(' @ ')[0]))).toEqual(
+      new Set(['participantRoleResponsibilities']),
+    );
+  });
+
+  it('denies the personal attributes both policies deny', () => {
+    for (const contact of contacts()) {
+      expect(contact.person?.sex).toBeUndefined();
+      expect(contact.person?.personId).toBeUndefined();
+      expect(contact.person?.birthDate).toBeUndefined();
+      expect(contact.person?.addresses).toBeUndefined();
+      expect(contact.contacts).toBeUndefined();
+      expect(contact.penalties).toBeUndefined();
+    }
+  });
+});

--- a/src/tests/policies/privacy/surfaceConformance.test.ts
+++ b/src/tests/policies/privacy/surfaceConformance.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Participant privacy conformance, across every engine surface that emits participant data.
+ *
+ * The assertion is general by construction: nothing here names an attribute. For a given policy, no
+ * attribute the policy denies — explicitly `false` or simply absent — may appear anywhere in the
+ * response, at any depth, for any participantType. A `sex`-only test would pass the next time a
+ * different attribute was widened; that is precisely how the defect this suite exists to prevent
+ * survived for two and a half years.
+ *
+ * Every case carries a control (`participantsScanned`), because "no denied attribute found" in a
+ * response that contained no participants proves nothing.
+ */
+
+import {
+  analysePolicyConformance,
+  describeViolations,
+  participantTemplate,
+} from '@Tests/testHarness/privacyConformance';
+import { generatePrivacyFixture, SINGLES_DRAW_ID } from '@Tests/testHarness/privacyFixture';
+import { uncoveredDeniedPaths } from '@Tests/testHarness/privacySaturation';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it, test } from 'vitest';
+
+import POLICY_PRIVACY_DEFAULT from '@Fixtures/policies/POLICY_PRIVACY_DEFAULT';
+import { POLICY_TYPE_PARTICIPANT } from '@Constants/policyConstants';
+
+/**
+ * Attributes stapled onto `sides[].participant` AFTER the policy filter, by design: they describe the
+ * participant's ENTRY into a draw, not the participant. `hydrateSideParticipant` adds them
+ * deliberately. Declared here rather than tolerated silently — `annotationsSeen` proves each one is
+ * still real, so this list cannot rot into a blanket exemption.
+ */
+const CONTEXT_ANNOTATIONS = ['entryStatus', 'entryStage', 'luckyAdvancement'];
+
+/**
+ * `tournamentContacts` is a different population under a different policy: `getTournamentInfo` filters
+ * it with `POLICY_PRIVACY_STAFF`, which permits `participantRoleResponsibilities` (a contact without a
+ * role is useless) while denying the same personal attributes the competitor policy denies. It is
+ * excluded here and asserted on its own terms in `staffContacts.test.ts` — not exempted.
+ */
+const SEPARATELY_GOVERNED = ['tournamentContacts'];
+
+// Built at module scope, not in `beforeAll`: the surface table below is enumerated at collection
+// time, so `it.each` needs the eventIds/drawIds before any hook has run.
+const fixture = generatePrivacyFixture();
+
+/** Surfaces that accept `policyDefinitions` and emit participants. */
+function surfaces(policyDefinitions: any) {
+  const [eventId] = fixture.eventIds;
+  const drawId = SINGLES_DRAW_ID;
+  const withDraw = () => tournamentEngine.getEvent({ drawId });
+
+  return {
+    getParticipants: () => tournamentEngine.getParticipants({ policyDefinitions, withGroupings: true }),
+    'getParticipants withIndividualParticipants': () =>
+      tournamentEngine.getParticipants({ policyDefinitions, withGroupings: true, withIndividualParticipants: true }),
+    'getParticipants fully hydrated': () =>
+      tournamentEngine.getParticipants({
+        policyDefinitions,
+        withIndividualParticipants: true,
+        withScheduleItems: true,
+        withGroupings: true,
+        withStatistics: true,
+        withOpponents: true,
+        withMatchUps: true,
+        withEvents: true,
+        withDraws: true,
+      }),
+    getCompetitionParticipants: () => tournamentEngine.getCompetitionParticipants({ policyDefinitions }),
+    getParticipantSchedules: () => tournamentEngine.getParticipantSchedules({ policyDefinitions }),
+    getEventData: () => tournamentEngine.getEventData({ eventId, policyDefinitions }),
+    'getEventData usePublishState': () =>
+      tournamentEngine.getEventData({ eventId, policyDefinitions, usePublishState: true }),
+    getAllEventData: () => tournamentEngine.getAllEventData({ policyDefinitions }),
+    getDrawData: () => tournamentEngine.getDrawData({ drawId, policyDefinitions }),
+    getStructureData: () => {
+      const { drawDefinition } = withDraw();
+      return tournamentEngine.getStructureData({
+        structureId: drawDefinition.structures[0].structureId,
+        policyDefinitions,
+        drawId,
+      });
+    },
+    'competitionScheduleMatchUps hydrated': () =>
+      tournamentEngine.competitionScheduleMatchUps({
+        policyDefinitions,
+        hydrateParticipants: true,
+        usePublishState: true,
+      }),
+    // courthive-public asks for exactly this shape (tabDisplay.ts hard-codes hydrateParticipants:
+    // false), which is what makes `mappedParticipants` a public payload rather than an internal one.
+    'competitionScheduleMatchUps mappedParticipants': () =>
+      tournamentEngine.competitionScheduleMatchUps({
+        policyDefinitions,
+        hydrateParticipants: false,
+        usePublishState: true,
+      }),
+    allTournamentMatchUps: () => tournamentEngine.allTournamentMatchUps({ policyDefinitions }),
+    tournamentMatchUps: () => tournamentEngine.tournamentMatchUps({ policyDefinitions }),
+    allCompetitionMatchUps: () => tournamentEngine.allCompetitionMatchUps({ policyDefinitions }),
+    allDrawMatchUps: () => {
+      const { drawDefinition, event } = withDraw();
+      return tournamentEngine.allDrawMatchUps({ drawDefinition, event, policyDefinitions, inContext: true });
+    },
+    drawMatchUps: () => {
+      const { drawDefinition, event } = withDraw();
+      return tournamentEngine.drawMatchUps({ drawDefinition, event, policyDefinitions, inContext: true });
+    },
+    allEventMatchUps: () => {
+      const { event } = tournamentEngine.getEvent({ eventId });
+      return tournamentEngine.allEventMatchUps({ event, policyDefinitions, inContext: true });
+    },
+    eventMatchUps: () => {
+      const { event } = tournamentEngine.getEvent({ eventId });
+      return tournamentEngine.eventMatchUps({ event, policyDefinitions, inContext: true });
+    },
+    getAllStructureMatchUps: () => {
+      const { drawDefinition, event } = withDraw();
+      return tournamentEngine.getAllStructureMatchUps({
+        structure: drawDefinition.structures[0],
+        drawDefinition,
+        policyDefinitions,
+        inContext: true,
+        event,
+      });
+    },
+    findParticipant: () =>
+      tournamentEngine.findParticipant({ participantId: fixture.individualParticipantIds[0], policyDefinitions }),
+  };
+}
+
+/**
+ * A policy unrelated to the historical `sex` defect: it denies attributes the shipped default PERMITS
+ * (`participantName`, `rankings`, `ratings`, `representing`, `person.nationalityCode`) and permits one
+ * the default denies (`person.birthDate`). If conformance were an artefact of the default's shape
+ * rather than of the filter honouring whatever it is handed, this policy would expose it.
+ */
+function invertedPolicy() {
+  const template = structuredClone(POLICY_PRIVACY_DEFAULT);
+  const participant = template[POLICY_TYPE_PARTICIPANT].participant;
+  for (const level of [participant, participant.individualParticipants]) {
+    level.participantName = false;
+    level.rankings = false;
+    level.ratings = false;
+    level.representing = false;
+    level.person.nationalityCode = false;
+    level.person.birthDate = true;
+  }
+  return template;
+}
+
+const POLICIES: [string, () => any][] = [
+  ['POLICY_PRIVACY_DEFAULT', () => POLICY_PRIVACY_DEFAULT],
+  ['inverted policy', invertedPolicy],
+];
+
+describe('the fixture can prove anything at all', () => {
+  it('holds a value for every attribute the policy denies', () => {
+    for (const [policyName, buildPolicy] of POLICIES) {
+      const template = participantTemplate(buildPolicy());
+      const uncovered = uncoveredDeniedPaths({ participants: fixture.hydratedParticipants, template });
+      expect(uncovered, `${policyName}: denied attributes with no value to leak`).toEqual([]);
+    }
+    expect(fixture.saturatedCount).toBeGreaterThan(0);
+  });
+
+  it('emits every participantType, and staff, so the matrix is not hypothetical', () => {
+    const types = new Set(fixture.participants.map((participant: any) => participant.participantType));
+    expect([...types].sort((a, b) => a.localeCompare(b, 'en'))).toEqual(['GROUP', 'INDIVIDUAL', 'PAIR', 'TEAM']);
+  });
+});
+
+describe.each(POLICIES)('%s is honoured', (_policyName, buildPolicy) => {
+  const policyDefinitions = buildPolicy();
+  const surfaceEntries = Object.entries(surfaces(policyDefinitions));
+
+  it.each(surfaceEntries)('%s emits nothing the policy denies', (_name, invoke) => {
+    const node = invoke();
+    expect(node?.error).toBeUndefined();
+
+    const analysis = analysePolicyConformance({
+      contextAnnotations: CONTEXT_ANNOTATIONS,
+      skipSubtrees: SEPARATELY_GOVERNED,
+      participants: fixture.hydratedParticipants,
+      policyDefinitions,
+      node,
+    });
+
+    // the control: a scan that examined no participants cannot testify to anything
+    expect(analysis.unpermitted.participantsScanned).toBeGreaterThan(0);
+    expect(analysis.forbidden.length).toBeGreaterThan(0);
+    expect(describeViolations(analysis)).toEqual([]);
+  });
+});
+
+describe('the check can report dirty', () => {
+  // Falsification. Each case widens the policy the surface was given, exactly as CFS did in place on
+  // the shared fixture, and requires the SAME assertion to fail. Without this pair, a green run is
+  // evidence about the fixture rather than about the filter.
+  const widened = () => {
+    const policy = structuredClone(POLICY_PRIVACY_DEFAULT);
+    policy[POLICY_TYPE_PARTICIPANT].participant.person.sex = true;
+    policy[POLICY_TYPE_PARTICIPANT].participant.individualParticipants.person.sex = true;
+    return policy;
+  };
+
+  /** Judge a widened response against the STRICT policy — what the strict policy's holder expects. */
+  const analyseWidened = (invoke: () => any) =>
+    analysePolicyConformance({
+      contextAnnotations: CONTEXT_ANNOTATIONS,
+      participants: fixture.hydratedParticipants,
+      policyDefinitions: POLICY_PRIVACY_DEFAULT,
+      node: invoke(),
+    });
+
+  it.each(Object.entries(surfaces(widened())))('%s goes red when the policy is widened', (_name, invoke) => {
+    const analysis = analyseWidened(invoke);
+    expect(analysis.unpermitted.participantsScanned).toBeGreaterThan(0);
+    expect(describeViolations(analysis).some((violation) => violation.startsWith('person.sex'))).toEqual(true);
+  });
+});
+
+test('declared context annotations are real, not a blanket exemption', () => {
+  const node = tournamentEngine.getEventData({
+    policyDefinitions: POLICY_PRIVACY_DEFAULT,
+    eventId: fixture.eventIds[0],
+  });
+  const analysis = analysePolicyConformance({
+    contextAnnotations: CONTEXT_ANNOTATIONS,
+    participants: fixture.hydratedParticipants,
+    policyDefinitions: POLICY_PRIVACY_DEFAULT,
+    node,
+  });
+  // If this ever empties, the exemption has stopped exempting anything and should be deleted rather
+  // than left standing as a permanent hole.
+  expect(analysis.unpermitted.annotationsSeen.length).toBeGreaterThan(0);
+});

--- a/src/tests/policies/privacy/surfaceConformance.test.ts
+++ b/src/tests/policies/privacy/surfaceConformance.test.ts
@@ -11,16 +11,17 @@
  * response that contained no participants proves nothing.
  */
 
+import { generatePrivacyFixture, SINGLES_DRAW_ID } from '@Tests/testHarness/privacyFixture';
+import { uncoveredDeniedPaths } from '@Tests/testHarness/privacySaturation';
+import { describe, expect, it, test } from 'vitest';
+import tournamentEngine from '@Engines/syncEngine';
 import {
   analysePolicyConformance,
   describeViolations,
   participantTemplate,
 } from '@Tests/testHarness/privacyConformance';
-import { generatePrivacyFixture, SINGLES_DRAW_ID } from '@Tests/testHarness/privacyFixture';
-import { uncoveredDeniedPaths } from '@Tests/testHarness/privacySaturation';
-import tournamentEngine from '@Engines/syncEngine';
-import { describe, expect, it, test } from 'vitest';
 
+// constants and types
 import POLICY_PRIVACY_DEFAULT from '@Fixtures/policies/POLICY_PRIVACY_DEFAULT';
 import { POLICY_TYPE_PARTICIPANT } from '@Constants/policyConstants';
 

--- a/src/tests/refactoring/tieFormatMutationsCoverage.test.ts
+++ b/src/tests/refactoring/tieFormatMutationsCoverage.test.ts
@@ -10,11 +10,7 @@ import { COLLEGE_D3, USTA_BREWER_CUP } from '@Constants/tieFormatConstants';
 import { POLICY_TYPE_SCORING } from '@Constants/policyConstants';
 import { DELETED_MATCHUP_IDS } from '@Constants/topicConstants';
 import { TEAM } from '@Constants/eventConstants';
-import {
-  INVALID_VALUES,
-  MISSING_TOURNAMENT_RECORD,
-  NOT_FOUND,
-} from '@Constants/errorConditionConstants';
+import { INVALID_VALUES, MISSING_TOURNAMENT_RECORD, NOT_FOUND } from '@Constants/errorConditionConstants';
 
 const scoringPolicy = {
   [POLICY_TYPE_SCORING]: { requireParticipantsForScoring: false },
@@ -319,7 +315,7 @@ describe('modifyTieFormat branch coverage', () => {
     const tieFormat = tieFormatResult.tieFormat;
 
     // Create modified format with different name on a collection
-    const modifiedTieFormat = JSON.parse(JSON.stringify(tieFormat));
+    const modifiedTieFormat = structuredClone(tieFormat);
     modifiedTieFormat.collectionDefinitions[0].collectionName = 'Renamed Singles';
     // Don't set tieFormatName — should trigger removal
     delete modifiedTieFormat.tieFormatName;

--- a/src/tests/testHarness/privacyConformance.ts
+++ b/src/tests/testHarness/privacyConformance.ts
@@ -84,9 +84,9 @@ function deepEqual(a: unknown, b: unknown): boolean {
   }
   if (isObject(a) && isObject(b)) {
     const aKeys = Object.keys(a as object);
-    const bKeys = Object.keys(b as object);
-    if (aKeys.length !== bKeys.length) return false;
-    return aKeys.every((key) => bKeys.includes(key) && deepEqual(a?.[key], b?.[key]));
+    const bKeys = new Set(Object.keys(b as object));
+    if (aKeys.length !== bKeys.size) return false;
+    return aKeys.every((key) => bKeys.has(key) && deepEqual(a?.[key], b?.[key]));
   }
   return false;
 }

--- a/src/tests/testHarness/privacyConformance.ts
+++ b/src/tests/testHarness/privacyConformance.ts
@@ -1,0 +1,359 @@
+/**
+ * Participant privacy conformance harness.
+ *
+ * The defect this exists to prevent was never a broken filter — it was an UNASSERTED one. A public
+ * endpoint emitted `person.sex` for two and a half years because no test anywhere asserted its
+ * absence, and a `sex`-only assertion would have passed the next time a different attribute was
+ * widened. So nothing here names an attribute: every check is derived from the policy itself.
+ *
+ * Two complementary detectors, because neither alone is sufficient:
+ *
+ *  1. `deriveForbiddenData` + `scanForForbiddenData` — takes the RECORD's participants, computes what
+ *     the policy removes from them, and then scans an arbitrary response tree for those exact
+ *     (attribute, value) pairs at any depth. This catches data that escapes through a shape the
+ *     policy never sees (a `sides[].participant`, a `positionAssignments` entry, a matchUp context
+ *     blob) — anywhere the value physically reappears.
+ *
+ *  2. `collectUnpermittedAttributes` — finds participant-shaped objects in a response and re-applies
+ *     `attributeFilter` as an ORACLE, reporting every attribute the policy would have dropped. This
+ *     catches attributes that are COMPUTED rather than stored (`rankings`, `ratings`, `seedings`,
+ *     `groupings`) and therefore have no counterpart on the record for detector 1 to key on.
+ *
+ * Both report a scanned-count so a caller can assert the control — "no violations" in a response
+ * that contained no participants proves nothing. See `expectPolicyConformance`.
+ */
+
+import { attributeFilter } from '@Tools/attributeFilter';
+import { isObject } from '@Tools/objects';
+
+// constants and types
+import { POLICY_TYPE_PARTICIPANT } from '@Constants/policyConstants';
+
+export type AttributeTemplate = { [key: string]: any };
+
+/** A datum the policy removes from a record participant, with the value it held. */
+export type ForbiddenDatum = {
+  participantId?: string;
+  sourcePath: string;
+  attribute: string;
+  value: unknown;
+};
+
+/** A forbidden datum found in an emitted response, with the path it was found at. */
+export type Violation = {
+  participantId?: string;
+  sourcePath: string;
+  attribute: string;
+  value: unknown;
+  path: string;
+};
+
+export type ScanResult = {
+  /** Number of objects walked — the control. A scan of nothing finds nothing. */
+  objectsScanned: number;
+  /** Declared skip-subtree keys actually encountered, so an obsolete declaration can be failed. */
+  skippedSubtrees: string[];
+  violations: Violation[];
+};
+
+/** An emitted participant carrying attributes the policy would have removed. */
+export type UnpermittedFinding = {
+  participantId?: string;
+  /** Attribute paths, relative to the participant, that `attributeFilter` drops. */
+  attributes: string[];
+  path: string;
+};
+
+export type ParticipantScanResult = {
+  /** Number of participant-shaped objects examined — the control. */
+  participantsScanned: number;
+  /** Declared context annotations actually encountered, so an unused declaration can be failed. */
+  annotationsSeen: string[];
+  findings: UnpermittedFinding[];
+};
+
+/** The `participant` attribute template of a participant privacy policy, or undefined. */
+export function participantTemplate(policyDefinitions?: any): AttributeTemplate | undefined {
+  return policyDefinitions?.[POLICY_TYPE_PARTICIPANT]?.participant;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((member, index) => deepEqual(member, b[index]));
+  }
+  if (isObject(a) && isObject(b)) {
+    const aKeys = Object.keys(a as object);
+    const bKeys = Object.keys(b as object);
+    if (aKeys.length !== bKeys.length) return false;
+    return aKeys.every((key) => bKeys.includes(key) && deepEqual(a?.[key], b?.[key]));
+  }
+  return false;
+}
+
+/**
+ * Values so widely shared that matching on them says nothing about a leak. Only `false`, `0` and the
+ * empty string qualify: every richer value (a name, a date, a code) is specific enough that finding
+ * it under the same attribute name in a response IS the leak. Keeping this list this short is
+ * deliberate — an exclusion here is a hole in the detector.
+ */
+function isDiscriminating(value: unknown): boolean {
+  if (value === undefined || value === null) return false;
+  if (value === false || value === 0 || value === '') return false;
+  if (Array.isArray(value) && !value.length) return false;
+  if (isObject(value) && !Object.keys(value as object).length) return false;
+  return true;
+}
+
+/**
+ * Diff each record participant against its policy-filtered form and collect what the policy removes.
+ *
+ * Scalars are collected leaf-by-leaf so a partial leak (`person.sex` alone) is detectable. A subtree
+ * the policy drops WHOLE (`addresses`, `contacts`, `penalties`) is collected at its container key
+ * with its entire value, not leaf-by-leaf: a person's `city` and a venue's `city` are the same string
+ * under the same attribute name, and matching on the leaf would report the venue as a privacy leak.
+ */
+export function deriveForbiddenData(params: { participants?: any[]; template?: AttributeTemplate }): ForbiddenDatum[] {
+  const { participants, template } = params;
+  const forbidden: ForbiddenDatum[] = [];
+  if (!template) return forbidden;
+
+  for (const participant of participants ?? []) {
+    if (!isObject(participant)) continue;
+    const permitted = attributeFilter({ source: participant, template });
+    walk({
+      participantId: participant.participantId,
+      path: 'participant',
+      source: participant,
+      permitted,
+    });
+  }
+
+  return forbidden;
+
+  function push(attribute: string, value: unknown, path: string, participantId?: string) {
+    if (!isDiscriminating(value)) return;
+    forbidden.push({ attribute, value, sourcePath: `${path}.${attribute}`, participantId });
+  }
+
+  function walk({ source, permitted, path, participantId }: any) {
+    if (!isObject(source)) return;
+
+    for (const [attribute, value] of Object.entries(source)) {
+      const permittedValue = isObject(permitted) ? permitted[attribute] : undefined;
+      const childPath = `${path}.${attribute}`;
+
+      if (permittedValue === undefined) {
+        // the policy dropped this attribute entirely — record it at container level
+        push(attribute, value, path, participantId);
+      } else if (Array.isArray(value) && Array.isArray(permittedValue)) {
+        value.forEach((member, index) =>
+          walk({ source: member, permitted: permittedValue[index], path: `${childPath}[${index}]`, participantId }),
+        );
+      } else if (isObject(value)) {
+        walk({ source: value, permitted: permittedValue, path: childPath, participantId });
+      }
+    }
+  }
+}
+
+/**
+ * Walk an arbitrary response tree looking for any forbidden datum, at any depth, under any shape.
+ *
+ * Deliberately shape-blind: it does not ask whether an object "is a participant". A leaked birthDate
+ * on a `sides[].participant.person` and a leaked birthDate stapled onto a scheduling row are the same
+ * defect, and only one of them is reachable by asking about participants.
+ */
+export function scanForForbiddenData(params: {
+  /** See `collectUnpermittedAttributes`. */
+  skipSubtrees?: string[];
+  forbidden: ForbiddenDatum[];
+  node: unknown;
+}): ScanResult {
+  const { node, forbidden } = params;
+  const skip = new Set(params.skipSubtrees ?? []);
+  const skipped = new Set<string>();
+  const violations: Violation[] = [];
+  const seen = new WeakSet<object>();
+  let objectsScanned = 0;
+
+  const byAttribute = new Map<string, ForbiddenDatum[]>();
+  for (const datum of forbidden) {
+    const existing = byAttribute.get(datum.attribute);
+    if (existing) existing.push(datum);
+    else byAttribute.set(datum.attribute, [datum]);
+  }
+
+  visit(node, '$');
+
+  return { violations, objectsScanned, skippedSubtrees: [...skipped].sort((a, b) => a.localeCompare(b, 'en')) };
+
+  function visit(value: unknown, path: string) {
+    if (typeof value === 'function' || !value || typeof value !== 'object') return;
+    if (seen.has(value as object)) return;
+    seen.add(value as object);
+
+    if (Array.isArray(value)) {
+      value.forEach((member, index) => visit(member, `${path}[${index}]`));
+      return;
+    }
+
+    objectsScanned += 1;
+
+    for (const [attribute, attributeValue] of Object.entries(value as object)) {
+      if (skip.has(attribute)) {
+        skipped.add(attribute);
+        continue;
+      }
+      const candidates = byAttribute.get(attribute);
+      const match = candidates?.find((datum) => deepEqual(datum.value, attributeValue));
+      if (match) {
+        violations.push({ ...match, path: `${path}.${attribute}` });
+      }
+      visit(attributeValue, `${path}.${attribute}`);
+    }
+  }
+}
+
+function looksLikeParticipant(value: any): boolean {
+  if (!isObject(value)) return false;
+  if (!value.participantId) return false;
+  return !!(value.participantType || value.person || value.participantName || value.individualParticipantIds);
+}
+
+/** Attribute paths, relative to `source`, that `attributeFilter` removes under `template`. */
+function droppedAttributePaths(source: any, template: AttributeTemplate): string[] {
+  const filtered = attributeFilter({ source, template });
+  const dropped: string[] = [];
+
+  compare(source, filtered, '');
+  return dropped;
+
+  function compare(sourceNode: any, filteredNode: any, path: string) {
+    if (!isObject(sourceNode)) return;
+    for (const [attribute, value] of Object.entries(sourceNode)) {
+      const attributePath = path ? `${path}.${attribute}` : attribute;
+      const filteredValue = isObject(filteredNode) ? filteredNode[attribute] : undefined;
+      if (filteredValue === undefined) {
+        if (value !== undefined) dropped.push(attributePath);
+      } else if (Array.isArray(value) && Array.isArray(filteredValue)) {
+        value.forEach((member, index) => compare(member, filteredValue[index], `${attributePath}[${index}]`));
+      } else if (isObject(value)) {
+        compare(value, filteredValue, attributePath);
+      }
+    }
+  }
+}
+
+/**
+ * Find participant-shaped objects in a response and report every attribute the policy would drop.
+ *
+ * Uses `attributeFilter` itself as the oracle, so the check stays correct as the policy changes and
+ * names no attribute of its own. Matched participants are NOT recursed into: `attributeFilter`
+ * already descends (including through `individualParticipants`, which carries its own sub-template),
+ * and re-visiting a nested participant with the top-level template would judge it against the wrong
+ * rules.
+ */
+export function collectUnpermittedAttributes(params: {
+  /**
+   * Attribute paths (relative to a participant) that a surface attaches AFTER filtering, by design —
+   * `entryStatus`, `entryStage`, `luckyAdvancement`. They are draw-entry context, not participant
+   * record data, so the policy has nothing to say about them. Declaring one here is a claim that must
+   * be paid for: `annotationsSeen` reports which were actually encountered so a test can fail a
+   * declaration that no longer matches reality.
+   */
+  contextAnnotations?: string[];
+  /**
+   * Attribute keys whose subtree is governed by a DIFFERENT policy and must not be judged against
+   * this one — `tournamentContacts`, which `getTournamentInfo` filters with `POLICY_PRIVACY_STAFF`
+   * for a different population. Each declaration is reported back in `skippedSubtrees` so a test can
+   * fail one that no longer matches anything, and each needs its own conformance test against the
+   * policy that does govern it.
+   */
+  skipSubtrees?: string[];
+  template?: AttributeTemplate;
+  node: unknown;
+}): ParticipantScanResult {
+  const { node, template, contextAnnotations = [] } = params;
+  const skip = new Set(params.skipSubtrees ?? []);
+  const annotations = new Set(contextAnnotations);
+  const encountered = new Set<string>();
+  const findings: UnpermittedFinding[] = [];
+  const seen = new WeakSet<object>();
+  let participantsScanned = 0;
+
+  if (!template) return { participantsScanned, findings, annotationsSeen: [] };
+  const activeTemplate: AttributeTemplate = template;
+
+  visit(node, '$');
+
+  return { participantsScanned, findings, annotationsSeen: [...encountered].sort((a, b) => a.localeCompare(b, 'en')) };
+
+  function visit(value: unknown, path: string) {
+    if (typeof value === 'function' || !value || typeof value !== 'object') return;
+    if (seen.has(value as object)) return;
+    seen.add(value as object);
+
+    if (Array.isArray(value)) {
+      value.forEach((member, index) => visit(member, `${path}[${index}]`));
+      return;
+    }
+
+    if (looksLikeParticipant(value)) {
+      participantsScanned += 1;
+      const dropped = droppedAttributePaths(value, activeTemplate);
+      for (const attribute of dropped) if (annotations.has(attribute)) encountered.add(attribute);
+      const attributes = dropped.filter((attribute) => !annotations.has(attribute));
+      if (attributes.length) findings.push({ path, attributes, participantId: (value as any).participantId });
+      return;
+    }
+
+    for (const [attribute, attributeValue] of Object.entries(value as object)) {
+      if (skip.has(attribute)) continue;
+      visit(attributeValue, `${path}.${attribute}`);
+    }
+  }
+}
+
+export type ConformanceReport = {
+  unpermitted: ParticipantScanResult;
+  forbidden: ForbiddenDatum[];
+  data: ScanResult;
+};
+
+/**
+ * Run both detectors over a response.
+ *
+ * `participants` are the RECORD's participants (unfiltered) — the source of truth for what the policy
+ * removes. `node` is the emitted response.
+ */
+export function analysePolicyConformance(params: {
+  contextAnnotations?: string[];
+  skipSubtrees?: string[];
+  policyDefinitions?: any;
+  participants?: any[];
+  node: unknown;
+}): ConformanceReport {
+  const template = participantTemplate(params.policyDefinitions);
+  const forbidden = deriveForbiddenData({ participants: params.participants, template });
+  return {
+    unpermitted: collectUnpermittedAttributes({
+      contextAnnotations: params.contextAnnotations,
+      skipSubtrees: params.skipSubtrees,
+      node: params.node,
+      template,
+    }),
+    data: scanForForbiddenData({ skipSubtrees: params.skipSubtrees, node: params.node, forbidden }),
+    forbidden,
+  };
+}
+
+/** Compact, readable failure output — the attribute path and where it was found. */
+export function describeViolations(report: ConformanceReport): string[] {
+  return [
+    ...report.data.violations.map((violation) => `${violation.attribute} @ ${violation.path}`),
+    ...report.unpermitted.findings.flatMap((finding) =>
+      finding.attributes.map((attribute) => `${attribute} @ ${finding.path}`),
+    ),
+  ].sort((a, b) => a.localeCompare(b, 'en'));
+}

--- a/src/tests/testHarness/privacyFixture.ts
+++ b/src/tests/testHarness/privacyFixture.ts
@@ -1,0 +1,150 @@
+/**
+ * One tournament that exercises every participant type a privacy policy has to govern.
+ *
+ * INDIVIDUAL (seeded singles), PAIR (doubles), TEAM (team event) and GROUP all appear, individuals
+ * belong to teams/pairs/groups so `withGroupings` produces `teams` / `groups` attributes, a staff
+ * participant exists so `tournamentContacts` is non-empty, and order of play is published so the
+ * schedule surface returns matchUps rather than an empty shell.
+ *
+ * Persons are saturated (see `privacySaturation.ts`) so every attribute the policy denies actually
+ * holds a value — an absence assertion against an attribute that was never populated is vacuous.
+ */
+
+import { saturateParticipants } from './privacySaturation';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+
+// constants and types
+import { DOUBLES, SINGLES, TEAM } from '@Constants/eventConstants';
+import { GROUP, INDIVIDUAL } from '@Constants/participantConstants';
+import { COMPETITOR, OFFICIAL, OTHER } from '@Constants/participantRoles';
+
+export const SINGLES_DRAW_ID = 'privacy-singles-draw';
+export const DOUBLES_DRAW_ID = 'privacy-doubles-draw';
+export const TEAM_DRAW_ID = 'privacy-team-draw';
+export const GROUP_PARTICIPANT_ID = 'privacy-group-participant';
+export const STAFF_PARTICIPANT_ID = 'privacy-staff-official';
+
+const VENUE_ID = 'e8e4c0b0-216c-426f-bba2-18e16caa74b8';
+const START_DATE = '2024-01-01';
+
+export function generatePrivacyFixture() {
+  const venueProfiles = [
+    {
+      venueId: VENUE_ID,
+      venueName: 'Club Courts',
+      venueAbbreviation: 'CC',
+      startTime: '08:00',
+      endTime: '20:00',
+      courtsCount: 8,
+    },
+  ];
+
+  const schedulingProfile = [
+    {
+      scheduleDate: START_DATE,
+      venues: [
+        {
+          venueId: VENUE_ID,
+          rounds: [
+            { drawId: SINGLES_DRAW_ID, roundNumber: 1 },
+            { drawId: SINGLES_DRAW_ID, roundNumber: 2 },
+            { drawId: DOUBLES_DRAW_ID, roundNumber: 1 },
+          ],
+        },
+      ],
+    },
+  ];
+
+  const { tournamentRecord, eventIds, drawIds } = mocksEngine.generateTournamentRecord({
+    // `withScaleValues` + a rating category are what make `rankings` / `ratings` / `seedings` real:
+    // they are computed during hydration, so without them a policy that denies them has nothing to
+    // deny and the assertion is vacuous.
+    participantsProfile: {
+      addressProps: { citiesCount: 5, statesCount: 3, postalCodesCount: 5 },
+      category: { categoryName: 'U18' },
+      scaledParticipantsCount: 8,
+      rankingRange: [1, 20],
+      withScaleValues: true,
+    },
+    drawProfiles: [
+      {
+        category: { ratingType: 'WTN', ratingMin: 14, ratingMax: 19.99 },
+        drawId: SINGLES_DRAW_ID,
+        eventType: SINGLES,
+        drawName: 'Singles',
+        seedsCount: 4,
+        drawSize: 8,
+      },
+      { drawSize: 8, seedsCount: 4, eventType: DOUBLES, drawId: DOUBLES_DRAW_ID, drawName: 'Doubles' },
+      { drawSize: 4, eventType: TEAM, drawId: TEAM_DRAW_ID, drawName: 'Team' },
+    ],
+    scheduleCompletedMatchUps: true,
+    schedulingProfile,
+    venueProfiles,
+    endDate: '2024-01-03',
+    startDate: START_DATE,
+    nonRandom: 1,
+  });
+
+  const individualParticipantIds = (tournamentRecord.participants ?? [])
+    .filter((participant: any) => participant.participantType === INDIVIDUAL)
+    .slice(0, 3)
+    .map((participant: any) => participant.participantId);
+
+  tournamentRecord.participants.push(
+    {
+      individualParticipantIds,
+      participantId: GROUP_PARTICIPANT_ID,
+      participantName: 'Squad One',
+      participantRole: OTHER,
+      participantType: GROUP,
+    } as any,
+    {
+      participantId: STAFF_PARTICIPANT_ID,
+      participantName: 'Official Person',
+      participantRole: OFFICIAL,
+      participantType: INDIVIDUAL,
+      person: {
+        personId: 'privacy-staff-person',
+        standardFamilyName: 'Official',
+        standardGivenName: 'Person',
+        nationalityCode: 'GBR',
+        sex: 'FEMALE',
+      },
+    } as any,
+  );
+
+  const { saturatedCount } = saturateParticipants({ tournamentRecord });
+
+  tournamentEngine.setState(tournamentRecord);
+  // Scheduled explicitly rather than via a mocksEngine flag: `getParticipantSchedules` keeps only
+  // matchUps that carry a `schedule`, so without this it returns an empty array and every assertion
+  // about it is vacuous — which is exactly the failure mode this suite exists to prevent.
+  tournamentEngine.scheduleProfileRounds({ scheduleDates: [START_DATE] });
+  tournamentEngine.publishOrderOfPlay();
+  for (const eventId of eventIds) tournamentEngine.publishEvent({ eventId });
+
+  // The reference emission: every participant, fully hydrated, with NO policy applied. This — rather
+  // than the stored record — is what the conformance checks diff against, because it is the only place
+  // COMPUTED attributes exist. `rankings`, `ratings`, `seedings`, `teams` and `groups` are derived
+  // during hydration and appear nowhere on the record, so a check anchored to the record could neither
+  // prove a policy denying them was honoured nor notice one that was not.
+  const hydratedParticipants = tournamentEngine.getParticipants({
+    withIndividualParticipants: true,
+    withScaleValues: true,
+    withGroupings: true,
+  }).participants;
+
+  return {
+    participants: tournamentEngine.getTournament().tournamentRecord.participants,
+    hydratedParticipants,
+    individualParticipantIds,
+    tournamentRecord,
+    saturatedCount,
+    eventIds,
+    drawIds,
+    venueId: VENUE_ID,
+    competitorRole: COMPETITOR,
+  };
+}

--- a/src/tests/testHarness/privacyFixture.ts
+++ b/src/tests/testHarness/privacyFixture.ts
@@ -15,9 +15,9 @@ import mocksEngine from '@Assemblies/engines/mock';
 import tournamentEngine from '@Engines/syncEngine';
 
 // constants and types
-import { DOUBLES, SINGLES, TEAM } from '@Constants/eventConstants';
-import { GROUP, INDIVIDUAL } from '@Constants/participantConstants';
 import { COMPETITOR, OFFICIAL, OTHER } from '@Constants/participantRoles';
+import { GROUP, INDIVIDUAL } from '@Constants/participantConstants';
+import { DOUBLES, SINGLES, TEAM } from '@Constants/eventConstants';
 
 export const SINGLES_DRAW_ID = 'privacy-singles-draw';
 export const DOUBLES_DRAW_ID = 'privacy-doubles-draw';

--- a/src/tests/testHarness/privacySaturation.ts
+++ b/src/tests/testHarness/privacySaturation.ts
@@ -1,0 +1,124 @@
+/**
+ * Saturate a tournament record's participants with a value for every attribute a participant privacy
+ * policy can filter.
+ *
+ * Why this exists: "the response does not contain `birthDate`" proves nothing if no participant in
+ * the fixture ever had a `birthDate`. mocksEngine emits a deliberately sparse person (personId,
+ * addresses, standard names, nationalityCode, sex), so most of what `POLICY_PRIVACY_DEFAULT` marks
+ * `false` has no value to leak and every assertion about it is vacuous.
+ *
+ * Values are derived from the participantId so each is unique to its participant. That matters for
+ * the value-matching detector in `privacyConformance.ts`: a shared literal would collide across
+ * participants and turn a precise "this person's native family name reached the response" into a
+ * guess.
+ *
+ * `assertSaturationCovers` is the control. It fails if the policy names an attribute `false` that
+ * saturation left empty — so extending the policy without extending the fixture is caught here
+ * rather than silently degrading every downstream assertion to vacuity.
+ */
+
+import { isObject } from '@Tools/objects';
+
+import type { AttributeTemplate } from './privacyConformance';
+
+/** Attributes saturated on every participant, whatever its participantType. */
+function participantSaturation(participantId: string) {
+  return {
+    contacts: [
+      { firstName: 'Emergency', lastName: `Contact-${participantId}`, email: `${participantId}@example.test` },
+    ],
+    onlineResources: [
+      { name: 'website', identifier: `https://example.test/participant/${participantId}`, resourceType: 'URL' },
+    ],
+    penalties: [
+      { penaltyId: `penalty-${participantId}`, penaltyType: 'BALL_ABUSE', notes: `penalty-${participantId}` },
+    ],
+    participantRoleResponsibilities: [`RESPONSIBILITY-${participantId}`],
+    participantOtherName: `OtherName-${participantId}`,
+    participantStatus: 'ACTIVE',
+    representing: `REP-${participantId}`,
+  };
+}
+
+/** Attributes saturated on every `person`. */
+function personSaturation(participantId: string) {
+  return {
+    biographicalInformation: [{ bioType: 'NOTE', value: `bio-${participantId}` }],
+    contacts: [{ firstName: 'Person', lastName: `Contact-${participantId}` }],
+    onlineResources: [
+      { name: 'social', identifier: `https://example.test/person/${participantId}`, resourceType: 'URL' },
+    ],
+    personOtherIds: [{ organisationId: `org-${participantId}`, personId: `other-${participantId}` }],
+    previousNames: [{ standardFamilyName: `Previous-${participantId}` }],
+    otherNames: [{ standardGivenName: `Alias-${participantId}` }],
+    parentOrganisationId: `parentOrg-${participantId}`,
+    passportFamilyName: `Passport-${participantId}`,
+    passportGivenName: `Given-${participantId}`,
+    nativeFamilyName: `Native-${participantId}`,
+    nativeGivenName: `NativeGiven-${participantId}`,
+    tennisId: `tennisId-${participantId}`,
+    birthDate: '1999-09-09',
+    status: 'ACTIVE',
+    wheelchair: false,
+  };
+}
+
+/** Mutates `tournamentRecord.participants` in place. Call BEFORE `setState`. */
+export function saturateParticipants({ tournamentRecord }: { tournamentRecord: any }): { saturatedCount: number } {
+  let saturatedCount = 0;
+  for (const participant of tournamentRecord?.participants ?? []) {
+    if (!isObject(participant)) continue;
+    Object.assign(participant, participantSaturation(participant.participantId));
+    if (isObject(participant.person)) Object.assign(participant.person, personSaturation(participant.participantId));
+    saturatedCount += 1;
+  }
+  return { saturatedCount };
+}
+
+/** Dotted paths of every attribute the template marks `false`, at any depth. */
+export function templateDeniedPaths(template?: AttributeTemplate): string[] {
+  const denied: string[] = [];
+  collect(template, '');
+  return denied;
+
+  function collect(node: any, path: string) {
+    if (!isObject(node)) return;
+    for (const [attribute, value] of Object.entries(node)) {
+      const attributePath = path ? `${path}.${attribute}` : attribute;
+      if (value === false) denied.push(attributePath);
+      else if (isObject(value)) collect(value, attributePath);
+    }
+  }
+}
+
+/**
+ * The control: every attribute the policy denies must actually hold a value on the record, or the
+ * assertion that it is absent from a response is vacuous.
+ *
+ * Returns the denied paths that saturation did NOT cover. An empty array is the passing case.
+ */
+export function uncoveredDeniedPaths(params: { participants?: any[]; template?: AttributeTemplate }): string[] {
+  const { participants, template } = params;
+  return templateDeniedPaths(template).filter((deniedPath) => !participants?.some((p) => holdsValue(p, deniedPath)));
+
+  function holdsValue(participant: any, deniedPath: string): boolean {
+    // `individualParticipants` is hydrated from `individualParticipantIds`, so that is where the
+    // record holds the value a policy denying it would have to remove.
+    if (deniedPath === 'individualParticipants') return !!participant?.individualParticipantIds?.length;
+    // Elsewhere `individualParticipants` is a policy sub-template, not a record attribute: individual
+    // participants live in the flat `participants` array and are covered by their own entries.
+    const segments = deniedPath.replace('individualParticipants.', '').split('.');
+    let node = participant;
+    for (const segment of segments) {
+      if (Array.isArray(node)) node = node[0];
+      if (!isObject(node)) return false;
+      node = node[segment];
+    }
+    if (node === undefined || node === null) return false;
+    if (Array.isArray(node)) return node.length > 0;
+    // An empty object is not a value: `{ }` under `ratings` would let a denied attribute count as
+    // covered while having nothing to leak, which is the vacuity this control exists to catch.
+    if (typeof node === 'object') return Object.keys(node).length > 0;
+    return true;
+  }
+}

--- a/src/tests/testHarness/privacySaturation.ts
+++ b/src/tests/testHarness/privacySaturation.ts
@@ -19,6 +19,7 @@
 
 import { isObject } from '@Tools/objects';
 
+// constants and types
 import type { AttributeTemplate } from './privacyConformance';
 
 /** Attributes saturated on every participant, whatever its participantType. */


### PR DESCRIPTION
`hydrateParticipants` declared `policyDefinitions` and never read it, so every surface returning participants from it emitted them **raw** while a policy was supplied.

Measured against production, one POST to the same public endpoint courthive-public calls (`hydrateParticipants: false`, which is what `tabDisplay.ts:18` hard-codes):

```text
mappedParticipants:            170 entries (157 INDIVIDUAL, 13 PAIR)
  … carrying person.sex:       157
  … carrying person.personId:  157
  … carrying person.addresses: 158   (city, countryCode)

completedMatchUps sides:       424 — with .participant.person: 0
```

The matchUp sides were correctly filtered — the leak was entirely the sibling map, on a `@Public()`, unauthenticated, cached route, under the strict **unmutated** `POLICY_PRIVACY_DEFAULT`.

## Why the fix is at the boundary, not in hydration

Filtering inside hydration breaks context assembly for exactly the callers that asked for privacy: `getScaleValues` reads `timeItems`, participant resolution reads `person.personId`, gender enforcement reads `person.sex` — all deniable. So the policy is applied to the copy that **leaves** the engine and to nothing else (`query/participants/participantPrivacy.ts`).

## Seven gaps closed

Each individually falsified — reverting its file turns a named set of tests red.

| surface | leaked |
|---|---|
| `competitionScheduleMatchUps().mappedParticipants` | whole raw participant |
| `tournamentMatchUps().participants` | whole raw participant |
| `getParticipants().participantMap` | raw, beside a correctly-filtered `participants` |
| `getParticipantSchedules()` | accepted no `policyDefinitions` at all |
| `sides[].teamParticipant` on tie matchUps | `penalties`, `timeItems`, `representing` |
| `groupInfo` | `participantName` of TEAM/GROUP/PAIR entities |
| nested `individualParticipants` | judged by the top-level template, not the `individualParticipants` sub-template |

The last was invisible because the two templates are identical in the shipped default. It would surface the first time a provider tightened one.

## The suite

`src/tests/policies/privacy/` — nothing in it names an attribute. It derives what is forbidden from the policy and requires that none of it appear at any depth, for any participantType. A `sex`-only assertion would pass the next time a different attribute was widened, which is how the original defect survived.

Two detectors, because neither alone suffices: a **value scan** diffing the record against its filtered form and hunting those pairs anywhere in the response, and a **shape scan** re-applying `attributeFilter` as an oracle to catch computed attributes (`rankings`, `ratings`, `seedings`, `teams`) that have no record counterpart.

Discipline:

- every surface is re-run under a **widened** policy and must go red
- `detectorFalsification.test.ts` feeds each detector known-bad input and requires it to fire, known-good and requires silence
- every case asserts a control (`participantsScanned > 0`) before asserting absence — `getParticipantSchedules` initially scanned zero and the control caught it
- exemptions (`contextAnnotations`, `skipSubtrees`) report what they matched, so one that stops exempting anything fails

Matrix: INDIVIDUAL / PAIR / TEAM / GROUP plus staff, under both the shipped default and an **inverted** policy that denies what the default permits. Includes the load-bearing case — filtering the `teams` attribute must not remove TEAM participants — and proves draw/event/structure views render identically when `seedings` is denied.

## Second commit

`chore(lint)` bans `JSON.parse(JSON.stringify())` as a deep-copy idiom, with two documented exemptions: `ScoringEngine.getState()` (structuredClone throws `DataCloneError` on the framework proxies that state holds — its JSDoc already said so) and `FactoryError.test.ts` (genuine `toJSON` round-trips).

## Consumer impact

`courthive-public/src/components/formatters/participantFormatter.ts:85` tints participant names by `person.sex`. Names will render in the default colour. Nothing else reads it on these routes.

## Gates

`pnpm verify` — all 15 steps. vitest 11273 passed / 1 skipped; `test:server` 9 suites; coverage 95.32 / 87.15 / 98.07 / 97.75, all above floor.