### PR TITLE
chore(docs): pin the documentation toolchain to pnpm@11.22.0

### DIFF
--- a/documentation/package.json
+++ b/documentation/package.json
@@ -1,5 +1,6 @@
 {
   "name": "documentation",
+  "packageManager": "pnpm@11.22.0",
   "version": "0.0.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
`documentation/` is its own pnpm context — own `pnpm-workspace.yaml` (`packages: []`), own overrides, own lockfile — but carried **no `packageManager` field**, so it resolved whatever pnpm happened to be on `PATH` while the repo root was pinned.

Measured in one checkout, before this change:

```text
factory root       packageManager: pnpm@11.21.0   ->  pnpm --version  11.21.0
documentation/     packageManager: (none)         ->  pnpm --version   11.9.0
```

## Why it matters

An unpinned lockfile context is a churn generator: a contributor whose ambient pnpm differs from the one that last wrote `documentation/pnpm-lock.yaml` produces a large resolution diff unrelated to their change.

That is not hypothetical — during the 2026-08-21 renovate merges, resolving a conflict by regenerating that lockfile produced **1,554 changed lines that had nothing to do with the dependency bump** (peer-suffix normalisation across the graph). It was discarded and replaced with a five-line surgical edit matching what renovate itself produced.

## Verified inert before committing

With the pin:

- `pnpm --version` in `documentation/` moves 11.9.0 → 11.22.0 (corepack honours it)
- `pnpm install --lockfile-only` regenerates `pnpm-lock.yaml` **byte-identical**

So this changes *which toolchain runs*, not *what it resolves* — the diff is one line in one `package.json`, with no lockfile change.

It also settles the earlier question: the lockfile is now known stable across both 11.9.0 and 11.22.0, which confirms that 1,554-line churn came from the `courthive-components` upgrade itself and not from pnpm version drift.

Matches the root's `packageManager` and `.tool-versions` as of #4669.

## Gates

`verify:audit` (the step that reads `documentation/`), `verify:types`, `verify:lint`, `verify:generated` — all pass locally. Full `verify (node 24)` runs here.