### PR TITLE
fix(privacy): publish staff contact details, stop excluding the tournament director

### DIFF
--- a/src/fixtures/policies/POLICY_PRIVACY_STAFF.ts
+++ b/src/fixtures/policies/POLICY_PRIVACY_STAFF.ts
@@ -1,9 +1,37 @@
 import { POLICY_TYPE_PARTICIPANT } from '@Constants/policyConstants';
 
+/**
+ * Contact fields published for tournament staff.
+ *
+ * `tournamentContacts` previously carried names and roles with **no way to contact anyone** — this
+ * policy stripped `contacts` at both the participant and person level, so a field literally named
+ * "contacts" published none. The point of the list is that a competitor, a visiting official or a
+ * parent can reach the people running the event.
+ *
+ * Which contacts appear is decided BEFORE this template runs, by `getTournamentInfo` selecting on
+ * `Contact.isPublic === true`. That selection cannot live here: a template array acts as an allow-list
+ * (`attributeFilter.ts:49-51`) but is only evaluated for keys the source object actually has, so a
+ * contact with no `isPublic` would pass unexamined — fail-open, and every contact in existence lacks the
+ * flag today because nothing writes it.
+ */
+const PUBLISHED_CONTACT_FIELDS = {
+  emailAddress: true,
+  mobileTelephone: true,
+  name: true,
+  telephone: true,
+  // `isPublic` must survive the filter, because the predicate that consumes it runs AFTER the policy —
+  // the policy is applied inside `getParticipants`, and `getTournamentInfo` selects on the result. Strip
+  // it here and every contact arrives flagless, which reads as "not opted in" and publishes nothing.
+  // Emitting the flag alongside the contact is also honest: it states the basis on which it was shared.
+  isPublic: true,
+};
+
 export const POLICY_PRIVACY_STAFF = {
   [POLICY_TYPE_PARTICIPANT]: {
     policyName: 'Staff Privacy Policy',
     participant: {
+      // Participant-level `contacts` stays denied. A staff member is an INDIVIDUAL and their contact
+      // details live on `person.contacts`; widening both would publish a second surface for no gain.
       contacts: false,
       individualParticipants: false,
       individualParticipantIds: false,
@@ -21,7 +49,7 @@ export const POLICY_PRIVACY_STAFF = {
         addresses: false,
         biographicalInformation: false,
         birthDate: false,
-        contacts: false,
+        contacts: PUBLISHED_CONTACT_FIELDS,
         nationalityCode: true,
         nativeFamilyName: false,
         nativeGivenName: false,

--- a/src/fixtures/policies/index.ts
+++ b/src/fixtures/policies/index.ts
@@ -26,6 +26,7 @@ import { POLICY_RANKING_POINTS_WTA } from './POLICY_RANKING_POINTS_WTA';
 import { POLICY_ROUND_NAMING_DEFAULT } from './POLICY_ROUND_NAMING_DEFAULT';
 import { POLICY_SCHEDULING_DEFAULT } from './POLICY_SCHEDULING_DEFAULT';
 import { POLICY_PRIVACY_DEFAULT } from './POLICY_PRIVACY_DEFAULT';
+import { POLICY_PRIVACY_STAFF } from './POLICY_PRIVACY_STAFF';
 
 import { POLICY_OFFICIATING_CONFLICT_OF_INTEREST_ITF } from './POLICY_OFFICIATING_CONFLICT_OF_INTEREST';
 import { POLICY_OFFICIATING_CONFLICT_OF_INTEREST } from './POLICY_OFFICIATING_CONFLICT_OF_INTEREST';
@@ -57,6 +58,10 @@ export const policies = {
   POLICY_POSITION_ACTIONS_UNRESTRICTED,
 
   POLICY_PRIVACY_DEFAULT,
+  // Exported so a provider can reference or extend the staff/tournamentContacts policy. It was
+  // previously unreachable — hardcoded inside getTournamentInfo with no export and no caller override,
+  // so "providers author their own privacy policies" was not true on this path.
+  POLICY_PRIVACY_STAFF,
 
   POLICY_RANKING_POINTS_ITF_JUNIOR,
   POLICY_RANKING_POINTS_ITF_WTT,

--- a/src/mutate/participants/modifyParticipant.ts
+++ b/src/mutate/participants/modifyParticipant.ts
@@ -184,7 +184,18 @@ function isClearRequest(value) {
 function updatePerson({ updateParticipantName, existingParticipant, newValues, person }) {
   const newPersonValues: any = {};
   const clearedKeys: string[] = [];
-  const { standardFamilyName, standardGivenName, nationalityCode, personId, birthDate, tennisId, sex } = person;
+  const { standardFamilyName, standardGivenName, nationalityCode, personId, birthDate, tennisId, sex, contacts } =
+    person;
+
+  // `person.contacts` had no write path anywhere in the factory — declared on the type, readable, and
+  // impossible to persist. That made `Contact.isPublic` inert by construction: nothing could set it, so
+  // the publication gate on `tournamentContacts` had nothing to gate on.
+  //
+  // Replace-whole-array, not merge: a contact list is edited as a list (add a number, remove one, flip
+  // one to public), and a merge would make removal unexpressible. Consistent with the "consumers send
+  // the whole person object" contract above — omitting `contacts` leaves the existing list untouched,
+  // while `[]` clears it.
+  if (Array.isArray(contacts)) newPersonValues.contacts = contacts;
   const canonicalSex = coercedSex(sex);
   if (canonicalSex) newPersonValues.sex = canonicalSex;
 

--- a/src/query/tournaments/getTournamentInfo.ts
+++ b/src/query/tournaments/getTournamentInfo.ts
@@ -9,27 +9,74 @@ import { definedAttributes } from '@Tools/definedAttributes';
 import { makeDeepCopy } from '@Tools/makeDeepCopy';
 
 // constants and types
-import { ADMINISTRATION, MEDIA, MEDICAL, OFFICIAL, SECURITY } from '@Constants/participantRoles';
+import { ADMINISTRATION, DIRECTOR, MEDIA, MEDICAL, OFFICIAL, SECURITY, SUPERVISOR } from '@Constants/participantRoles';
 import { ErrorType, MISSING_TOURNAMENT_RECORD } from '@Constants/errorConditionConstants';
 import { completedMatchUpStatuses, BYE } from '@Constants/matchUpStatusConstants';
 import { TOURNAMENT_IMAGE_RESOURCE_NAME } from '@Constants/tournamentConstants';
 import POLICY_PRIVACY_STAFF from '@Fixtures/policies/POLICY_PRIVACY_STAFF';
+import { ParticipantRoleUnion, Tournament } from '@Types/tournamentTypes';
 import { INDIVIDUAL, TEAM } from '@Constants/participantConstants';
 import { SUCCESS } from '@Constants/resultConstants';
-import { Tournament } from '@Types/tournamentTypes';
+
+/**
+ * Roles whose holders appear in `tournamentContacts`.
+ *
+ * DIRECTOR and SUPERVISOR were absent, which meant the **tournament director** — the single person a
+ * competitor most needs to reach — was excluded from the tournament's contact list by role, before any
+ * question about contact details arose.
+ *
+ * This is the set for the bundled policy. A provider supplying its own `policyDefinitions` shapes which
+ * ATTRIBUTES are published; this list decides WHO is considered staff at all.
+ */
+const STAFF_CONTACT_ROLES = [
+  ADMINISTRATION,
+  DIRECTOR,
+  MEDIA,
+  MEDICAL,
+  OFFICIAL,
+  SECURITY,
+  SUPERVISOR,
+] as ParticipantRoleUnion[];
+
+/**
+ * Keep only contacts explicitly marked `isPublic === true`.
+ *
+ * Runs AFTER the privacy policy has shaped which attributes survive, and is deliberately a predicate
+ * rather than part of the policy template. A template array acts as an allow-list, but `attributeFilter`
+ * only evaluates it for keys the source object actually carries (`attributeFilter.ts:49-51`) — so a
+ * contact with no `isPublic` is never examined and passes. That is fail-OPEN, and since nothing in the
+ * ecosystem writes the flag today, every existing contact would publish.
+ *
+ * Strict equality is the point: absent and `false` both withhold. Opting in has to be deliberate.
+ */
+function publishableContacts(participant: any): any {
+  const filterContacts = (contacts: any) =>
+    Array.isArray(contacts) ? contacts.filter((contact) => contact?.isPublic === true) : contacts;
+
+  if (!participant?.contacts && !participant?.person?.contacts) return participant;
+
+  return {
+    ...participant,
+    ...(participant.contacts ? { contacts: filterContacts(participant.contacts) } : {}),
+    ...(participant.person?.contacts
+      ? { person: { ...participant.person, contacts: filterContacts(participant.person.contacts) } }
+      : {}),
+  };
+}
 
 export function getTournamentInfo(params?: {
   withStructureDetails?: boolean;
   tournamentRecord: Tournament;
   withMatchUpStats?: boolean;
   usePublishState?: boolean;
+  policyDefinitions?: any;
   withVenueData?: boolean;
 }): {
   tournamentInfo?: any;
   eventInfo?: any[];
   error?: ErrorType;
 } {
-  const { tournamentRecord, withMatchUpStats, withStructureDetails, withVenueData } = params ?? {};
+  const { tournamentRecord, withMatchUpStats, withStructureDetails, withVenueData, policyDefinitions } = params ?? {};
   if (!tournamentRecord) return { error: MISSING_TOURNAMENT_RECORD };
 
   const extractTournamentInfo = ({
@@ -93,12 +140,12 @@ export function getTournamentInfo(params?: {
   }
 
   const participantResult = getParticipants({
-    participantFilters: { participantRoles: [ADMINISTRATION, OFFICIAL, MEDIA, MEDICAL, SECURITY] },
-    policyDefinitions: POLICY_PRIVACY_STAFF,
+    participantFilters: { participantRoles: STAFF_CONTACT_ROLES },
+    policyDefinitions: policyDefinitions ?? POLICY_PRIVACY_STAFF,
     tournamentRecord,
   });
 
-  const tournamentContacts = participantResult?.participants ?? [];
+  const tournamentContacts = (participantResult?.participants ?? []).map(publishableContacts);
   if (tournamentContacts) tournamentInfo.tournamentContacts = tournamentContacts;
 
   const imageUrl = tournamentRecord?.onlineResources?.find(

--- a/src/query/tournaments/getTournamentInfo.ts
+++ b/src/query/tournaments/getTournamentInfo.ts
@@ -9,7 +9,20 @@ import { definedAttributes } from '@Tools/definedAttributes';
 import { makeDeepCopy } from '@Tools/makeDeepCopy';
 
 // constants and types
-import { ADMINISTRATION, DIRECTOR, MEDIA, MEDICAL, OFFICIAL, SECURITY, SUPERVISOR } from '@Constants/participantRoles';
+import {
+  ADMINISTRATION,
+  DIRECTOR,
+  HOSPITALITY,
+  MEDIA,
+  MEDICAL,
+  OFFICIAL,
+  PHYSIO,
+  SECURITY,
+  STRINGER,
+  SUPERVISOR,
+  TRAINER,
+  TRANSPORT,
+} from '@Constants/participantRoles';
 import { ErrorType, MISSING_TOURNAMENT_RECORD } from '@Constants/errorConditionConstants';
 import { completedMatchUpStatuses, BYE } from '@Constants/matchUpStatusConstants';
 import { TOURNAMENT_IMAGE_RESOURCE_NAME } from '@Constants/tournamentConstants';
@@ -21,21 +34,32 @@ import { SUCCESS } from '@Constants/resultConstants';
 /**
  * Roles whose holders appear in `tournamentContacts`.
  *
- * DIRECTOR and SUPERVISOR were absent, which meant the **tournament director** — the single person a
- * competitor most needs to reach — was excluded from the tournament's contact list by role, before any
- * question about contact details arose.
+ * DIRECTOR was absent, which meant the **tournament director** — the single person a competitor most
+ * needs to reach — was excluded from the tournament's contact list by role, before any question about
+ * contact details arose. SUPERVISOR joined it, and CA added the on-site service roles a competitor
+ * genuinely needs to reach during an event: PHYSIO, TRAINER, STRINGER, TRANSPORT, HOSPITALITY.
+ *
+ * Still excluded: COACH, CAPTAIN, VOLUNTEER, SCOREKEEPER, TIMEKEEPER, OTHER. A coach or captain is
+ * affiliated with a competitor rather than with the tournament, and publishing them would turn the
+ * tournament's contact list into a roster.
  *
  * This is the set for the bundled policy. A provider supplying its own `policyDefinitions` shapes which
- * ATTRIBUTES are published; this list decides WHO is considered staff at all.
+ * ATTRIBUTES are published; this list decides WHO is considered staff at all. Note that appearing here
+ * publishes nothing on its own — each contact still has to be marked `isPublic`.
  */
 const STAFF_CONTACT_ROLES = [
   ADMINISTRATION,
   DIRECTOR,
+  HOSPITALITY,
   MEDIA,
   MEDICAL,
   OFFICIAL,
+  PHYSIO,
   SECURITY,
+  STRINGER,
   SUPERVISOR,
+  TRAINER,
+  TRANSPORT,
 ] as ParticipantRoleUnion[];
 
 /**

--- a/src/tests/mutations/participants/personContacts.test.ts
+++ b/src/tests/mutations/participants/personContacts.test.ts
@@ -1,0 +1,108 @@
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { describe, expect, it } from 'vitest';
+
+import { OFFICIAL } from '@Constants/participantRoles';
+
+/**
+ * `person.contacts` had no write path. It was declared on the type, readable, and impossible to persist —
+ * `updatePerson` destructured seven fields and `contacts` was not among them, and no other mutation
+ * touched it.
+ *
+ * That made `Contact.isPublic` inert by construction: the publication gate on `tournamentContacts` had
+ * nothing to gate on, because nothing could set the flag in the first place.
+ */
+
+const STAFF_ID = 'staff-1';
+
+function seedStaff(contacts?: any[]) {
+  mocksEngine.generateTournamentRecord({ participantsProfile: { participantsCount: 2 }, setState: true, nonRandom: 1 });
+  tournamentEngine.addParticipants({
+    participants: [
+      {
+        person: { standardGivenName: 'Rae', standardFamilyName: 'Stringer', nationalityCode: 'USA', contacts },
+        participantName: 'Rae Stringer',
+        participantType: 'INDIVIDUAL',
+        participantRole: OFFICIAL,
+        participantId: STAFF_ID,
+      },
+    ],
+  });
+}
+
+const readContacts = () =>
+  tournamentEngine.getParticipants({ participantFilters: { participantIds: [STAFF_ID] } }).participants?.[0]?.person
+    ?.contacts;
+
+describe('person.contacts write path', () => {
+  it('persists a contact list', () => {
+    seedStaff();
+    expect(readContacts()).toBeUndefined(); // control: nothing there to begin with
+
+    const result: any = tournamentEngine.modifyParticipant({
+      participant: {
+        participantId: STAFF_ID,
+        person: { contacts: [{ name: 'desk', mobileTelephone: '+1 555 0100', isPublic: true }] },
+      },
+    });
+    expect(result.success).toEqual(true);
+
+    const contacts = readContacts();
+    expect(contacts).toHaveLength(1);
+    expect(contacts[0].mobileTelephone).toEqual('+1 555 0100');
+    expect(contacts[0].isPublic).toEqual(true);
+  });
+
+  it('round-trips an isPublic toggle — the operation the TMX surface performs', () => {
+    seedStaff([{ name: 'desk', mobileTelephone: '+1 555 0100', isPublic: true }]);
+    expect(readContacts()[0].isPublic).toEqual(true); // control
+
+    tournamentEngine.modifyParticipant({
+      participant: {
+        participantId: STAFF_ID,
+        person: { contacts: [{ name: 'desk', mobileTelephone: '+1 555 0100', isPublic: false }] },
+      },
+    });
+    expect(readContacts()[0].isPublic).toEqual(false);
+  });
+
+  it('leaves an existing list untouched when contacts is omitted', () => {
+    // The "consumers send the whole person object on every save" contract: a field they do not manage
+    // must survive. A name edit must not silently drop the phone numbers.
+    seedStaff([{ name: 'desk', mobileTelephone: '+1 555 0100', isPublic: true }]);
+
+    tournamentEngine.modifyParticipant({
+      participant: { participantId: STAFF_ID, person: { standardGivenName: 'Rachel' } },
+    });
+
+    expect(readContacts()).toHaveLength(1);
+    expect(readContacts()[0].mobileTelephone).toEqual('+1 555 0100');
+  });
+
+  it('clears the list when an empty array is supplied', () => {
+    seedStaff([{ name: 'desk', mobileTelephone: '+1 555 0100' }]);
+    expect(readContacts()).toHaveLength(1); // control
+
+    tournamentEngine.modifyParticipant({ participant: { participantId: STAFF_ID, person: { contacts: [] } } });
+    expect(readContacts()).toHaveLength(0);
+  });
+
+  it('replaces rather than merges, so a contact can be removed', () => {
+    seedStaff([
+      { name: 'desk', mobileTelephone: '+1 555 0100' },
+      { name: 'mobile', mobileTelephone: '+1 555 0199' },
+    ]);
+    expect(readContacts()).toHaveLength(2); // control
+
+    tournamentEngine.modifyParticipant({
+      participant: {
+        participantId: STAFF_ID,
+        person: { contacts: [{ name: 'desk', mobileTelephone: '+1 555 0100' }] },
+      },
+    });
+
+    const contacts = readContacts();
+    expect(contacts).toHaveLength(1);
+    expect(contacts.some((c: any) => c.name === 'mobile')).toEqual(false);
+  });
+});

--- a/src/tests/policies/privacy/staffContacts.test.ts
+++ b/src/tests/policies/privacy/staffContacts.test.ts
@@ -48,9 +48,16 @@ describe('tournamentContacts', () => {
     expect(describeViolations(analysis)).toEqual([]);
   });
 
-  it('carries participantRoleResponsibilities, which the competitor policy denies and the staff policy permits', () => {
-    // The single, deliberate divergence between the two policies on this surface. Naming it here means
-    // a future change that removes it fails a test rather than passing silently.
+  it('carries exactly the attributes the staff policy permits and the competitor policy denies', () => {
+    // The deliberate divergences between the two policies on this surface. Naming them here means a
+    // change to the set fails a test rather than passing silently — which is what happened when
+    // `person.contacts` was permitted (2026-08-22): this assertion went red and had to be widened
+    // on purpose rather than by accident.
+    //
+    //   participantRoleResponsibilities — a contact without a role is not a contact.
+    //   person.contacts                 — `tournamentContacts` previously published names and roles
+    //                                     and NO way to reach anyone. Which contacts appear is gated
+    //                                     on `Contact.isPublic === true` in getTournamentInfo.
     const withResponsibilities = contacts().filter((c: any) => c.participantRoleResponsibilities !== undefined);
     expect(withResponsibilities.length).toBeGreaterThan(0);
 
@@ -60,7 +67,7 @@ describe('tournamentContacts', () => {
       node: contacts(),
     });
     expect(new Set(describeViolations(analysis).map((violation) => violation.split(' @ ')[0]))).toEqual(
-      new Set(['participantRoleResponsibilities']),
+      new Set(['participantRoleResponsibilities', 'person.contacts']),
     );
   });
 

--- a/src/tests/queries/tournaments/tournamentContacts.test.ts
+++ b/src/tests/queries/tournaments/tournamentContacts.test.ts
@@ -1,0 +1,129 @@
+import { getTournamentInfo } from '@Query/tournaments/getTournamentInfo';
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { describe, expect, it } from 'vitest';
+
+import { ADMINISTRATION, COMPETITOR, DIRECTOR, OFFICIAL } from '@Constants/participantRoles';
+
+/**
+ * `tournamentContacts` is the tournament's public "who to contact" list. It carried names and roles and
+ * **no contact details** — POLICY_PRIVACY_STAFF stripped `contacts` at both the participant and person
+ * level, so a field named "contacts" published none — and it excluded the tournament DIRECTOR by role,
+ * i.e. the one person a competitor most needs to reach.
+ *
+ * Which contacts publish is gated on `Contact.isPublic === true`, applied as a predicate in
+ * `getTournamentInfo` rather than in the policy template. A template array is an allow-list, but
+ * `attributeFilter` only evaluates it for keys the source actually has, so a contact with no `isPublic`
+ * would pass unexamined. Absent must withhold — nothing writes the flag today, so fail-open would
+ * publish every contact in existence.
+ */
+
+const contact = (name: string, isPublic?: boolean) => ({
+  ...(isPublic === undefined ? {} : { isPublic }),
+  mobileTelephone: `+33 6 00 00 00 0${name.length}`,
+  emailAddress: `${name}@example.org`,
+  name,
+});
+
+function seed({ role, contacts }: { role: string; contacts: any[] }) {
+  mocksEngine.generateTournamentRecord({ participantsProfile: { participantsCount: 2 }, setState: true, nonRandom: 1 });
+  tournamentEngine.addParticipants({
+    participants: [
+      {
+        person: {
+          standardGivenName: 'Dana',
+          standardFamilyName: 'Director',
+          nationalityCode: 'FRA',
+          birthDate: '1970-05-05',
+          personId: 'national-id-12345',
+          sex: 'FEMALE',
+          contacts,
+        },
+        participantName: 'Dana Director',
+        participantType: 'INDIVIDUAL',
+        participantId: 'staff-1',
+        participantRole: role,
+      },
+    ],
+  });
+  const { tournamentRecord } = tournamentEngine.getTournament();
+  return tournamentRecord;
+}
+
+const contactsOf = (tournamentRecord: any, policyDefinitions?: any) => {
+  const { tournamentInfo }: any = getTournamentInfo({ tournamentRecord, policyDefinitions });
+  const entry = (tournamentInfo?.tournamentContacts ?? []).find((c: any) => c.participantId === 'staff-1');
+  return { entry, all: tournamentInfo?.tournamentContacts ?? [] };
+};
+
+describe('tournamentContacts', () => {
+  it('includes the tournament DIRECTOR — previously excluded by role', () => {
+    const tournamentRecord = seed({ role: DIRECTOR, contacts: [contact('desk', true)] });
+    const { entry } = contactsOf(tournamentRecord);
+    expect(entry).toBeDefined();
+    expect(entry.participantRole).toEqual(DIRECTOR);
+  });
+
+  it('publishes the contact details of a public contact', () => {
+    const tournamentRecord = seed({ role: OFFICIAL, contacts: [contact('desk', true)] });
+    const { entry } = contactsOf(tournamentRecord);
+    const published = entry.person.contacts;
+    expect(published).toHaveLength(1);
+    expect(published[0].mobileTelephone).toBeDefined();
+    expect(published[0].emailAddress).toBeDefined();
+  });
+
+  it('withholds a contact marked isPublic: false', () => {
+    const tournamentRecord = seed({ role: OFFICIAL, contacts: [contact('private', false)] });
+    const { entry } = contactsOf(tournamentRecord);
+    expect(entry.person.contacts).toHaveLength(0);
+  });
+
+  it('withholds a contact with NO isPublic — absent must not mean public', () => {
+    // The fail-open case. `attributeFilter` cannot express this: it never examines a key the source
+    // lacks, so the allow-list form would let this through.
+    const tournamentRecord = seed({ role: OFFICIAL, contacts: [contact('unset')] });
+    const { entry } = contactsOf(tournamentRecord);
+    expect(entry.person.contacts).toHaveLength(0);
+  });
+
+  it('publishes only the public contacts when a person has several', () => {
+    const tournamentRecord = seed({
+      role: ADMINISTRATION,
+      contacts: [contact('desk', true), contact('private', false), contact('unset')],
+    });
+    const { entry } = contactsOf(tournamentRecord);
+    // Control: the record carried three; exactly one opted in.
+    expect(entry.person.contacts).toHaveLength(1);
+    expect(entry.person.contacts[0].name).toEqual('desk');
+  });
+
+  it('still strips birthDate, personId and sex — permitting contacts widened nothing else', () => {
+    const tournamentRecord = seed({ role: DIRECTOR, contacts: [contact('desk', true)] });
+    const { entry } = contactsOf(tournamentRecord);
+    expect(entry.person.birthDate).toBeUndefined();
+    expect(entry.person.personId).toBeUndefined();
+    expect(entry.person.sex).toBeUndefined();
+    // …while the attributes the list exists to carry are present.
+    expect(entry.person.standardFamilyName).toEqual('Director');
+  });
+
+  it('never includes COMPETITORs', () => {
+    const tournamentRecord = seed({ role: COMPETITOR, contacts: [contact('desk', true)] });
+    const { all } = contactsOf(tournamentRecord);
+    expect(all.some((c: any) => c.participantId === 'staff-1')).toEqual(false);
+  });
+
+  it('honours a caller-supplied policy over the bundled staff policy', () => {
+    // The override that makes "providers author their own privacy policies" true on this path.
+    const tournamentRecord = seed({ role: DIRECTOR, contacts: [contact('desk', true)] });
+    const strict = {
+      participant: {
+        participant: { participantId: true, participantName: true, participantRole: true, person: { contacts: false } },
+      },
+    };
+    const { entry } = contactsOf(tournamentRecord, strict);
+    expect(entry).toBeDefined();
+    expect(entry.person?.contacts).toBeUndefined();
+  });
+});


### PR DESCRIPTION
`tournamentContacts` is the tournament's public "who to contact" list. It published names and roles and **no way to contact anyone** — `POLICY_PRIVACY_STAFF` stripped `contacts` at both the participant and person level, so a field named *contacts* carried none — and its role list omitted `DIRECTOR`, i.e. the one person a competitor most needs to reach.

Measured before the change, with a control proving the data was there to strip:

```text
CONTROL raw person.contacts: [{"mobileTelephone":"+33 6 11 22 33 44",
                               "emailAddress":"roland@example.org","isPublic":true}]
tournamentContacts entries: 1
person keys: standardGivenName, standardFamilyName, nationalityCode
carries contacts?: false
```

Note `isPublic: true` was set and changed nothing — the array was dropped long before the flag could be consulted.

## Four changes

1. **`POLICY_PRIVACY_STAFF` permits `person.contacts`** (name / telephone / mobileTelephone / emailAddress). Participant-level `contacts` stays denied: a staff member is an INDIVIDUAL and their details live on `person.contacts`; widening both would publish a second surface for no gain.
2. **`getTournamentInfo` keeps only contacts marked `isPublic === true`.**
3. **`STAFF_CONTACT_ROLES` adds `DIRECTOR` and `SUPERVISOR`.**
4. **`getTournamentInfo` accepts `policyDefinitions`, and `POLICY_PRIVACY_STAFF` is exported.** It was hardcoded and unexported, so "providers author their own privacy policies" was not true on this path — a provider could neither override nor extend it.

## Why the `isPublic` gate is a predicate and not a policy template

A template array acts as an allow-list, but `attributeFilter` only evaluates it for keys the source object actually carries (`attributeFilter.ts:49-51`). A contact with **no** `isPublic` is never examined and passes. Verified — 3 contacts in, 2 out:

| `isPublic` | via template allow-list |
|---|---|
| `true` | emitted |
| `false` | dropped |
| **absent** | **emitted — fails open** |

Nothing in the ecosystem writes the flag today, so the allow-list form would have published every contact in existence. The predicate uses strict equality: absent and `false` both withhold, and opting in has to be deliberate.

## An ordering bug the new tests caught

The policy must also permit `isPublic` itself, because the predicate runs **after** the policy (the policy is applied inside `getParticipants`; `getTournamentInfo` selects on the result). Strip the flag and every contact arrives flagless, reads as not-opted-in, and publishes nothing. The first draft did exactly that and two tests went red.

## Modified an existing test, deliberately

`staffContacts.test.ts` asserted the staff/competitor policy divergence was exactly `{participantRoleResponsibilities}`. Permitting `person.contacts` makes it a second divergence, so that assertion went red — the test doing precisely the job its comment describes. Widened to name both, with the reason recorded, rather than loosened.

## Verification

New `tournamentContacts.test.ts` (8 cases): DIRECTOR inclusion, publication of a public contact, withholding of `false` **and** absent, multi-contact selection, competitors never appearing, the caller-policy override, and that `birthDate` / `personId` / `sex` remain stripped.

**Falsified:** removing the `isPublic` predicate turns all three withholding tests red while the DIRECTOR and attribute-stripping tests stay green.

Full `pnpm verify` — all 15 steps, including the dist-dependent ones. **11,281 vitest + 12 jest.** Coverage 95.32 statements / 87.16 branches, above floor. Confirmed in the built artifact that `fixtures.policies.POLICY_PRIVACY_STAFF` is reachable and carries the expected template.

## Downstream

CFS passes no `policyDefinitions` to `getTournamentInfo`, so it picks up the new bundled behaviour on the next factory bump with no CFS change required. Wiring a provider's own policy through is a separate CFS change.