### PR TITLE
feat(scheduling): preserve scheduling when a BYE is assigned

### DIFF
--- a/documentation/docs/governors/schedule-governor.md
+++ b/documentation/docs/governors/schedule-governor.md
@@ -1505,6 +1505,53 @@ This also governs `bulkScheduleMatchUps`, which delegates to
 primitive does **not** clear grid position; use `addMatchUpScheduleItems` (the path
 TMX and integrations use) for date changes.
 
+### Assigning a BYE preserves scheduling
+
+A tournament director may schedule an entire event and then swap participants around,
+placing byes temporarily or permanently. The engine therefore **never discards scheduling
+on its own**: a matchUp that becomes a BYE keeps its court, courtOrder and times.
+
+`assignDrawPositionBye` (and `setMatchUpStatus` with `matchUpStatus: 'BYE'`) accepts
+`preserveScheduling`:
+
+| value       | behaviour                                                                                                                                                                                                                                                                               |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `true`      | keep the placement                                                                                                                                                                                                                                                                      |
+| `false`     | release `allocatedCourts`, `courtId`, `venueId`, `courtAnnotation`, `courtOrder`, `scheduledDate`, `scheduledTime`, `timeModifiers` — on both `matchUp.schedule` and legacy `timeItems`. Actual-play timestamps (`startTime` / `stopTime` / `resumeTime` / `endTime`) are never touched |
+| `undefined` | preserve — **except** on an operator position-action against a matchUp that already holds scheduling, which returns `MATCHUP_HAS_SCHEDULING`                                                                                                                                            |
+
+```js
+engine.assignDrawPositionBye({ drawId, structureId, drawPosition, isPositionAction: true });
+// → { error: MATCHUP_HAS_SCHEDULING } when that drawPosition's matchUp holds a court or a time
+
+engine.assignDrawPositionBye({ drawId, structureId, drawPosition, preserveScheduling: false });
+// → { success: true }, court released
+```
+
+The refusal is deliberately scoped to `isPositionAction` — the flag the engine's own
+`positionActions` payload carries, i.e. an action an operator chose. Engine-internal callers
+(`directLoser` while a score is being entered, `doubleExitAdvancement`, `positionSwap`, draw
+generation, and this function's own BYE cascade) never receive it and take the preserving
+default, so entering a score can never hard-fail because the draw happened to be scheduled.
+An explicit `preserveScheduling: false` propagates through the cascade: one operator decision
+covers every matchUp that BYE reaches.
+
+### A BYE that holds a court is shown, not hidden
+
+BYE matchUps are excluded from `competitionScheduleMatchUps` by default. Pass
+**`courtByeMatchUps: true`** to include the ones holding a `courtId`, so they occupy a cell on
+the schedule grid. `proConflicts` annotates them `CONFLICT_BYE_SCHEDULED` at `SCHEDULE_WARNING`
+severity — a real double-booking or participant conflict on the same matchUp still outranks it.
+
+This is what keeps a preserved placement honest. Before it, a byed matchUp kept its court and
+disappeared from every schedule surface at once: the slot read as free, the next matchUp was
+dropped onto it, and `proConflicts` reported a `courtDoubleBooking` naming a partner that had no
+cell to click through to (production, 2026-08-22). Making the occupant visible — rather than
+deleting the director's placement — is the fix.
+
+Byes holding only a date/time occupy no cell and are not included; the WARNING tracks court
+occupancy specifically.
+
 ---
 
 ## Auto-captured `scoredTime`

--- a/src/constants/errorConditionConstants.ts
+++ b/src/constants/errorConditionConstants.ts
@@ -8,6 +8,14 @@ export const ANACHRONISM = {
   message: 'Chronological error; time violation.',
   code: 'ANACHRONISM',
 };
+// Assigning a BYE to a drawPosition whose matchUp already holds a court/time is
+// ambiguous: the operator may be mid-swap and want the placement kept, or may want
+// the slot released. Rather than guess, the position-action path refuses until the
+// caller states which, via `preserveScheduling: true | false`.
+export const MATCHUP_HAS_SCHEDULING = {
+  message: 'MatchUp has scheduling information; specify preserveScheduling.',
+  code: 'ERR_MATCHUP_HAS_SCHEDULING',
+};
 export const DUPLICATE_ENTRY = {
   message: 'Duplicate entry',
   code: 'DUPLICATE_ENTRY',
@@ -991,6 +999,7 @@ export const errorConditionConstants = {
   INVALID_WINNING_SIDE,
   LUCKY_DRAW_BYE_LIMIT,
   MATCHUPS_COMPLETED_OUTSIDE_DATES,
+  MATCHUP_HAS_SCHEDULING,
   MATCHUP_NOT_FOUND,
   METHOD_NOT_FOUND,
   MUTATION_LOCKED,

--- a/src/constants/scheduleConstants.ts
+++ b/src/constants/scheduleConstants.ts
@@ -9,6 +9,10 @@ export const CONFLICT_POTENTIAL_PARTICIPANTS = 'potentialParticipantConflict';
 export const CONFLICT_MATCHUP_ORDER = 'matchUpConflict';
 export const CONFLICT_COURT_DOUBLE_BOOKING = 'courtDoubleBooking';
 export const CONFLICT_POSITION_LINK = 'positionLinkConflict';
+// A BYE holding a court. Not an error and not a conflict — the placement may be
+// deliberate while a director swaps participants around — but a slot that cannot
+// be played on is worth surfacing, so it is annotated at WARNING severity.
+export const CONFLICT_BYE_SCHEDULED = 'byeScheduledOnCourt';
 export const SCHEDULE_ISSUE_IDS = 'ISSUE_IDS';
 export const SCHEDULE_CONFLICT = 'CONFLICT';
 export const SCHEDULE_WARNING = 'WARNING';
@@ -34,6 +38,7 @@ export const scheduleConstants = {
   CONFLICT_POTENTIAL_PARTICIPANTS,
   CONFLICT_COURT_DOUBLE_BOOKING,
   CONFLICT_POSITION_LINK,
+  CONFLICT_BYE_SCHEDULED,
   SCHEDULE_ISSUE_IDS,
   SCHEDULE_CONFLICT,
   SCHEDULE_WARNING,

--- a/src/mutate/drawDefinitions/matchUpGovernor/attemptToSetMatchUpStatus.ts
+++ b/src/mutate/drawDefinitions/matchUpGovernor/attemptToSetMatchUpStatus.ts
@@ -98,6 +98,7 @@ export function attemptToSetMatchUpStatus(params) {
     (nonDirecting && clearScore()) ||
     (isBYE &&
       attemptToSetMatchUpStatusBYE({
+        preserveScheduling: params.preserveScheduling,
         tournamentRecord,
         drawDefinition,
         structure,

--- a/src/mutate/drawDefinitions/removeDrawPositionAssignment.ts
+++ b/src/mutate/drawDefinitions/removeDrawPositionAssignment.ts
@@ -15,7 +15,16 @@ import { PAIR } from '@Constants/participantConstants';
 import { ResultType } from '@Types/factoryTypes';
 
 export function removeDrawPositionAssignment(params): ResultType & { participantId?: string } {
-  const { tournamentRecord, replaceWithBye, drawDefinition, destroyPair, entryStatus, matchUpsMap, drawId } = params;
+  const {
+    tournamentRecord,
+    preserveScheduling,
+    replaceWithBye,
+    drawDefinition,
+    destroyPair,
+    entryStatus,
+    matchUpsMap,
+    drawId,
+  } = params;
 
   const stack = 'removeDrawPositionAssignment';
 
@@ -71,6 +80,11 @@ export function removeDrawPositionAssignment(params): ResultType & { participant
 
   if (replaceWithBye) {
     const result = assignDrawPositionBye({
+      // Forwarded, not defaulted: `undefined` keeps the placement, matching the
+      // BYE-assignment default. This path does not set `isPositionAction`, so the
+      // ambiguity gate never fires here — removing a participant must not hard-fail
+      // because the seat happened to be scheduled.
+      preserveScheduling,
       tournamentRecord,
       drawDefinition,
       drawPosition,

--- a/src/mutate/matchUps/drawPositions/assignDrawPositionBye.ts
+++ b/src/mutate/matchUps/drawPositions/assignDrawPositionBye.ts
@@ -2,6 +2,7 @@ import { addPositionActionTelemetry } from '@Mutate/drawDefinitions/positionGove
 import { modifyMatchUpNotice, modifyPositionAssignmentsNotice } from '@Mutate/notifications/drawNotifications';
 import { getStructureDrawPositionProfiles } from '@Query/structure/getStructureDrawPositionProfiles';
 import { getAllStructureMatchUps } from '@Query/matchUps/getAllStructureMatchUps';
+import { matchUpHoldsScheduling, releaseByeScheduling } from '@Mutate/matchUps/schedule/byeScheduling';
 import { getInitialRoundNumber } from '@Query/matchUps/getInitialRoundNumber';
 import { getPositionAssignments } from '@Query/drawDefinition/positionsGetter';
 import { getAppliedPolicies } from '@Query/extensions/getAppliedPolicies';
@@ -28,6 +29,7 @@ import {
   DRAW_POSITION_ACTIVE,
   DRAW_POSITION_ASSIGNED,
   LUCKY_DRAW_BYE_LIMIT,
+  MATCHUP_HAS_SCHEDULING,
   MISSING_DRAW_DEFINITION,
   STRUCTURE_NOT_FOUND,
 } from '@Constants/errorConditionConstants';
@@ -66,6 +68,7 @@ import {
 
 type AssignDrawPositionByeArgs = {
   provisionalPositioning?: boolean;
+  preserveScheduling?: boolean;
   tournamentRecord?: Tournament;
   drawDefinition: DrawDefinition;
   isPositionAction?: boolean;
@@ -79,6 +82,7 @@ type AssignDrawPositionByeArgs = {
 
 export function assignDrawPositionBye({
   provisionalPositioning,
+  preserveScheduling,
   isPositionAction,
   tournamentRecord,
   drawDefinition,
@@ -168,6 +172,33 @@ export function assignDrawPositionBye({
     structure,
   });
 
+  // ############ Scheduling is the operator's, not ours ############
+  // A director may schedule a whole event and then swap participants around,
+  // placing byes temporarily or permanently. Silently wiping the surrounding plan
+  // to keep a conflict detector quiet destroys careful work — so a BYE KEEPS its
+  // placement unless the caller says otherwise, and a court-holding BYE is
+  // rendered in the grid and flagged CONFLICT_BYE_SCHEDULED (WARNING) instead.
+  //
+  // When the caller is an operator position-action and the target already holds
+  // scheduling, the intent is genuinely ambiguous — keep the slot mid-swap, or give
+  // it back? Refuse rather than guess; TMX catches this and asks. The gate is scoped
+  // to `isPositionAction` on purpose: 10 of this function's 14 call sites are
+  // engine-internal (directLoser during SCORE ENTRY, doubleExitAdvancement,
+  // positionSwap, draw generation, this function's own recursion) and must never
+  // start hard-failing on a scheduled draw. They take the non-destructive default.
+  const byeTargets = byeTargetMatchUps({ structure, matchUps, drawPosition });
+  if (
+    isPositionAction &&
+    preserveScheduling === undefined &&
+    byeTargets.some((m) => matchUpHoldsScheduling({ matchUp: m }))
+  ) {
+    return decorateResult({
+      info: 'assigning a BYE to a scheduled matchUp requires preserveScheduling: true | false',
+      result: { error: MATCHUP_HAS_SCHEDULING },
+      stack,
+    });
+  }
+
   // modifies the structure's positionAssignments
   // applies to both ELIMINATION and ROUND_ROBIN structures
   positionAssignments?.forEach((assignment) => {
@@ -183,6 +214,7 @@ export function assignDrawPositionBye({
 
   if (structure.structureType === CONTAINER) {
     assignRoundRobinBYE({
+      preserveScheduling,
       tournamentRecord,
       drawDefinition,
       drawPosition,
@@ -225,7 +257,7 @@ export function assignDrawPositionBye({
     ? roundMatchUps?.[roundNumber].find(({ drawPositions }) => drawPositions?.includes(drawPosition))
     : undefined;
 
-  matchUp && setMatchUpStatusBYE({ tournamentRecord, drawDefinition, matchUp, event });
+  matchUp && setMatchUpStatusBYE({ preserveScheduling, tournamentRecord, drawDefinition, matchUp, event });
 
   const drawPositionToAdvance = matchUp?.drawPositions?.find((position) => position !== drawPosition);
 
@@ -234,6 +266,7 @@ export function assignDrawPositionBye({
       matchUpId: matchUp.matchUpId,
       inContextDrawMatchUps,
       drawPositionToAdvance,
+      preserveScheduling,
       tournamentRecord,
       drawDefinition,
       matchUpsMap,
@@ -259,6 +292,39 @@ export function assignDrawPositionBye({
   });
 }
 
+/**
+ * The matchUps this BYE assignment will set to `BYE` status directly.
+ *
+ * ROUND_ROBIN (CONTAINER): every matchUp in the group containing the drawPosition.
+ * ELIMINATION: the single matchUp at the drawPosition's furthest advancement — the
+ * same one the main body picks for BYE-advancement. Derived from `matchUp.drawPositions`
+ * and so is safe to compute BEFORE positionAssignments are mutated, which is what lets
+ * the ambiguity gate refuse without leaving a half-applied change behind.
+ *
+ * Does NOT include matchUps a BYE later cascades into; those take the caller's decision
+ * (see advanceWinner) rather than re-opening the question mid-cascade.
+ */
+function byeTargetMatchUps({
+  structure,
+  matchUps,
+  drawPosition,
+}: {
+  matchUps?: MatchUp[];
+  structure: Structure;
+  drawPosition: number;
+}): MatchUp[] {
+  const containing = (matchUps ?? []).filter((matchUp) => matchUp.drawPositions?.includes(drawPosition));
+  if (structure.structureType === CONTAINER) return containing;
+
+  const furthestRoundNumber = containing.reduce(
+    (furthest: number | undefined, matchUp) =>
+      matchUp.roundNumber && (!furthest || matchUp.roundNumber > furthest) ? matchUp.roundNumber : furthest,
+    undefined,
+  );
+  const target = containing.find((matchUp) => matchUp.roundNumber === furthestRoundNumber);
+  return target ? [target] : [];
+}
+
 function successNotice({
   assignedParticipantId,
   isPositionAction,
@@ -282,18 +348,31 @@ function successNotice({
 }
 
 type SetMatchUpStatusByeArgs = {
+  preserveScheduling?: boolean;
   tournamentRecord?: Tournament;
   drawDefinition?: DrawDefinition;
   eventId?: string;
   matchUp: MatchUp;
   event?: Event;
 };
-function setMatchUpStatusBYE({ tournamentRecord, drawDefinition, eventId, matchUp, event }: SetMatchUpStatusByeArgs) {
+function setMatchUpStatusBYE({
+  preserveScheduling,
+  tournamentRecord,
+  drawDefinition,
+  eventId,
+  matchUp,
+  event,
+}: SetMatchUpStatusByeArgs) {
   Object.assign(matchUp, {
     matchUpStatus: BYE,
     score: undefined,
     winningSide: undefined,
   });
+
+  // ONLY on an explicit release. `undefined` preserves — see the gate in
+  // assignDrawPositionBye. Folded in before the notice below so the release ships
+  // with the same modifyMatchUpNotice rather than emitting a second one.
+  if (preserveScheduling === false) releaseByeScheduling({ matchUp });
 
   modifyMatchUpNotice({
     tournamentId: tournamentRecord?.tournamentId,
@@ -306,6 +385,7 @@ function setMatchUpStatusBYE({ tournamentRecord, drawDefinition, eventId, matchU
 }
 
 type AssignRoundRobinByeArgs = {
+  preserveScheduling?: boolean;
   tournamentRecord?: Tournament;
   drawDefinition: DrawDefinition;
   drawPosition: number;
@@ -314,6 +394,7 @@ type AssignRoundRobinByeArgs = {
 };
 
 function assignRoundRobinBYE({
+  preserveScheduling,
   tournamentRecord,
   drawDefinition,
   drawPosition,
@@ -324,6 +405,7 @@ function assignRoundRobinBYE({
     if (matchUp.drawPositions?.includes(drawPosition)) {
       setMatchUpStatusBYE({
         eventId: event?.eventId,
+        preserveScheduling,
         tournamentRecord,
         drawDefinition,
         matchUp,
@@ -337,6 +419,7 @@ function assignRoundRobinBYE({
 type AdvanceDrawPositionType = {
   inContextDrawMatchUps: HydratedMatchUp[];
   drawPositionToAdvance: number;
+  preserveScheduling?: boolean;
   tournamentRecord?: Tournament;
   drawDefinition: DrawDefinition;
   matchUpsMap: MatchUpsMap;
@@ -346,6 +429,7 @@ type AdvanceDrawPositionType = {
 export function advanceDrawPosition({
   drawPositionToAdvance,
   inContextDrawMatchUps,
+  preserveScheduling,
   tournamentRecord,
   drawDefinition,
   matchUpsMap,
@@ -394,6 +478,7 @@ export function advanceDrawPosition({
     advanceWinner({
       drawPositionToAdvance,
       inContextDrawMatchUps,
+      preserveScheduling,
       tournamentRecord,
       drawDefinition,
       winnerMatchUp,
@@ -411,6 +496,7 @@ export function advanceDrawPosition({
       const result = assignDrawPositionBye({
         structureId: loserTargetLink.target.structureId,
         drawPosition: loserTargetDrawPosition,
+        preserveScheduling,
         tournamentRecord,
         drawDefinition,
         event,
@@ -419,6 +505,7 @@ export function advanceDrawPosition({
     } else {
       assignFedDrawPositionBye({
         loserTargetDrawPosition,
+        preserveScheduling,
         tournamentRecord,
         loserTargetLink,
         drawDefinition,
@@ -435,6 +522,7 @@ export function advanceDrawPosition({
 function advanceWinner({
   drawPositionToAdvance,
   inContextDrawMatchUps,
+  preserveScheduling,
   tournamentRecord,
   drawDefinition,
   winnerMatchUp,
@@ -531,6 +619,13 @@ function advanceWinner({
     drawPositions,
   });
 
+  // The cascade carries the operator's decision rather than re-opening the question
+  // per matchUp: an explicit release applies to everything this BYE reaches, and the
+  // default (undefined / true) leaves downstream placements alone.
+  if (matchUpStatus === BYE && preserveScheduling === false) {
+    releaseByeScheduling({ matchUp: noContextWinnerMatchUp });
+  }
+
   const changedDrawPosition = noContextWinnerMatchUp.drawPositions.find(
     (position) => !twoDrawPositions.includes(position),
   );
@@ -569,6 +664,7 @@ function advanceWinner({
         drawPositionToAdvance: advancingDrawPosition,
         matchUpId: winnerMatchUp.matchUpId,
         inContextDrawMatchUps,
+        preserveScheduling,
         tournamentRecord,
         drawDefinition,
         matchUpsMap,
@@ -577,6 +673,7 @@ function advanceWinner({
       if (loserMatchUp.feedRound) {
         assignFedDrawPositionBye({
           loserTargetDrawPosition,
+          preserveScheduling,
           tournamentRecord,
           loserTargetLink,
           drawDefinition,
@@ -592,6 +689,7 @@ function advanceWinner({
         const result = assignDrawPositionBye({
           structureId: loserTargetLink.target.structureId,
           drawPosition: targetDrawPosition,
+          preserveScheduling,
           tournamentRecord,
           drawDefinition,
           event,
@@ -657,6 +755,7 @@ function resolvePropagatedExitOnAdvance({
 
 type AssignFedDrawPositionByeType = {
   loserTargetDrawPosition: number;
+  preserveScheduling?: boolean;
   tournamentRecord?: Tournament;
   drawDefinition: DrawDefinition;
   loserMatchUp: HydratedMatchUp;
@@ -667,6 +766,7 @@ type AssignFedDrawPositionByeType = {
 
 function assignFedDrawPositionBye({
   loserTargetDrawPosition,
+  preserveScheduling,
   tournamentRecord,
   loserTargetLink,
   drawDefinition,
@@ -689,6 +789,7 @@ function assignFedDrawPositionBye({
     const result = assignDrawPositionBye({
       structureId: loserTargetLink.target.structureId,
       drawPosition: loserTargetDrawPosition,
+      preserveScheduling,
       tournamentRecord,
       drawDefinition,
       event,

--- a/src/mutate/matchUps/matchUpStatus/attemptToSetMatchUpStatusBYE.ts
+++ b/src/mutate/matchUps/matchUpStatus/attemptToSetMatchUpStatusBYE.ts
@@ -1,4 +1,5 @@
 import { structureAssignedDrawPositions } from '@Query/drawDefinition/positionsGetter';
+import { releaseByeScheduling } from '@Mutate/matchUps/schedule/byeScheduling';
 import { modifyMatchUpNotice } from '../../notifications/drawNotifications';
 import { decorateResult } from '@Functions/global/decorateResult';
 
@@ -6,7 +7,14 @@ import { BYE } from '@Constants/matchUpStatusConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 import { INVALID_MATCHUP_STATUS, INVALID_MATCHUP_STATUS_BYE } from '@Constants/errorConditionConstants';
 
-export function attemptToSetMatchUpStatusBYE({ tournamentRecord, drawDefinition, structure, matchUp, event }) {
+export function attemptToSetMatchUpStatusBYE({
+  preserveScheduling,
+  tournamentRecord,
+  drawDefinition,
+  structure,
+  matchUp,
+  event,
+}) {
   const stack = 'attemptToSetMatchUpStatusBYE';
   if (matchUp?.winningSide) {
     return decorateResult({
@@ -31,6 +39,9 @@ export function attemptToSetMatchUpStatusBYE({ tournamentRecord, drawDefinition,
   if (matchUpIncludesBye) {
     matchUp.matchUpStatus = BYE;
     matchUp.matchUpStatusCodes = [];
+    // Preserve by default: a director may be mid-swap and the surrounding schedule is
+    // theirs. Only an explicit `preserveScheduling: false` gives the slot back.
+    if (preserveScheduling === false) releaseByeScheduling({ matchUp });
     modifyMatchUpNotice({
       tournamentId: tournamentRecord?.tournamentId,
       context: stack,

--- a/src/mutate/matchUps/schedule/byeScheduling.ts
+++ b/src/mutate/matchUps/schedule/byeScheduling.ts
@@ -1,0 +1,113 @@
+import { pushGlobalLog } from '@Functions/global/globalLog';
+
+// constants and types
+import { MatchUp } from '@Types/tournamentTypes';
+import {
+  ALLOCATE_COURTS,
+  ASSIGN_COURT,
+  ASSIGN_VENUE,
+  COURT_ANNOTATION,
+  COURT_ORDER,
+  SCHEDULED_DATE,
+  SCHEDULED_TIME,
+  TIME_MODIFIERS,
+} from '@Constants/timeItemConstants';
+
+/**
+ * Placement + order-of-play attributes, as `timeItem.itemType` → first-class
+ * `matchUp.schedule` attribute. This is the set that answers "does this matchUp
+ * hold a place on somebody's schedule?", and the set released when an operator
+ * says a BYE should give that place back.
+ *
+ * Deliberately EXCLUDES the actual-play timestamps (START_TIME / STOP_TIME /
+ * RESUME_TIME / END_TIME): those record that something happened on a court and
+ * are not ours to erase. A drawPosition cannot be byed while it is active
+ * (`DRAW_POSITION_ACTIVE`), so in practice a BYE carries none of them.
+ */
+const SCHEDULING_ATTRIBUTES: Record<string, string> = {
+  [ALLOCATE_COURTS]: 'allocatedCourts',
+  [ASSIGN_COURT]: 'courtId',
+  [ASSIGN_VENUE]: 'venueId',
+  [COURT_ANNOTATION]: 'courtAnnotation',
+  [COURT_ORDER]: 'courtOrder',
+  [SCHEDULED_DATE]: 'scheduledDate',
+  [SCHEDULED_TIME]: 'scheduledTime',
+  [TIME_MODIFIERS]: 'timeModifiers',
+};
+
+const SCHEDULING_ITEM_TYPES = new Set(Object.keys(SCHEDULING_ATTRIBUTES));
+const SCHEDULING_ATTRIBUTE_NAMES = Object.values(SCHEDULING_ATTRIBUTES);
+
+/**
+ * Whether a matchUp currently holds placement or order-of-play information.
+ *
+ * Used to decide whether assigning a BYE is an unambiguous action. If the matchUp
+ * holds nothing, there is no operator work at stake and no question to ask.
+ *
+ * Checks BOTH surfaces: first-class `matchUp.schedule.*` (NATIVE writeMode, what
+ * production runs) and legacy `matchUp.timeItems[]` (LEGACY writeMode).
+ */
+export function matchUpHoldsScheduling({ matchUp }: { matchUp?: MatchUp }): boolean {
+  if (!matchUp) return false;
+
+  const schedule = matchUp.schedule as Record<string, any> | undefined;
+  if (schedule && SCHEDULING_ATTRIBUTE_NAMES.some((attribute) => schedule[attribute] !== undefined)) return true;
+
+  return !!matchUp.timeItems?.some((timeItem) => timeItem?.itemType && SCHEDULING_ITEM_TYPES.has(timeItem.itemType));
+}
+
+/**
+ * Release the placement a matchUp is holding, because an operator has explicitly
+ * said a BYE should give it up (`preserveScheduling: false`).
+ *
+ * This is NOT a default. A tournament director may schedule an entire event and
+ * then swap participants around, temporarily or permanently placing byes; wiping
+ * the surrounding plan to keep a conflict detector quiet would destroy careful
+ * work. A BYE that keeps its slot is rendered in the schedule grid and flagged
+ * `CONFLICT_BYE_SCHEDULED` (WARNING) instead — visible, and the operator's call.
+ *
+ * Mutates `matchUp` in place and reports whether anything was released, so the
+ * caller can fold it into the `modifyMatchUpNotice` it already emits rather than
+ * issuing a second one. Intentionally does NOT consult the schedule lock: a lock
+ * pins a placement against scheduling MOVES, and this is an explicit release.
+ *
+ * @param matchUp - the (no-context) matchUp being set to BYE
+ * @returns true when a placement or order-of-play attribute was released
+ */
+export function releaseByeScheduling({ matchUp }: { matchUp?: MatchUp }): boolean {
+  if (!matchUp) return false;
+
+  let released = false;
+
+  const timeItems = matchUp.timeItems;
+  if (timeItems?.length) {
+    const retained = timeItems.filter(
+      (timeItem) => !(timeItem?.itemType && SCHEDULING_ITEM_TYPES.has(timeItem.itemType)),
+    );
+    if (retained.length !== timeItems.length) {
+      matchUp.timeItems = retained;
+      released = true;
+    }
+  }
+
+  const schedule = matchUp.schedule as Record<string, any> | undefined;
+  if (schedule) {
+    for (const attribute of SCHEDULING_ATTRIBUTE_NAMES) {
+      if (schedule[attribute] !== undefined) {
+        delete schedule[attribute];
+        released = true;
+      }
+    }
+    if (!Object.keys(schedule).length) delete matchUp.schedule;
+  }
+
+  if (released) {
+    pushGlobalLog({
+      method: 'releaseByeScheduling',
+      color: 'brightyellow',
+      matchUpId: matchUp.matchUpId,
+    });
+  }
+
+  return released;
+}

--- a/src/mutate/matchUps/schedule/schedulers/proScheduler/proConflicts.ts
+++ b/src/mutate/matchUps/schedule/schedulers/proScheduler/proConflicts.ts
@@ -6,6 +6,7 @@ import { ensureInt } from '@Tools/ensureInt';
 
 // Constants and types
 import { ErrorType, MISSING_CONTEXT, MISSING_MATCHUPS } from '@Constants/errorConditionConstants';
+import { BYE } from '@Constants/matchUpStatusConstants';
 import { Tournament } from '@Types/tournamentTypes';
 import { HydratedMatchUp } from '@Types/hydrated';
 import {
@@ -19,6 +20,7 @@ import {
   CONFLICT_PARTICIPANTS,
   CONFLICT_POTENTIAL_PARTICIPANTS,
   CONFLICT_COURT_DOUBLE_BOOKING,
+  CONFLICT_BYE_SCHEDULED,
   CONFLICT_POSITION_LINK,
 } from '@Constants/scheduleConstants';
 
@@ -33,8 +35,7 @@ export function proConflicts({
   tournamentRecords,
   matchUps,
 }: ProConflictsArgs):
-  | { error: ErrorType; info?: any }
-  | { courtIssues: { [key: string]: any }; rowIssues: { [key: string]: any } } {
+  { error: ErrorType; info?: any } | { courtIssues: { [key: string]: any }; rowIssues: { [key: string]: any } } {
   if (!validMatchUps(matchUps)) return { error: MISSING_MATCHUPS };
   if (matchUps.some(({ matchUpId, hasContext }) => matchUpId && !hasContext)) {
     return {
@@ -285,6 +286,15 @@ export function proConflicts({
       }
 
       // WARNINGS Section
+      // A BYE holding a court. Assigning a BYE deliberately PRESERVES scheduling
+      // (a director may be mid-swap), so this is not a defect to be auto-corrected
+      // — but a court slot that cannot be played on should be visible rather than
+      // silently absorbed. Annotated last-but-one in severity so a genuine
+      // double-booking or participant conflict on the same matchUp still wins.
+      if (mappedMatchUps[matchUpId].matchUpStatus === BYE && mappedMatchUps[matchUpId].schedule?.courtId) {
+        annotate(matchUpId, SCHEDULE_WARNING, CONFLICT_BYE_SCHEDULED, []);
+      }
+
       if (participantConflicts[matchUpId]?.[SCHEDULE_WARNING]) {
         annotate(matchUpId, SCHEDULE_WARNING, CONFLICT_PARTICIPANTS, participantConflicts[matchUpId][SCHEDULE_WARNING]);
       }

--- a/src/query/matchUps/competitionScheduleMatchUps.ts
+++ b/src/query/matchUps/competitionScheduleMatchUps.ts
@@ -22,6 +22,7 @@ type CompetitionScheduleMatchUpsArgs = {
   tournamentRecords: TournamentRecords;
   policyDefinitions?: PolicyDefinitions;
   courtCompletedMatchUps?: boolean;
+  courtByeMatchUps?: boolean;
   alwaysReturnCompleted?: boolean;
   contextFilters?: MatchUpFilters;
   matchUpFilters?: MatchUpFilters;
@@ -55,6 +56,7 @@ export function competitionScheduleMatchUps(params: CompetitionScheduleMatchUpsA
   const {
     sortDateMatchUps = true,
     courtCompletedMatchUps,
+    courtByeMatchUps,
     alwaysReturnCompleted,
     activeTournamentId,
     tournamentRecords,
@@ -121,14 +123,39 @@ export function competitionScheduleMatchUps(params: CompetitionScheduleMatchUpsA
 
   applyCompletedExclusion(params, alwaysReturnCompleted);
 
-  const { completedMatchUps, upcomingMatchUps, pendingMatchUps, abandonedMatchUps, groupInfo, mappedParticipants } =
-    getCompetitionMatchUps({
-      ...params,
-      matchUpFilters: params.matchUpFilters,
-      contextFilters: params.contextFilters,
-    });
+  const {
+    completedMatchUps,
+    upcomingMatchUps,
+    pendingMatchUps,
+    abandonedMatchUps,
+    byeMatchUps,
+    groupInfo,
+    mappedParticipants,
+  } = getCompetitionMatchUps({
+    ...params,
+    matchUpFilters: params.matchUpFilters,
+    contextFilters: params.contextFilters,
+  });
 
   let relevantMatchUps = [...(upcomingMatchUps ?? []), ...(pendingMatchUps ?? [])];
+
+  // BYE matchUps are bucketed out of the schedule by default — there are tens of
+  // thousands of them and none are played. But a BYE that HOLDS A COURT is a
+  // different animal: assigning a BYE deliberately preserves scheduling (a director
+  // may be mid-swap), so the slot really is taken, and hiding it produced exactly the
+  // failure this option exists to prevent — an invisible occupant that the operator
+  // then double-books, reported as a conflict against a cell that was never drawn.
+  //
+  // Opt-in, and narrowed to court-holders: a date/time-only BYE occupies no grid cell,
+  // and publishing surfaces (`usePublishState`) must not start emitting byes.
+  if (courtByeMatchUps && byeMatchUps?.length) {
+    const scheduledDate = params.matchUpFilters?.scheduledDate;
+    relevantMatchUps = relevantMatchUps.concat(
+      byeMatchUps.filter(
+        (matchUp) => matchUp.schedule?.courtId && (!scheduledDate || matchUp.schedule?.scheduledDate === scheduledDate),
+      ),
+    );
+  }
 
   if (detailsMap && (!publishedDrawIds?.length || Object.keys(detailsMap).length)) {
     relevantMatchUps = relevantMatchUps.filter((matchUp) => filterByPublishState(matchUp, detailsMap));

--- a/src/tests/mutations/scheduling/byeSchedulingPreservation.test.ts
+++ b/src/tests/mutations/scheduling/byeSchedulingPreservation.test.ts
@@ -1,0 +1,331 @@
+import { setSchemaWriteMode } from '@Global/state/globalState';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { afterEach, describe, expect, it } from 'vitest';
+
+// constants and types
+import { CONFLICT_BYE_SCHEDULED, CONFLICT_COURT_DOUBLE_BOOKING } from '@Constants/scheduleConstants';
+import { MATCHUP_HAS_SCHEDULING } from '@Constants/errorConditionConstants';
+import { LEGACY, NATIVE } from '@Constants/schemaWriteModeConstants';
+import { BYE } from '@Constants/matchUpStatusConstants';
+
+/**
+ * Assigning a BYE PRESERVES scheduling.
+ *
+ * A tournament director may schedule an entire event and then swap participants
+ * around, placing byes temporarily or permanently. Wiping the surrounding plan to
+ * keep a conflict detector quiet destroys careful work, so:
+ *
+ * - the default, and every engine-internal path, keeps the placement;
+ * - an operator position-action on a matchUp that already holds scheduling is
+ *   AMBIGUOUS and returns `MATCHUP_HAS_SCHEDULING` rather than guessing;
+ * - `preserveScheduling: true | false` states the intent and is honoured;
+ * - a BYE that ends up holding a court is rendered in the grid and annotated
+ *   `CONFLICT_BYE_SCHEDULED` at WARNING severity — visible, not silently absorbed.
+ *
+ * Context: production 2026-08-22 (Battle of Boca). A scheduled R64 matchUp was byed,
+ * kept Court 12, and — because byes were bucketed out of every schedule surface —
+ * became an invisible occupant. The operator dropped another match on the slot and
+ * `proConflicts` reported a `courtDoubleBooking` against a cell that was never drawn.
+ * The fix is to make the occupant visible, not to delete the placement.
+ *
+ * Both write modes are covered: the suite's setup hook pins LEGACY (schedule in
+ * `matchUp.timeItems[]`) while production runs NATIVE (first-class `matchUp.schedule.*`).
+ */
+
+const START_DATE = '2026-08-22';
+const END_DATE = '2026-08-25';
+
+// The setup hook re-pins LEGACY before each test; restore it after each so a
+// mode set here doesn't leak into unrelated specs sharing the module worker.
+afterEach(() => setSchemaWriteMode(LEGACY));
+
+function setup(mode: string) {
+  setSchemaWriteMode(mode as any);
+  tournamentEngine.reset();
+  const {
+    drawIds: [drawId],
+  } = mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ drawSize: 8, participantsCount: 8, drawId: 'byeSchedulingDraw' }],
+    venueProfiles: [{ courtsCount: 4, startTime: '07:00', endTime: '20:00' }],
+    startDate: START_DATE,
+    endDate: END_DATE,
+    setState: true,
+  });
+  const { courts } = tournamentEngine.getVenuesAndCourts();
+  const { matchUps } = tournamentEngine.allTournamentMatchUps({ matchUpFilters: { roundNumbers: [1] } });
+  const playable = matchUps.filter((m: any) => m.sides?.every((side: any) => side.participant));
+  return { courts, drawId, matchUps: playable, structureId: playable[0].structureId };
+}
+
+function readSchedule(drawId: string, matchUpId: string) {
+  return tournamentEngine.findMatchUp({ matchUpId, drawId }).matchUp.schedule ?? {};
+}
+
+function readStatus(drawId: string, matchUpId: string) {
+  return tournamentEngine.findMatchUp({ matchUpId, drawId }).matchUp.matchUpStatus;
+}
+
+function place(drawId: string, matchUpId: string, court: any, courtOrder: number, extra: any = {}) {
+  return tournamentEngine.addMatchUpScheduleItems({
+    schedule: {
+      courtId: court.courtId,
+      venueId: court.venueId,
+      courtOrder,
+      scheduledDate: START_DATE,
+      scheduledTime: '07:45',
+      ...extra,
+    },
+    removePriorValues: true,
+    matchUpId,
+    drawId,
+  });
+}
+
+function issuesOfType(issueType: string) {
+  const { matchUps } = tournamentEngine.allTournamentMatchUps({ inContext: true, nextMatchUps: true });
+  const scheduled = matchUps.filter((m: any) => m.schedule?.courtId && m.schedule?.scheduledDate === START_DATE);
+  const { rowIssues } = tournamentEngine.proConflicts({ matchUps: scheduled });
+  return Object.values(rowIssues ?? {})
+    .flat()
+    .filter((issue: any) => issue.issueType === issueType);
+}
+
+describe.each([LEGACY, NATIVE])('assigning a BYE preserves scheduling (%s writeMode)', (mode) => {
+  it('keeps the placement by default — the engine never discards operator scheduling unasked', () => {
+    const { courts, drawId, matchUps, structureId } = setup(mode);
+    const target = matchUps[0];
+    const court = courts[0];
+
+    expect(place(drawId, target.matchUpId, court, 1).success).toEqual(true);
+    const byedPosition = target.drawPositions[1];
+
+    // No isPositionAction, no preserveScheduling — the internal/default path.
+    expect(
+      tournamentEngine.removeDrawPositionAssignment({ drawPosition: byedPosition, structureId, drawId }).success,
+    ).toEqual(true);
+    expect(tournamentEngine.assignDrawPositionBye({ drawPosition: byedPosition, structureId, drawId }).success).toEqual(
+      true,
+    );
+
+    expect(readStatus(drawId, target.matchUpId)).toEqual(BYE);
+
+    const schedule = readSchedule(drawId, target.matchUpId);
+    expect(schedule.courtId).toEqual(court.courtId);
+    expect(schedule.courtOrder).toEqual(1);
+    expect(schedule.scheduledDate).toEqual(START_DATE);
+    expect(schedule.scheduledTime).toEqual('07:45');
+  });
+
+  it('refuses an ambiguous position-action rather than guessing, and mutates NOTHING', () => {
+    const { courts, drawId, matchUps, structureId } = setup(mode);
+    const target = matchUps[0];
+    const byedPosition = target.drawPositions[1];
+
+    place(drawId, target.matchUpId, courts[0], 1);
+    tournamentEngine.removeDrawPositionAssignment({ drawPosition: byedPosition, structureId, drawId });
+
+    const result = tournamentEngine.assignDrawPositionBye({
+      drawPosition: byedPosition,
+      isPositionAction: true,
+      structureId,
+      drawId,
+    });
+    expect(result.error).toEqual(MATCHUP_HAS_SCHEDULING);
+
+    // The gate runs before any mutation: the position must NOT have become a BYE.
+    expect(readStatus(drawId, target.matchUpId)).not.toEqual(BYE);
+    const assignments = tournamentEngine.getPositionAssignments({ structureId, drawId }).positionAssignments;
+    expect(assignments.find((a: any) => a.drawPosition === byedPosition)?.bye).toBeFalsy();
+    expect(readSchedule(drawId, target.matchUpId).courtId).toEqual(courts[0].courtId);
+  });
+
+  it('honours preserveScheduling: true', () => {
+    const { courts, drawId, matchUps, structureId } = setup(mode);
+    const target = matchUps[0];
+    const byedPosition = target.drawPositions[1];
+
+    place(drawId, target.matchUpId, courts[0], 1);
+    tournamentEngine.removeDrawPositionAssignment({ drawPosition: byedPosition, structureId, drawId });
+
+    const result = tournamentEngine.assignDrawPositionBye({
+      drawPosition: byedPosition,
+      preserveScheduling: true,
+      isPositionAction: true,
+      structureId,
+      drawId,
+    });
+    expect(result.success).toEqual(true);
+    expect(readStatus(drawId, target.matchUpId)).toEqual(BYE);
+    expect(readSchedule(drawId, target.matchUpId).courtId).toEqual(courts[0].courtId);
+  });
+
+  it('honours preserveScheduling: false', () => {
+    const { courts, drawId, matchUps, structureId } = setup(mode);
+    const target = matchUps[0];
+    const byedPosition = target.drawPositions[1];
+
+    place(drawId, target.matchUpId, courts[0], 1);
+    tournamentEngine.removeDrawPositionAssignment({ drawPosition: byedPosition, structureId, drawId });
+
+    const result = tournamentEngine.assignDrawPositionBye({
+      drawPosition: byedPosition,
+      preserveScheduling: false,
+      isPositionAction: true,
+      structureId,
+      drawId,
+    });
+    expect(result.success).toEqual(true);
+    expect(readStatus(drawId, target.matchUpId)).toEqual(BYE);
+
+    const schedule = readSchedule(drawId, target.matchUpId);
+    expect(schedule.courtId).toBeUndefined();
+    expect(schedule.venueId).toBeUndefined();
+    expect(schedule.courtOrder).toBeUndefined();
+    expect(schedule.scheduledDate).toBeUndefined();
+    expect(schedule.scheduledTime).toBeUndefined();
+  });
+
+  it('CONTROL: an UNSCHEDULED position-action is unambiguous and needs no boolean', () => {
+    // Falsifies the refusal above — if the gate fired on `isPositionAction` alone
+    // rather than on held scheduling, this would error too and the test that
+    // matters would be proving nothing about scheduling.
+    const { drawId, matchUps, structureId } = setup(mode);
+    const target = matchUps[0];
+    const byedPosition = target.drawPositions[1];
+
+    tournamentEngine.removeDrawPositionAssignment({ drawPosition: byedPosition, structureId, drawId });
+
+    const result = tournamentEngine.assignDrawPositionBye({
+      drawPosition: byedPosition,
+      isPositionAction: true,
+      structureId,
+      drawId,
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.success).toEqual(true);
+    expect(readStatus(drawId, target.matchUpId)).toEqual(BYE);
+  });
+});
+
+describe('a court-holding BYE is visible and flagged, not hidden', () => {
+  it('proConflicts annotates CONFLICT_BYE_SCHEDULED at WARNING severity', () => {
+    const { courts, drawId, matchUps, structureId } = setup(NATIVE);
+    const target = matchUps[0];
+    const byedPosition = target.drawPositions[1];
+
+    place(drawId, target.matchUpId, courts[0], 1);
+    tournamentEngine.removeDrawPositionAssignment({ drawPosition: byedPosition, structureId, drawId });
+    tournamentEngine.assignDrawPositionBye({
+      drawPosition: byedPosition,
+      preserveScheduling: true,
+      structureId,
+      drawId,
+    });
+
+    const flagged = issuesOfType(CONFLICT_BYE_SCHEDULED);
+    expect(flagged.length).toEqual(1);
+    expect((flagged[0] as any).matchUpId).toEqual(target.matchUpId);
+    expect((flagged[0] as any).issue).toEqual('WARNING');
+  });
+
+  it('CONTROL: an unscheduled BYE is not flagged — the annotation tracks court occupancy', () => {
+    const { drawId, matchUps, structureId } = setup(NATIVE);
+    const byedPosition = matchUps[0].drawPositions[1];
+
+    tournamentEngine.removeDrawPositionAssignment({ drawPosition: byedPosition, structureId, drawId });
+    tournamentEngine.assignDrawPositionBye({ drawPosition: byedPosition, structureId, drawId });
+
+    expect(issuesOfType(CONFLICT_BYE_SCHEDULED)).toEqual([]);
+  });
+
+  it('a real double booking outranks the BYE warning on the same matchUp', () => {
+    const { courts, drawId, matchUps, structureId } = setup(NATIVE);
+    const [target, other] = matchUps;
+    const byedPosition = target.drawPositions[1];
+
+    place(drawId, target.matchUpId, courts[0], 1);
+    tournamentEngine.removeDrawPositionAssignment({ drawPosition: byedPosition, structureId, drawId });
+    tournamentEngine.assignDrawPositionBye({
+      drawPosition: byedPosition,
+      preserveScheduling: true,
+      structureId,
+      drawId,
+    });
+
+    // The operator can now SEE the BYE on Court 12 — but if they place over it anyway,
+    // the double booking is real and must win the annotation.
+    place(drawId, other.matchUpId, courts[0], 1);
+
+    expect(issuesOfType(CONFLICT_COURT_DOUBLE_BOOKING).length).toBeGreaterThan(0);
+    expect(issuesOfType(CONFLICT_BYE_SCHEDULED)).toEqual([]);
+  });
+
+  it('competitionScheduleMatchUps hides the BYE by default and surfaces it under courtByeMatchUps', () => {
+    const { courts, drawId, matchUps, structureId } = setup(NATIVE);
+    const target = matchUps[0];
+    const byedPosition = target.drawPositions[1];
+
+    place(drawId, target.matchUpId, courts[0], 1);
+    tournamentEngine.removeDrawPositionAssignment({ drawPosition: byedPosition, structureId, drawId });
+    tournamentEngine.assignDrawPositionBye({
+      drawPosition: byedPosition,
+      preserveScheduling: true,
+      structureId,
+      drawId,
+    });
+
+    const courtMatchUpIds = (courtByeMatchUps?: boolean) =>
+      tournamentEngine
+        .competitionScheduleMatchUps({ matchUpFilters: { scheduledDate: START_DATE }, courtByeMatchUps })
+        .courtsData.flatMap((court: any) => court.matchUps.map((m: any) => m.matchUpId));
+
+    expect(courtMatchUpIds()).not.toContain(target.matchUpId);
+    expect(courtMatchUpIds(true)).toContain(target.matchUpId);
+  });
+
+  it('a date/time-only BYE stays out of the grid — it occupies no cell', () => {
+    const { drawId, matchUps, structureId } = setup(NATIVE);
+    const target = matchUps[0];
+    const byedPosition = target.drawPositions[1];
+
+    tournamentEngine.addMatchUpScheduleItems({
+      schedule: { scheduledDate: START_DATE, scheduledTime: '09:00' },
+      matchUpId: target.matchUpId,
+      removePriorValues: true,
+      drawId,
+    });
+    tournamentEngine.removeDrawPositionAssignment({ drawPosition: byedPosition, structureId, drawId });
+    tournamentEngine.assignDrawPositionBye({
+      drawPosition: byedPosition,
+      preserveScheduling: true,
+      structureId,
+      drawId,
+    });
+
+    const courtsData = tournamentEngine.competitionScheduleMatchUps({
+      matchUpFilters: { scheduledDate: START_DATE },
+      courtByeMatchUps: true,
+    }).courtsData;
+    const ids = courtsData.flatMap((court: any) => court.matchUps.map((m: any) => m.matchUpId));
+    expect(ids).not.toContain(target.matchUpId);
+
+    // ...but the placement it does hold is still intact.
+    expect(readSchedule(drawId, target.matchUpId).scheduledTime).toEqual('09:00');
+  });
+
+  it('addMatchUpScheduleItems can still place a BYE — a visible cell must be movable', () => {
+    const { courts, drawId, matchUps, structureId } = setup(NATIVE);
+    const target = matchUps[0];
+    const byedPosition = target.drawPositions[1];
+
+    tournamentEngine.removeDrawPositionAssignment({ drawPosition: byedPosition, structureId, drawId });
+    tournamentEngine.assignDrawPositionBye({ drawPosition: byedPosition, structureId, drawId });
+    expect(readStatus(drawId, target.matchUpId)).toEqual(BYE);
+
+    const result = place(drawId, target.matchUpId, courts[2], 3);
+    expect(result.success).toEqual(true);
+    expect(result.warnings).toBeUndefined();
+    expect(readSchedule(drawId, target.matchUpId).courtId).toEqual(courts[2].courtId);
+  });
+});

--- a/src/tests/queries/matchUps/competitiveProfileEngineAgreement.test.ts
+++ b/src/tests/queries/matchUps/competitiveProfileEngineAgreement.test.ts
@@ -14,6 +14,13 @@ function seededMatchUps() {
   mocksEngine.generateTournamentRecord({
     drawProfiles: [{ drawSize: 16, category: { ratingType: WTN } }],
     completeAllMatchUps: true,
+    // `nonRandom: 1` pins the generated scores. Without it the competitiveness bands
+    // are random, and this file's own tripwire — `nonZeroBands > 1` — fails on the runs
+    // where all 15 completed matchUps happen to land in a single band. Measured at
+    // 1 failure in 40 sequential runs on master (2026-08-22), which is enough to abort
+    // `verify:coverage` before it writes its summary. Same failure class the sibling
+    // `inferredGender.test.ts` documents.
+    nonRandom: 1,
     setState: true,
   });
 


### PR DESCRIPTION
## The problem

Reported on production `Battle of Boca - August 22` (`e9de0cd1`): the scheduling grid showed
`courtDoubleBooking: Austin Taco vs Thomas Rickards conflicts with Nicolas Eduardo Barros Corredor`
with only one visible cell. The conflict was real — both matchUps held Court 12 / courtOrder 1 /
2026-08-22 — but the partner was a **BYE**, and BYE matchUps are bucketed out of every schedule
surface, so nothing was drawn there.

From `audit_log`:

```
09:21:22Z  addMatchUpScheduleItems  a064ec23 -> Court 12 / courtOrder 1   (still playable)
10:46:52Z  removeDrawPositionAssignment { drawPosition: 2 }
10:46:55Z  assignDrawPositionBye        { drawPosition: 2 }
10:48:37Z  addMatchUpScheduleItems  289d37f7 -> Court 12 / courtOrder 1   (slot looked free)
```

## What this does NOT do

An earlier draft cleared the placement when a matchUp became a BYE. That was wrong: a director may
schedule an entire event and then swap participants around, placing byes temporarily or permanently,
and discarding the surrounding plan to keep a detector quiet destroys careful work. **The defect was
never the retained placement — it was that the occupant was invisible.** The fix is to show it.

## Behaviour

`assignDrawPositionBye` takes `preserveScheduling`:

| value | behaviour |
| --- | --- |
| `true` | keep the placement |
| `false` | release `allocatedCourts` / `courtId` / `venueId` / `courtAnnotation` / `courtOrder` / `scheduledDate` / `scheduledTime` / `timeModifiers`, on both `matchUp.schedule` and legacy `timeItems`. Actual-play timestamps are never touched |
| `undefined` | preserve — **except** on an operator position-action against a matchUp that already holds scheduling, which returns `MATCHUP_HAS_SCHEDULING` |

The refusal is scoped to `isPositionAction` deliberately: 10 of this function's 14 call sites are
engine-internal (`directLoser` during **score entry**, `doubleExitAdvancement`, `positionSwap`, draw
generation, its own cascade) and must never hard-fail on a scheduled draw. The gate runs **before any
mutation**, so a refusal cannot leave a half-applied change; an explicit `false` propagates through
the cascade so one operator decision covers every matchUp the BYE reaches.

Visibility: `competitionScheduleMatchUps({ courtByeMatchUps: true })` includes byes holding a
`courtId`, and `proConflicts` annotates them `CONFLICT_BYE_SCHEDULED` at `SCHEDULE_WARNING` — a real
double booking on the same matchUp still outranks it. Date/time-only byes occupy no cell and stay out.

**No scheduler consumes `proConflicts`** (`proAutoSchedule` references it only in a comment), so the
new annotation cannot change auto-scheduling behaviour.

## Tests

16 new cases in `byeSchedulingPreservation.test.ts`, parameterised over LEGACY and NATIVE writeModes.

Falsified rather than merely green: four independent neuters (gate / release / annotation /
`courtByeMatchUps`) produce exactly the predicted **6 of 16** failures, each mapping to one feature,
with all 10 controls still passing. Restored -> 16/16.

Honest caveat: the two "keeps the placement by default" cases also pass on unmodified `master` — they
are regression locks against re-introducing the earlier clearing behaviour, not evidence of new
behaviour.

## Second commit

`test(query): pin the competitiveProfile seed to stop a 1-in-40 flake` — unrelated pre-existing
nondeterminism found while running coverage, reproduced on clean `master` (1 failure in 40 runs
unpinned, 0 in 40 pinned).

## Verification

Full `pnpm verify` green — all 15 steps through `verify:pack`. Coverage 95.32% statements, 139 items
of headroom.

## Downstream

TMX consumes `courtByeMatchUps`, `MATCHUP_HAS_SCHEDULING` and `CONFLICT_BYE_SCHEDULED` (operator
prompt + grid cells). That work is held back until this publishes, since TMX CI installs the
published pin.