### PR TITLE
feat(types): contact relationship and grouping contact pointers

### DIFF
--- a/documentation/docs/concepts/participants.md
+++ b/documentation/docs/concepts/participants.md
@@ -168,6 +168,10 @@ Participants can have different roles within a tournament:
 | **COACH**          | Player coach                                                                              |
 | **ADMINISTRATION** | Administrative staff                                                                      |
 | **MEDICAL**        | Medical personnel: doctors, physiotherapists, trainers                                    |
+| **PHYSIO**         | Physiotherapist                                                                           |
+| **TRAINER**        | Athletic trainer                                                                          |
+| **SCOREKEEPER**    | Records the score of a matchUp                                                            |
+| **TIMEKEEPER**     | Manages match timing: warm-up, changeovers, shot clock                                    |
 | **MEDIA**          | Press, broadcasters, photographers                                                        |
 | **SECURITY**       | Security personnel                                                                        |
 | **HOSPITALITY**    | Player lounge, catering, accommodation liaison                                            |
@@ -485,6 +489,78 @@ tournamentEngine.toggleParticipantCheckInState({
   matchUpId: 'matchup-456',
 });
 ```
+
+## Contact Information
+
+Contacts live on `participant.contacts` and on `participant.person.contacts`, and are written through
+`modifyParticipant`. The array is **replaced**, not merged — editing one contact means reading the
+existing array, changing it, and sending the whole thing back. Sending only the contact you edited
+deletes the others; omitting `contacts` entirely leaves them untouched, and `[]` clears them.
+
+**API Reference:** [modifyParticipant](/docs/governors/participant-governor#modifyparticipant)
+
+```js
+tournamentEngine.modifyParticipant({
+  participant: {
+    participantId: 'player-123',
+    person: {
+      contacts: [
+        { name: 'Ana Rivas', mobileTelephone: '+33 6 00 00 00 00', relationship: 'GUARDIAN' },
+        { name: 'own mobile', mobileTelephone: '+33 6 11 11 11 11', relationship: 'SELF', isPublic: true },
+      ],
+    },
+  },
+});
+```
+
+### relationship
+
+`Contact.relationship` says **whose number this is**. A minor's contact is routinely a parent, a guardian
+or a travelling chaperone, and without it "Ana Rivas, +33…" is ambiguous between the competitor's own
+mobile and somebody else's — the distinction that decides who a director may ring at 9pm.
+
+| Value         | Meaning                                   |
+| ------------- | ----------------------------------------- |
+| **SELF**      | The person's own contact                  |
+| **PARENT**    | A parent                                  |
+| **GUARDIAN**  | A legal guardian                          |
+| **CHAPERONE** | A travelling chaperone or team supervisor |
+| **EMERGENCY** | An emergency contact                      |
+| **OTHER**     | Any relationship not covered above        |
+
+`relationship` is optional; a contact without one is accepted unchanged.
+
+A parent or guardian is an attribute of a person's contact details — **not a Participant**. Modelling
+them as participants would make them draw-enterable, count them among the tournament's competitors, and
+give them a ranking identity, because those paths gate on `participantType`.
+
+### isPublic
+
+`Contact.isPublic` records consent on the **contact** — "this contact may be shared publicly". It is not
+a promise about any particular surface. `getTournamentInfo` publishes only contacts explicitly marked
+`isPublic === true`, and only for staff roles; absent and `false` both withhold.
+
+### Contacts for a grouping
+
+`Participant.contactParticipantIds` designates which members hold contact information for a TEAM or
+GROUP — "who do I call about this group". It is a **pointer** to members, not details copied onto the
+grouping: a copy is a snapshot that goes stale on a rename or a number change.
+
+```js
+tournamentEngine.modifyParticipant({
+  participant: {
+    participantId: 'group-123',
+    contactParticipantIds: ['player-123'],
+  },
+});
+```
+
+Every id must appear in the grouping's `individualParticipantIds`. A pointer to a non-member is stale
+rather than authoritative, so it is rejected on write with `INVALID_PARTICIPANT_IDS` instead of being
+tolerated and filtered on every read. Membership is validated against the state the participant will
+have **after** the call, so "add these members and make one of them the contact" works as a single
+mutation. Deleting a participant prunes them from both `individualParticipantIds` and
+`contactParticipantIds`.
 
 ## Privacy and Data Protection
 

--- a/documentation/docs/concepts/participants.md
+++ b/documentation/docs/concepts/participants.md
@@ -26,7 +26,7 @@ The most basic participant type representing a single player or competitor.
 type IndividualParticipant = {
   participantId: string;
   participantType: 'INDIVIDUAL';
-  participantRole: 'COMPETITOR' | 'ALTERNATE' | 'OFFICIAL';
+  participantRole: 'COMPETITOR' | 'OFFICIAL' | 'DIRECTOR'; // see Participant Roles below
   participantOtherName?: string; // Nickname / display name
   person: {
     personId: string;

--- a/src/mutate/participants/deleteParticipants.ts
+++ b/src/mutate/participants/deleteParticipants.ts
@@ -9,7 +9,7 @@ import { intersection } from '@Tools/arrays';
 
 // Constants
 import { ARRAY, ERROR, OF_TYPE, TOURNAMENT_RECORD } from '@Constants/attributeConstants';
-import { PAIR, TEAM as participantTeam } from '@Constants/participantConstants';
+import { GROUP, PAIR, TEAM as participantTeam } from '@Constants/participantConstants';
 import { DELETE_PARTICIPANTS } from '@Constants/topicConstants';
 import { UNGROUPED } from '@Constants/entryStatusConstants';
 import { SUCCESS } from '@Constants/resultConstants';
@@ -104,15 +104,31 @@ export function deleteParticipants(params: DeleteParticipantsArgs): {
       (participant.participantType === PAIR &&
         participant.individualParticipantIds?.some((id) => participantIds.includes(id)));
 
-    // remove deleted individualParticipantIds from TEAMs
+    // Remove deleted individuals from every grouping that referenced them — TEAM *and* GROUP.
+    //
+    // GROUP was missing, so a deleted participant stayed in every group they belonged to. Those dangling
+    // ids are not inert: they reach draw avoidance (`addParticipantGroupings`), SHARED_GROUPING conflict
+    // evaluation, `membersCount`, and the public participants payload. The sibling path
+    // `removeParticipantIdsFromAllTeams` does not cover it either — its role filter defaults to
+    // COMPETITOR, and a GROUP carries OTHER or a relationship role, so it skips them.
+    //
+    // `contactParticipantIds` is pruned alongside, or a grouping would keep pointing at a deleted
+    // participant as its contact person.
     if (
       !participantToRemove &&
-      participant.participantType === TEAM &&
-      participant.individualParticipantIds?.some((id) => participantIds.includes(id))
+      participant.participantType &&
+      [participantTeam, GROUP].includes(participant.participantType)
     ) {
-      participant.individualParticipantIds = participant.individualParticipantIds.filter(
-        (id) => !participantIds.includes(id),
-      );
+      if (participant.individualParticipantIds?.some((id) => participantIds.includes(id))) {
+        participant.individualParticipantIds = participant.individualParticipantIds.filter(
+          (id) => !participantIds.includes(id),
+        );
+      }
+      if (participant.contactParticipantIds?.some((id) => participantIds.includes(id))) {
+        participant.contactParticipantIds = participant.contactParticipantIds.filter(
+          (id) => !participantIds.includes(id),
+        );
+      }
     }
 
     if (

--- a/src/mutate/participants/modifyParticipant.ts
+++ b/src/mutate/participants/modifyParticipant.ts
@@ -14,7 +14,11 @@ import { coercedSex } from '@Helpers/coercedSex';
 import { isString } from '@Tools/objects';
 
 // constants
-import { CANNOT_MODIFY_PARTICIPANT_TYPE, INVALID_DATE } from '@Constants/errorConditionConstants';
+import {
+  CANNOT_MODIFY_PARTICIPANT_TYPE,
+  INVALID_DATE,
+  INVALID_PARTICIPANT_IDS,
+} from '@Constants/errorConditionConstants';
 import { GROUP, INDIVIDUAL, PAIR, participantTypes } from '@Constants/participantConstants';
 import { PARTICIPANT_NAME_DERIVED_FROM_PERSON } from '@Constants/infoConstants';
 import { TOURNAMENT_RECORD, PARTICIPANT } from '@Constants/attributeConstants';
@@ -44,6 +48,7 @@ export function modifyParticipant(params) {
 
   const {
     participantRoleResponsibilities,
+    contactParticipantIds,
     individualParticipantIds,
     participantOtherName,
     participantName,
@@ -78,6 +83,20 @@ export function modifyParticipant(params) {
       newValues,
     });
   }
+  // Designated contact people for a grouping. Validated against the membership the participant will
+  // HAVE after this call — `newValues.individualParticipantIds` when membership is being changed in the
+  // same mutation, the existing list otherwise. Validating against the stale list would reject a
+  // legitimate "add these members and make one of them the contact" in a single call.
+  //
+  // A pointer to a non-member is stale rather than authoritative, so it is refused on write instead of
+  // being tolerated and filtered on every read.
+  if (Array.isArray(contactParticipantIds)) {
+    const membership = newValues.individualParticipantIds ?? existingParticipant.individualParticipantIds ?? [];
+    const invalid = contactParticipantIds.filter((participantId) => !membership.includes(participantId));
+    if (invalid.length) return { error: INVALID_PARTICIPANT_IDS, invalid };
+    newValues.contactParticipantIds = contactParticipantIds;
+  }
+
   if (Object.keys(participantRoles).includes(participantRole)) newValues.participantRole = participantRole;
   if (Object.keys(participantTypes).includes(participantType)) newValues.participantType = participantType;
 

--- a/src/tests/constants/enumConstConformance.test.ts
+++ b/src/tests/constants/enumConstConformance.test.ts
@@ -184,6 +184,11 @@ const ENUM_ONLY = [
   // PracticeRegistrationStatusEnum.CONFIRMED.
   'PracticeRegistrationStatusEnum',
   'BallTypeEnum',
+  // Genuinely enum-only: the relationship vocabulary describes a Contact and has no domain-constant twin
+  // for callers to destructure. Recorded here as a deliberate decision rather than by omission — the
+  // previous ParticipantRoleEnum entry sat in this list on the FALSE premise that it had no twin, which
+  // is how SCOREKEEPER and TIMEKEEPER stayed inexpressible for months.
+  'ContactRelationshipEnum',
   'CountryCodeEnum',
   'CourtPositionEnum',
   'DrawTypeEnum',

--- a/src/tests/mutations/participants/contactModel.test.ts
+++ b/src/tests/mutations/participants/contactModel.test.ts
@@ -1,0 +1,184 @@
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { describe, expect, it } from 'vitest';
+
+import { INVALID_PARTICIPANT_IDS } from '@Constants/errorConditionConstants';
+import { ContactRelationshipEnum } from '@Types/tournamentTypes';
+import { COMPETITOR, OTHER } from '@Constants/participantRoles';
+import { INDIVIDUAL } from '@Constants/participantConstants';
+
+/**
+ * Two CODES additions and one cascade fix.
+ *
+ * `Contact.relationship` says WHOSE number this is. A minor's contact is routinely a parent, guardian or
+ * chaperone, and a Contact could previously carry only a `name` — leaving the competitor's own mobile
+ * indistinguishable from somebody else's.
+ *
+ * `Participant.contactParticipantIds` designates members who hold contact information for a grouping. A
+ * pointer, not copied details: a copy is a snapshot that goes stale on a rename or a number change.
+ *
+ * A guardian is deliberately NOT a Participant. `addEventEntries` gates on participantType with no role
+ * check, tournament counts filter on participantType, and rankings ingest walks all participants —
+ * a guardian-as-participant would be draw-enterable, counted as a player, and given a ranking identity.
+ */
+
+const seedIndividuals = (count = 4) => {
+  mocksEngine.generateTournamentRecord({
+    participantsProfile: { participantsCount: count },
+    setState: true,
+    nonRandom: 1,
+  });
+  return tournamentEngine
+    .getParticipants({ participantFilters: { participantTypes: [INDIVIDUAL] } })
+    .participants.map(({ participantId }: any) => participantId);
+};
+
+const readParticipant = (participantId: string) =>
+  tournamentEngine.getParticipants({ participantFilters: { participantIds: [participantId] } }).participants?.[0];
+
+describe('Contact.relationship', () => {
+  it('persists a guardian contact with a name, distinct from the competitor', () => {
+    const [competitorId] = seedIndividuals();
+
+    const result: any = tournamentEngine.modifyParticipant({
+      participant: {
+        participantId: competitorId,
+        person: {
+          contacts: [
+            { name: 'Ana Rivas', mobileTelephone: '+1 555 0100', relationship: ContactRelationshipEnum.GUARDIAN },
+            { name: 'own mobile', mobileTelephone: '+1 555 0199', relationship: ContactRelationshipEnum.SELF },
+          ],
+        },
+      },
+    });
+    expect(result.success).toEqual(true);
+
+    const contacts = readParticipant(competitorId).person.contacts;
+    expect(contacts).toHaveLength(2);
+    expect(contacts[0].relationship).toEqual('GUARDIAN');
+    expect(contacts[0].name).toEqual('Ana Rivas');
+    // SELF is the reason the enum carries it: without it this is indistinguishable from an unlabelled
+    // number, and a director cannot tell whose phone they are about to ring.
+    expect(contacts[1].relationship).toEqual('SELF');
+  });
+
+  it('carries PARENT and CHAPERONE, and tolerates a contact with no relationship', () => {
+    const [competitorId] = seedIndividuals();
+    tournamentEngine.modifyParticipant({
+      participant: {
+        participantId: competitorId,
+        person: {
+          contacts: [
+            { name: 'dad', mobileTelephone: '+1 555 0001', relationship: ContactRelationshipEnum.PARENT },
+            { name: 'team chaperone', mobileTelephone: '+1 555 0002', relationship: ContactRelationshipEnum.CHAPERONE },
+            { name: 'unlabelled', mobileTelephone: '+1 555 0003' },
+          ],
+        },
+      },
+    });
+    const contacts = readParticipant(competitorId).person.contacts;
+    expect(contacts.map((c: any) => c.relationship)).toEqual(['PARENT', 'CHAPERONE', undefined]);
+  });
+});
+
+describe('Participant.contactParticipantIds', () => {
+  const seedGroup = () => {
+    const ids = seedIndividuals();
+    const created: any = tournamentEngine.createGroupParticipant({
+      individualParticipantIds: ids.slice(0, 3),
+      groupName: 'Coach Ramirez stable',
+      participantRole: OTHER,
+    });
+    return { groupId: created.participant.participantId, ids };
+  };
+
+  it('designates members as the grouping contacts', () => {
+    const { groupId, ids } = seedGroup();
+    const result: any = tournamentEngine.modifyParticipant({
+      participant: { participantId: groupId, contactParticipantIds: [ids[0], ids[1]] },
+    });
+    expect(result.success).toEqual(true);
+    expect(readParticipant(groupId).contactParticipantIds).toEqual([ids[0], ids[1]]);
+  });
+
+  it('REFUSES a pointer to a non-member', () => {
+    // Stale rather than authoritative: resolving it would advertise the contact details of somebody the
+    // group does not contain. Refused on write instead of filtered on every read.
+    const { groupId, ids } = seedGroup();
+    const result: any = tournamentEngine.modifyParticipant({
+      participant: { participantId: groupId, contactParticipantIds: [ids[3]] },
+    });
+    expect(result.error).toEqual(INVALID_PARTICIPANT_IDS);
+    expect(readParticipant(groupId).contactParticipantIds).toBeUndefined();
+  });
+
+  it('validates against membership set in the SAME call', () => {
+    // "Add these members and make one of them the contact" is a legitimate single mutation; validating
+    // against the pre-call membership would reject it.
+    const { groupId, ids } = seedGroup();
+    const result: any = tournamentEngine.modifyParticipant({
+      participant: {
+        participantId: groupId,
+        individualParticipantIds: [ids[0], ids[3]],
+        contactParticipantIds: [ids[3]],
+      },
+    });
+    expect(result.success).toEqual(true);
+    expect(readParticipant(groupId).contactParticipantIds).toEqual([ids[3]]);
+  });
+
+  it('accepts an empty array as "no designated contact"', () => {
+    const { groupId, ids } = seedGroup();
+    tournamentEngine.modifyParticipant({ participant: { participantId: groupId, contactParticipantIds: [ids[0]] } });
+    tournamentEngine.modifyParticipant({ participant: { participantId: groupId, contactParticipantIds: [] } });
+    expect(readParticipant(groupId).contactParticipantIds).toEqual([]);
+  });
+});
+
+describe('delete cascade reaches GROUPs', () => {
+  it('removes a deleted participant from a role-bearing GROUP and its contact pointers', () => {
+    // The F5 bug. `removeParticipantIdsFromAllTeams` filters groupings on
+    // `participantRole === COMPETITOR || !participantRole`, and every GROUP the UI creates carries a
+    // role — so no role-bearing GROUP was ever pruned. Dangling ids reach draw avoidance,
+    // SHARED_GROUPING evaluation, membersCount and the public payload.
+    const ids = seedIndividuals();
+    const created: any = tournamentEngine.createGroupParticipant({
+      individualParticipantIds: [ids[0], ids[1]],
+      participantRole: OTHER,
+      groupName: 'Squad',
+    });
+    const groupId = created.participant.participantId;
+    tournamentEngine.modifyParticipant({
+      participant: { participantId: groupId, contactParticipantIds: [ids[0]] },
+    });
+    // control: both the membership and the pointer are there to be pruned
+    expect(readParticipant(groupId).individualParticipantIds).toEqual([ids[0], ids[1]]);
+    expect(readParticipant(groupId).contactParticipantIds).toEqual([ids[0]]);
+
+    const result: any = tournamentEngine.deleteParticipants({ participantIds: [ids[0]] });
+    expect(result.success).toEqual(true);
+
+    const group = readParticipant(groupId);
+    expect(group.individualParticipantIds).toEqual([ids[1]]);
+    expect(group.contactParticipantIds).toEqual([]);
+  });
+
+  it('still prunes TEAMs', () => {
+    const ids = seedIndividuals();
+    tournamentEngine.addParticipants({
+      participants: [
+        {
+          individualParticipantIds: [ids[0], ids[1]],
+          participantRole: COMPETITOR,
+          participantId: 'team-1',
+          participantName: 'Team One',
+          participantType: 'TEAM',
+        },
+      ],
+    });
+    expect(readParticipant('team-1').individualParticipantIds).toHaveLength(2); // control
+
+    tournamentEngine.deleteParticipants({ participantIds: [ids[0]] });
+    expect(readParticipant('team-1').individualParticipantIds).toEqual([ids[1]]);
+  });
+});

--- a/src/types/enumExports.ts
+++ b/src/types/enumExports.ts
@@ -8,7 +8,7 @@
  *
  * Regenerate:   pnpm gen:enum-exports
  * Drift guard:  pnpm check:enum-exports
- * Covers 62 enums across 4 modules.
+ * Covers 63 enums across 4 modules.
  */
 
 export { SportEnum } from './competitionFormat';
@@ -34,6 +34,7 @@ export { AddressTypeEnum } from './tournamentTypes';
 export { BallTypeEnum } from './tournamentTypes';
 export { BookingTypeEnum } from './tournamentTypes';
 export { CategoryEnum } from './tournamentTypes';
+export { ContactRelationshipEnum } from './tournamentTypes';
 export { CountryCodeEnum } from './tournamentTypes';
 export { CourtPositionEnum } from './tournamentTypes';
 export { DisciplineEnum } from './tournamentTypes';

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -1463,7 +1463,7 @@ export interface Participant {
  * Note what this is NOT. A parent or guardian is an attribute of a person's contact details, not a
  * Participant. Modelling them as participants would put them inside `addEventEntries` (which gates on
  * participantType and would make them draw-enterable), the tournament's player counts, and rankings
- * ingest — none of which consult `participantRole`. See planning/CODES_CONTACT_MODEL.md.
+ * ingest — none of which consult `participantRole`.
  */
 export enum ContactRelationshipEnum {
   CHAPERONE = 'CHAPERONE',

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -1408,6 +1408,16 @@ export type OnlineResourceTypeUnion = `${OnlineResourceTypeEnum}`;
 
 export interface Participant {
   contacts?: Contact[];
+  /**
+   * Members who hold contact information for this grouping — "who do I call about this group".
+   * Only relevant when participantType is TEAM or GROUP, and entirely optional.
+   *
+   * A POINTER to members rather than contact details copied onto the grouping. A copy is a snapshot:
+   * rename the person or change their number and the group keeps advertising the old one. Entries must
+   * appear in `individualParticipantIds` — a pointer to a non-member is stale rather than authoritative,
+   * so it is rejected on write rather than tolerated on read.
+   */
+  contactParticipantIds?: string[];
   createdAt?: Date | string;
   extensions?: Extension[];
   homeVenueIds?: string[]; // only releveant when participantType is TEAM
@@ -1436,6 +1446,35 @@ export interface Participant {
   useOtherName?: boolean;
 }
 
+/**
+ * Whose number this is.
+ *
+ * A minor's contact is routinely a parent, a guardian or a travelling chaperone, and a `Contact` could
+ * previously carry only a `name` — leaving "Ana Rivas, +33…" ambiguous between the competitor's own
+ * mobile and somebody else's. That distinction decides who a director may ring at 9pm.
+ *
+ * An enum rather than a free string, deliberately. `participantRoleResponsibilities` is the cautionary
+ * case: an unvalidated `string[]` that already carries four incompatible dialects in-tree ('Home',
+ * 'CLUB', 'SCOREKEEPER', 'Captain'). A vocabulary with no enum becomes several vocabularies.
+ *
+ * SELF earns its place: without it, "the competitor's own mobile" and "an unlabelled number" are the
+ * same state.
+ *
+ * Note what this is NOT. A parent or guardian is an attribute of a person's contact details, not a
+ * Participant. Modelling them as participants would put them inside `addEventEntries` (which gates on
+ * participantType and would make them draw-enterable), the tournament's player counts, and rankings
+ * ingest — none of which consult `participantRole`. See planning/CODES_CONTACT_MODEL.md.
+ */
+export enum ContactRelationshipEnum {
+  CHAPERONE = 'CHAPERONE',
+  EMERGENCY = 'EMERGENCY',
+  GUARDIAN = 'GUARDIAN',
+  OTHER = 'OTHER',
+  PARENT = 'PARENT',
+  SELF = 'SELF',
+}
+export type ContactRelationshipUnion = `${ContactRelationshipEnum}`;
+
 export interface Contact {
   createdAt?: Date | string;
   emailAddress?: string;
@@ -1446,6 +1485,8 @@ export interface Contact {
   mobileTelephone?: string;
   name?: string;
   notes?: string;
+  /** Whose contact this is — the person themselves, or a parent / guardian / chaperone acting for them. */
+  relationship?: ContactRelationshipUnion;
   telephone?: string;
   timeItems?: TimeItem[];
   updatedAt?: Date | string;


### PR DESCRIPTION
Two CODES additions requested by CA, plus the cascade fix they depend on. Design and rationale: `Mentat/planning/CODES_CONTACT_MODEL.md`.

## 1. `Contact.relationship`

`PARENT` / `GUARDIAN` / `CHAPERONE` / `EMERGENCY` / `SELF` / `OTHER`, on the shared `Contact` interface — so it is available on `Person.contacts`, `Participant.contacts` and `Venue.contacts` alike.

A minor's contact is routinely a parent, guardian or travelling chaperone, and a `Contact` could previously carry only a `name` — leaving the competitor's own mobile indistinguishable from somebody else's. **`SELF` earns its place for exactly that reason**: without it, "the competitor's own number" and "an unlabelled number" are the same state.

An **enum, not a free string**. `participantRoleResponsibilities` is the cautionary case: an unvalidated `string[]` already carrying four incompatible dialects in-tree (`'Home'`, `'CLUB'`, `'SCOREKEEPER'`, `'Captain'`). Registered as `ENUM_ONLY` in the conformance guard as a **deliberate decision** — the guard caught the omission and failed until it was recorded, which is precisely the behaviour `ParticipantRoleEnum`'s false exemption should have had.

### A guardian is an attribute, not a Participant

Deliberate, and the reason is mechanical rather than aesthetic. Three live surfaces gate on `participantType` and ignore `participantRole`:

| mechanism | consequence if a guardian were a Participant |
|---|---|
| `addEventEntries` — **zero** `participantRole` references | a guardian would be **draw-enterable** |
| `getTournamentInfo` counts `participantType === INDIVIDUAL` | every guardian inflates the player count |
| rankings ingest walks all participants, guarded only by `person?.personId` | a guardian acquires a canonical ranking identity |

The attribute model needs none of them, and both bundled privacy policies already strip `person.contacts` from public payloads by default.

## 2. `Participant.contactParticipantIds`

Members who hold contact information for a grouping — "who do I call about this group". Optional; TEAM and GROUP alike.

A **pointer, not copied details**: a copy is a snapshot that goes stale on a rename or a number change. Entries must be members — a pointer to a non-member is stale rather than authoritative, so `modifyParticipant` **refuses it on write** instead of every reader filtering it on read.

Validated against the membership the participant will **have after the call**, so "add these members and designate one of them" works as a single mutation rather than requiring two.

## 3. `deleteParticipants` now prunes GROUPs, not only TEAMs

A deleted participant stayed in every group they belonged to. Those dangling ids are not inert — they reach draw avoidance (`addParticipantGroupings`), `SHARED_GROUPING` conflict evaluation, `membersCount`, and the public participants payload.

The sibling path `removeParticipantIdsFromAllTeams` does not cover it: its role filter defaults to `COMPETITOR`, and a GROUP carries `OTHER` or a relationship role. **I left that default alone deliberately** — it is also used by `removeFromOtherTeams`, where widening it would make team assignment silently disturb relationship groups. `contactParticipantIds` is pruned alongside.

Noticed while there: `TEAM` in `deleteParticipants` was the **eventConstants** `TEAM`, not the participant type. Both are `'TEAM'` so it worked by coincidence; the new branch uses `participantConstants`.

## Verification

Falsified individually — dropping GROUP from the cascade reddens only the cascade test; removing the pointer validation reddens only the non-member test.

Full `pnpm verify`, **all 15 steps** including the dist-dependent ones. **11,310 vitest + 12 jest.** Coverage headroom 141 statements. Built artifact confirmed to carry `ContactRelationshipEnum` and `contactParticipantIds`.

## Follow-ups (separate PRs)

- `addEventEntries` should require the `COMPETITOR` role; `getTournamentInfo` counts should filter on role. Both are behaviour changes with real blast radius and deserve their own PR — CA agreed.
- TMX migrates its group contact-person extension onto `contactParticipantIds` after this publishes.