### PR TITLE
fix(entries): gate event entries and tournament counts on the competitor role

### DIFF
--- a/documentation/docs/concepts/events/entries.mdx
+++ b/documentation/docs/concepts/events/entries.mdx
@@ -18,6 +18,19 @@ tournamentEngine.addEventEntries({
 });
 ```
 
+## Role Eligibility
+
+Only competitors compete. A participant carrying a `participantRole` other than `COMPETITOR` — `OFFICIAL`,
+`COACH`, `PHYSIO`, `TRANSPORT` and the rest of the staff roles — is refused entry with
+`INVALID_PARTICIPANT_IDS`, whatever their `participantType`. Staff and officials are `INDIVIDUAL`
+participants like players are, so without this gate nothing prevented a referee being entered into a draw.
+
+A participant with **no** `participantRole` at all is still accepted: records written before the role was
+universally present carry none, and those are players.
+
+The same rule shapes `getTournamentInfo`'s `individualParticipantCount`, which counts competitors rather
+than people.
+
 ## Category Validation
 
 When adding entries to events with category constraints (age ranges, rating requirements), you can optionally enforce validation to ensure participants meet eligibility criteria.

--- a/src/mutate/entries/addEventEntries.ts
+++ b/src/mutate/entries/addEventEntries.ts
@@ -39,6 +39,7 @@ import { PolicyDefinitions, ResultType } from '@Types/factoryTypes';
 import { ROUND_TARGET } from '@Constants/extensionConstants';
 import { DOUBLES, SINGLES } from '@Constants/matchUpTypes';
 import { MAIN } from '@Constants/drawDefinitionConstants';
+import { COMPETITOR } from '@Constants/participantRoles';
 import { SUCCESS } from '@Constants/resultConstants';
 import { unique } from '@Tools/arrays';
 import {
@@ -174,6 +175,19 @@ function getTypedParticipantIdsHelper({
     tournamentRecord?.participants
       ?.filter((participant) => {
         if (!participantIds.includes(participant.participantId)) return false;
+
+        // Only competitors compete.
+        //
+        // Every eligibility predicate below gates on `participantType` and none consulted
+        // `participantRole`, so an OFFICIAL, a COACH, a PHYSIO or a TRANSPORT driver was as enterable
+        // into a draw as a player — they are all INDIVIDUAL participants. Nothing prevented a referee
+        // being drawn against a competitor.
+        //
+        // Phrased as "has a role, and it is not COMPETITOR" rather than "is COMPETITOR" on purpose: PAIR
+        // participants and older records may carry no `participantRole` at all, and rejecting those
+        // would break entry for existing tournaments. The hole being closed is a participant carrying a
+        // NON-competitor role; an absent role stays permitted.
+        if (participant.participantRole && participant.participantRole !== COMPETITOR) return false;
 
         if (isValidSinglesParticipant(participant, event, entryStatus)) {
           return isValidSinglesGender(participant, event, genderEnforced, mismatchedGender);

--- a/src/query/tournaments/getTournamentInfo.ts
+++ b/src/query/tournaments/getTournamentInfo.ts
@@ -11,6 +11,7 @@ import { makeDeepCopy } from '@Tools/makeDeepCopy';
 // constants and types
 import {
   ADMINISTRATION,
+  COMPETITOR,
   DIRECTOR,
   HOSPITALITY,
   MEDIA,
@@ -227,8 +228,19 @@ export function getTournamentInfo(params?: {
   }
 
   if (withMatchUpStats) {
+    // Count competitors, not people.
+    //
+    // Staff, officials and coaches are INDIVIDUAL participants too, so a tournament with 32 players and
+    // 8 officials reported 40 — a number displayed beside a draw size and read as "how many players are
+    // in this tournament". The same file publishes `tournamentContacts` from those very staff records,
+    // so the two outputs disagreed about what the staff were.
+    //
+    // "Has a role and it is not COMPETITOR" rather than "is COMPETITOR", matching the entry gate in
+    // `addEventEntries`: most records carry no `participantRole` at all, and those are players.
     const individualParticipantCount =
-      tournamentRecord.participants?.filter((p) => p.participantType === INDIVIDUAL).length ?? 0;
+      tournamentRecord.participants?.filter(
+        (p) => p.participantType === INDIVIDUAL && (!p.participantRole || p.participantRole === COMPETITOR),
+      ).length ?? 0;
     const teamParticipantCount = tournamentRecord.participants?.filter((p) => p.participantType === TEAM).length ?? 0;
     const eventCount = tournamentRecord.events?.length ?? 0;
 

--- a/src/tests/mutations/entries/competitorRoleGate.test.ts
+++ b/src/tests/mutations/entries/competitorRoleGate.test.ts
@@ -1,0 +1,115 @@
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { describe, expect, it } from 'vitest';
+
+import { INVALID_PARTICIPANT_IDS } from '@Constants/errorConditionConstants';
+import { COMPETITOR, OFFICIAL } from '@Constants/participantRoles';
+import { INDIVIDUAL } from '@Constants/participantConstants';
+import { SINGLES_EVENT } from '@Constants/eventConstants';
+import { ANY } from '@Constants/genderConstants';
+
+/**
+ * Only competitors compete, and only competitors are counted as competitors.
+ *
+ * Every eligibility predicate in `addEventEntries` gated on `participantType`; none consulted
+ * `participantRole`. An OFFICIAL, a COACH, a PHYSIO and a TRANSPORT driver are all INDIVIDUAL
+ * participants, so nothing stopped a referee being entered into a draw and drawn against a player.
+ *
+ * `getTournamentInfo` had the mirror-image hole: `individualParticipantCount` counted every INDIVIDUAL,
+ * so 32 players plus 8 officials reported 40 — a number displayed beside a draw size.
+ *
+ * Each test below moves ONE participant between roles and asserts the outcome flips, so a passing
+ * result cannot be explained by gender enforcement, category enforcement or entry-status handling.
+ */
+
+// `stripRole` models a stored record written before `participantRole` was universally present.
+// `addParticipants` REFUSES a participant with no role (ERR_MISSING_PARTICIPANT_ROLE), so the only
+// honest way to produce one is to author it on the record — which is exactly how such records exist.
+const seed = ({ stripRole }: { stripRole?: boolean } = {}) => {
+  const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+    eventProfiles: [{ eventName: 'Singles', eventType: SINGLES_EVENT, gender: ANY }],
+    participantsProfile: { participantsCount: 4 },
+    nonRandom: 1,
+  });
+  let rolelessId;
+  if (stripRole) {
+    const legacy = tournamentRecord.participants.find((p: any) => p.participantType === INDIVIDUAL);
+    delete legacy.participantRole;
+    rolelessId = legacy.participantId;
+  }
+  tournamentEngine.setState(tournamentRecord);
+  const eventId = tournamentRecord.events[0].eventId;
+  const participantIds = tournamentEngine
+    .getParticipants({ participantFilters: { participantTypes: [INDIVIDUAL] } })
+    .participants.map(({ participantId }: any) => participantId);
+  return { eventId, participantIds, rolelessId };
+};
+
+const enteredIds = (eventId: string) =>
+  tournamentEngine.getEvent({ eventId }).event.entries?.map(({ participantId }: any) => participantId) ?? [];
+
+describe('addEventEntries role gate', () => {
+  it('REFUSES an entry for a participant carrying a non-competitor role, and accepts the same participant once the role is COMPETITOR', () => {
+    const { eventId, participantIds } = seed();
+    const [staffId] = participantIds;
+
+    tournamentEngine.modifyParticipant({ participant: { participantId: staffId, participantRole: OFFICIAL } });
+    const refused: any = tournamentEngine.addEventEntries({ participantIds: [staffId], eventId });
+    expect(refused.error).toEqual(INVALID_PARTICIPANT_IDS);
+    expect(enteredIds(eventId)).not.toContain(staffId);
+
+    // control — the ONLY thing that changes is participantRole
+    tournamentEngine.modifyParticipant({ participant: { participantId: staffId, participantRole: COMPETITOR } });
+    const accepted: any = tournamentEngine.addEventEntries({ participantIds: [staffId], eventId });
+    expect(accepted.success).toEqual(true);
+    expect(enteredIds(eventId)).toContain(staffId);
+  });
+
+  it('still enters participants that carry no participantRole at all', () => {
+    // The gate is "has a role and it is not COMPETITOR", not "is COMPETITOR". Most existing records —
+    // and every participant mocksEngine generates without a profile role — carry no role, and those
+    // are players. Rejecting them would break entry for every tournament already in storage.
+    const { eventId, rolelessId } = seed({ stripRole: true });
+    // control: nothing downstream re-stamped a role on the way into state
+    expect(
+      tournamentEngine.getParticipants({ participantFilters: { participantIds: [rolelessId] } }).participants[0]
+        .participantRole,
+    ).toBeUndefined();
+
+    const result: any = tournamentEngine.addEventEntries({ participantIds: [rolelessId], eventId });
+    expect(result.success).toEqual(true);
+    expect(enteredIds(eventId)).toContain(rolelessId);
+  });
+
+  it('admits the competitors in a mixed batch and refuses only the staff member', () => {
+    const { eventId, participantIds } = seed();
+    const [staffId, ...others] = participantIds;
+    tournamentEngine.modifyParticipant({ participant: { participantId: staffId, participantRole: OFFICIAL } });
+
+    const result: any = tournamentEngine.addEventEntries({ participantIds, eventId });
+    expect(result.error).toEqual(INVALID_PARTICIPANT_IDS);
+
+    const entered = enteredIds(eventId);
+    expect(entered).not.toContain(staffId);
+    expect(entered).toEqual(expect.arrayContaining(others));
+  });
+});
+
+describe('getTournamentInfo individualParticipantCount', () => {
+  const count = () =>
+    tournamentEngine.getTournamentInfo({ withMatchUpStats: true }).tournamentInfo.individualParticipantCount;
+
+  it('excludes staff and includes competitors and role-less participants', () => {
+    // one of the four carries no role at all; it must stay in the count throughout
+    const { participantIds, rolelessId } = seed({ stripRole: true });
+    expect(count()).toEqual(participantIds.length); // control: all four counted before any role changes
+
+    const staffId = participantIds.find((participantId: string) => participantId !== rolelessId);
+    tournamentEngine.modifyParticipant({ participant: { participantId: staffId, participantRole: OFFICIAL } });
+    expect(count()).toEqual(participantIds.length - 1);
+
+    // and the exclusion reverses — an explicit COMPETITOR is counted exactly as an absent role is
+    tournamentEngine.modifyParticipant({ participant: { participantId: staffId, participantRole: COMPETITOR } });
+    expect(count()).toEqual(participantIds.length);
+  });
+});


### PR DESCRIPTION
Follow-up to #4683, which CA asked be opened separately.

## `addEventEntries` had no role gate at all

Every eligibility predicate in that file gates on `participantType`; none consulted `participantRole`. Staff and officials are `INDIVIDUAL` participants exactly as players are, so an `OFFICIAL`, a `COACH`, a `PHYSIO` or a `TRANSPORT` driver was as enterable into a draw as a competitor. Nothing prevented a referee being entered and drawn against a player.

```ts
if (participant.participantRole && participant.participantRole !== COMPETITOR) return false;
```

A refused participant returns `INVALID_PARTICIPANT_IDS`, the same as a type or gender mismatch; the valid participants in a mixed batch are still entered.

## `getTournamentInfo` had the mirror-image hole

`individualParticipantCount` counted every `INDIVIDUAL`, so a tournament with 32 players and 8 officials reported **40** — a number displayed beside a draw size and read as "how many players are in this tournament". The same function publishes `tournamentContacts` from those very staff records, so its two outputs disagreed about what the staff were.

## Why "has a role and it is not COMPETITOR" rather than "is COMPETITOR"

Not a hedge — a probe settled it. `addParticipants` **refuses** a participant with no role today (`ERR_MISSING_PARTICIPANT_ROLE`), so a role-less participant can only reach state as a stored record written before that was true. Those are players. Rejecting them would break entry for every tournament already in storage, so an absent role stays permitted and only a *non-competitor* role is refused. Both call sites use the identical phrasing.

## Falsification

| production change reverted | red | green |
|---|---|---|
| entry gate removed | *REFUSES an entry…*, *mixed batch* | role-less test |
| count filter reverted | *excludes staff…* | the other three |

The role-less test staying green under both is the point of it: it asserts what the gate must **not** do.

## Gates

`pnpm verify` — all 15 steps, exit 0. Full suite **11306 passed | 1 skipped**. No generated-registry drift.

## Docs

`documentation/docs/concepts/events/entries.mdx` gains a **Role Eligibility** section.
