### PR TITLE
docs: backfill the six public changes shipped since the last docs publish

### DIFF
--- a/documentation/docs/concepts/venues-courts.md
+++ b/documentation/docs/concepts/venues-courts.md
@@ -125,6 +125,7 @@ A **court** represents an individual playing surface within a venue. Courts have
 
   // Court attributes
   altitude?: number;            // Elevation in meters
+  discipline?: string;          // The sport this court is for — see Court Discipline below
   surfaceType?: string;         // 'HARD', 'CLAY', 'GRASS', 'CARPET', etc.
   surfaceCategory?: string;     // 'INDOOR', 'OUTDOOR', 'COVERED'
   courtDimensions?: string;     // Dimensions description
@@ -144,6 +145,28 @@ A **court** represents an individual playing surface within a venue. Courts have
   }>;
 }
 ```
+
+### Court Discipline
+
+`court.discipline` says what sport a court **is** for. CODES is sport-agnostic, and a venue can hold a mix — three padel courts beside eight tennis courts, or a beach-volleyball pit.
+
+```js
+tournamentEngine.modifyVenue({
+  venueId: 'venue-uuid',
+  modifications: {
+    courts: [{ courtId: 'court-uuid', courtName: 'Padel 1', discipline: 'PADEL' }],
+  },
+});
+```
+
+The curated vocabulary is `TENNIS`, `BEACH_TENNIS`, `WHEELCHAIR_TENNIS`, `PADEL`, `PICKLEBALL`, `VOLLEYBALL`, `BEACH_VOLLEYBALL` — but the type is deliberately **open** and accepts any string, so a new sport needs no factory release. Normalize incoming values with `normalizeDiscipline`, and constrain them to a fixed list with the `allowedDisciplines` policy where a provider requires one.
+
+Two things it deliberately does not do:
+
+- **Absent means unspecified, not `TENNIS`.** A court nobody has declared a discipline for is not evidence that it is a tennis court, and defaulting it would invent data.
+- **It is not a list of capabilities.** A physical surface can serve several sports — a tennis court with pickleball lines, or a portable net dropped onto it. That is a court _capability_ and is deliberately not modelled here, because this field says what the court **is**: it is what makes a dedicated pickleball court distinguishable from a tennis court that sometimes hosts pickleball. Repurposing it to mean "can also host" turns one physical slab into two schedulable courts.
+
+`Event.discipline` uses the same open vocabulary.
 
 ### Creating Courts
 

--- a/documentation/docs/engines/subscriptions.md
+++ b/documentation/docs/engines/subscriptions.md
@@ -92,6 +92,24 @@ This is a tested property. A conformance harness (`src/tests/mutations/notificat
 
 These topics are additive; existing subscribers are unaffected.
 
+## The MODIFY_MATCHUP envelope
+
+`tournamentId`, `eventId`, `drawId` and `structureId` ride the notice **envelope**, alongside the `matchUp` itself:
+
+```js
+[topicConstants.MODIFY_MATCHUP]: (payload) => {
+  payload.forEach(({ matchUp, tournamentId, eventId, drawId, structureId }) => {
+    // route or evict without resolving the matchUp first
+  });
+};
+```
+
+A subscriber that only needs to know *which* event or structure changed — cache eviction, fan-out routing, a read-model projection — should not have to hydrate the matchUp to find out.
+
+`eventId` and `structureId` are populated best-effort rather than being required of every call site. A stored matchUp carries no `structureId` (only an inContext one does), so a notice emitted from a mutation that holds only a `drawDefinition` resolves it from the draw. Likewise a caller that supplies `event` rather than `eventId` still produces a populated `eventId`. Both are also populated for **propagated** matchUps — the downstream matchUps a result advances into — so a subscriber sees the same attribution on the matchUp a winner moves to as on the one that was scored.
+
+Notices additionally carry a flattened sanctioning origin — `originOrganisationId`, `originTournamentId`, `originEventId`, `originDrawId` — absent in the ordinary single-sanction case. The most specific grain wins: an origin declared on the draw takes precedence over one declared on the event, so a flight that models a draw but no event still carries attribution.
+
 ## Typed event bus (`engine.on / once / off / waitFor`)
 
 The forge namespace provides a multi-subscriber ergonomic surface on top of `setSubscriptions`. Handlers receive **one payload per call** (the bus iterates the underlying notice array for you), supports unsubscribe by returned closure, and a Promise-based `waitFor` for tests.

--- a/documentation/docs/governors/participant-governor.md
+++ b/documentation/docs/governors/participant-governor.md
@@ -481,6 +481,25 @@ engine.modifyParticipant({
 });
 ```
 
+### Writing contacts
+
+`person.contacts` (and `participant.contacts`) is **replaced**, not merged — deliberately, so that removing a contact is expressible. Read the existing array, change it, and send the whole thing back; sending only the contact you edited deletes the rest. Omitting the key leaves the stored list untouched, and `[]` clears it. See [Contact Information](../concepts/participants#contact-information).
+
+### PARTICIPANT_NAME_DERIVED_FROM_PERSON
+
+A supplied `participantName` can be superseded by a derived one — from `person` for an INDIVIDUAL, or from the individuals of a PAIR. That precedence is intended, but returning plain success while silently dropping a value the caller passed makes a partial no-op indistinguishable from a full success. So when it happens the response carries an `info`:
+
+```js
+const result = engine.modifyParticipant({
+  participant: { participantId, participantName: 'Ignored', person: { standardGivenName: 'Roger', standardFamilyName: 'Federer' } },
+});
+// result.success → true
+// result.info    → PARTICIPANT_NAME_DERIVED_FROM_PERSON
+// the stored participantName is 'Roger Federer'
+```
+
+The key is **conditional**: callers that did not hit the precedence see the response shape they always have, so nothing needs to start checking for it.
+
 ---
 
 ## modifyParticipantName

--- a/documentation/docs/governors/query-governor.md
+++ b/documentation/docs/governors/query-governor.md
@@ -609,6 +609,8 @@ const { eventData } = engine.getEventData({
   usePublishState, // optional - filter out draws which are not published; enforces embargo timestamps
   contextProfile, // optional: { inferGender: true, withCompetitiveness: true, withScaleValues: true, exclude: ['attribute', 'to', 'exclude']}
   drawsProfile, // optional: 'FULL' (default) | 'STUBS' — how much of each draw to return
+  withParticipantsVersion, // optional boolean; return a participantsVersion stamp
+  participantsVersion, // optional string; a stamp previously received, to be checked
   eventId,
 });
 const { drawsData, venuesData, eventInfo, tournamentInfo } = eventData;
@@ -643,6 +645,28 @@ A stub carries:
 `participantPlacements`, `drawActive` and `structures` are **absent** from a stub: they cannot be derived without the structure assembly this profile exists to skip. Request `FULL`, or fetch the draw individually, when they are needed.
 
 `drawsProfile` is purely additive — omitting it is byte-identical to `FULL`. An unrecognised value returns `INVALID_VALUES` rather than falling back, so a typo cannot silently return the full payload.
+
+### participantsVersion
+
+A conditional-fetch handshake for the `participants` array, in the spirit of an HTTP `ETag`. A client that already holds the current participant set can be told so instead of being sent it again.
+
+```js
+// first call — ask for a stamp
+const first = engine.getEventData({ eventId, withParticipantsVersion: true });
+// first.participants        → the full array
+// first.participantsVersion → e.g. 'a3f9…'
+
+// later calls — send the stamp back
+const next = engine.getEventData({ eventId, participantsVersion: first.participantsVersion });
+// next.participants === undefined   when the set is unchanged
+// next.participants === [...]       when it has changed (and a fresh version accompanies it)
+```
+
+Only an **exact** match omits `participants`. A mismatch, an absent stamp, or a stale one all send the array exactly as before, so the failure direction is "sent bytes that were not needed" rather than a blank bracket.
+
+**Opt-in, deliberately.** Hashing the participant set costs roughly 18 ms of an ~89 ms five-event build (~20%), so the stamp is computed only when it can be used — when the caller either supplied a version to check or asked for one with `withParticipantsVersion`. There is no separate enabling flag: supplying a version implies wanting the comparison, and a two-things-to-set design eventually gets one of them set, silently selecting the slow-and-useless combination.
+
+`participantsVersion` is present on the response **only** when it was computed. It is a conditional key rather than an explicitly-`undefined` one, so a caller that did not ask sees the response shape it has always seen.
 
 **See**: [Embargo](../concepts/publishing/publishing-embargo) for details on how embargo timestamps work.
 
@@ -2258,8 +2282,29 @@ const {
 
   registrationProfile,
   parentOrganisation, // { organisationId, organisationName, organisationAbbreviation }
+  tournamentContacts, // staff whose contacts are marked public — see below
 } = tournamentInfo;
 ```
+
+### tournamentContacts
+
+The tournament's publishable personnel: participants holding a staff role, carrying the contact details they consented to publish.
+
+```js
+const { tournamentInfo } = engine.getTournamentInfo({
+  policyDefinitions, // optional — override the bundled POLICY_PRIVACY_STAFF
+});
+
+tournamentInfo.tournamentContacts;
+// [{ participantId, participantName, participantRole, participantRoleResponsibilities,
+//    person: { contacts: [{ name, mobileTelephone, emailAddress, isPublic: true }] } }]
+```
+
+Two gates decide what appears — the staff **role** list, and `Contact.isPublic === true` on each individual contact. Appearing in the role list publishes nothing on its own, and absent or `false` both withhold. This subtree is filtered by the bundled `POLICY_PRIVACY_STAFF` rather than by a caller's participant policy; `policyDefinitions` replaces it where a provider needs different attributes. See [Staff contacts](../policies/participantPolicy#staff-contacts) for the role list and the reasoning.
+
+### Counts
+
+With `withMatchUpStats: true`, `individualParticipantCount` counts **competitors** — individuals whose `participantRole` is `COMPETITOR` or absent — rather than every INDIVIDUAL participant. Staff and officials are INDIVIDUAL participants too, so counting people would report a tournament of 32 players and 8 officials as 40, beside a draw size.
 
 `tournamentInfo.eventInfo` carries one projection per event (filtered to published events when
 `usePublishState` is set). Alongside the event's own attributes it includes two format fields:

--- a/documentation/docs/policies/participantPolicy.md
+++ b/documentation/docs/policies/participantPolicy.md
@@ -48,6 +48,46 @@ const privacyPolicy = {
 };
 ```
 
+## Where the policy is applied
+
+The filter runs at every **emission boundary** — the point where participants leave the engine — and not at hydration.
+
+This matters because hydration deliberately keeps participants whole: `getScaleValues` reads `timeItems`, participant lookup resolves by `personId`, and gender enforcement reads `person.sex`. A policy denying any of those would silently break context assembly if it were applied upstream. So the policy is applied to the copy that is returned, and to nothing else.
+
+Applying it at the boundary means it holds wherever participants surface, not only on `getParticipants`: hydrated `matchUp.sides[].participant`, `getParticipantSchedules`, `getTournamentMatchUps`, collection assignments in team events, and the `groupInfo` lookup of the TEAM / GROUP / PAIR entities an individual belongs to. `groupInfo` is participant data under a different shape, so a policy denying `participantName` denies it there too.
+
+Two invariants hold everywhere:
+
+- **Filtering attributes never removes a participant.** The returned array has the same length and the same entities as the unfiltered one, whatever the policy denies. Entries are stripped, not dropped.
+- **No policy means no filtering, never "filter everything".** An absent `policyDefinitions` returns participants whole.
+
+:::caution
+A template array acts as an allow-list, but it is only evaluated for keys the source object actually carries. An attribute absent from the source is never examined, so a rule written to *withhold* something that is sometimes missing fails **open**. Where a value must be withheld unless explicitly permitted, gate it with a predicate at the call site rather than relying on the template alone — this is what `getTournamentInfo` does for `Contact.isPublic`.
+:::
+
+## Staff contacts
+
+`tournamentContacts` on [getTournamentInfo](../governors/query-governor#gettournamentinfo) is the one participant population the caller's policy does **not** govern. It is filtered with the bundled `POLICY_PRIVACY_STAFF` instead, because a contact stripped of `participantRoleResponsibilities` is not a contact — a caller supplying a strict competitor policy would otherwise receive a contact list it could not use.
+
+```js
+import { fixtures } from 'tods-competition-factory';
+
+const { POLICY_PRIVACY_STAFF } = fixtures.policies;
+
+// the bundled staff policy is used by default
+const { tournamentInfo } = engine.getTournamentInfo();
+
+// a provider may supply its own, shaping which ATTRIBUTES are published
+const custom = engine.getTournamentInfo({ policyDefinitions: myStaffPolicy });
+```
+
+Two independent gates decide what appears:
+
+1. **Who is staff at all** — the factory's staff role list: `ADMINISTRATION`, `DIRECTOR`, `HOSPITALITY`, `MEDIA`, `MEDICAL`, `OFFICIAL`, `PHYSIO`, `SECURITY`, `STRINGER`, `SUPERVISOR`, `TRAINER`, `TRANSPORT`. `COACH`, `CAPTAIN`, `VOLUNTEER`, `SCOREKEEPER`, `TIMEKEEPER` and `OTHER` are excluded — a coach or captain is affiliated with a competitor rather than with the tournament, and publishing them would turn the contact list into a roster.
+2. **Which contacts that person consented to publish** — only contacts marked `isPublic === true` survive. Strict equality: absent and `false` both withhold, so opting in has to be deliberate. Appearing in the staff list publishes nothing on its own.
+
+A provider supplying `policyDefinitions` shapes which **attributes** are published; the role list decides **who** is considered staff, and the `isPublic` gate decides **which contacts**.
+
 ## Advanced Filtering
 
 - Multible attributes may share the same privacy template via the use of `||` syntax, as shown below.


### PR DESCRIPTION
The Docusaurus site was last published **2026-08-17** (gh-pages `89b8f7b4`, built from master `d827910b0` / #4647). Master has taken **33 commits** since, of which three touched documentation content (#4681, #4683, #4684). Six public changes shipped with none.

## What was missing

| Change | Documented in |
|---|---|
| `participantsVersion` handshake on `getEventData`, and the opt-in change (#4664, #4665) | `governors/query-governor.md` |
| `Court.discipline` (#4662) | `concepts/venues-courts.md` |
| `PARTICIPANT_NAME_DERIVED_FROM_PERSON` (#4667) | `governors/participant-governor.md` |
| Participant privacy applied at every emission boundary (#4676) | `policies/participantPolicy.md` |
| `tournamentContacts` + `POLICY_PRIVACY_STAFF` + `policyDefinitions` override (#4680) | `policies/participantPolicy.md`, `governors/query-governor.md` |
| `eventId` / `structureId` on the `MODIFY_MATCHUP` envelope (#4647, #4649, #4651) | `engines/subscriptions.md` |

Neither `participantsVersion`, `POLICY_PRIVACY_STAFF`, `tournamentContacts`, `discipline` nor `PARTICIPANT_NAME_DERIVED_FROM_PERSON` had a single occurrence anywhere under `docs/` before this.

Two smaller gaps closed alongside, both of which landed with type and concept docs but no governor entry: the **replace-whole-array** contract for `person.contacts` (sending only the contact you edited deletes the rest), and `individualParticipantCount` counting competitors rather than people.

## Checked and deliberately excluded

- **`applyMatchUpFormat` (#4653)** — internal, absent from `factoryEngineMethods.ts`, so the rename needs no governor entry. Neither the old nor the new name was ever documented, so there is nothing stale either.
- **Practice status vocabulary (#4660)** — `practice-governor.md` already states `'CONFIRMED' | 'CANCELLED'` correctly.
- **verify / forge / coverage commits** — tooling, not public surface.

## Verification

`pnpm build` in `documentation/` is clean — no broken links, no broken anchors.

**The detector was falsified**: appending a deliberately bad anchor produces `[WARNING] Docusaurus found broken anchors!` with the offending page named, so a clean build is evidence rather than silence. (`onBrokenLinks` is `warn`, not `throw`, which is exactly why this needed checking.)

Every claim was read out of the source rather than inferred — including the correction that `POLICY_PRIVACY_STAFF` is reached via `fixtures.policies`, not as a root named export.

## Note

This PR only *writes* the docs. Publishing is still a manual `USE_SSH=true pnpm docpub`, and the three already-written pages (#4681, #4683, #4684) are unpublished too — one publish covers all of it.
