### PR TITLE
fix(scheduling): stop discarding the categoryType resolved from an event

### DIFF
--- a/src/query/extensions/matchUpFormatTiming/getEventMatchUpFormatTiming.ts
+++ b/src/query/extensions/matchUpFormatTiming/getEventMatchUpFormatTiming.ts
@@ -22,7 +22,11 @@ type GetEventMatchUpFormatTimingArgs = {
 export function getEventMatchUpFormatTiming({
   tournamentRecord,
   matchUpFormats, // optional - can be retrieved from policy
-  categoryType, // optional - categoryType is not part of event attributes
+  // optional - falls back to the event's own category when not passed. The
+  // previous comment here claimed categoryType "is not part of event
+  // attributes", which is false (`Category.categoryType`) and is the likely
+  // origin of the clobber this pairs with.
+  categoryType,
   event,
 }: GetEventMatchUpFormatTimingArgs): {
   eventMatchUpFormatTiming?: any;
@@ -75,6 +79,7 @@ export function getEventMatchUpFormatTiming({
   }
   const { eventType, eventId, category } = event;
   const categoryName = category?.categoryName ?? category?.ageCategoryCode ?? eventId;
+  const resolvedCategoryType = categoryType ?? category?.categoryType ?? category?.subType;
 
   if (!eventId) return { error: MISSING_EVENT };
 
@@ -83,7 +88,7 @@ export function getEventMatchUpFormatTiming({
       tournamentRecord,
       matchUpFormat,
       categoryName,
-      categoryType,
+      categoryType: resolvedCategoryType,
       eventType,
       event,
     });

--- a/src/query/extensions/matchUpFormatTiming/getMatchUpFormatTiming.ts
+++ b/src/query/extensions/matchUpFormatTiming/getMatchUpFormatTiming.ts
@@ -91,7 +91,15 @@ export function getMatchUpFormatTiming({
     ...scheduleTiming,
     policy: policyWithFallback,
     matchUpFormat,
-    categoryType,
+    // `scheduleTiming.categoryType` is already resolved — `getScheduleTiming`
+    // derives it from `event.category.categoryType ?? subType` when the caller
+    // supplied an event rather than an explicit value. Listing the *parameter*
+    // here unconditionally overwrote that with `undefined`, so passing an event
+    // resolved recovery as if the event had no category at all: a JUNIOR
+    // doubles event took the ADULT figure (30) instead of its own (60).
+    // An explicitly-passed categoryType still wins, which is why this is `??`
+    // rather than a plain removal of the key.
+    categoryType: categoryType ?? scheduleTiming.categoryType,
     defaultTiming,
   };
 

--- a/src/tests/mutations/scheduling/matchUpFormatTimingCategoryType.test.ts
+++ b/src/tests/mutations/scheduling/matchUpFormatTimingCategoryType.test.ts
@@ -1,0 +1,159 @@
+import { getEventMatchUpFormatTiming } from '@Query/extensions/matchUpFormatTiming/getEventMatchUpFormatTiming';
+import { getMatchUpFormatTiming } from '@Query/extensions/matchUpFormatTiming/getMatchUpFormatTiming';
+import mocksEngine from '@Assemblies/engines/mock';
+import { describe, expect, it } from 'vitest';
+
+import { DOUBLES_EVENT } from '@Constants/eventConstants';
+
+// categoryTypes
+const JUNIOR = 'JUNIOR';
+const ADULT = 'ADULT';
+
+// POLICY_SCHEDULING_DEFAULT gives this format ADULT/WHEELCHAIR doubles 30 minutes
+// of recovery and JUNIOR doubles 60. The gap is what makes the category
+// observable at all — a format where both agree could not detect the clobber.
+const MATCHUP_FORMAT = 'SET3-S:6/TB7';
+const ADULT_DOUBLES_RECOVERY = 30;
+const JUNIOR_DOUBLES_RECOVERY = 60;
+
+function tournamentWith(category?: { categoryType?: string; subType?: string }) {
+  const eventProfiles = [
+    {
+      eventName: 'Doubles',
+      eventType: DOUBLES_EVENT,
+      ...(category && { category }),
+      drawProfiles: [{ drawSize: 4, matchUpFormat: MATCHUP_FORMAT }],
+    },
+  ];
+  const { tournamentRecord } = mocksEngine.generateTournamentRecord({ eventProfiles });
+  return { tournamentRecord, event: tournamentRecord.events?.[0] };
+}
+
+/**
+ * Regression guard for a silent category loss.
+ *
+ * `getScheduleTiming` resolves `categoryType` from `event.category`, but
+ * `getMatchUpFormatTiming` then rebuilt `timingDetails` listing the
+ * `categoryType` *parameter* after spreading `scheduleTiming` — so a caller that
+ * passed an `event` rather than an explicit value had the resolved category
+ * overwritten with `undefined`, and every JUNIOR event silently took ADULT
+ * recovery times.
+ */
+describe('getMatchUpFormatTiming — categoryType resolved from the event', () => {
+  it('resolves JUNIOR doubles recovery when only the event is passed', () => {
+    const { tournamentRecord, event } = tournamentWith({ categoryType: JUNIOR });
+    const timing: any = getMatchUpFormatTiming({
+      eventType: DOUBLES_EVENT,
+      matchUpFormat: MATCHUP_FORMAT,
+      tournamentRecord,
+      event,
+    });
+    expect(timing.recoveryMinutes).toEqual(JUNIOR_DOUBLES_RECOVERY);
+  });
+
+  it('resolves ADULT doubles recovery from the event, so the JUNIOR case is not a constant', () => {
+    const { tournamentRecord, event } = tournamentWith({ categoryType: ADULT });
+    const timing: any = getMatchUpFormatTiming({
+      eventType: DOUBLES_EVENT,
+      matchUpFormat: MATCHUP_FORMAT,
+      tournamentRecord,
+      event,
+    });
+    expect(timing.recoveryMinutes).toEqual(ADULT_DOUBLES_RECOVERY);
+  });
+
+  it('lets an explicitly-passed categoryType override the event', () => {
+    const { tournamentRecord, event } = tournamentWith({ categoryType: ADULT });
+    const timing: any = getMatchUpFormatTiming({
+      eventType: DOUBLES_EVENT,
+      matchUpFormat: MATCHUP_FORMAT,
+      categoryType: JUNIOR,
+      tournamentRecord,
+      event,
+    });
+    expect(timing.recoveryMinutes).toEqual(JUNIOR_DOUBLES_RECOVERY);
+  });
+
+  it('still resolves an explicit categoryType with no event at all', () => {
+    const { tournamentRecord } = tournamentWith(undefined);
+    const timing: any = getMatchUpFormatTiming({
+      eventType: DOUBLES_EVENT,
+      matchUpFormat: MATCHUP_FORMAT,
+      categoryType: JUNIOR,
+      tournamentRecord,
+    });
+    expect(timing.recoveryMinutes).toEqual(JUNIOR_DOUBLES_RECOVERY);
+  });
+
+  it('reads the category from `subType` when `categoryType` is absent', () => {
+    // `getScheduleTiming` resolves `categoryType ?? subType`; the fallback added
+    // alongside the clobber fix has to honour the same pair or the two disagree
+    // about what an event's category is.
+    const { tournamentRecord, event } = tournamentWith({ subType: JUNIOR });
+    const timing: any = getMatchUpFormatTiming({
+      eventType: DOUBLES_EVENT,
+      matchUpFormat: MATCHUP_FORMAT,
+      tournamentRecord,
+      event,
+    });
+    expect(timing.recoveryMinutes).toEqual(JUNIOR_DOUBLES_RECOVERY);
+  });
+
+  it('falls back to the uncategorised figure when the event carries no category', () => {
+    const { tournamentRecord, event } = tournamentWith(undefined);
+    const timing: any = getMatchUpFormatTiming({
+      eventType: DOUBLES_EVENT,
+      matchUpFormat: MATCHUP_FORMAT,
+      tournamentRecord,
+      event,
+    });
+    expect(timing.recoveryMinutes).toEqual(ADULT_DOUBLES_RECOVERY);
+  });
+});
+
+describe('getEventMatchUpFormatTiming — categoryType defaults to the event category', () => {
+  it('reports JUNIOR recovery without being told the categoryType', () => {
+    const { tournamentRecord, event } = tournamentWith({ categoryType: JUNIOR });
+    const result: any = getEventMatchUpFormatTiming({
+      matchUpFormats: [MATCHUP_FORMAT],
+      tournamentRecord,
+      event,
+    });
+    const timing = result.eventMatchUpFormatTiming?.find((t) => t.matchUpFormat === MATCHUP_FORMAT);
+    expect(timing.recoveryMinutes).toEqual(JUNIOR_DOUBLES_RECOVERY);
+  });
+
+  it('reports ADULT recovery for an adult event, so the JUNIOR case is not a constant', () => {
+    const { tournamentRecord, event } = tournamentWith({ categoryType: ADULT });
+    const result: any = getEventMatchUpFormatTiming({
+      matchUpFormats: [MATCHUP_FORMAT],
+      tournamentRecord,
+      event,
+    });
+    const timing = result.eventMatchUpFormatTiming?.find((t) => t.matchUpFormat === MATCHUP_FORMAT);
+    expect(timing.recoveryMinutes).toEqual(ADULT_DOUBLES_RECOVERY);
+  });
+
+  it('reads the category from `subType` when `categoryType` is absent', () => {
+    const { tournamentRecord, event } = tournamentWith({ subType: JUNIOR });
+    const result: any = getEventMatchUpFormatTiming({
+      matchUpFormats: [MATCHUP_FORMAT],
+      tournamentRecord,
+      event,
+    });
+    const timing = result.eventMatchUpFormatTiming?.find((t) => t.matchUpFormat === MATCHUP_FORMAT);
+    expect(timing.recoveryMinutes).toEqual(JUNIOR_DOUBLES_RECOVERY);
+  });
+
+  it('lets an explicit categoryType override the event category', () => {
+    const { tournamentRecord, event } = tournamentWith({ categoryType: ADULT });
+    const result: any = getEventMatchUpFormatTiming({
+      matchUpFormats: [MATCHUP_FORMAT],
+      categoryType: JUNIOR,
+      tournamentRecord,
+      event,
+    });
+    const timing = result.eventMatchUpFormatTiming?.find((t) => t.matchUpFormat === MATCHUP_FORMAT);
+    expect(timing.recoveryMinutes).toEqual(JUNIOR_DOUBLES_RECOVERY);
+  });
+});


### PR DESCRIPTION
## The bug

`getScheduleTiming` resolves `categoryType` from `event.category.categoryType ?? subType`. `getMatchUpFormatTiming` then rebuilt its `timingDetails`:

```ts
const timingDetails = {
  ...scheduleTiming,   // carries the RESOLVED categoryType
  policy: policyWithFallback,
  matchUpFormat,
  categoryType,        // <-- the PARAMETER: undefined when the caller passed only `event`
  defaultTiming,
};
```

The later key wins, so the resolved category was overwritten with `undefined` and recovery resolved as if the event had no category.

`POLICY_SCHEDULING_DEFAULT` gives ADULT/WHEELCHAIR doubles **30** minutes of recovery and JUNIOR doubles **60**, so every junior doubles event silently took the adult figure. Measured on `SET3-S:6/TB7` with a JUNIOR DOUBLES event:

| call | `recoveryMinutes` |
|---|---|
| `{ matchUpFormat, eventType }` | 30 |
| `{ matchUpFormat, eventType, event }` | 30 ❌ |
| `{ matchUpFormat, eventType, categoryType: 'JUNIOR' }` | **60** ✓ |

`categoryName` was never clobbered (it is not re-listed), so average-times-by-categoryName were unaffected — only recovery-by-categoryType.

## The fix

`categoryType: categoryType ?? scheduleTiming.categoryType` — an explicitly-passed value still wins, and the event-resolved one is no longer erased. `??` rather than deleting the key, so the existing precedence is preserved rather than inverted.

**`getEventMatchUpFormatTiming` is affected in its own right**, and it is a public engine method: it never derived `categoryType` from the event at all, so its callers got the adult figure unless they happened to pass one — and passing `event` could not rescue them because of the clobber above. It now falls back to the event's own category.

Its parameter carried this comment:

```ts
categoryType, // optional - categoryType is not part of event attributes
```

That is false — `Category.categoryType` is a declared attribute (`tournamentTypes.ts:165`), and `getScheduleTiming` reads exactly it. This looks like the belief that motivated the clobber, so the comment is corrected to record what actually happened rather than left to motivate it again.

## Verification

- **8 regression tests**, `matchUpFormatTimingCategoryType.test.ts`, covering both entry points.
- **Falsified in both directions:** with the fix reverted, **2 fail** — one per affected entry point; restored, 8/8 pass.
- Every category assertion is paired with its opposite (JUNIOR *and* ADULT, event-derived *and* explicit-override), so a constant return value cannot pass the suite.
- Full `pnpm verify` green: `verify:generated` (no registry drift), types, lint, attr-audit, coverage + headroom, server, audit, build, publint, runtime, shakeable, bundle-size, `verify:surface` (no exports removed), `verify:pack`.
- Baseline before the change: **11314 passed, 1 skipped**.

## Consumer note

TMX [#1326](https://github.com/CourtHive/TMX/pull/1326) works around this by resolving the category itself and passing it explicitly. That workaround was written to keep working unchanged once this lands — it passes `categoryType` *and* `event`, so it is correct either way and needs no follow-up.
