### PR TITLE
fix(participants): stop createGroupParticipant emitting a duplicate notice

### DIFF
--- a/src/mutate/participants/createGroupParticipant.ts
+++ b/src/mutate/participants/createGroupParticipant.ts
@@ -1,6 +1,5 @@
 import { getParticipants } from '@Query/participants/getParticipants';
 import { requireParams } from '@Helpers/parameters/requireParams';
-import { addNotice, getTopics } from '@Global/state/globalState';
 import { definedAttributes } from '@Tools/definedAttributes';
 import { makeDeepCopy } from '@Tools/makeDeepCopy';
 import { addParticipant } from './addParticipant';
@@ -10,7 +9,6 @@ import { ErrorType, INVALID_PARTICIPANT_TYPE, INVALID_VALUES, MISSING_VALUE } fr
 import { GROUP, INDIVIDUAL } from '@Constants/participantConstants';
 import { TOURNAMENT_RECORD } from '@Constants/attributeConstants';
 import { Participant, Tournament } from '@Types/tournamentTypes';
-import { ADD_PARTICIPANTS } from '@Constants/topicConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 import { OTHER } from '@Constants/participantRoles';
 
@@ -68,22 +66,22 @@ export function createGroupParticipant({
     participantRole,
   });
 
+  // `addParticipant` emits ADD_PARTICIPANTS itself (addParticipant.ts:232) with an identical payload —
+  // `{ tournamentId, participants: [participant] }` on the same topic. This function used to emit a
+  // second, hand-rolled copy on top of it, so creating one group queued the notice TWICE.
+  //
+  // The cost is not an extra callback: subscribers are invoked ONCE per flush with an ARRAY of
+  // payloads, so the duplicate showed up as a two-element array where every other single-participant
+  // mutation produces one. Consumers that iterate the payloads therefore did the work twice.
+  //
+  // Fixed by deleting the duplicate rather than by passing `disableNotice: true`. The batch emitters
+  // (`addParticipants`) disable the per-participant notice because they collapse N additions into one;
+  // a group is a single addition, so there is nothing to batch and the callee's notice is already right.
   const result = addParticipant({
     participant: groupParticipant,
     tournamentRecord,
   });
   if (result.error) return result;
-
-  const { topics } = getTopics();
-  if (topics.includes(ADD_PARTICIPANTS)) {
-    addNotice({
-      topic: ADD_PARTICIPANTS,
-      payload: {
-        tournamentId: tournamentRecord.tournamentId,
-        participants: [groupParticipant],
-      },
-    });
-  }
 
   return { ...SUCCESS, participant: makeDeepCopy(groupParticipant) };
 }

--- a/src/tests/mutations/participants/createGroupParticipant.test.ts
+++ b/src/tests/mutations/participants/createGroupParticipant.test.ts
@@ -5,6 +5,7 @@ import tournamentEngine from '@Engines/syncEngine';
 import { expect, it } from 'vitest';
 
 import { GROUP, INDIVIDUAL } from '@Constants/participantConstants';
+import { COMPETITOR } from '@Constants/participantRoles';
 import { ADD_PARTICIPANTS } from '@Constants/topicConstants';
 
 it('can create group participants', () => {
@@ -62,4 +63,73 @@ it('can create group participants', () => {
   });
 
   expect(groupParticipants?.length).toEqual(1);
+});
+
+/**
+ * F4 — creating one group used to fire ADD_PARTICIPANTS **twice**.
+ *
+ * `createGroupParticipant` called `addParticipant` (which emits) and then emitted a second,
+ * hand-rolled notice with an identical payload, so every subscriber did double work per group.
+ *
+ * Two things make this easy to test WRONGLY, and both were hit while writing it:
+ *
+ * 1. The test above cannot catch it — `expect(participantAddCounter).toBeGreaterThan(0)` is satisfied
+ *    by 1 and by 2 alike, which is exactly how the duplicate survived.
+ * 2. Counting SUBSCRIBER CALLS cannot catch it either. Subscribers are invoked **once per flush** with
+ *    an **array** of payloads, so the duplicate reads as `callbackCalls: 1, payloads: [2]` — measured.
+ *    A first draft of this test counted callbacks, passed, and stayed passing when the bug was put
+ *    back. It proved nothing.
+ *
+ * So this counts PAYLOADS, and pairs the assertion with a control — a single ordinary
+ * `addParticipants` call, which must produce exactly one — so a probe that silently counts nothing
+ * cannot be mistaken for a fix.
+ */
+it('fires ADD_PARTICIPANTS exactly ONCE per group created', () => {
+  const { tournamentRecord } = mocksEngine.generateTournamentRecord({ participantsCount: 4 });
+  tournamentEngine.setState(tournamentRecord);
+
+  let payloadCount = 0;
+  setSubscriptions({
+    subscriptions: {
+      [ADD_PARTICIPANTS]: (payloads: any) => {
+        payloadCount += Array.isArray(payloads) ? payloads.length : 1;
+      },
+    },
+  });
+
+  const individualParticipantIds = (
+    getParticipants({
+      participantFilters: { participantTypes: [INDIVIDUAL] },
+      tournamentRecord: tournamentEngine.getTournament().tournamentRecord,
+    }).participants ?? []
+  )
+    .slice(0, 2)
+    .map(({ participantId }) => participantId);
+
+  // CONTROL: one ordinary participant addition emits exactly one notice, so the counter is known to
+  // count — a probe that reported 1 because it never fired would prove nothing.
+  const controlResult = tournamentEngine.addParticipants({
+    participants: [
+      {
+        // `participantRole` is required — `addParticipant` refuses a role-less participant.
+        participantId: 'control-individual',
+        participantName: 'Control',
+        participantType: INDIVIDUAL,
+        participantRole: COMPETITOR,
+        person: { standardGivenName: 'Con', standardFamilyName: 'Trol' },
+      },
+    ],
+  });
+  expect(controlResult.success).toEqual(true);
+  expect(payloadCount).toEqual(1);
+
+  payloadCount = 0;
+  const result = tournamentEngine.createGroupParticipant({
+    groupName: 'Notice Count Group',
+    individualParticipantIds,
+  });
+  expect(result.success).toEqual(true);
+
+  // The assertion. Measured against the pre-fix code this was 2.
+  expect(payloadCount).toEqual(1);
 });


### PR DESCRIPTION
F4 from `Mentat/planning/TMX_PARTICIPANTS_PERSONNEL_AND_GROUPS.md`.

`createGroupParticipant` called `addParticipant` — which emits `ADD_PARTICIPANTS` itself at `addParticipant.ts:232` with an identical payload (`{ tournamentId, participants: [participant] }`, same topic) — and then emitted a second, hand-rolled copy. Creating one group queued the notice **twice**.

## The cost is not an extra callback

Subscribers are invoked **once per flush with an ARRAY of payloads**. Measured on the pre-fix code:

```text
callbackCalls: 1   payloadArrayLengths: [2]
```

So the duplicate shows up as a two-element array where every other single-participant mutation produces one. Any consumer that iterates payloads did the work twice per group creation.

## Why deletion rather than `disableNotice: true`

Both would fix it. The batch emitters (`addParticipants`) pass `disableNotice: true` because they genuinely collapse N additions into one notice — a real reason. A group is a **single** addition, so there is nothing to batch, and the callee's own notice is already exactly right. Deleting the duplicate leaves one emitter instead of two.

## The test, and a trap worth reading

The existing test could not catch this: `expect(participantAddCounter).toBeGreaterThan(0)` is satisfied by 1 and by 2 alike, which is how the duplicate survived. It is left untouched.

The new test counts **payloads**, not subscriber calls — because **a first draft counted calls, passed, and stayed passing when the bug was reinstated.** It is paired with a control (one ordinary `addParticipants` call must produce exactly 1) so a probe that silently counts nothing cannot be mistaken for a fix.

**Falsified:** reinstating the duplicate emit turns the new test red while the existing one stays green.

## Verification

`lint 0 · tsc 0 · full suite 11,326 pass` (baseline 11,324).

## Follow-up filed

`TASKS.md` now carries a sweep item for this **shape** — a mutation that calls a helper which already emits, then emits again on the same topic — since the detection difficulty above means a code read is not enough to rule it out elsewhere.