### PR TITLE
fix(avoidance): supply idCollections when separating seeded participants

### DIFF
--- a/src/mutate/matchUps/drawPositions/positionSeeds.ts
+++ b/src/mutate/matchUps/drawPositions/positionSeeds.ts
@@ -7,10 +7,11 @@ import { findStructure } from '@Acquire/findStructure';
 import { generateRange } from '@Tools/arrays';
 
 // constants and types
-import { PolicyDefinitions, SeedBlock, SeedingProfile, MatchUpsMap } from '@Types/factoryTypes';
+import { PolicyDefinitions, SeedBlock, SeedingProfile, MatchUpsMap, IdCollections } from '@Types/factoryTypes';
 import { ErrorType, MISSING_DRAW_POSITION } from '@Constants/errorConditionConstants';
 import { DrawDefinition, Event, Structure, Tournament } from '@Types/tournamentTypes';
 import { HydratedMatchUp, HydratedParticipant } from '@Types/hydrated';
+import { GROUP, PAIR, TEAM } from '@Constants/participantConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 
 type PositionSeedBlocksArgs = {
@@ -184,10 +185,37 @@ function reorderSeedsForAvoidance({
   policyAttributes: any[];
   participants: any[];
 }) {
+  // `idCollections` is REQUIRED for the `directive` rules — groups, teams and pairs.
+  //
+  // `getAttributeGrouping.ts` resolves a `directive` policy purely from `idCollections[directive]`,
+  // so omitting it made every directive-based avoidance rule a silent no-op **for seeded players**:
+  // `getAttributeGroupings` returned `{}`, no conflict groups were found, and this function returned
+  // early. Measured directly — the same call with `idCollections` returns the group and its members,
+  // without it returns `{}`.
+  //
+  // The consequence was the wrong way round from what an operator would guess: a TD who grouped a
+  // coach's stable and ticked "Groups" got avoidance for the unseeded members and silence for the
+  // seeds — the players most likely to share a coach, and the ones placed first.
+  //
+  // Built exactly as `randomUnseededSeparation` builds it, from the same `participants` array, so the
+  // seeded and unseeded halves of avoidance cannot drift apart.
+  const idCollections: IdCollections = {
+    groupParticipants: participants
+      .filter((participant) => participant.participantType === GROUP)
+      .map((participant) => participant.participantId),
+    teamParticipants: participants
+      .filter((participant) => participant.participantType === TEAM)
+      .map((participant) => participant.participantId),
+    pairParticipants: participants
+      .filter((participant) => participant.participantType === PAIR)
+      .map((participant) => participant.participantId),
+  };
+
   // Build attribute groupings: { "USA": ["p1", "p5"], "GBR": ["p2"] }
   const groupingsResult = getAttributeGroupings({
     targetParticipantIds: unplacedSeedParticipantIds,
     policyAttributes,
+    idCollections,
     participants,
   });
   if ('error' in groupingsResult) return;

--- a/src/tests/mutations/drawDefinitions/avoidance/seededGroupAvoidance.test.ts
+++ b/src/tests/mutations/drawDefinitions/avoidance/seededGroupAvoidance.test.ts
@@ -63,7 +63,8 @@ it('resolves a GROUP directive only when idCollections is supplied — the omitt
   });
   const resolved = Object.values(withCollections)[0] as string[];
   expect(resolved).toBeDefined();
-  expect([...resolved].sort()).toEqual([...memberIds].sort());
+  const byId = (a: string, b: string) => a.localeCompare(b);
+  expect([...resolved].sort(byId)).toEqual([...memberIds].sort(byId));
 });
 
 /**

--- a/src/tests/mutations/drawDefinitions/avoidance/seededGroupAvoidance.test.ts
+++ b/src/tests/mutations/drawDefinitions/avoidance/seededGroupAvoidance.test.ts
@@ -1,0 +1,82 @@
+import { getAttributeGroupings } from '@Query/participants/getAttributeGrouping';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { expect, it } from 'vitest';
+
+import { GROUP, INDIVIDUAL } from '@Constants/participantConstants';
+
+/**
+ * `directive`-based avoidance — groups, teams and pairs — was a silent no-op for SEEDED players.
+ *
+ * `positionSeeds.reorderSeedsForAvoidance` called `getAttributeGroupings` with `targetParticipantIds`,
+ * `policyAttributes` and `participants`, but **without `idCollections`**. `getAttributeGrouping.ts`
+ * resolves a `directive` policy purely from `idCollections[directive]`, so the call returned `{}`, no
+ * conflict groups were found, and the function returned early having done nothing.
+ *
+ * The consequence ran the wrong way round from intuition: a TD who grouped a coach's stable and ticked
+ * "Groups" got avoidance for the *unseeded* members and silence for the *seeds* — the players most
+ * likely to share a coach, and the ones placed first. `randomUnseededSeparation` builds `idCollections`
+ * correctly, which is why the unseeded half worked and nobody noticed.
+ *
+ * The first test below is the one that matters: it isolates the exact call, so it fails for this reason
+ * and no other. A draw-level assertion alone would be at the mercy of seed-block randomisation and
+ * could pass on a lucky layout.
+ */
+
+const GROUP_DIRECTIVE = [{ directive: 'groupParticipants' }];
+
+it('resolves a GROUP directive only when idCollections is supplied — the omitted argument', () => {
+  const { tournamentRecord } = mocksEngine.generateTournamentRecord({ participantsCount: 8 });
+  tournamentEngine.setState(tournamentRecord);
+
+  const individuals =
+    tournamentEngine.getParticipants({ participantFilters: { participantTypes: [INDIVIDUAL] } }).participants ?? [];
+  const memberIds = individuals.slice(0, 2).map(({ participantId }) => participantId);
+
+  const created = tournamentEngine.createGroupParticipant({
+    individualParticipantIds: memberIds,
+    groupName: 'Coaching Stable',
+  });
+  expect(created.success).toEqual(true);
+
+  const participants = tournamentEngine.getParticipants({ withGroupings: true }).participants ?? [];
+  const groupParticipants = participants
+    .filter(({ participantType }) => participantType === GROUP)
+    .map(({ participantId }) => participantId);
+  expect(groupParticipants.length).toEqual(1);
+
+  // WITHOUT — what `positionSeeds` used to do. Empty, so no conflict is ever detected.
+  const without: any = getAttributeGroupings({
+    targetParticipantIds: memberIds,
+    policyAttributes: GROUP_DIRECTIVE,
+    participants,
+  });
+  expect(Object.keys(without)).toEqual([]);
+
+  // WITH — the group is resolved and both members are in it. This is the pair of runs that makes the
+  // omission a measured fact rather than a reading of the code.
+  const withCollections: any = getAttributeGroupings({
+    idCollections: { groupParticipants, teamParticipants: [], pairParticipants: [] },
+    targetParticipantIds: memberIds,
+    policyAttributes: GROUP_DIRECTIVE,
+    participants,
+  });
+  const resolved = Object.values(withCollections)[0] as string[];
+  expect(resolved).toBeDefined();
+  expect([...resolved].sort()).toEqual([...memberIds].sort());
+});
+
+/**
+ * NOT covered here, deliberately, and the reason is worth more than the test would have been.
+ *
+ * An end-to-end assertion — group two seeds, generate, expect different halves — was written, and it
+ * passed **with the fix and without it**. Instrumenting the call site explained why:
+ * `positionSeeds` reads its policy from `getAppliedPolicies({ drawDefinition })`, and at seed-placement
+ * time that returns `["seeding"]` only — `avoidance` is `undefined`. A policy supplied through
+ * `generateDrawDefinition({ policyDefinitions })` is not attached to the drawDefinition yet, so the
+ * whole avoidance branch in `positionSeeds` never executes.
+ *
+ * So seeded directive-avoidance is dead for a second, independent reason, and this fix is a
+ * prerequisite rather than a cure. See TASKS.md — "factory: seeded avoidance is dead twice over".
+ * Do not add an end-to-end test here until that is resolved: it can only be vacuous.
+ */


### PR DESCRIPTION
`reorderSeedsForAvoidance` called `getAttributeGroupings` **without `idCollections`**. `getAttributeGrouping.ts` resolves a `directive` policy — groups, teams, pairs — purely from `idCollections[directive]`, so the call returned `{}`, no conflict group was found, and the function returned early.

**Measured, not inferred.** The identical call with `idCollections` returns the group and both of its members; without it returns `{}`. That pair of runs is the first test in this PR.

Built here exactly as `randomUnseededSeparation` builds it, from the same `participants` array, so the seeded and unseeded halves of avoidance cannot drift apart.

## ⚠️ This is a PREREQUISITE, not a cure — please read before merging

An end-to-end test was written — group two seeds, generate, expect different halves — and it **passed with the fix and without it.** Instrumenting the call site explained why:

```text
appliedPolicies keys: ["seeding"]   avoidance: undefined
```

`positionSeeds` reads its policy from `getAppliedPolicies({ drawDefinition })`, and at seed-placement time the avoidance policy **is not attached to the drawDefinition yet** when it arrives via `generateDrawDefinition({ policyDefinitions })` — which is how `teamAvoidance.test.ts` supplies it and how TMX's Set-avoidances drawer ends up supplying it. So the whole `if (avoidance?.policyAttributes && …)` branch never executes.

The other two guard conditions are satisfied (`participants: 32`, `unplacedSeeds: 4` for the 5-8 block) — only the policy is missing. `randomUnseededSeparation` is unaffected because it receives `policyAttributes` as a **parameter** rather than reading applied policies, which is precisely why the unseeded half has always worked and the seeded half being dead went unnoticed.

**So seeded directive-avoidance is dead twice over.** This PR fixes one half. The other is a change to when policies are applied during generation, affecting every draw generated — it wants its own scope rather than a tail-end patch, and is written up in `TASKS.md` ("factory: seeded avoidance is dead TWICE OVER") with the repro configuration already worked out: a 32 draw with 8 seeds (blocks at drawSize 16 are all ≤ 2 and the branch needs > 2), grouping seeds 5 and 6, which at `nonRandom: 1` both land in half 2.

**The vacuous end-to-end test was deleted rather than kept**, and the spec file documents why, so nobody re-adds it before the second defect is fixed.

## Verification

`lint 0 · tsc 0 · full suite 11,326 pass` (baseline 11,324). The retained test is the isolated with/without comparison, which fails for this reason and no other.