### PR TITLE
feat(reports): recovery time + participant experience, policy overnight/duration axes

### DIFF
--- a/scripts/verify/baseline/bundle-size.json
+++ b/scripts/verify/baseline/bundle-size.json
@@ -4,28 +4,28 @@
     "gzip": 155
   },
   "tods-competition-factory.d.ts": {
-    "raw": 773200,
-    "gzip": 118410
+    "raw": 850994,
+    "gzip": 129816
   },
   "tods-competition-factory.d.mts": {
-    "raw": 773200,
-    "gzip": 118410
+    "raw": 850994,
+    "gzip": 129816
   },
   "tods-competition-factory.d.cts": {
-    "raw": 773200,
-    "gzip": 118410
+    "raw": 850994,
+    "gzip": 129816
   },
   "tods-competition-factory.development.cjs.js": {
-    "raw": 3491243,
-    "gzip": 599620
+    "raw": 3708457,
+    "gzip": 640090
   },
   "tods-competition-factory.production.cjs.min.js": {
-    "raw": 1557992,
-    "gzip": 411448
+    "raw": 1665202,
+    "gzip": 442217
   },
   "esm/** (aggregate)": {
-    "raw": 4086626,
-    "gzip": 1029357,
-    "files": 1201
+    "raw": 4338195,
+    "gzip": 1094191,
+    "files": 1265
   }
 }

--- a/src/constants/reportConstants.ts
+++ b/src/constants/reportConstants.ts
@@ -8,6 +8,8 @@ export const MATCHUP_STATUS_REPORT = 'matchUp.statusSummary';
 export const SEEDING_PERFORMANCE_REPORT = 'participant.seedingPerformance';
 export const COMPETITIVENESS_REPORT = 'matchUp.competitiveness';
 export const CALL_TIMING_VARIANCE_REPORT = 'scheduling.callTimingVariance';
+export const PARTICIPANT_RECOVERY_REPORT = 'participant.recoveryTime';
+export const PARTICIPANT_EXPERIENCE_REPORT = 'participant.experience';
 
 // Phase 4: Audit-trail reports (server-sourced, not computable from tournament record)
 export const DRAW_REVISIONS_REPORT = 'audit.drawRevisions';

--- a/src/fixtures/policies/POLICY_SCHEDULING_DEFAULT.ts
+++ b/src/fixtures/policies/POLICY_SCHEDULING_DEFAULT.ts
@@ -16,6 +16,12 @@ export const POLICY_SCHEDULING_DEFAULT = {
     defaultTimes: {
       averageTimes: [{ categoryNames: [], minutes: { default: 90 } }],
       recoveryTimes: [{ minutes: { [DOUBLES]: 30, default: 60 } }],
+      // Minimum rest between the last matchUp of one day and the first of the
+      // next. USTA Friend at Court states 12 hours for junior divisions; adult
+      // play carries no equivalent constraint, hence the unconstrained
+      // catch-all rather than a single flat figure. Zero means "no rule",
+      // which is what a consumer must report rather than inventing one.
+      overnightTimes: [{ categoryTypes: [JUNIOR], minutes: { default: 720 } }, { minutes: { default: 0 } }],
     },
     defaultDailyLimits: {
       [SINGLES]: 2,

--- a/src/query/extensions/matchUpFormatTiming/getBandedRecoveryMinutes.ts
+++ b/src/query/extensions/matchUpFormatTiming/getBandedRecoveryMinutes.ts
@@ -1,0 +1,55 @@
+/**
+ * Recovery keyed to how long the previous matchUp *actually ran*.
+ *
+ * Some sanctioning bodies scale rest by elapsed duration rather than by format —
+ * the long-standing USTA table gives 30 minutes after a match under an hour, an
+ * hour after one to one-and-a-half, and ninety minutes beyond that. Expressed as
+ * an ordered band list on a recovery-times entry:
+ *
+ *     byPlayedMinutes: [{ upTo: 60, minutes: 30 }, { upTo: 90, minutes: 60 }, { minutes: 90 }]
+ *
+ * ── Why this is opt-in on BOTH sides ──
+ *
+ * It returns `undefined` unless the policy authors `byPlayedMinutes` AND the
+ * caller supplies a `playedMinutes` it actually measured. Neither half is
+ * incidental:
+ *
+ * - Applied to an *estimated* duration the banding is circular. The estimate is
+ *   `averageMinutes`, drawn from the very policy being consulted, so the band
+ *   would be selected by the number the policy already predicted.
+ * - No scheduler call site supplies `playedMinutes`, and none can: recovery is
+ *   resolved once per matchUpFormat cohort and fanned out to every matchUp in it
+ *   (`getScheduledRoundsDetails.ts:137-167`), one level coarser than the
+ *   per-instance quantity a band needs. Scheduling therefore stays bit-identical
+ *   by construction rather than behind a feature flag.
+ *
+ * The report layer is the intended consumer, where every duration is
+ * retrospective and its provenance is known per row.
+ */
+
+type Band = { upTo?: number; minutes?: number };
+
+export function getBandedRecoveryMinutes({
+  byPlayedMinutes,
+  playedMinutes,
+}: {
+  byPlayedMinutes?: Band[];
+  playedMinutes?: number;
+}): number | undefined {
+  if (!Array.isArray(byPlayedMinutes) || !byPlayedMinutes.length) return undefined;
+  if (typeof playedMinutes !== 'number' || !Number.isFinite(playedMinutes) || playedMinutes < 0) return undefined;
+
+  // Ordered ascending so the table may be authored in any order; the catch-all
+  // (no `upTo`) always sorts last. Copied rather than sorted in place —
+  // `findCategoryTiming` already mutates policy arrays and that is not a habit
+  // worth spreading to authored fixtures.
+  const bands = [...byPlayedMinutes].sort((a, b) => (a.upTo ?? Infinity) - (b.upTo ?? Infinity));
+
+  for (const band of bands) {
+    if (typeof band.minutes !== 'number') continue;
+    if (band.upTo === undefined) return band.minutes;
+    if (playedMinutes <= band.upTo) return band.minutes;
+  }
+
+  return undefined;
+}

--- a/src/query/extensions/matchUpFormatTiming/getMatchUpFormatTiming.ts
+++ b/src/query/extensions/matchUpFormatTiming/getMatchUpFormatTiming.ts
@@ -1,9 +1,9 @@
 import { isMatchUpEventType } from '@Helpers/matchUpEventTypes/isMatchUpEventType';
 import { getMatchUpFormatRecoveryTimes } from './getMatchUpFormatRecoveryTimes';
-import { getOvernightRecoveryTimes } from './getOvernightRecoveryTimes';
-import { getBandedRecoveryMinutes } from './getBandedRecoveryMinutes';
 import { parse as parseMatchUpFormat } from '@Helpers/matchUpFormatCode/parse';
 import { getMatchUpFormatAverageTimes } from './getMatchUpFormatAverageTimes';
+import { getOvernightRecoveryTimes } from './getOvernightRecoveryTimes';
+import { getBandedRecoveryMinutes } from './getBandedRecoveryMinutes';
 import { getScheduleTiming } from './getScheduleTiming';
 
 // constants, types and fixtures
@@ -11,9 +11,9 @@ import { POLICY_SCHEDULING_DEFAULT } from '@Fixtures/policies/POLICY_SCHEDULING_
 import { DOUBLES_SINGLES, SINGLES_DOUBLES } from '@Constants/scheduleConstants';
 import { MISSING_TOURNAMENT_RECORD } from '@Constants/errorConditionConstants';
 import { Event, Tournament, EventTypeUnion } from '@Types/tournamentTypes';
+import { PolicyDefinitions, ResultType } from '@Types/factoryTypes';
 import { POLICY_TYPE_SCHEDULING } from '@Constants/policyConstants';
 import { SINGLES_EVENT } from '@Constants/eventConstants';
-import { PolicyDefinitions, ResultType } from '@Types/factoryTypes';
 
 type GetMatchUpFormatTimingArgs = {
   policyDefinitions?: PolicyDefinitions;

--- a/src/query/extensions/matchUpFormatTiming/getMatchUpFormatTiming.ts
+++ b/src/query/extensions/matchUpFormatTiming/getMatchUpFormatTiming.ts
@@ -11,9 +11,10 @@ import { MISSING_TOURNAMENT_RECORD } from '@Constants/errorConditionConstants';
 import { Event, Tournament, EventTypeUnion } from '@Types/tournamentTypes';
 import { POLICY_TYPE_SCHEDULING } from '@Constants/policyConstants';
 import { SINGLES_EVENT } from '@Constants/eventConstants';
-import { ResultType } from '@Types/factoryTypes';
+import { PolicyDefinitions, ResultType } from '@Types/factoryTypes';
 
 type GetMatchUpFormatTimingArgs = {
+  policyDefinitions?: PolicyDefinitions;
   defaultRecoveryMinutes?: number;
   defaultAverageMinutes?: number;
   tournamentRecord: Tournament;
@@ -27,6 +28,7 @@ type GetMatchUpFormatTimingArgs = {
 export function getMatchUpFormatTiming({
   defaultAverageMinutes = 90,
   defaultRecoveryMinutes = 0,
+  policyDefinitions,
   tournamentRecord,
   matchUpFormat,
   categoryName,
@@ -59,6 +61,7 @@ export function getMatchUpFormatTiming({
   };
 
   const { scheduleTiming } = getScheduleTiming({
+    policyDefinitions,
     tournamentRecord,
     categoryName,
     categoryType,

--- a/src/query/extensions/matchUpFormatTiming/getMatchUpFormatTiming.ts
+++ b/src/query/extensions/matchUpFormatTiming/getMatchUpFormatTiming.ts
@@ -1,5 +1,7 @@
 import { isMatchUpEventType } from '@Helpers/matchUpEventTypes/isMatchUpEventType';
 import { getMatchUpFormatRecoveryTimes } from './getMatchUpFormatRecoveryTimes';
+import { getOvernightRecoveryTimes } from './getOvernightRecoveryTimes';
+import { getBandedRecoveryMinutes } from './getBandedRecoveryMinutes';
 import { parse as parseMatchUpFormat } from '@Helpers/matchUpFormatCode/parse';
 import { getMatchUpFormatAverageTimes } from './getMatchUpFormatAverageTimes';
 import { getScheduleTiming } from './getScheduleTiming';
@@ -15,6 +17,7 @@ import { PolicyDefinitions, ResultType } from '@Types/factoryTypes';
 
 type GetMatchUpFormatTimingArgs = {
   policyDefinitions?: PolicyDefinitions;
+  playedMinutes?: number;
   defaultRecoveryMinutes?: number;
   defaultAverageMinutes?: number;
   tournamentRecord: Tournament;
@@ -30,6 +33,7 @@ export function getMatchUpFormatTiming({
   defaultRecoveryMinutes = 0,
   policyDefinitions,
   tournamentRecord,
+  playedMinutes,
   matchUpFormat,
   categoryName,
   categoryType,
@@ -106,7 +110,7 @@ export function getMatchUpFormatTiming({
     defaultTiming,
   };
 
-  return matchUpFormatTimes({ eventType, timingDetails });
+  return matchUpFormatTimes({ eventType, timingDetails, playedMinutes });
 }
 
 function deriveTimedDefaultMinutes(parsed: ReturnType<typeof parseMatchUpFormat>): number | undefined {
@@ -133,12 +137,16 @@ function deriveTimedDefaultMinutes(parsed: ReturnType<typeof parseMatchUpFormat>
 
 type MatchUpFormatTimesArgs = {
   eventType: EventTypeUnion;
+  playedMinutes?: number;
   timingDetails: any;
 };
-export function matchUpFormatTimes({ timingDetails, eventType }: MatchUpFormatTimesArgs): ResultType & {
+export function matchUpFormatTimes({ timingDetails, playedMinutes, eventType }: MatchUpFormatTimesArgs): ResultType & {
   typeChangeRecoveryMinutes?: number;
   recoveryMinutes?: number;
+  overnightMinutes?: number;
   averageMinutes?: number;
+  /** True when `recoveryMinutes` came from a `byPlayedMinutes` band rather than the flat table. */
+  recoveryFromPlayedMinutes?: boolean;
 } {
   const averageTimes = getMatchUpFormatAverageTimes(timingDetails);
   const averageKeys = Object.keys(averageTimes?.minutes ?? {});
@@ -153,9 +161,18 @@ export function matchUpFormatTimes({ timingDetails, eventType }: MatchUpFormatTi
   });
 
   const recoveryKeys = Object.keys(recoveryTimes?.minutes ?? {});
-  const recoveryMinutes =
+  const flatRecoveryMinutes =
     recoveryTimes?.minutes &&
     ((recoveryKeys?.includes(eventType) && recoveryTimes.minutes[eventType]) || recoveryTimes.minutes.default);
+
+  // A duration band wins over the flat figure, but only when the policy authors
+  // one AND the caller measured a duration to key it on. Absent either, this is
+  // undefined and resolution is exactly what it was.
+  const bandedMinutes = getBandedRecoveryMinutes({
+    byPlayedMinutes: recoveryTimes?.byPlayedMinutes,
+    playedMinutes,
+  });
+  const recoveryMinutes = bandedMinutes ?? flatRecoveryMinutes;
 
   const formatChangeKey = isMatchUpEventType(SINGLES_EVENT)(eventType) ? SINGLES_DOUBLES : DOUBLES_SINGLES;
 
@@ -163,5 +180,20 @@ export function matchUpFormatTimes({ timingDetails, eventType }: MatchUpFormatTi
     recoveryTimes?.minutes &&
     ((recoveryKeys?.includes(formatChangeKey) && recoveryTimes.minutes[formatChangeKey]) || recoveryMinutes);
 
-  return { averageMinutes, recoveryMinutes, typeChangeRecoveryMinutes };
+  // Overnight is a property of the day boundary rather than of the format, so it
+  // is resolved independently of averageMinutes. Stays undefined when no policy
+  // configures it — callers must read that as "no rule", not as zero.
+  const overnightTimes = getOvernightRecoveryTimes(timingDetails);
+  const overnightKeys = Object.keys(overnightTimes?.minutes ?? {});
+  const overnightMinutes =
+    overnightTimes?.minutes &&
+    ((overnightKeys?.includes(eventType) && overnightTimes.minutes[eventType]) || overnightTimes.minutes.default);
+
+  return {
+    recoveryFromPlayedMinutes: bandedMinutes !== undefined,
+    typeChangeRecoveryMinutes,
+    overnightMinutes,
+    recoveryMinutes,
+    averageMinutes,
+  };
 }

--- a/src/query/extensions/matchUpFormatTiming/getOvernightRecoveryTimes.ts
+++ b/src/query/extensions/matchUpFormatTiming/getOvernightRecoveryTimes.ts
@@ -1,0 +1,51 @@
+import { findCategoryTiming } from '@Acquire/findCategoryTiming';
+
+/**
+ * Minimum rest between the last matchUp of one day and the first of the next.
+ *
+ * Distinct from `getMatchUpFormatRecoveryTimes` in two ways that matter:
+ *
+ * 1. **It is not per-format.** An overnight rule is a property of the day
+ *    boundary, not of what was played — USTA Friend at Court states it as a flat
+ *    12 hours for junior divisions regardless of format. So there is no
+ *    `matchUpFormat` axis and no `averageMinutes` input.
+ * 2. **It is category-dependent.** The 12-hour figure is a *junior* rule; adult
+ *    play has no equivalent constraint. That is why this returns a category
+ *    timing block rather than a scalar, and why the default policy pairs a
+ *    JUNIOR entry with an unconstrained catch-all.
+ *
+ * Precedence mirrors recovery: event scheduling extension, then tournament
+ * scheduling (the CODES `scheduling.timing` group leaf), then the attached or
+ * supplied policy, then the caller's default. Absent everywhere, the caller sees
+ * `undefined` and must treat it as *no overnight rule configured* rather than
+ * substituting a figure of its own — the same contract `getMatchUpDailyLimits`
+ * already has.
+ */
+export function getOvernightRecoveryTimes({
+  tournamentScheduling,
+  eventScheduling,
+  defaultTiming,
+  categoryName,
+  categoryType,
+  policy,
+}: {
+  tournamentScheduling?: any;
+  eventScheduling?: any;
+  defaultTiming?: any;
+  categoryName?: string;
+  categoryType?: string;
+  policy?: any;
+}) {
+  const timesBlockArray = [
+    eventScheduling?.overnightTimes,
+    tournamentScheduling?.overnightTimes,
+    policy?.defaultTimes?.overnightTimes,
+    defaultTiming?.overnightTimes,
+  ];
+
+  return findCategoryTiming({
+    categoryName,
+    categoryType,
+    timesBlockArray,
+  });
+}

--- a/src/query/extensions/matchUpFormatTiming/getScheduleTiming.ts
+++ b/src/query/extensions/matchUpFormatTiming/getScheduleTiming.ts
@@ -5,23 +5,37 @@ import { findPolicy } from '@Acquire/findPolicy';
 import { POLICY_TYPE_SCHEDULING } from '@Constants/policyConstants';
 import { SCHEDULE_TIMING } from '@Constants/extensionConstants';
 import { Event, Tournament } from '@Types/tournamentTypes';
+import { PolicyDefinitions } from '@Types/factoryTypes';
 
 type GetScheduleTimingArgs = {
+  policyDefinitions?: PolicyDefinitions;
   tournamentRecord?: Tournament;
   categoryName?: string;
   categoryType?: string;
   event?: Event;
 };
-export function getScheduleTiming({ tournamentRecord, categoryName, categoryType, event }: GetScheduleTimingArgs) {
+export function getScheduleTiming({
+  policyDefinitions,
+  tournamentRecord,
+  categoryName,
+  categoryType,
+  event,
+}: GetScheduleTimingArgs) {
   categoryName = categoryName ?? event?.category?.categoryName ?? event?.category?.ageCategoryCode;
 
   categoryType = categoryType ?? event?.category?.categoryType ?? event?.category?.subType;
 
-  const { policy } = findPolicy({
+  // A caller-supplied scheduling policy wins over whatever is attached to the
+  // record, matching the `policyDefinitions ?? appliedPolicies` idiom used
+  // throughout the generators. This is what lets a report answer "what would
+  // this tournament look like under a *different* policy" without mutating it;
+  // every existing caller omits it and resolves exactly as before.
+  const { policy: attachedPolicy } = findPolicy({
     policyType: POLICY_TYPE_SCHEDULING,
     tournamentRecord,
     event,
   });
+  const policy = policyDefinitions?.[POLICY_TYPE_SCHEDULING] ?? attachedPolicy;
 
   // CODES: tournament-level scheduling timing has been promoted to
   // `tournamentRecord.scheduling.timing` (group leaf). Event-level

--- a/src/query/reports/generateReport.ts
+++ b/src/query/reports/generateReport.ts
@@ -1,4 +1,6 @@
+import { wrapParticipantExperienceReport } from './wrappers/wrapParticipantExperienceReport';
 import { wrapCallTimingVarianceReport } from './wrappers/wrapCallTimingVarianceReport';
+import { wrapRecoveryTimeReport } from './wrappers/wrapRecoveryTimeReport';
 import { wrapSeedingPerformanceReport } from './wrappers/wrapSeedingPerformanceReport';
 import { wrapParticipantResultsReport } from './wrappers/wrapParticipantResultsReport';
 import { wrapCompetitivenessReport } from './wrappers/wrapCompetitivenessReport';
@@ -17,6 +19,8 @@ import { ReportResult } from '@Types/reportTypes';
 import {
   CALL_TIMING_VARIANCE_REPORT,
   COMPETITIVENESS_REPORT,
+  PARTICIPANT_EXPERIENCE_REPORT,
+  PARTICIPANT_RECOVERY_REPORT,
   ENTRY_STATUS_REPORT,
   MATCH_RESULTS_REPORT,
   MATCHUP_STATUS_REPORT,
@@ -48,6 +52,8 @@ const wrapperMap: Record<string, (args: WrapperArgs) => ReportResult | { error: 
   [PARTICIPANT_STATS_REPORT]: wrapParticipantStats,
   [VENUE_UTILIZATION_REPORT]: wrapVenuesReport,
   [CALL_TIMING_VARIANCE_REPORT]: wrapCallTimingVarianceReport,
+  [PARTICIPANT_RECOVERY_REPORT]: wrapRecoveryTimeReport,
+  [PARTICIPANT_EXPERIENCE_REPORT]: wrapParticipantExperienceReport,
 };
 
 export function generateReport({

--- a/src/query/reports/generateReport.ts
+++ b/src/query/reports/generateReport.ts
@@ -1,10 +1,10 @@
 import { wrapParticipantExperienceReport } from './wrappers/wrapParticipantExperienceReport';
-import { wrapCallTimingVarianceReport } from './wrappers/wrapCallTimingVarianceReport';
-import { wrapRecoveryTimeReport } from './wrappers/wrapRecoveryTimeReport';
 import { wrapSeedingPerformanceReport } from './wrappers/wrapSeedingPerformanceReport';
 import { wrapParticipantResultsReport } from './wrappers/wrapParticipantResultsReport';
+import { wrapCallTimingVarianceReport } from './wrappers/wrapCallTimingVarianceReport';
 import { wrapCompetitivenessReport } from './wrappers/wrapCompetitivenessReport';
 import { wrapMatchUpStatusReport } from './wrappers/wrapMatchUpStatusReport';
+import { wrapRecoveryTimeReport } from './wrappers/wrapRecoveryTimeReport';
 import { wrapMatchResultsReport } from './wrappers/wrapMatchResultsReport';
 import { wrapEntryStatusReport } from './wrappers/wrapEntryStatusReport';
 import { wrapParticipantStats } from './wrappers/wrapParticipantStats';

--- a/src/query/reports/getAvailableReports.ts
+++ b/src/query/reports/getAvailableReports.ts
@@ -11,6 +11,8 @@ import {
   MATCH_RESULTS_REPORT,
   MATCHUP_STATUS_REPORT,
   MUTATION_LOG_REPORT,
+  PARTICIPANT_EXPERIENCE_REPORT,
+  PARTICIPANT_RECOVERY_REPORT,
   PARTICIPANT_RESULTS_REPORT,
   PARTICIPANT_STATS_REPORT,
   POSITION_CHANGES_REPORT,
@@ -84,6 +86,18 @@ const REPORT_REGISTRY = [
     category: REPORT_CATEGORIES.SCHEDULING,
   },
   {
+    reportId: PARTICIPANT_RECOVERY_REPORT,
+    name: 'Participant Recovery Time',
+    description: 'Per-participant recovery between matchUps, time on court, and waiting — across every day played',
+    category: REPORT_CATEGORIES.SCHEDULING,
+  },
+  {
+    reportId: PARTICIPANT_EXPERIENCE_REPORT,
+    name: 'Participant Experience',
+    description: 'Whole-tournament summary of each participant’s experience of time — rests, nights, waits, load',
+    category: REPORT_CATEGORIES.PARTICIPANTS,
+  },
+  {
     reportId: MUTATION_LOG_REPORT,
     name: 'Mutation Log',
     description: 'Chronological log of all server mutations with user attribution',
@@ -137,6 +151,16 @@ export function getAvailableReports({
   const hasTeamParticipants = (tournamentRecord.participants ?? []).some(
     (p: any) => p.participantType === TEAM_PARTICIPANT,
   );
+  // Recovery needs a start anchor of some kind — an explicit start, a call to
+  // court, or at minimum a planned time. Without any of those, every matchUp is
+  // undatable and both reports would return zero rows.
+  const hasScheduledMatchUps = (tournamentRecord.events ?? []).some((e: any) =>
+    (e.drawDefinitions ?? []).some((d: any) =>
+      (d.structures ?? []).some((s: any) =>
+        (s.matchUps ?? []).some((m: any) => m.schedule?.scheduledTime || m.schedule?.startTime || m.schedule?.calledAt),
+      ),
+    ),
+  );
 
   const computableMap: Record<string, boolean> = {
     [ENTRY_STATUS_REPORT]: hasEvents,
@@ -149,6 +173,8 @@ export function getAvailableReports({
     [PARTICIPANT_STATS_REPORT]: hasTeamParticipants,
     [VENUE_UTILIZATION_REPORT]: hasVenues,
     [CALL_TIMING_VARIANCE_REPORT]: hasVenues,
+    [PARTICIPANT_RECOVERY_REPORT]: hasScheduledMatchUps,
+    [PARTICIPANT_EXPERIENCE_REPORT]: hasScheduledMatchUps,
     // Audit reports are always listed; TMX checks server connectivity
     [MUTATION_LOG_REPORT]: true,
     [DRAW_REVISIONS_REPORT]: true,

--- a/src/query/reports/recoveryTimeline.ts
+++ b/src/query/reports/recoveryTimeline.ts
@@ -38,6 +38,7 @@
  */
 
 import { getMatchUpFormatTiming } from '@Query/extensions/matchUpFormatTiming/getMatchUpFormatTiming';
+import { zonedWallClockToMs, zonedParts } from '@Tools/zonedTime';
 import { allTournamentMatchUps } from '@Query/matchUps/getAllTournamentMatchUps';
 import { getParticipants } from '@Query/participants/getParticipants';
 
@@ -80,15 +81,21 @@ export function wasPlayed(matchUp: any): boolean {
   return true;
 }
 
+/**
+ * The venue frame every conversion in this module runs through.
+ *
+ * A bare `utcOffsetMinutes` is the offset at ONE moment, so a tournament that
+ * spans a DST change converts an hour wrong on the far side of it — silently,
+ * in a report whose entire subject is minutes. Supplying an IANA `timeZone`
+ * resolves the offset per instant instead. Both are carried because the offset
+ * path stays correct for the great majority of tournaments and remains the
+ * fallback when a zone is absent or unrecognised.
+ */
+type VenueFrame = { utcOffsetMinutes: number; timeZone?: string };
+
 /** `YYYY-MM-DD` + `HH:MM` venue-local → UTC ms. Null when either part is missing or malformed. */
-function wallClockToMs(date?: string, time?: string, utcOffsetMinutes = 0): number | null {
-  if (!date || !time) return null;
-  const match = /^(\d{1,2}):(\d{2})/.exec(time);
-  if (!match) return null;
-  const base = Date.parse(`${date}T00:00:00.000Z`);
-  if (Number.isNaN(base)) return null;
-  const wallClockMinutes = Number(match[1]) * 60 + Number(match[2]);
-  return base + (wallClockMinutes - utcOffsetMinutes) * MS_PER_MINUTE;
+function wallClockToMs(date: string | undefined, time: string | undefined, frame: VenueFrame): number | null {
+  return zonedWallClockToMs({ ...frame, date, time });
 }
 
 /** UTC ISO instant → UTC ms. Null when absent or unparseable. */
@@ -99,25 +106,20 @@ function isoToMs(iso?: string): number | null {
 }
 
 /** UTC ms → venue-local calendar date + wall clock. */
-function localParts(ms: number, utcOffsetMinutes: number): { date: string; time: string } {
-  const shifted = new Date(ms + utcOffsetMinutes * MS_PER_MINUTE);
-  const pad = (n: number) => String(n).padStart(2, '0');
-  return {
-    date: `${shifted.getUTCFullYear()}-${pad(shifted.getUTCMonth() + 1)}-${pad(shifted.getUTCDate())}`,
-    time: `${pad(shifted.getUTCHours())}:${pad(shifted.getUTCMinutes())}`,
-  };
+function localParts(ms: number, frame: VenueFrame): { date: string; time: string } {
+  return zonedParts({ ...frame, ms });
 }
 
 /**
  * When the matchUp began, strongest rung first: an operator-recorded start, the
  * moment it was called to court, then the plan.
  */
-function resolveStart(schedule: any, utcOffsetMinutes: number): { ms: number; source: string } | null {
-  const started = wallClockToMs(schedule?.scheduledDate, schedule?.startTime, utcOffsetMinutes);
+function resolveStart(schedule: any, frame: VenueFrame): { ms: number; source: string } | null {
+  const started = wallClockToMs(schedule?.scheduledDate, schedule?.startTime, frame);
   if (started !== null) return { ms: started, source: 'startTime' };
   const called = isoToMs(schedule?.calledAt);
   if (called !== null) return { ms: called, source: 'calledAt' };
-  const planned = wallClockToMs(schedule?.scheduledDate, schedule?.scheduledTime, utcOffsetMinutes);
+  const planned = wallClockToMs(schedule?.scheduledDate, schedule?.scheduledTime, frame);
   if (planned !== null) return { ms: planned, source: 'scheduledTime' };
   return null;
 }
@@ -135,17 +137,17 @@ function resolveFinish(
   schedule: any,
   averageMinutes: number,
   startMs: number | null,
-  utcOffsetMinutes: number,
+  frame: VenueFrame,
 ): { ms: number; source: FinishSource } | null {
   // `endDate` is sparse and only present when the matchUp crossed midnight.
-  const ended = wallClockToMs(schedule?.endDate ?? schedule?.scheduledDate, schedule?.endTime, utcOffsetMinutes);
+  const ended = wallClockToMs(schedule?.endDate ?? schedule?.scheduledDate, schedule?.endTime, frame);
   if (ended !== null) return { ms: ended, source: 'endTime' };
 
   const scored = isoToMs(schedule?.scoredTime);
   if (scored !== null) return { ms: scored, source: 'scoredTime' };
 
   const projected = averageMinutes * MS_PER_MINUTE;
-  const startedMs = wallClockToMs(schedule?.scheduledDate, schedule?.startTime, utcOffsetMinutes);
+  const startedMs = wallClockToMs(schedule?.scheduledDate, schedule?.startTime, frame);
   if (startedMs !== null) return { ms: startedMs + projected, source: 'startTime' };
 
   const called = isoToMs(schedule?.calledAt);
@@ -163,10 +165,10 @@ function resolveFinish(
 function resolveDuration(
   schedule: any,
   averageMinutes: number,
-  utcOffsetMinutes: number,
+  frame: VenueFrame,
 ): { minutes: number; source: DurationSource } {
-  const startedMs = wallClockToMs(schedule?.scheduledDate, schedule?.startTime, utcOffsetMinutes);
-  const endedMs = wallClockToMs(schedule?.endDate ?? schedule?.scheduledDate, schedule?.endTime, utcOffsetMinutes);
+  const startedMs = wallClockToMs(schedule?.scheduledDate, schedule?.startTime, frame);
+  const endedMs = wallClockToMs(schedule?.endDate ?? schedule?.scheduledDate, schedule?.endTime, frame);
   const scoredMs = isoToMs(schedule?.scoredTime);
   const calledMs = isoToMs(schedule?.calledAt);
 
@@ -221,6 +223,8 @@ type BuildArgs = {
   policyDefinitions?: any;
   utcOffsetMinutes?: number;
   tournamentRecord: Tournament;
+  /** IANA zone identifier; when supplied it wins over `utcOffsetMinutes` and is DST-correct. */
+  timeZone?: string;
   /** Bound for an in-progress tournament; caller-supplied, never read from a clock here. */
   asOfMs?: number;
 };
@@ -234,6 +238,7 @@ export function buildRecoveryTimeline({
   policyDefinitions,
   utcOffsetMinutes = 0,
   tournamentRecord,
+  timeZone,
   asOfMs,
 }: BuildArgs): {
   byParticipant: Map<string, TimelineAppearance[]>;
@@ -241,6 +246,7 @@ export function buildRecoveryTimeline({
   estimatedCount: number;
   totalCount: number;
 } {
+  const frame: VenueFrame = { utcOffsetMinutes, timeZone };
   const { matchUps } = allTournamentMatchUps({ tournamentRecord, inContext: true });
   const { participants } = getParticipants({ tournamentRecord, withIndividualParticipants: true });
 
@@ -258,8 +264,8 @@ export function buildRecoveryTimeline({
 
   for (const matchUp of (matchUps ?? []) as any[]) {
     const appearances = appearancesForMatchUp({
-      utcOffsetMinutes,
       eventNames,
+      frame,
       drawNames,
       timingFor,
       matchUp,
@@ -326,12 +332,12 @@ function makeTimingResolver({ tournamentRecord, policyDefinitions, eventsById }:
 
 /** Every individual appearance a single matchUp contributes, or an empty list. */
 function appearancesForMatchUp({
-  utcOffsetMinutes,
   eventNames,
   drawNames,
   timingFor,
   matchUp,
   asOfMs,
+  frame,
 }: any): TimelineAppearance[] {
   if (!wasPlayed(matchUp)) return [];
 
@@ -339,12 +345,12 @@ function appearancesForMatchUp({
   const baseTiming = timingFor(matchUp);
   const averageMinutes = baseTiming?.averageMinutes ?? 90;
 
-  const start = resolveStart(schedule, utcOffsetMinutes);
+  const start = resolveStart(schedule, frame);
   if (!start) return []; // genuinely undatable — excluded rather than guessed at
   if (asOfMs !== undefined && start.ms > asOfMs) return [];
 
-  const duration = resolveDuration(schedule, averageMinutes, utcOffsetMinutes);
-  const finish = resolveFinish(schedule, averageMinutes, start.ms, utcOffsetMinutes);
+  const duration = resolveDuration(schedule, averageMinutes, frame);
+  const finish = resolveFinish(schedule, averageMinutes, start.ms, frame);
   if (!finish) return [];
 
   // A measured or proxied duration may key a `byPlayedMinutes` band; an estimated
@@ -359,11 +365,11 @@ function appearancesForMatchUp({
   ].filter(Boolean);
 
   return individualIds.map((participantId: string) => ({
-    scheduledMs: wallClockToMs(schedule.scheduledDate, schedule.scheduledTime, utcOffsetMinutes) ?? undefined,
+    scheduledMs: wallClockToMs(schedule.scheduledDate, schedule.scheduledTime, frame) ?? undefined,
     roundName: matchUp.roundName ?? (matchUp.roundNumber ? `R${matchUp.roundNumber}` : ''),
     recoveryFromPlayedMinutes: !!timing?.recoveryFromPlayedMinutes,
     typeChangeRecoveryMinutes: timing?.typeChangeRecoveryMinutes ?? 0,
-    scheduledDate: localParts(start.ms, utcOffsetMinutes).date,
+    scheduledDate: localParts(start.ms, frame).date,
     calledMs: isoToMs(schedule.calledAt) ?? undefined,
     overnightMinutes: timing?.overnightMinutes,
     recoveryMinutes: timing?.recoveryMinutes ?? 0,
@@ -385,3 +391,4 @@ function appearancesForMatchUp({
 }
 
 export { MS_PER_MINUTE, MINUTES_PER_DAY, localParts };
+export type { VenueFrame };

--- a/src/query/reports/recoveryTimeline.ts
+++ b/src/query/reports/recoveryTimeline.ts
@@ -38,15 +38,30 @@
  */
 
 import { getMatchUpFormatTiming } from '@Query/extensions/matchUpFormatTiming/getMatchUpFormatTiming';
-import { zonedWallClockToMs, zonedParts } from '@Tools/zonedTime';
 import { allTournamentMatchUps } from '@Query/matchUps/getAllTournamentMatchUps';
 import { getParticipants } from '@Query/participants/getParticipants';
+import { zonedWallClockToMs, zonedParts } from '@Tools/zonedTime';
 
 import { DOUBLES_MATCHUP } from '@Constants/matchUpTypes';
 import { Tournament } from '@Types/tournamentTypes';
 
 const MS_PER_MINUTE = 60_000;
 const MINUTES_PER_DAY = 1440;
+
+/**
+ * How long after its start a matchUp's finish may plausibly land.
+ *
+ * `scoredTime` is stamped when the score is *entered*, not when play ended. That
+ * is usually within minutes of the finish, which is why it is the workhorse rung
+ * — but a score entered the next morning, or corrected days later, is not a
+ * finish proxy at all. Unbounded, such a stamp yields a matchUp that "ran" for
+ * three days, an absurd duration, and a day span to match.
+ *
+ * Twelve hours comfortably covers any real match including long weather
+ * suspensions, while excluding next-day entry. Past it the ladder falls through
+ * to a projection from the start, which is wrong by minutes rather than by days.
+ */
+const MAX_PLAUSIBLE_MATCH_MINUTES = 12 * 60;
 
 /** Which rung of the finish ladder produced a matchUp's end anchor. */
 export type FinishSource = 'endTime' | 'scoredTime' | 'startTime' | 'calledAt' | 'scheduledTime';
@@ -98,6 +113,19 @@ function wallClockToMs(date: string | undefined, time: string | undefined, frame
   return zonedWallClockToMs({ ...frame, date, time });
 }
 
+/**
+ * Whether a candidate finish sits a plausible distance after a known start.
+ *
+ * Guards the score-entry rungs against a stamp that records bookkeeping rather
+ * than play. Returns false when there is no start to measure against, so an
+ * unanchored score never becomes a duration.
+ */
+function isPlausibleFinish(finishMs: number, startMs: number | null): boolean {
+  if (startMs === null) return false;
+  const elapsed = finishMs - startMs;
+  return elapsed > 0 && elapsed <= MAX_PLAUSIBLE_MATCH_MINUTES * MS_PER_MINUTE;
+}
+
 /** UTC ISO instant → UTC ms. Null when absent or unparseable. */
 function isoToMs(iso?: string): number | null {
   if (!iso) return null;
@@ -143,11 +171,14 @@ function resolveFinish(
   const ended = wallClockToMs(schedule?.endDate ?? schedule?.scheduledDate, schedule?.endTime, frame);
   if (ended !== null) return { ms: ended, source: 'endTime' };
 
-  const scored = isoToMs(schedule?.scoredTime);
-  if (scored !== null) return { ms: scored, source: 'scoredTime' };
-
   const projected = averageMinutes * MS_PER_MINUTE;
   const startedMs = wallClockToMs(schedule?.scheduledDate, schedule?.startTime, frame);
+
+  const scored = isoToMs(schedule?.scoredTime);
+  if (scored !== null && isPlausibleFinish(scored, startedMs ?? startMs)) {
+    return { ms: scored, source: 'scoredTime' };
+  }
+
   if (startedMs !== null) return { ms: startedMs + projected, source: 'startTime' };
 
   const called = isoToMs(schedule?.calledAt);
@@ -175,10 +206,10 @@ function resolveDuration(
   if (startedMs !== null && endedMs !== null && endedMs > startedMs) {
     return { minutes: Math.round((endedMs - startedMs) / MS_PER_MINUTE), source: 'measured' };
   }
-  if (startedMs !== null && scoredMs !== null && scoredMs > startedMs) {
+  if (startedMs !== null && scoredMs !== null && isPlausibleFinish(scoredMs, startedMs)) {
     return { minutes: Math.round((scoredMs - startedMs) / MS_PER_MINUTE), source: 'scoredTime' };
   }
-  if (calledMs !== null && scoredMs !== null && scoredMs > calledMs) {
+  if (calledMs !== null && scoredMs !== null && isPlausibleFinish(scoredMs, calledMs)) {
     return { minutes: Math.round((scoredMs - calledMs) / MS_PER_MINUTE), source: 'calledAt' };
   }
   return { minutes: averageMinutes, source: 'estimated' };

--- a/src/query/reports/recoveryTimeline.ts
+++ b/src/query/reports/recoveryTimeline.ts
@@ -1,0 +1,387 @@
+/**
+ * Participant recovery timeline — the retrospective counterpart to TMX's live
+ * Inspector rest analysis.
+ *
+ * The Inspector answers *"how long has this player had off, as of now"* for one
+ * decision on one day. This answers *"across the whole tournament, what was each
+ * participant's experience of time"* — recovery actually received between
+ * matchUps, time actually spent on court, and time spent waiting.
+ *
+ * Two properties follow from being retrospective, and both are load-bearing:
+ *
+ * 1. **It is not day-scoped.** The Inspector scopes rest to one calendar day by
+ *    design, which makes overnight turnaround structurally invisible — and the
+ *    overnight rule carries the largest figure in the rulebook (12 hours between
+ *    a junior's last matchUp of one day and the first of the next). Spanning days
+ *    is the whole point.
+ * 2. **It needs no clock.** Every anchor is historical, so the factory's purity
+ *    is not strained. `asOfMs` exists only to bound an in-progress tournament and
+ *    is supplied by the caller, never read from a clock here.
+ *
+ * ── Time representation ──
+ *
+ * The underlying values sit in two different frames: `endTime` / `startTime` /
+ * `scheduledTime` are bare `HH:MM` venue-local wall clock, while `calledAt` and
+ * `scoredTime` are full UTC ISO instants. Mixing them without an explicit
+ * conversion yields a figure wrong by the UTC offset, which is worse than
+ * showing nothing. Everything here is normalised to **UTC milliseconds** at the
+ * single pair of entry points below, given the venue's `utcOffsetMinutes`
+ * (local = UTC + offset).
+ *
+ * ── The honesty rule ──
+ *
+ * Two quantities are *derived* and neither has a single source, so every row
+ * reports which rung produced it. An inferred number must never read as a
+ * measured one; a report that quietly presents `averageMinutes` as "time on
+ * court" is a restatement of the scheduling policy wearing the costume of an
+ * observation.
+ */
+
+import { getMatchUpFormatTiming } from '@Query/extensions/matchUpFormatTiming/getMatchUpFormatTiming';
+import { allTournamentMatchUps } from '@Query/matchUps/getAllTournamentMatchUps';
+import { getParticipants } from '@Query/participants/getParticipants';
+
+import { DOUBLES_MATCHUP } from '@Constants/matchUpTypes';
+import { Tournament } from '@Types/tournamentTypes';
+
+const MS_PER_MINUTE = 60_000;
+const MINUTES_PER_DAY = 1440;
+
+/** Which rung of the finish ladder produced a matchUp's end anchor. */
+export type FinishSource = 'endTime' | 'scoredTime' | 'startTime' | 'calledAt' | 'scheduledTime';
+
+/** Which rung produced the time-on-court figure. `estimated` is not an observation. */
+export type DurationSource = 'measured' | 'scoredTime' | 'calledAt' | 'estimated';
+
+/**
+ * Statuses that advance a participant without their playing.
+ *
+ * Ported from TMX `participantRest.ts` rather than re-derived, so the report and
+ * the Inspector badge cannot disagree about what counts as a matchUp played.
+ * `completedMatchUpStatuses` is NOT usable here: it includes every walkover and
+ * default, so reusing it charges a player full recovery, a daily ordinal and
+ * estimated court time for a matchUp they never played.
+ *
+ * `CANCELLED` is present here and absent from the TMX set only because it falls
+ * outside that module's domain — a cancelled matchUp plainly put nobody on court.
+ * `RETIRED` and `ABANDONED` are deliberately absent from this set: both mean time
+ * was spent on court.
+ */
+const UNPLAYED_STATUSES = new Set(['WALKOVER', 'DOUBLE_WALKOVER', 'CANCELLED']);
+const DEFAULT_STATUSES = new Set(['DEFAULTED', 'DOUBLE_DEFAULT']);
+
+/** True when this matchUp actually put its participants on court. */
+export function wasPlayed(matchUp: any): boolean {
+  const status = matchUp?.matchUpStatus;
+  if (status && UNPLAYED_STATUSES.has(status)) return false;
+  // A default with a score was played up to the point of the default; a default
+  // with no score is a no-show. Nothing else about the record tells them apart.
+  if (status && DEFAULT_STATUSES.has(status)) return !!matchUp?.score?.sets?.length;
+  return true;
+}
+
+/** `YYYY-MM-DD` + `HH:MM` venue-local → UTC ms. Null when either part is missing or malformed. */
+function wallClockToMs(date?: string, time?: string, utcOffsetMinutes = 0): number | null {
+  if (!date || !time) return null;
+  const match = /^(\d{1,2}):(\d{2})/.exec(time);
+  if (!match) return null;
+  const base = Date.parse(`${date}T00:00:00.000Z`);
+  if (Number.isNaN(base)) return null;
+  const wallClockMinutes = Number(match[1]) * 60 + Number(match[2]);
+  return base + (wallClockMinutes - utcOffsetMinutes) * MS_PER_MINUTE;
+}
+
+/** UTC ISO instant → UTC ms. Null when absent or unparseable. */
+function isoToMs(iso?: string): number | null {
+  if (!iso) return null;
+  const ms = Date.parse(iso);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+/** UTC ms → venue-local calendar date + wall clock. */
+function localParts(ms: number, utcOffsetMinutes: number): { date: string; time: string } {
+  const shifted = new Date(ms + utcOffsetMinutes * MS_PER_MINUTE);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return {
+    date: `${shifted.getUTCFullYear()}-${pad(shifted.getUTCMonth() + 1)}-${pad(shifted.getUTCDate())}`,
+    time: `${pad(shifted.getUTCHours())}:${pad(shifted.getUTCMinutes())}`,
+  };
+}
+
+/**
+ * When the matchUp began, strongest rung first: an operator-recorded start, the
+ * moment it was called to court, then the plan.
+ */
+function resolveStart(schedule: any, utcOffsetMinutes: number): { ms: number; source: string } | null {
+  const started = wallClockToMs(schedule?.scheduledDate, schedule?.startTime, utcOffsetMinutes);
+  if (started !== null) return { ms: started, source: 'startTime' };
+  const called = isoToMs(schedule?.calledAt);
+  if (called !== null) return { ms: called, source: 'calledAt' };
+  const planned = wallClockToMs(schedule?.scheduledDate, schedule?.scheduledTime, utcOffsetMinutes);
+  if (planned !== null) return { ms: planned, source: 'scheduledTime' };
+  return null;
+}
+
+/**
+ * When the matchUp finished, strongest rung first.
+ *
+ * Rung 2 (`scoredTime`) carries the load in practice, not rung 1: TMX writes
+ * `END_TIME` only on an explicit operator action, while the factory auto-captures
+ * `scoredTime` on every first meaningful score. A late-entered score pushes the
+ * anchor *after* the true finish, so recovery is understated — the conservative
+ * direction, since it reports a player as less rested rather than more.
+ */
+function resolveFinish(
+  schedule: any,
+  averageMinutes: number,
+  startMs: number | null,
+  utcOffsetMinutes: number,
+): { ms: number; source: FinishSource } | null {
+  // `endDate` is sparse and only present when the matchUp crossed midnight.
+  const ended = wallClockToMs(schedule?.endDate ?? schedule?.scheduledDate, schedule?.endTime, utcOffsetMinutes);
+  if (ended !== null) return { ms: ended, source: 'endTime' };
+
+  const scored = isoToMs(schedule?.scoredTime);
+  if (scored !== null) return { ms: scored, source: 'scoredTime' };
+
+  const projected = averageMinutes * MS_PER_MINUTE;
+  const startedMs = wallClockToMs(schedule?.scheduledDate, schedule?.startTime, utcOffsetMinutes);
+  if (startedMs !== null) return { ms: startedMs + projected, source: 'startTime' };
+
+  const called = isoToMs(schedule?.calledAt);
+  if (called !== null) return { ms: called + projected, source: 'calledAt' };
+
+  if (startMs !== null) return { ms: startMs + projected, source: 'scheduledTime' };
+  return null;
+}
+
+/**
+ * Time on court. Rung 4 is not an observation at all — it is the scheduling
+ * policy's prediction — which is why `durationSource` travels with every figure
+ * and why the summary counts how many rows landed there.
+ */
+function resolveDuration(
+  schedule: any,
+  averageMinutes: number,
+  utcOffsetMinutes: number,
+): { minutes: number; source: DurationSource } {
+  const startedMs = wallClockToMs(schedule?.scheduledDate, schedule?.startTime, utcOffsetMinutes);
+  const endedMs = wallClockToMs(schedule?.endDate ?? schedule?.scheduledDate, schedule?.endTime, utcOffsetMinutes);
+  const scoredMs = isoToMs(schedule?.scoredTime);
+  const calledMs = isoToMs(schedule?.calledAt);
+
+  if (startedMs !== null && endedMs !== null && endedMs > startedMs) {
+    return { minutes: Math.round((endedMs - startedMs) / MS_PER_MINUTE), source: 'measured' };
+  }
+  if (startedMs !== null && scoredMs !== null && scoredMs > startedMs) {
+    return { minutes: Math.round((scoredMs - startedMs) / MS_PER_MINUTE), source: 'scoredTime' };
+  }
+  if (calledMs !== null && scoredMs !== null && scoredMs > calledMs) {
+    return { minutes: Math.round((scoredMs - calledMs) / MS_PER_MINUTE), source: 'calledAt' };
+  }
+  return { minutes: averageMinutes, source: 'estimated' };
+}
+
+/** Every individual behind a side — recovery is a property of a person, not of an entry. */
+function sideIndividualIds(side: any, matchUpType?: string): string[] {
+  if (!side) return [];
+  if (matchUpType === DOUBLES_MATCHUP) {
+    const ids = side.participant?.individualParticipantIds ?? [];
+    return ids.length ? ids : [side.participantId].filter(Boolean);
+  }
+  return [side.participantId ?? side.participant?.participantId].filter(Boolean);
+}
+
+export type TimelineAppearance = {
+  recoveryFromPlayedMinutes: boolean;
+  typeChangeRecoveryMinutes: number;
+  overnightMinutes?: number;
+  durationSource: DurationSource;
+  finishSource: FinishSource;
+  durationMinutes: number;
+  recoveryMinutes: number;
+  averageMinutes: number;
+  scheduledDate: string;
+  participantId: string;
+  matchUpType?: string;
+  scheduledMs?: number;
+  structureId?: string;
+  matchUpId: string;
+  roundName: string;
+  eventName: string;
+  calledMs?: number;
+  drawName: string;
+  eventId?: string;
+  finishMs: number;
+  drawId?: string;
+  startMs: number;
+};
+
+type BuildArgs = {
+  policyDefinitions?: any;
+  utcOffsetMinutes?: number;
+  tournamentRecord: Tournament;
+  /** Bound for an in-progress tournament; caller-supplied, never read from a clock here. */
+  asOfMs?: number;
+};
+
+/**
+ * One entry per (individual participant × matchUp played), chronologically
+ * ordered per participant. The shared core behind both the per-appearance log and
+ * the per-participant roll-up, so the two can never disagree.
+ */
+export function buildRecoveryTimeline({
+  policyDefinitions,
+  utcOffsetMinutes = 0,
+  tournamentRecord,
+  asOfMs,
+}: BuildArgs): {
+  byParticipant: Map<string, TimelineAppearance[]>;
+  participantNameMap: Record<string, string>;
+  estimatedCount: number;
+  totalCount: number;
+} {
+  const { matchUps } = allTournamentMatchUps({ tournamentRecord, inContext: true });
+  const { participants } = getParticipants({ tournamentRecord, withIndividualParticipants: true });
+
+  const participantNameMap: Record<string, string> = {};
+  for (const participant of participants ?? []) {
+    participantNameMap[participant.participantId] = participant.participantName ?? '';
+  }
+
+  const { eventNames, drawNames, eventsById } = buildNameMaps(tournamentRecord);
+  const timingFor = makeTimingResolver({ tournamentRecord, policyDefinitions, eventsById });
+
+  const byParticipant = new Map<string, TimelineAppearance[]>();
+  let estimatedCount = 0;
+  let totalCount = 0;
+
+  for (const matchUp of (matchUps ?? []) as any[]) {
+    const appearances = appearancesForMatchUp({
+      utcOffsetMinutes,
+      eventNames,
+      drawNames,
+      timingFor,
+      matchUp,
+      asOfMs,
+    });
+
+    for (const appearance of appearances) {
+      totalCount += 1;
+      if (appearance.durationSource === 'estimated') estimatedCount += 1;
+      const existing = byParticipant.get(appearance.participantId);
+      if (existing) existing.push(appearance);
+      else byParticipant.set(appearance.participantId, [appearance]);
+    }
+  }
+
+  for (const appearances of byParticipant.values()) appearances.sort((a, b) => a.startMs - b.startMs);
+
+  return { byParticipant, participantNameMap, estimatedCount, totalCount };
+}
+
+/** `eventId`/`drawId` → display names, plus events by id for category resolution. */
+function buildNameMaps(tournamentRecord: Tournament) {
+  const eventNames: Record<string, string> = {};
+  const drawNames: Record<string, string> = {};
+  const eventsById: Record<string, any> = {};
+  for (const event of tournamentRecord.events ?? []) {
+    eventNames[event.eventId] = event.eventName ?? '';
+    eventsById[event.eventId] = event;
+    for (const draw of event.drawDefinitions ?? []) drawNames[draw.drawId] = draw.drawName ?? '';
+  }
+  return { eventNames, drawNames, eventsById };
+}
+
+/**
+ * Timing resolved per (format × matchUpType × event × playedMinutes) — a
+ * tournament has a handful of distinct combinations, not one per matchUp.
+ */
+function makeTimingResolver({ tournamentRecord, policyDefinitions, eventsById }: any) {
+  const cache = new Map<string, any>();
+  return (matchUp: any, playedMinutes?: number) => {
+    const key = [matchUp.matchUpFormat, matchUp.matchUpType, matchUp.eventId, playedMinutes].join('|');
+    const cached = cache.get(key);
+    if (cached) return cached;
+
+    const event = eventsById[matchUp.eventId];
+    const category = event?.category;
+    const timing: any = getMatchUpFormatTiming({
+      categoryName: category?.categoryName ?? category?.ageCategoryCode,
+      // Passed explicitly as well as via `event`: an explicit value still wins,
+      // and published factories at or below 6.29.1 discard the resolved one.
+      categoryType: category?.categoryType ?? category?.subType,
+      matchUpFormat: matchUp.matchUpFormat ?? '',
+      eventType: matchUp.matchUpType,
+      policyDefinitions,
+      tournamentRecord,
+      playedMinutes,
+      event,
+    });
+    const resolved = timing?.error ? {} : timing;
+    cache.set(key, resolved);
+    return resolved;
+  };
+}
+
+/** Every individual appearance a single matchUp contributes, or an empty list. */
+function appearancesForMatchUp({
+  utcOffsetMinutes,
+  eventNames,
+  drawNames,
+  timingFor,
+  matchUp,
+  asOfMs,
+}: any): TimelineAppearance[] {
+  if (!wasPlayed(matchUp)) return [];
+
+  const schedule = matchUp.schedule ?? {};
+  const baseTiming = timingFor(matchUp);
+  const averageMinutes = baseTiming?.averageMinutes ?? 90;
+
+  const start = resolveStart(schedule, utcOffsetMinutes);
+  if (!start) return []; // genuinely undatable — excluded rather than guessed at
+  if (asOfMs !== undefined && start.ms > asOfMs) return [];
+
+  const duration = resolveDuration(schedule, averageMinutes, utcOffsetMinutes);
+  const finish = resolveFinish(schedule, averageMinutes, start.ms, utcOffsetMinutes);
+  if (!finish) return [];
+
+  // A measured or proxied duration may key a `byPlayedMinutes` band; an estimated
+  // one may not — banding on `averageMinutes` selects the band by the very number
+  // the policy already predicted.
+  const playedMinutes = duration.source === 'estimated' ? undefined : duration.minutes;
+  const timing = playedMinutes === undefined ? baseTiming : timingFor(matchUp, playedMinutes);
+
+  const individualIds = [
+    ...sideIndividualIds(matchUp.sides?.[0], matchUp.matchUpType),
+    ...sideIndividualIds(matchUp.sides?.[1], matchUp.matchUpType),
+  ].filter(Boolean);
+
+  return individualIds.map((participantId: string) => ({
+    scheduledMs: wallClockToMs(schedule.scheduledDate, schedule.scheduledTime, utcOffsetMinutes) ?? undefined,
+    roundName: matchUp.roundName ?? (matchUp.roundNumber ? `R${matchUp.roundNumber}` : ''),
+    recoveryFromPlayedMinutes: !!timing?.recoveryFromPlayedMinutes,
+    typeChangeRecoveryMinutes: timing?.typeChangeRecoveryMinutes ?? 0,
+    scheduledDate: localParts(start.ms, utcOffsetMinutes).date,
+    calledMs: isoToMs(schedule.calledAt) ?? undefined,
+    overnightMinutes: timing?.overnightMinutes,
+    recoveryMinutes: timing?.recoveryMinutes ?? 0,
+    eventName: eventNames[matchUp.eventId] ?? '',
+    drawName: drawNames[matchUp.drawId] ?? '',
+    durationMinutes: duration.minutes,
+    durationSource: duration.source,
+    structureId: matchUp.structureId,
+    matchUpType: matchUp.matchUpType,
+    matchUpId: matchUp.matchUpId,
+    finishSource: finish.source,
+    eventId: matchUp.eventId,
+    drawId: matchUp.drawId,
+    finishMs: finish.ms,
+    startMs: start.ms,
+    averageMinutes,
+    participantId,
+  }));
+}
+
+export { MS_PER_MINUTE, MINUTES_PER_DAY, localParts };

--- a/src/query/reports/wrappers/wrapCallTimingVarianceReport.ts
+++ b/src/query/reports/wrappers/wrapCallTimingVarianceReport.ts
@@ -95,6 +95,10 @@ function buildRow(
     drawId: matchUp.drawId,
     structureId: matchUp.structureId,
     eventId: matchUp.eventId,
+    // Side ids alongside the composite `matchUp` label, so a consumer can reach
+    // the participants behind "A vs B".
+    side1ParticipantId: matchUp?.sides?.[0]?.participantId ?? matchUp?.sides?.[0]?.participant?.participantId ?? '',
+    side2ParticipantId: matchUp?.sides?.[1]?.participantId ?? matchUp?.sides?.[1]?.participant?.participantId ?? '',
     eventName: eventNameMap[matchUp.eventId] || matchUp.eventId || '',
     drawName: drawNameMap[matchUp.drawId] || matchUp.drawId || '',
     roundName: matchUp.roundName ?? (matchUp.roundNumber ? `R${matchUp.roundNumber}` : ''),

--- a/src/query/reports/wrappers/wrapCompetitivenessReport.ts
+++ b/src/query/reports/wrappers/wrapCompetitivenessReport.ts
@@ -35,6 +35,12 @@ export function wrapCompetitivenessReport({
       const profile: any = getMatchUpCompetitiveProfile({ matchUp: m, tournamentRecord });
 
       return {
+        structureId: m.structureId,
+        matchUpId: m.matchUpId,
+        eventId: m.eventId,
+        drawId: m.drawId,
+        ...sideIds(m),
+
         roundName: m.roundName ?? `R${m.roundNumber ?? ''}`,
         side1: m.sides?.[0]?.participant?.participantName ?? '',
         side2: m.sides?.[1]?.participant?.participantName ?? '',
@@ -49,5 +55,20 @@ export function wrapCompetitivenessReport({
     generatedAt: new Date().toISOString(),
     columns,
     rows,
+  };
+}
+
+/**
+ * Side participant ids alongside the display names.
+ *
+ * Not displayed as columns — consumers hide them — but they are what lets a table
+ * resolve the participant behind a name and open a participant card, and they
+ * survive to CSV/JSON export. A doubles side yields its PAIR id; the consumer
+ * hydrates individuals from that, so a partner can be opened individually.
+ */
+function sideIds(matchUp: any) {
+  return {
+    side1ParticipantId: matchUp?.sides?.[0]?.participantId ?? matchUp?.sides?.[0]?.participant?.participantId ?? '',
+    side2ParticipantId: matchUp?.sides?.[1]?.participantId ?? matchUp?.sides?.[1]?.participant?.participantId ?? '',
   };
 }

--- a/src/query/reports/wrappers/wrapMatchResultsReport.ts
+++ b/src/query/reports/wrappers/wrapMatchResultsReport.ts
@@ -37,6 +37,15 @@ export function wrapMatchResultsReport({
       const scoreString = m.score?.scoreStringSide1 ?? '';
 
       return {
+        // Location ids (not displayed) so a consumer can navigate from a row to
+        // the matchUp in its draw, as Call Timing Variance already does.
+        structureId: m.structureId,
+        matchUpId: m.matchUpId,
+        eventId: m.eventId,
+        drawId: m.drawId,
+        ...sideIds(m),
+        winningParticipantId: winnerSide?.participantId ?? winnerSide?.participant?.participantId ?? '',
+
         roundName: m.roundName ?? `R${m.roundNumber ?? ''}`,
         side1: side1Name,
         side2: side2Name,
@@ -51,5 +60,20 @@ export function wrapMatchResultsReport({
     generatedAt: new Date().toISOString(),
     columns,
     rows,
+  };
+}
+
+/**
+ * Side participant ids alongside the display names.
+ *
+ * Not displayed as columns — consumers hide them — but they are what lets a table
+ * resolve the participant behind a name and open a participant card, and they
+ * survive to CSV/JSON export. A doubles side yields its PAIR id; the consumer
+ * hydrates individuals from that, so a partner can be opened individually.
+ */
+function sideIds(matchUp: any) {
+  return {
+    side1ParticipantId: matchUp?.sides?.[0]?.participantId ?? matchUp?.sides?.[0]?.participant?.participantId ?? '',
+    side2ParticipantId: matchUp?.sides?.[1]?.participantId ?? matchUp?.sides?.[1]?.participant?.participantId ?? '',
   };
 }

--- a/src/query/reports/wrappers/wrapParticipantExperienceReport.ts
+++ b/src/query/reports/wrappers/wrapParticipantExperienceReport.ts
@@ -7,7 +7,7 @@ import { ReportResult } from '@Types/reportTypes';
 
 type WrapArgs = {
   tournamentRecord: Tournament;
-  parameters?: { utcOffsetMinutes?: number; policyDefinitions?: any; asOfMs?: number };
+  parameters?: { utcOffsetMinutes?: number; timeZone?: string; policyDefinitions?: any; asOfMs?: number };
 };
 
 const minutesBetween = (fromMs: number, toMs: number) => Math.round((toMs - fromMs) / MS_PER_MINUTE);
@@ -77,11 +77,13 @@ export function wrapParticipantExperienceReport({
   parameters,
 }: WrapArgs): ReportResult | { error: any } {
   const utcOffsetMinutes = parameters?.utcOffsetMinutes ?? 0;
+  const timeZone = parameters?.timeZone;
   const { byParticipant, participantNameMap, estimatedCount, totalCount } = buildRecoveryTimeline({
     policyDefinitions: parameters?.policyDefinitions,
     asOfMs: parameters?.asOfMs,
     utcOffsetMinutes,
     tournamentRecord,
+    timeZone,
   });
 
   if (!totalCount) return { error: 'No played matchUps with resolvable times' };
@@ -193,6 +195,7 @@ export function wrapParticipantExperienceReport({
       participantsWithShortOvernight: rows.filter((row) => row.shortOvernightCount > 0).length,
       estimatedDurationPercentage: totalCount ? Math.round((estimatedCount / totalCount) * 100) : 0,
       utcOffsetMinutes,
+      timeZone,
     },
   };
 }

--- a/src/query/reports/wrappers/wrapParticipantExperienceReport.ts
+++ b/src/query/reports/wrappers/wrapParticipantExperienceReport.ts
@@ -1,0 +1,198 @@
+import { buildRecoveryTimeline, MS_PER_MINUTE, TimelineAppearance } from '../recoveryTimeline';
+
+// Constants and Types
+import { PARTICIPANT_EXPERIENCE_REPORT } from '@Constants/reportConstants';
+import { Tournament } from '@Types/tournamentTypes';
+import { ReportResult } from '@Types/reportTypes';
+
+type WrapArgs = {
+  tournamentRecord: Tournament;
+  parameters?: { utcOffsetMinutes?: number; policyDefinitions?: any; asOfMs?: number };
+};
+
+const minutesBetween = (fromMs: number, toMs: number) => Math.round((toMs - fromMs) / MS_PER_MINUTE);
+
+function requiredAfter(previous: TimelineAppearance, next: TimelineAppearance): number {
+  const typeChanged = !!previous.matchUpType && !!next.matchUpType && previous.matchUpType !== next.matchUpType;
+  if (typeChanged && previous.typeChangeRecoveryMinutes) return previous.typeChangeRecoveryMinutes;
+  return previous.recoveryMinutes;
+}
+
+type Accumulator = {
+  worstOvernightReceived?: number;
+  shortOvernightCount: number;
+  worstRecoveryDeficit: number;
+  shortRecoveryCount: number;
+  longestDayMinutes: number;
+  busiestDayMatches: number;
+  estimatedRows: number;
+  maxWaitMinutes?: number;
+  courtMinutes: number;
+  waitTotal: number;
+  waitCount: number;
+  matches: number;
+  days: Set<string>;
+};
+
+/** Per-day spans, used for "at the site nine hours, played three". */
+function accumulateDays(appearances: TimelineAppearance[], acc: Accumulator): void {
+  const byDate = new Map<string, TimelineAppearance[]>();
+  for (const appearance of appearances) {
+    const existing = byDate.get(appearance.scheduledDate);
+    if (existing) existing.push(appearance);
+    else byDate.set(appearance.scheduledDate, [appearance]);
+  }
+
+  for (const dayAppearances of byDate.values()) {
+    if (dayAppearances.length > acc.busiestDayMatches) acc.busiestDayMatches = dayAppearances.length;
+
+    // The day starts when the participant was first *expected* — being told to
+    // arrive at 09:00 and first playing at 14:00 is five hours of the experience
+    // that a first-start anchor would erase.
+    const firstExpectedMs = Math.min(...dayAppearances.map((a) => a.scheduledMs ?? a.startMs));
+    const lastFinishMs = Math.max(...dayAppearances.map((a) => a.finishMs));
+    const dayMinutes = minutesBetween(firstExpectedMs, lastFinishMs);
+    if (dayMinutes > acc.longestDayMinutes) acc.longestDayMinutes = dayMinutes;
+  }
+}
+
+/**
+ * Participant Experience — one row per individual participant, rolled up across
+ * the whole tournament, over the same timeline the per-appearance recovery report
+ * uses so the two can never disagree.
+ *
+ * **Deliberately not a composite score.** A weighted "experience index" would
+ * invent an authority the data does not have and would launder estimated
+ * durations into a single confident number. These are sortable counts; the
+ * operator decides what "worst" means. If a band is ever wanted, derive it from
+ * `worstRecoveryDeficit` alone — the one quantity with a rulebook behind it.
+ *
+ * `meanWait` and `maxWait` rather than a standard deviation: a participant
+ * consistently called 15 minutes late had a predictable tournament and one
+ * swinging −30/+180 had a chaotic one at the same mean, and operators read
+ * minutes rather than sigma.
+ */
+export function wrapParticipantExperienceReport({
+  tournamentRecord,
+  parameters,
+}: WrapArgs): ReportResult | { error: any } {
+  const utcOffsetMinutes = parameters?.utcOffsetMinutes ?? 0;
+  const { byParticipant, participantNameMap, estimatedCount, totalCount } = buildRecoveryTimeline({
+    policyDefinitions: parameters?.policyDefinitions,
+    asOfMs: parameters?.asOfMs,
+    utcOffsetMinutes,
+    tournamentRecord,
+  });
+
+  if (!totalCount) return { error: 'No played matchUps with resolvable times' };
+
+  const columns = [
+    { key: 'participantName', title: 'Participant', type: 'string' as const },
+    { key: 'daysPlayed', title: 'Days', type: 'number' as const, width: 70 },
+    { key: 'matchesPlayed', title: 'Matches', type: 'number' as const, width: 85 },
+    { key: 'busiestDayMatches', title: 'Busiest Day', type: 'number' as const, width: 95, headerWordWrap: true },
+    { key: 'courtMinutes', title: 'On Court', type: 'number' as const, width: 90, headerWordWrap: true },
+    { key: 'estimatedPct', title: 'Estimated %', type: 'number' as const, width: 95, headerWordWrap: true },
+    { key: 'shortRecoveryCount', title: 'Short Rests', type: 'number' as const, width: 95, headerWordWrap: true },
+    { key: 'worstRecoveryDeficit', title: 'Worst Deficit', type: 'number' as const, width: 95, headerWordWrap: true },
+    { key: 'shortOvernightCount', title: 'Short Nights', type: 'number' as const, width: 95, headerWordWrap: true },
+    { key: 'worstOvernight', title: 'Worst Night', type: 'number' as const, width: 95, headerWordWrap: true },
+    { key: 'meanWaitMinutes', title: 'Mean Wait', type: 'number' as const, width: 90, headerWordWrap: true },
+    { key: 'maxWaitMinutes', title: 'Max Wait', type: 'number' as const, width: 90, headerWordWrap: true },
+    { key: 'longestDayMinutes', title: 'Longest Day', type: 'number' as const, width: 95, headerWordWrap: true },
+  ];
+
+  const rows: Record<string, any>[] = [];
+
+  for (const [participantId, appearances] of byParticipant) {
+    const acc: Accumulator = {
+      shortOvernightCount: 0,
+      worstRecoveryDeficit: 0,
+      shortRecoveryCount: 0,
+      longestDayMinutes: 0,
+      busiestDayMatches: 0,
+      estimatedRows: 0,
+      courtMinutes: 0,
+      waitTotal: 0,
+      waitCount: 0,
+      matches: appearances.length,
+      days: new Set(),
+    };
+
+    appearances.forEach((appearance, index) => {
+      acc.days.add(appearance.scheduledDate);
+      acc.courtMinutes += appearance.durationMinutes;
+      if (appearance.durationSource === 'estimated') acc.estimatedRows += 1;
+
+      if (appearance.scheduledMs !== undefined && appearance.calledMs !== undefined) {
+        const wait = minutesBetween(appearance.scheduledMs, appearance.calledMs);
+        acc.waitTotal += wait;
+        acc.waitCount += 1;
+        if (acc.maxWaitMinutes === undefined || wait > acc.maxWaitMinutes) acc.maxWaitMinutes = wait;
+      }
+
+      if (!index) return;
+      const previous = appearances[index - 1];
+      const gap = minutesBetween(previous.finishMs, appearance.startMs);
+
+      if (previous.scheduledDate === appearance.scheduledDate) {
+        const deficit = requiredAfter(previous, appearance) - gap;
+        if (deficit > 0) {
+          acc.shortRecoveryCount += 1;
+          if (deficit > acc.worstRecoveryDeficit) acc.worstRecoveryDeficit = deficit;
+        }
+        return;
+      }
+
+      // Cross-day. An overnight requirement of 0 means "no rule configured" —
+      // counting a short night against it would invent a constraint.
+      const overnightRequired = appearance.overnightMinutes ?? 0;
+      if (acc.worstOvernightReceived === undefined || gap < acc.worstOvernightReceived) {
+        acc.worstOvernightReceived = gap;
+      }
+      if (overnightRequired > 0 && gap < overnightRequired) acc.shortOvernightCount += 1;
+    });
+
+    accumulateDays(appearances, acc);
+
+    rows.push({
+      participantId,
+      participantName: participantNameMap[participantId] ?? participantId,
+      daysPlayed: acc.days.size,
+      matchesPlayed: acc.matches,
+      busiestDayMatches: acc.busiestDayMatches,
+      courtMinutes: acc.courtMinutes,
+      estimatedPct: acc.matches ? Math.round((acc.estimatedRows / acc.matches) * 100) : 0,
+      shortRecoveryCount: acc.shortRecoveryCount,
+      worstRecoveryDeficit: acc.worstRecoveryDeficit,
+      shortOvernightCount: acc.shortOvernightCount,
+      worstOvernight: acc.worstOvernightReceived,
+      meanWaitMinutes: acc.waitCount ? Math.round(acc.waitTotal / acc.waitCount) : undefined,
+      maxWaitMinutes: acc.maxWaitMinutes,
+      longestDayMinutes: acc.longestDayMinutes,
+    });
+  }
+
+  rows.sort(
+    (a, b) =>
+      b.shortRecoveryCount - a.shortRecoveryCount ||
+      b.worstRecoveryDeficit - a.worstRecoveryDeficit ||
+      (b.maxWaitMinutes ?? -Infinity) - (a.maxWaitMinutes ?? -Infinity) ||
+      String(a.participantName).localeCompare(String(b.participantName)),
+  );
+
+  return {
+    reportId: PARTICIPANT_EXPERIENCE_REPORT,
+    generatedAt: new Date().toISOString(),
+    columns,
+    rows,
+    summary: {
+      participants: rows.length,
+      appearances: totalCount,
+      participantsWithShortRecovery: rows.filter((row) => row.shortRecoveryCount > 0).length,
+      participantsWithShortOvernight: rows.filter((row) => row.shortOvernightCount > 0).length,
+      estimatedDurationPercentage: totalCount ? Math.round((estimatedCount / totalCount) * 100) : 0,
+      utcOffsetMinutes,
+    },
+  };
+}

--- a/src/query/reports/wrappers/wrapParticipantStats.ts
+++ b/src/query/reports/wrappers/wrapParticipantStats.ts
@@ -26,7 +26,11 @@ export function wrapParticipantStats({
     { key: 'tiebreaksLost', title: 'TBs Lost', type: 'number' as const },
   ];
 
+  // `participantId` is not a displayed column — consumers hide it — but it is
+  // what lets a table resolve the full participant and open a participant card,
+  // and it survives to CSV/JSON export. `getParticipantStats` already carries it.
   const rows = (result.allParticipantStats ?? []).map((stat: any) => ({
+    participantId: stat.participantId ?? '',
     participantName: stat.participantName ?? '',
     matchUpsWon: stat.matchUps?.[0] ?? 0,
     matchUpsLost: stat.matchUps?.[1] ?? 0,

--- a/src/query/reports/wrappers/wrapRecoveryTimeReport.ts
+++ b/src/query/reports/wrappers/wrapRecoveryTimeReport.ts
@@ -1,0 +1,181 @@
+import { buildRecoveryTimeline, localParts, MS_PER_MINUTE, TimelineAppearance } from '../recoveryTimeline';
+
+// Constants and Types
+import { PARTICIPANT_RECOVERY_REPORT } from '@Constants/reportConstants';
+import { Tournament } from '@Types/tournamentTypes';
+import { ReportResult } from '@Types/reportTypes';
+
+type WrapArgs = {
+  tournamentRecord: Tournament;
+  parameters?: { utcOffsetMinutes?: number; policyDefinitions?: any; asOfMs?: number };
+};
+
+/** Signed minutes between two instants, rounded to whole minutes. */
+const minutesBetween = (fromMs: number, toMs: number) => Math.round((toMs - fromMs) / MS_PER_MINUTE);
+
+/**
+ * Recovery required after `previous`, before the next matchUp begins.
+ *
+ * Recovery is a property of the matchUp just *completed* — the scheduler reads it
+ * the same way (`updateTimeAfterRecovery` computes when a participant is next
+ * free from the matchUp they have just finished). When the participant crosses
+ * singles ↔ doubles, the previous matchUp's `typeChangeRecoveryMinutes` applies
+ * instead, which is generally the larger figure.
+ */
+function requiredAfter(previous: TimelineAppearance, next: TimelineAppearance): number {
+  const typeChanged = !!previous.matchUpType && !!next.matchUpType && previous.matchUpType !== next.matchUpType;
+  if (typeChanged && previous.typeChangeRecoveryMinutes) return previous.typeChangeRecoveryMinutes;
+  return previous.recoveryMinutes;
+}
+
+/**
+ * Participant Recovery Time — one row per individual participant per matchUp
+ * played, in chronological order, spanning every day of the tournament.
+ *
+ * Each row reports what the participant actually got between this matchUp and
+ * their previous one, against what the scheduling policy required:
+ *
+ * - `recoveryReceived` / `recoveryRequired` / `recoveryDeficit` — same-day gap.
+ *   Deficit is positive when the participant was short-changed.
+ * - `overnightReceived` / `overnightRequired` — the gap from the previous day's
+ *   last finish. Invisible to the day-scoped Inspector analysis, and the rule
+ *   with the largest figure attached (12 hours, junior divisions).
+ * - `waitMinutes` — planned `scheduledTime` to actual `calledAt`. The "told
+ *   10:00, walked on at 12:40" number, projected onto the person who lived it.
+ * - `finishSource` / `durationSource` — which rung of each ladder produced the
+ *   figure, so an inferred number never reads as a measured one.
+ *
+ * `parameters.utcOffsetMinutes` is the venue's offset from UTC (local = UTC +
+ * offset); `parameters.policyDefinitions` evaluates the tournament against a
+ * policy other than the one attached to it.
+ */
+export function wrapRecoveryTimeReport({ tournamentRecord, parameters }: WrapArgs): ReportResult | { error: any } {
+  const utcOffsetMinutes = parameters?.utcOffsetMinutes ?? 0;
+  const { byParticipant, participantNameMap, estimatedCount, totalCount } = buildRecoveryTimeline({
+    policyDefinitions: parameters?.policyDefinitions,
+    asOfMs: parameters?.asOfMs,
+    utcOffsetMinutes,
+    tournamentRecord,
+  });
+
+  if (!totalCount) return { error: 'No played matchUps with resolvable times' };
+
+  const columns = [
+    { key: 'participantName', title: 'Participant', type: 'string' as const },
+    { key: 'scheduledDate', title: 'Date', type: 'date' as const, fitData: true, width: 110 },
+    { key: 'matchNumber', title: '#', type: 'number' as const, width: 60 },
+    { key: 'eventName', title: 'Event', type: 'string' as const, fitData: true },
+    { key: 'roundName', title: 'Round', type: 'string' as const, fitData: true },
+    { key: 'startTime', title: 'Start', type: 'string' as const, fitData: true },
+    { key: 'finishTime', title: 'Finish', type: 'string' as const, fitData: true },
+    { key: 'durationMinutes', title: 'On Court', type: 'number' as const, width: 90, headerWordWrap: true },
+    { key: 'durationSource', title: 'Duration From', type: 'string' as const, fitData: true, headerWordWrap: true },
+    { key: 'recoveryReceived', title: 'Recovery', type: 'number' as const, width: 90 },
+    { key: 'recoveryRequired', title: 'Required', type: 'number' as const, width: 90 },
+    { key: 'recoveryDeficit', title: 'Deficit', type: 'number' as const, width: 90 },
+    { key: 'overnightReceived', title: 'Overnight', type: 'number' as const, width: 95, headerWordWrap: true },
+    { key: 'overnightRequired', title: 'Overnight Req', type: 'number' as const, width: 95, headerWordWrap: true },
+    { key: 'waitMinutes', title: 'Wait', type: 'number' as const, width: 80 },
+    { key: 'finishSource', title: 'Finish From', type: 'string' as const, fitData: true, headerWordWrap: true },
+  ];
+
+  const rows: Record<string, any>[] = [];
+
+  for (const [participantId, appearances] of byParticipant) {
+    let ordinalDate = '';
+    let ordinal = 0;
+
+    appearances.forEach((appearance, index) => {
+      if (appearance.scheduledDate !== ordinalDate) {
+        ordinalDate = appearance.scheduledDate;
+        ordinal = 0;
+      }
+      ordinal += 1;
+
+      const previous = index > 0 ? appearances[index - 1] : undefined;
+      const sameDay = previous?.scheduledDate === appearance.scheduledDate;
+
+      const gapMinutes = previous ? minutesBetween(previous.finishMs, appearance.startMs) : undefined;
+      const required = previous ? requiredAfter(previous, appearance) : undefined;
+
+      // A same-day gap is measured against `recoveryMinutes`; a cross-day gap
+      // against `overnightMinutes`. Reporting one against the other would
+      // manufacture either a huge surplus or a huge deficit on every first
+      // matchUp of the day.
+      const recoveryReceived = previous && sameDay ? gapMinutes : undefined;
+      const recoveryRequired = previous && sameDay ? required : undefined;
+      const overnightReceived = previous && !sameDay ? gapMinutes : undefined;
+      const overnightRequired = previous && !sameDay ? appearance.overnightMinutes : undefined;
+
+      const deficit =
+        recoveryReceived !== undefined && recoveryRequired !== undefined
+          ? Math.max(0, recoveryRequired - recoveryReceived)
+          : undefined;
+
+      const waitMinutes =
+        appearance.scheduledMs !== undefined && appearance.calledMs !== undefined
+          ? minutesBetween(appearance.scheduledMs, appearance.calledMs)
+          : undefined;
+
+      rows.push({
+        // Location ids for navigation; hidden by consumers, retained in export.
+        structureId: appearance.structureId,
+        matchUpId: appearance.matchUpId,
+        eventId: appearance.eventId,
+        drawId: appearance.drawId,
+
+        participantId,
+        participantName: participantNameMap[participantId] ?? participantId,
+        scheduledDate: appearance.scheduledDate,
+        matchNumber: ordinal,
+        eventName: appearance.eventName,
+        drawName: appearance.drawName,
+        roundName: appearance.roundName,
+        startTime: localParts(appearance.startMs, utcOffsetMinutes).time,
+        finishTime: localParts(appearance.finishMs, utcOffsetMinutes).time,
+        durationMinutes: appearance.durationMinutes,
+        durationSource: appearance.durationSource,
+        recoveryReceived,
+        recoveryRequired,
+        recoveryDeficit: deficit,
+        overnightReceived,
+        overnightRequired,
+        waitMinutes,
+        finishSource: appearance.finishSource,
+      });
+    });
+  }
+
+  // Worst experience first: largest deficit, then longest wait — an operator
+  // opening this report is looking for who was treated worst, not for row one.
+  rows.sort(
+    (a, b) =>
+      (b.recoveryDeficit ?? -1) - (a.recoveryDeficit ?? -1) ||
+      (b.waitMinutes ?? -Infinity) - (a.waitMinutes ?? -Infinity) ||
+      String(a.participantName).localeCompare(String(b.participantName)) ||
+      a.scheduledDate.localeCompare(b.scheduledDate) ||
+      a.matchNumber - b.matchNumber,
+  );
+
+  const deficits = rows.map((row) => row.recoveryDeficit).filter((value) => typeof value === 'number');
+  const shortRecoveries = deficits.filter((value) => value > 0);
+
+  return {
+    reportId: PARTICIPANT_RECOVERY_REPORT,
+    generatedAt: new Date().toISOString(),
+    columns,
+    rows,
+    summary: {
+      appearances: totalCount,
+      participants: byParticipant.size,
+      shortRecoveryCount: shortRecoveries.length,
+      worstRecoveryDeficit: shortRecoveries.length ? Math.max(...shortRecoveries) : 0,
+      // What proportion of the court time in this report is the scheduling
+      // policy's prediction rather than an observation. Without this, an average
+      // built mostly from estimates reads as a finding.
+      estimatedDurationCount: estimatedCount,
+      estimatedDurationPercentage: totalCount ? Math.round((estimatedCount / totalCount) * 100) : 0,
+      utcOffsetMinutes,
+    },
+  };
+}

--- a/src/query/reports/wrappers/wrapRecoveryTimeReport.ts
+++ b/src/query/reports/wrappers/wrapRecoveryTimeReport.ts
@@ -7,7 +7,7 @@ import { ReportResult } from '@Types/reportTypes';
 
 type WrapArgs = {
   tournamentRecord: Tournament;
-  parameters?: { utcOffsetMinutes?: number; policyDefinitions?: any; asOfMs?: number };
+  parameters?: { utcOffsetMinutes?: number; timeZone?: string; policyDefinitions?: any; asOfMs?: number };
 };
 
 /** Signed minutes between two instants, rounded to whole minutes. */
@@ -51,11 +51,13 @@ function requiredAfter(previous: TimelineAppearance, next: TimelineAppearance): 
  */
 export function wrapRecoveryTimeReport({ tournamentRecord, parameters }: WrapArgs): ReportResult | { error: any } {
   const utcOffsetMinutes = parameters?.utcOffsetMinutes ?? 0;
+  const timeZone = parameters?.timeZone;
   const { byParticipant, participantNameMap, estimatedCount, totalCount } = buildRecoveryTimeline({
     policyDefinitions: parameters?.policyDefinitions,
     asOfMs: parameters?.asOfMs,
     utcOffsetMinutes,
     tournamentRecord,
+    timeZone,
   });
 
   if (!totalCount) return { error: 'No played matchUps with resolvable times' };
@@ -79,6 +81,7 @@ export function wrapRecoveryTimeReport({ tournamentRecord, parameters }: WrapArg
     { key: 'finishSource', title: 'Finish From', type: 'string' as const, fitData: true, headerWordWrap: true },
   ];
 
+  const frame = { utcOffsetMinutes, timeZone };
   const rows: Record<string, any>[] = [];
 
   for (const [participantId, appearances] of byParticipant) {
@@ -131,8 +134,8 @@ export function wrapRecoveryTimeReport({ tournamentRecord, parameters }: WrapArg
         eventName: appearance.eventName,
         drawName: appearance.drawName,
         roundName: appearance.roundName,
-        startTime: localParts(appearance.startMs, utcOffsetMinutes).time,
-        finishTime: localParts(appearance.finishMs, utcOffsetMinutes).time,
+        startTime: localParts(appearance.startMs, frame).time,
+        finishTime: localParts(appearance.finishMs, frame).time,
         durationMinutes: appearance.durationMinutes,
         durationSource: appearance.durationSource,
         recoveryReceived,
@@ -176,6 +179,7 @@ export function wrapRecoveryTimeReport({ tournamentRecord, parameters }: WrapArg
       estimatedDurationCount: estimatedCount,
       estimatedDurationPercentage: totalCount ? Math.round((estimatedCount / totalCount) * 100) : 0,
       utcOffsetMinutes,
+      timeZone,
     },
   };
 }

--- a/src/tests/mutations/scheduling/matchUpFormatTimingPolicyOverride.test.ts
+++ b/src/tests/mutations/scheduling/matchUpFormatTimingPolicyOverride.test.ts
@@ -1,0 +1,106 @@
+import { getMatchUpFormatTiming } from '@Query/extensions/matchUpFormatTiming/getMatchUpFormatTiming';
+import { getScheduleTiming } from '@Query/extensions/matchUpFormatTiming/getScheduleTiming';
+import mocksEngine from '@Assemblies/engines/mock';
+import { describe, expect, it } from 'vitest';
+
+import { POLICY_TYPE_SCHEDULING } from '@Constants/policyConstants';
+import { DOUBLES_EVENT } from '@Constants/eventConstants';
+
+const MATCHUP_FORMAT = 'SET3-S:6/TB7';
+
+// POLICY_SCHEDULING_DEFAULT gives DOUBLES 30 minutes of recovery for this
+// format. Both policies below are deliberately different from that default AND
+// from each other, so neither result can be produced by accident.
+const ATTACHED_RECOVERY = 45;
+const OVERRIDE_RECOVERY = 75;
+
+const schedulingPolicy = (recoveryMinutes: number) => ({
+  [POLICY_TYPE_SCHEDULING]: {
+    defaultTimes: {
+      averageTimes: [{ categoryNames: [], minutes: { default: 90 } }],
+      recoveryTimes: [{ minutes: { default: recoveryMinutes } }],
+    },
+  },
+});
+
+function tournamentWithAttachedPolicy() {
+  const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+    policyDefinitions: schedulingPolicy(ATTACHED_RECOVERY),
+    eventProfiles: [
+      {
+        drawProfiles: [{ drawSize: 4, matchUpFormat: MATCHUP_FORMAT }],
+        eventType: DOUBLES_EVENT,
+        eventName: 'Doubles',
+      },
+    ],
+  });
+  return { tournamentRecord, event: tournamentRecord.events?.[0] };
+}
+
+/**
+ * `getScheduleTiming` read the attached scheduling policy and offered no way to
+ * substitute one, unlike `allEventMatchUps` / `getParticipantEntries` and the
+ * rest of the query surface. A report therefore could not answer "what would
+ * this tournament look like under a *different* policy" without mutating it.
+ */
+describe('getScheduleTiming — policyDefinitions override', () => {
+  it('resolves the attached policy when no override is supplied', () => {
+    const { tournamentRecord, event } = tournamentWithAttachedPolicy();
+    const timing: any = getMatchUpFormatTiming({
+      matchUpFormat: MATCHUP_FORMAT,
+      eventType: DOUBLES_EVENT,
+      tournamentRecord,
+      event,
+    });
+    expect(timing.recoveryMinutes).toEqual(ATTACHED_RECOVERY);
+  });
+
+  it('a supplied policy wins over the attached one', () => {
+    const { tournamentRecord, event } = tournamentWithAttachedPolicy();
+    const timing: any = getMatchUpFormatTiming({
+      policyDefinitions: schedulingPolicy(OVERRIDE_RECOVERY),
+      matchUpFormat: MATCHUP_FORMAT,
+      eventType: DOUBLES_EVENT,
+      tournamentRecord,
+      event,
+    });
+    // Falsification: this differs from BOTH the attached policy and the
+    // POLICY_SCHEDULING_DEFAULT figure, so it cannot be a passthrough or a
+    // fallback masquerading as an override.
+    expect(timing.recoveryMinutes).toEqual(OVERRIDE_RECOVERY);
+    expect(timing.recoveryMinutes).not.toEqual(ATTACHED_RECOVERY);
+  });
+
+  it('surfaces the supplied policy on scheduleTiming itself', () => {
+    const { tournamentRecord, event } = tournamentWithAttachedPolicy();
+    const override = schedulingPolicy(OVERRIDE_RECOVERY);
+    const { scheduleTiming }: any = getScheduleTiming({
+      policyDefinitions: override,
+      tournamentRecord,
+      event,
+    });
+    expect(scheduleTiming.policy).toEqual(override[POLICY_TYPE_SCHEDULING]);
+  });
+
+  it('leaves resolution untouched for a tournament with no attached policy', () => {
+    const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+      eventProfiles: [
+        {
+          drawProfiles: [{ drawSize: 4, matchUpFormat: MATCHUP_FORMAT }],
+          eventType: DOUBLES_EVENT,
+          eventName: 'Doubles',
+        },
+      ],
+    });
+    const event = tournamentRecord.events?.[0];
+    const timing: any = getMatchUpFormatTiming({
+      matchUpFormat: MATCHUP_FORMAT,
+      eventType: DOUBLES_EVENT,
+      tournamentRecord,
+      event,
+    });
+    // POLICY_SCHEDULING_DEFAULT's DOUBLES figure — the existing fallback, proving
+    // the added parameter changes nothing when it is absent.
+    expect(timing.recoveryMinutes).toEqual(30);
+  });
+});

--- a/src/tests/mutations/scheduling/overnightAndBandedRecovery.test.ts
+++ b/src/tests/mutations/scheduling/overnightAndBandedRecovery.test.ts
@@ -1,5 +1,5 @@
-import { getMatchUpFormatTiming } from '@Query/extensions/matchUpFormatTiming/getMatchUpFormatTiming';
 import { getBandedRecoveryMinutes } from '@Query/extensions/matchUpFormatTiming/getBandedRecoveryMinutes';
+import { getMatchUpFormatTiming } from '@Query/extensions/matchUpFormatTiming/getMatchUpFormatTiming';
 import mocksEngine from '@Assemblies/engines/mock';
 import { describe, expect, it } from 'vitest';
 

--- a/src/tests/mutations/scheduling/overnightAndBandedRecovery.test.ts
+++ b/src/tests/mutations/scheduling/overnightAndBandedRecovery.test.ts
@@ -1,0 +1,183 @@
+import { getMatchUpFormatTiming } from '@Query/extensions/matchUpFormatTiming/getMatchUpFormatTiming';
+import { getBandedRecoveryMinutes } from '@Query/extensions/matchUpFormatTiming/getBandedRecoveryMinutes';
+import mocksEngine from '@Assemblies/engines/mock';
+import { describe, expect, it } from 'vitest';
+
+import { POLICY_TYPE_SCHEDULING } from '@Constants/policyConstants';
+import { DOUBLES_EVENT } from '@Constants/eventConstants';
+import { SINGLES_EVENT } from '@Constants/eventConstants';
+
+const MATCHUP_FORMAT = 'SET3-S:6/TB7';
+const JUNIOR = 'JUNIOR';
+const ADULT = 'ADULT';
+
+function tournamentWith({ categoryType, policyDefinitions }: any = {}) {
+  const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+    ...(policyDefinitions && { policyDefinitions }),
+    eventProfiles: [
+      {
+        ...(categoryType && { category: { categoryType } }),
+        drawProfiles: [{ drawSize: 4, matchUpFormat: MATCHUP_FORMAT }],
+        eventType: SINGLES_EVENT,
+        eventName: 'Singles',
+      },
+    ],
+  });
+  return { tournamentRecord, event: tournamentRecord.events?.[0] };
+}
+
+describe('overnight recovery', () => {
+  it('resolves the 12-hour junior figure from POLICY_SCHEDULING_DEFAULT', () => {
+    const { tournamentRecord, event } = tournamentWith({ categoryType: JUNIOR });
+    const timing: any = getMatchUpFormatTiming({
+      matchUpFormat: MATCHUP_FORMAT,
+      eventType: SINGLES_EVENT,
+      tournamentRecord,
+      event,
+    });
+    expect(timing.overnightMinutes).toEqual(720);
+  });
+
+  it('resolves no overnight constraint for adult play, so junior is not a constant', () => {
+    const { tournamentRecord, event } = tournamentWith({ categoryType: ADULT });
+    const timing: any = getMatchUpFormatTiming({
+      matchUpFormat: MATCHUP_FORMAT,
+      eventType: SINGLES_EVENT,
+      tournamentRecord,
+      event,
+    });
+    expect(timing.overnightMinutes).toEqual(0);
+  });
+
+  it('honours an overnight figure supplied via policyDefinitions', () => {
+    const policyDefinitions = {
+      [POLICY_TYPE_SCHEDULING]: {
+        defaultTimes: {
+          averageTimes: [{ categoryNames: [], minutes: { default: 90 } }],
+          recoveryTimes: [{ minutes: { default: 60 } }],
+          overnightTimes: [{ minutes: { default: 600 } }],
+        },
+      },
+    };
+    const { tournamentRecord, event } = tournamentWith({ categoryType: JUNIOR });
+    const timing: any = getMatchUpFormatTiming({
+      matchUpFormat: MATCHUP_FORMAT,
+      eventType: SINGLES_EVENT,
+      tournamentRecord,
+      policyDefinitions,
+      event,
+    });
+    // 600, not the default policy's 720 — the supplied policy wins even for a
+    // JUNIOR event, which the default policy would otherwise answer.
+    expect(timing.overnightMinutes).toEqual(600);
+  });
+});
+
+describe('getBandedRecoveryMinutes', () => {
+  // The long-standing USTA table: rest scales with how long the match ran.
+  const usta = [{ upTo: 60, minutes: 30 }, { upTo: 90, minutes: 60 }, { minutes: 90 }];
+
+  it('selects the band the played duration falls in', () => {
+    expect(getBandedRecoveryMinutes({ byPlayedMinutes: usta, playedMinutes: 45 })).toEqual(30);
+    expect(getBandedRecoveryMinutes({ byPlayedMinutes: usta, playedMinutes: 75 })).toEqual(60);
+    expect(getBandedRecoveryMinutes({ byPlayedMinutes: usta, playedMinutes: 150 })).toEqual(90);
+  });
+
+  it('treats upTo as inclusive', () => {
+    expect(getBandedRecoveryMinutes({ byPlayedMinutes: usta, playedMinutes: 60 })).toEqual(30);
+    expect(getBandedRecoveryMinutes({ byPlayedMinutes: usta, playedMinutes: 61 })).toEqual(60);
+  });
+
+  it('is order-independent — the table may be authored in any order', () => {
+    const shuffled = [{ minutes: 90 }, { upTo: 90, minutes: 60 }, { upTo: 60, minutes: 30 }];
+    expect(getBandedRecoveryMinutes({ byPlayedMinutes: shuffled, playedMinutes: 45 })).toEqual(30);
+    // The input array must not be reordered in place — policy fixtures are shared.
+    expect(shuffled[0]).toEqual({ minutes: 90 });
+  });
+
+  it('returns undefined without a measured duration — the opt-in that keeps scheduling unchanged', () => {
+    expect(getBandedRecoveryMinutes({ byPlayedMinutes: usta })).toBeUndefined();
+    expect(getBandedRecoveryMinutes({ byPlayedMinutes: usta, playedMinutes: undefined })).toBeUndefined();
+    expect(getBandedRecoveryMinutes({ byPlayedMinutes: usta, playedMinutes: -1 })).toBeUndefined();
+    expect(getBandedRecoveryMinutes({ byPlayedMinutes: usta, playedMinutes: NaN })).toBeUndefined();
+  });
+
+  it('returns undefined without a banded table', () => {
+    expect(getBandedRecoveryMinutes({ playedMinutes: 45 })).toBeUndefined();
+    expect(getBandedRecoveryMinutes({ byPlayedMinutes: [], playedMinutes: 45 })).toBeUndefined();
+  });
+
+  it('returns undefined when no band covers the duration', () => {
+    expect(
+      getBandedRecoveryMinutes({ byPlayedMinutes: [{ upTo: 30, minutes: 15 }], playedMinutes: 200 }),
+    ).toBeUndefined();
+  });
+});
+
+describe('banded recovery through getMatchUpFormatTiming', () => {
+  const bandedPolicy = {
+    [POLICY_TYPE_SCHEDULING]: {
+      defaultTimes: {
+        averageTimes: [{ categoryNames: [], minutes: { default: 90 } }],
+        recoveryTimes: [
+          {
+            minutes: { default: 60 },
+            byPlayedMinutes: [{ upTo: 60, minutes: 30 }, { minutes: 120 }],
+          },
+        ],
+      },
+    },
+  };
+
+  it('uses the flat figure when no playedMinutes is supplied — every scheduler call site', () => {
+    const { tournamentRecord, event } = tournamentWith({});
+    const timing: any = getMatchUpFormatTiming({
+      policyDefinitions: bandedPolicy,
+      matchUpFormat: MATCHUP_FORMAT,
+      eventType: SINGLES_EVENT,
+      tournamentRecord,
+      event,
+    });
+    expect(timing.recoveryMinutes).toEqual(60);
+    expect(timing.recoveryFromPlayedMinutes).toBe(false);
+  });
+
+  it('uses the band when a measured duration is supplied', () => {
+    const { tournamentRecord, event } = tournamentWith({});
+    const short: any = getMatchUpFormatTiming({
+      policyDefinitions: bandedPolicy,
+      matchUpFormat: MATCHUP_FORMAT,
+      eventType: SINGLES_EVENT,
+      tournamentRecord,
+      playedMinutes: 40,
+      event,
+    });
+    const long: any = getMatchUpFormatTiming({
+      policyDefinitions: bandedPolicy,
+      matchUpFormat: MATCHUP_FORMAT,
+      eventType: SINGLES_EVENT,
+      tournamentRecord,
+      playedMinutes: 180,
+      event,
+    });
+    // Both differ from the flat 60 and from each other, so neither can be a
+    // passthrough of the untouched figure.
+    expect(short.recoveryMinutes).toEqual(30);
+    expect(long.recoveryMinutes).toEqual(120);
+    expect(short.recoveryFromPlayedMinutes).toBe(true);
+  });
+
+  it('ignores playedMinutes when the policy authors no bands', () => {
+    const { tournamentRecord, event } = tournamentWith({});
+    const timing: any = getMatchUpFormatTiming({
+      matchUpFormat: MATCHUP_FORMAT,
+      eventType: DOUBLES_EVENT,
+      tournamentRecord,
+      playedMinutes: 40,
+      event,
+    });
+    // POLICY_SCHEDULING_DEFAULT's DOUBLES figure, unbanded.
+    expect(timing.recoveryMinutes).toEqual(30);
+    expect(timing.recoveryFromPlayedMinutes).toBe(false);
+  });
+});

--- a/src/tests/queries/reports/generateReport.test.ts
+++ b/src/tests/queries/reports/generateReport.test.ts
@@ -89,6 +89,14 @@ describe('generateReport', () => {
     expect(result.reportId).toBe(PARTICIPANT_STATS_REPORT);
     expect(Array.isArray(result.columns)).toBe(true);
     expect(Array.isArray(result.rows)).toBe(true);
+
+    // Every row carries participantId even though no column displays it: it is
+    // what lets a consumer resolve the participant and open a participant card,
+    // and it survives to CSV/JSON export. Asserted non-empty rather than merely
+    // present, since `?? ''` would satisfy a key-existence check.
+    expect(result.rows.length).toBeGreaterThan(0);
+    for (const row of result.rows) expect(row.participantId).toBeTruthy();
+    expect(result.columns.some((column: any) => column.key === 'participantId')).toBe(false);
   });
 
   it('returns error for unknown reportId', () => {

--- a/src/tests/queries/reports/participantExperienceReport.test.ts
+++ b/src/tests/queries/reports/participantExperienceReport.test.ts
@@ -1,0 +1,224 @@
+import { PARTICIPANT_EXPERIENCE_REPORT, PARTICIPANT_RECOVERY_REPORT } from '@Constants/reportConstants';
+import { POLICY_TYPE_SCHEDULING } from '@Constants/policyConstants';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+const DAY1 = '2026-08-20';
+const DAY2 = '2026-08-21';
+
+function seedTwoDays({ categoryType, day2Start = '06:00' }: { categoryType?: string; day2Start?: string } = {}) {
+  mocksEngine.generateTournamentRecord({
+    eventProfiles: [
+      {
+        ...(categoryType && { category: { categoryType } }),
+        drawProfiles: [{ drawSize: 4, matchUpFormat: 'SET3-S:6/TB7' }],
+        eventName: 'Singles',
+      },
+    ],
+    completeAllMatchUps: true,
+    startDate: DAY1,
+    endDate: DAY2,
+    setState: true,
+    nonRandom: 1,
+  });
+
+  const matchUps = tournamentEngine.allTournamentMatchUps({}).matchUps ?? [];
+  const first: any = matchUps.find((m: any) => m.roundNumber === 1);
+  const final: any = matchUps.find((m: any) => m.roundNumber === 2);
+  const winnerId = first.sides.find((s: any) => s.sideNumber === first.winningSide)?.participantId;
+
+  const place = (matchUp: any, scheduledDate: string, scheduledTime: string, startTime: string, endTime?: string) => {
+    tournamentEngine.addMatchUpScheduledDate({
+      matchUpId: matchUp.matchUpId,
+      drawId: matchUp.drawId,
+      scheduledDate,
+    });
+    tournamentEngine.addMatchUpScheduledTime({
+      matchUpId: matchUp.matchUpId,
+      drawId: matchUp.drawId,
+      scheduledTime,
+    });
+    tournamentEngine.addMatchUpStartTime({ drawId: matchUp.drawId, matchUpId: matchUp.matchUpId, startTime });
+    if (endTime) tournamentEngine.addMatchUpEndTime({ drawId: matchUp.drawId, matchUpId: matchUp.matchUpId, endTime });
+  };
+
+  // Day one: expected 09:00, played 20:00–22:00 — an eleven-hour day, most of it
+  // spent waiting, and two hours of it on court.
+  place(first, DAY1, '09:00', '20:00', '22:00');
+  place(final, DAY2, day2Start, day2Start);
+
+  return { winnerId };
+}
+
+const experience = (winnerId: string) => {
+  const result: any = tournamentEngine.generateReport({
+    reportId: PARTICIPANT_EXPERIENCE_REPORT,
+    parameters: { utcOffsetMinutes: 0 },
+  });
+  return { result, row: result.rows.find((r: any) => r.participantId === winnerId) };
+};
+
+describe('Participant Experience — overnight', () => {
+  it('flags a short night for a JUNIOR event, where the 12-hour rule applies', () => {
+    // 22:00 to 06:00 is eight hours against the 720-minute junior requirement in
+    // POLICY_SCHEDULING_DEFAULT.
+    const { winnerId } = seedTwoDays({ categoryType: 'JUNIOR' });
+    const { result, row } = experience(winnerId);
+
+    expect(row.worstOvernight).toEqual(8 * 60);
+    expect(row.shortOvernightCount).toEqual(1);
+    expect(result.summary.participantsWithShortOvernight).toBeGreaterThan(0);
+  });
+
+  it('does NOT flag the same night for an ADULT event, where no rule is configured', () => {
+    // The identical eight-hour turnaround. An overnight requirement of 0 means
+    // "no rule" — counting it would invent a constraint the policy never stated.
+    const { winnerId } = seedTwoDays({ categoryType: 'ADULT' });
+    const { result, row } = experience(winnerId);
+
+    expect(row.worstOvernight).toEqual(8 * 60);
+    expect(row.shortOvernightCount).toEqual(0);
+    expect(result.summary.participantsWithShortOvernight).toEqual(0);
+  });
+
+  it('does not flag a JUNIOR night that clears the requirement', () => {
+    // 22:00 to 11:00 is thirteen hours — over the twelve required.
+    const { winnerId } = seedTwoDays({ categoryType: 'JUNIOR', day2Start: '11:00' });
+    const { row } = experience(winnerId);
+    expect(row.worstOvernight).toEqual(13 * 60);
+    expect(row.shortOvernightCount).toEqual(0);
+  });
+});
+
+describe('Participant Experience — waiting and day length', () => {
+  it('measures the day from when the participant was expected, not when they played', () => {
+    const { winnerId } = seedTwoDays({ categoryType: 'ADULT' });
+    const { row } = experience(winnerId);
+
+    // Told 09:00, finished 22:00 — thirteen hours of the participant's day,
+    // of which two were on court. Anchoring on the first START would report
+    // two hours and erase the eleven spent waiting.
+    expect(row.longestDayMinutes).toEqual(13 * 60);
+    expect(row.courtMinutes).toBeGreaterThan(0);
+    expect(row.daysPlayed).toEqual(2);
+    expect(row.matchesPlayed).toEqual(2);
+    expect(row.busiestDayMatches).toEqual(1);
+  });
+
+  it('reports mean and max wait from planned time to actual call', () => {
+    const { winnerId } = seedTwoDays({ categoryType: 'ADULT' });
+    const matchUps = tournamentEngine.allTournamentMatchUps({}).matchUps ?? [];
+    const first: any = matchUps.find((m: any) => m.roundNumber === 1);
+
+    // Planned 09:00, called 12:00 — the "told 10:00, walked on at 12:40" number.
+    const called = tournamentEngine.setMatchUpCalledAt({
+      calledAt: `${DAY1}T12:00:00.000Z`,
+      matchUpId: first.matchUpId,
+      drawId: first.drawId,
+    });
+    expect(called.error).toBeUndefined();
+
+    const { row } = experience(winnerId);
+    // Only one matchUp carries a call, so mean and max are the same 180 minutes.
+    expect(row.maxWaitMinutes).toEqual(180);
+    expect(row.meanWaitMinutes).toEqual(180);
+  });
+
+  it('leaves wait undefined when nothing was ever called to court', () => {
+    const { winnerId } = seedTwoDays({ categoryType: 'ADULT' });
+    const { row } = experience(winnerId);
+    // Absent, not zero — a matchUp never called has no wait, and reporting 0
+    // would read as "called exactly on time".
+    expect(row.maxWaitMinutes).toBeUndefined();
+    expect(row.meanWaitMinutes).toBeUndefined();
+  });
+});
+
+describe('Participant Experience — singles/doubles type change', () => {
+  it('applies the larger type-change recovery when a participant crosses formats', () => {
+    // POLICY_SCHEDULING_DEFAULT recovery: DOUBLES 30, singles 60. A policy with an
+    // explicit DOUBLES_SINGLES figure proves the crossing is detected rather than
+    // the plain doubles recovery being reused.
+    const policyDefinitions = {
+      [POLICY_TYPE_SCHEDULING]: {
+        defaultTimes: {
+          averageTimes: [{ categoryNames: [], minutes: { default: 90 } }],
+          recoveryTimes: [{ minutes: { DOUBLES: 30, DOUBLES_SINGLES: 120, default: 60 } }],
+        },
+      },
+    };
+
+    mocksEngine.generateTournamentRecord({
+      drawProfiles: [
+        { drawSize: 4, eventName: 'Doubles', eventType: 'DOUBLES' },
+        { drawSize: 8, eventName: 'Singles' },
+      ],
+      completeAllMatchUps: true,
+      startDate: DAY1,
+      endDate: DAY1,
+      setState: true,
+      nonRandom: 1,
+    });
+
+    const matchUps: any[] = tournamentEngine.allTournamentMatchUps({ inContext: true }).matchUps ?? [];
+    const individualsOf = (matchUp: any): string[] =>
+      (matchUp.sides ?? []).flatMap((side: any) =>
+        matchUp.matchUpType === 'DOUBLES'
+          ? (side.participant?.individualParticipantIds ?? [])
+          : [side.participantId].filter(Boolean),
+      );
+
+    // Find a real crossing rather than assuming the two draws share players —
+    // separate drawProfiles need not draw from overlapping pools, and a test
+    // that silently found none would assert nothing.
+    let pair: { doubles: any; singles: any } | undefined;
+    for (const doubles of matchUps.filter((m) => m.matchUpType === 'DOUBLES')) {
+      const ids = new Set(individualsOf(doubles));
+      const singles = matchUps.find((m) => m.matchUpType === 'SINGLES' && individualsOf(m).some((id) => ids.has(id)));
+      if (singles) {
+        pair = { doubles, singles };
+        break;
+      }
+    }
+    expect(pair, 'seed produced no participant playing both doubles and singles').toBeTruthy();
+
+    tournamentEngine.addMatchUpScheduledDate({
+      matchUpId: pair!.doubles.matchUpId,
+      drawId: pair!.doubles.drawId,
+      scheduledDate: DAY1,
+    });
+    tournamentEngine.addMatchUpStartTime({
+      matchUpId: pair!.doubles.matchUpId,
+      drawId: pair!.doubles.drawId,
+      startTime: '09:00',
+    });
+    tournamentEngine.addMatchUpEndTime({
+      matchUpId: pair!.doubles.matchUpId,
+      drawId: pair!.doubles.drawId,
+      endTime: '10:00',
+    });
+    tournamentEngine.addMatchUpScheduledDate({
+      matchUpId: pair!.singles.matchUpId,
+      drawId: pair!.singles.drawId,
+      scheduledDate: DAY1,
+    });
+    tournamentEngine.addMatchUpStartTime({
+      matchUpId: pair!.singles.matchUpId,
+      drawId: pair!.singles.drawId,
+      startTime: '10:30',
+    });
+
+    const result: any = tournamentEngine.generateReport({
+      reportId: PARTICIPANT_RECOVERY_REPORT,
+      parameters: { utcOffsetMinutes: 0, policyDefinitions },
+    });
+    expect(result.error).toBeUndefined();
+
+    // The crossing participant is measured against 120, not the plain doubles 30.
+    const crossings = result.rows.filter((r: any) => r.matchNumber === 2 && r.recoveryRequired === 120);
+    expect(crossings.length).toBeGreaterThan(0);
+    expect(crossings.every((r: any) => r.recoveryReceived === 30)).toBe(true);
+    expect(crossings.every((r: any) => r.recoveryDeficit === 90)).toBe(true);
+  });
+});

--- a/src/tests/queries/reports/recoveryTimeReport.test.ts
+++ b/src/tests/queries/reports/recoveryTimeReport.test.ts
@@ -220,7 +220,10 @@ describe('Participant Experience report', () => {
       rollup.rows.filter((r: any) => r.shortRecoveryCount > 0).map((r: any) => r.participantId),
     );
     // Both derive from one core; a divergence means the roll-up drifted.
-    expect([...shortInRollup].sort()).toEqual([...shortInLog].sort());
+    // Explicit comparator: a bare `.sort()` coerces to string and orders wrong
+    // without saying so — house rule.
+    const ordered = (ids: Set<string>) => [...ids].sort((a, b) => a.localeCompare(b));
+    expect(ordered(shortInRollup)).toEqual(ordered(shortInLog));
   });
 
   it('does not count a short night when no overnight rule is configured', () => {

--- a/src/tests/queries/reports/recoveryTimeReport.test.ts
+++ b/src/tests/queries/reports/recoveryTimeReport.test.ts
@@ -233,3 +233,79 @@ describe('Participant Experience report', () => {
     expect(row.shortOvernightCount).toEqual(0);
   });
 });
+
+describe('DST', () => {
+  /**
+   * A tournament straddling the US spring-forward (2026-03-08). The clock jumps
+   * 02:00 → 03:00, so 22:00 on the 7th to 08:00 on the 8th is NINE hours
+   * elapsed, not ten. A single `utcOffsetMinutes` cannot express both sides of
+   * the change and reports ten — a silent 60-minute error in a report whose
+   * entire subject is minutes.
+   */
+  const SAT = '2026-03-07';
+  const SUN = '2026-03-08';
+  const NY = 'America/New_York';
+
+  function seedAcrossTransition() {
+    mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 4, eventName: 'Singles', matchUpFormat: 'SET3-S:6/TB7' }],
+      completeAllMatchUps: true,
+      startDate: SAT,
+      endDate: SUN,
+      setState: true,
+      nonRandom: 1,
+    });
+    const matchUps = tournamentEngine.allTournamentMatchUps({}).matchUps ?? [];
+    const first: any = matchUps.find((m: any) => m.roundNumber === 1);
+    const final: any = matchUps.find((m: any) => m.roundNumber === 2);
+    const winnerId = first.sides.find((s: any) => s.sideNumber === first.winningSide)?.participantId;
+
+    const place = (matchUp: any, scheduledDate: string, startTime: string, endTime?: string) => {
+      tournamentEngine.addMatchUpScheduledDate({
+        matchUpId: matchUp.matchUpId,
+        drawId: matchUp.drawId,
+        scheduledDate,
+      });
+      tournamentEngine.addMatchUpStartTime({ drawId: matchUp.drawId, matchUpId: matchUp.matchUpId, startTime });
+      if (endTime)
+        tournamentEngine.addMatchUpEndTime({ drawId: matchUp.drawId, matchUpId: matchUp.matchUpId, endTime });
+    };
+
+    place(first, SAT, '20:00', '22:00');
+    place(final, SUN, '08:00');
+    return { winnerId };
+  }
+
+  const overnightFor = (winnerId: string, parameters: any) => {
+    const result: any = tournamentEngine.generateReport({ reportId: PARTICIPANT_RECOVERY_REPORT, parameters });
+    return result.rows.find((r: any) => r.participantId === winnerId && r.scheduledDate === SUN)?.overnightReceived;
+  };
+
+  it('measures the true elapsed turnaround across a spring-forward when given a zone', () => {
+    const { winnerId } = seedAcrossTransition();
+    // 22:00 EST → 08:00 EDT is nine hours of actual rest.
+    expect(overnightFor(winnerId, { timeZone: NY })).toEqual(9 * 60);
+  });
+
+  it('is wrong by exactly the DST hour when given only a fixed offset', () => {
+    const { winnerId } = seedAcrossTransition();
+    // The failure this parameter exists to fix, pinned so it cannot regress
+    // unnoticed: a fixed EST offset reports ten hours for a nine-hour night.
+    expect(overnightFor(winnerId, { utcOffsetMinutes: -300 })).toEqual(10 * 60);
+  });
+
+  it('reports venue-local clock times per instant on both sides of the change', () => {
+    const { winnerId } = seedAcrossTransition();
+    const result: any = tournamentEngine.generateReport({
+      reportId: PARTICIPANT_RECOVERY_REPORT,
+      parameters: { timeZone: NY },
+    });
+    const saturday = result.rows.find((r: any) => r.participantId === winnerId && r.scheduledDate === SAT);
+    const sunday = result.rows.find((r: any) => r.participantId === winnerId && r.scheduledDate === SUN);
+    // The operator saw these clock faces; both must read back unchanged even
+    // though the two instants sit in different offsets.
+    expect(saturday.startTime).toEqual('20:00');
+    expect(saturday.finishTime).toEqual('22:00');
+    expect(sunday.startTime).toEqual('08:00');
+  });
+});

--- a/src/tests/queries/reports/recoveryTimeReport.test.ts
+++ b/src/tests/queries/reports/recoveryTimeReport.test.ts
@@ -1,0 +1,235 @@
+import { PARTICIPANT_EXPERIENCE_REPORT, PARTICIPANT_RECOVERY_REPORT } from '@Constants/reportConstants';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+const DATE = '2026-08-20';
+const NEXT_DATE = '2026-08-21';
+
+/**
+ * Build a tournament in which ONE known individual plays two matchUps whose gap
+ * we control exactly, so a deficit can be asserted rather than hoped for.
+ *
+ * Everything is written as venue-local wall clock and read back with
+ * `utcOffsetMinutes: 0`, so the arithmetic is frame-independent and the test
+ * holds in any timezone rather than only under TZ=UTC.
+ */
+function seedTwoMatchDay({ secondStart, secondDate = DATE }: { secondStart: string; secondDate?: string }) {
+  // The tournament must span both dates: `addMatchUpScheduledDate` rejects a
+  // date outside start/end with ERR_INVALID_DATE, and a matchUp with no
+  // scheduledDate is undatable and correctly excluded from the timeline.
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ drawSize: 4, eventName: 'Singles', matchUpFormat: 'SET3-S:6/TB7' }],
+    completeAllMatchUps: true,
+    endDate: NEXT_DATE,
+    startDate: DATE,
+    setState: true,
+    nonRandom: 1,
+  });
+
+  const matchUps = tournamentEngine.allTournamentMatchUps({}).matchUps ?? [];
+  const first = matchUps.find((m: any) => m.roundNumber === 1);
+  const final = matchUps.find((m: any) => m.roundNumber === 2);
+
+  // The R1 winner is the individual who appears in both matchUps.
+  const winnerId = first.sides.find((s: any) => s.sideNumber === first.winningSide)?.participantId;
+
+  const schedule = (matchUp: any, { scheduledTime, startTime, endTime, scheduledDate }: any) => {
+    tournamentEngine.addMatchUpScheduledTime({
+      drawId: matchUp.drawId,
+      matchUpId: matchUp.matchUpId,
+      scheduledTime,
+    });
+    tournamentEngine.addMatchUpScheduledDate({
+      drawId: matchUp.drawId,
+      matchUpId: matchUp.matchUpId,
+      scheduledDate,
+    });
+    tournamentEngine.addMatchUpStartTime({ drawId: matchUp.drawId, matchUpId: matchUp.matchUpId, startTime });
+    if (endTime) tournamentEngine.addMatchUpEndTime({ drawId: matchUp.drawId, matchUpId: matchUp.matchUpId, endTime });
+  };
+
+  schedule(first, { scheduledDate: DATE, scheduledTime: '09:00', startTime: '09:00', endTime: '10:00' });
+  schedule(final, { scheduledDate: secondDate, scheduledTime: secondStart, startTime: secondStart });
+
+  return { winnerId, firstMatchUpId: first.matchUpId, finalMatchUpId: final.matchUpId };
+}
+
+const generate = (reportId: string) =>
+  tournamentEngine.generateReport({ reportId, parameters: { utcOffsetMinutes: 0 } }) as any;
+
+describe('Participant Recovery Time report', () => {
+  it('reports a deficit when the gap is shorter than the policy requires', () => {
+    // R1 ends 10:00; the final starts 10:20 — a 20 minute gap against the
+    // POLICY_SCHEDULING_DEFAULT singles requirement of 60.
+    const { winnerId } = seedTwoMatchDay({ secondStart: '10:20' });
+
+    const result = generate(PARTICIPANT_RECOVERY_REPORT);
+    expect(result.error).toBeUndefined();
+
+    const row = result.rows.find((r: any) => r.participantId === winnerId && r.matchNumber === 2);
+    expect(row).toBeTruthy();
+    expect(row.recoveryReceived).toEqual(20);
+    expect(row.recoveryRequired).toEqual(60);
+    expect(row.recoveryDeficit).toEqual(40);
+    expect(result.summary.shortRecoveryCount).toBeGreaterThan(0);
+    expect(result.summary.worstRecoveryDeficit).toEqual(40);
+  });
+
+  it('reports NO deficit when the gap is sufficient — the detector is not stuck on', () => {
+    // Same fixture, final at 11:30: a 90 minute gap against the same 60 required.
+    const { winnerId } = seedTwoMatchDay({ secondStart: '11:30' });
+
+    const result = generate(PARTICIPANT_RECOVERY_REPORT);
+    const row = result.rows.find((r: any) => r.participantId === winnerId && r.matchNumber === 2);
+    expect(row.recoveryReceived).toEqual(90);
+    expect(row.recoveryDeficit).toEqual(0);
+    expect(result.summary.worstRecoveryDeficit).toEqual(0);
+  });
+
+  it('uses the measured duration and says so when start and end are both recorded', () => {
+    const { winnerId } = seedTwoMatchDay({ secondStart: '10:20' });
+    const result = generate(PARTICIPANT_RECOVERY_REPORT);
+
+    const firstRow = result.rows.find((r: any) => r.participantId === winnerId && r.matchNumber === 1);
+    // 09:00 → 10:00 measured, NOT the format's 90 minute average.
+    expect(firstRow.durationMinutes).toEqual(60);
+    expect(firstRow.durationSource).toEqual('measured');
+    expect(firstRow.finishSource).toEqual('endTime');
+  });
+
+  it('scopes a cross-day gap to overnight rather than reporting a vast recovery surplus', () => {
+    const { winnerId } = seedTwoMatchDay({ secondStart: '08:00', secondDate: NEXT_DATE });
+    const result = generate(PARTICIPANT_RECOVERY_REPORT);
+
+    const row = result.rows.find((r: any) => r.participantId === winnerId && r.scheduledDate === NEXT_DATE);
+    expect(row).toBeTruthy();
+    // 10:00 day one → 08:00 day two = 22 hours, reported as overnight...
+    expect(row.overnightReceived).toEqual(22 * 60);
+    // ...and NOT as a same-day recovery, which would manufacture a 1260-minute
+    // surplus on the first matchUp of every day.
+    expect(row.recoveryReceived).toBeUndefined();
+    expect(row.recoveryDeficit).toBeUndefined();
+  });
+
+  it('excludes walkovers — a player who did not take the court is not charged recovery', () => {
+    mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 4, eventName: 'Singles' }],
+      completeAllMatchUps: true,
+      endDate: NEXT_DATE,
+      startDate: DATE,
+      setState: true,
+      nonRandom: 1,
+    });
+    const matchUps = tournamentEngine.allTournamentMatchUps({}).matchUps ?? [];
+    const round1 = matchUps.filter((m: any) => m.roundNumber === 1);
+    // BOTH R1 matchUps are scheduled so the report still has rows after one is
+    // turned into a walkover — otherwise it errors on an empty timeline and the
+    // assertion would pass for the wrong reason.
+    for (const matchUp of round1) {
+      tournamentEngine.addMatchUpScheduledDate({
+        matchUpId: matchUp.matchUpId,
+        scheduledDate: DATE,
+        drawId: matchUp.drawId,
+      });
+      tournamentEngine.addMatchUpStartTime({
+        matchUpId: matchUp.matchUpId,
+        drawId: matchUp.drawId,
+        startTime: '09:00',
+      });
+    }
+    const target = round1[0];
+
+    const before = generate(PARTICIPANT_RECOVERY_REPORT);
+    expect(before.rows.filter((r: any) => r.matchUpId === target.matchUpId).length).toBeGreaterThan(0);
+
+    tournamentEngine.setMatchUpStatus({
+      outcome: { matchUpStatus: 'WALKOVER', winningSide: 1 },
+      matchUpId: target.matchUpId,
+      drawId: target.drawId,
+    });
+
+    const after = generate(PARTICIPANT_RECOVERY_REPORT);
+    expect(after.error).toBeUndefined();
+    // The walkover contributes nothing...
+    expect(after.rows.filter((r: any) => r.matchUpId === target.matchUpId).length).toEqual(0);
+    // ...while the other scheduled matchUp still does, proving the exclusion is
+    // targeted rather than a wholesale collapse of the timeline.
+    expect(after.rows.filter((r: any) => r.matchUpId === round1[1].matchUpId).length).toBeGreaterThan(0);
+  });
+
+  it('surfaces how much of the court time is estimated rather than observed', () => {
+    mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 4, eventName: 'Singles' }],
+      completeAllMatchUps: true,
+      endDate: NEXT_DATE,
+      startDate: DATE,
+      setState: true,
+      nonRandom: 1,
+    });
+    const matchUps = tournamentEngine.allTournamentMatchUps({}).matchUps ?? [];
+    for (const matchUp of matchUps) {
+      tournamentEngine.addMatchUpScheduledDate({
+        matchUpId: matchUp.matchUpId,
+        scheduledDate: DATE,
+        drawId: matchUp.drawId,
+      });
+      tournamentEngine.addMatchUpScheduledTime({
+        matchUpId: matchUp.matchUpId,
+        scheduledTime: '09:00',
+        drawId: matchUp.drawId,
+      });
+    }
+
+    const result = generate(PARTICIPANT_RECOVERY_REPORT);
+    // No start or end recorded anywhere, so every duration is the policy's
+    // prediction. The summary must say so rather than let an average built
+    // entirely from estimates read as a finding.
+    expect(result.summary.estimatedDurationPercentage).toBeGreaterThan(0);
+    expect(result.rows.every((r: any) => r.durationSource === 'estimated')).toBe(true);
+  });
+});
+
+describe('Participant Experience report', () => {
+  it('rolls the same timeline up per participant', () => {
+    const { winnerId } = seedTwoMatchDay({ secondStart: '10:20' });
+
+    const result = generate(PARTICIPANT_EXPERIENCE_REPORT);
+    expect(result.error).toBeUndefined();
+
+    const row = result.rows.find((r: any) => r.participantId === winnerId);
+    expect(row.matchesPlayed).toEqual(2);
+    expect(row.daysPlayed).toEqual(1);
+    expect(row.busiestDayMatches).toEqual(2);
+    expect(row.shortRecoveryCount).toEqual(1);
+    expect(row.worstRecoveryDeficit).toEqual(40);
+    // Worst experience sorts first.
+    expect(result.rows[0].participantId).toEqual(winnerId);
+  });
+
+  it('agrees with the per-appearance report on who was short-rested', () => {
+    seedTwoMatchDay({ secondStart: '10:20' });
+
+    const log = generate(PARTICIPANT_RECOVERY_REPORT);
+    const rollup = generate(PARTICIPANT_EXPERIENCE_REPORT);
+
+    const shortInLog = new Set(
+      log.rows.filter((r: any) => (r.recoveryDeficit ?? 0) > 0).map((r: any) => r.participantId),
+    );
+    const shortInRollup = new Set(
+      rollup.rows.filter((r: any) => r.shortRecoveryCount > 0).map((r: any) => r.participantId),
+    );
+    // Both derive from one core; a divergence means the roll-up drifted.
+    expect([...shortInRollup].sort()).toEqual([...shortInLog].sort());
+  });
+
+  it('does not count a short night when no overnight rule is configured', () => {
+    // An ADULT tournament: POLICY_SCHEDULING_DEFAULT gives overnight 0, meaning
+    // "no rule". A 4-hour turnaround must NOT be flagged.
+    const { winnerId } = seedTwoMatchDay({ secondStart: '02:00', secondDate: NEXT_DATE });
+    const result = generate(PARTICIPANT_EXPERIENCE_REPORT);
+    const row = result.rows.find((r: any) => r.participantId === winnerId);
+    expect(row.worstOvernight).toEqual(16 * 60);
+    expect(row.shortOvernightCount).toEqual(0);
+  });
+});

--- a/src/tests/queries/reports/recoveryTimelineLadders.test.ts
+++ b/src/tests/queries/reports/recoveryTimelineLadders.test.ts
@@ -33,6 +33,32 @@ function seed({ doubles = false }: { doubles?: boolean } = {}) {
   return { matchUps };
 }
 
+/**
+ * Set `schedule.scoredTime` directly on the stored matchUp.
+ *
+ * There is no public setter: the factory auto-captures it as `new Date()` on
+ * first scoring (`setMatchUpState.ts:535`). Tests that need a *specific* stamp —
+ * to exercise the plausibility bound in either direction — have to write it on
+ * the record and set the state back, since `getTournament` hands out a copy.
+ */
+function setScoredTime(matchUpId: string, scoredTime: string) {
+  const record: any = tournamentEngine.getTournament().tournamentRecord;
+  for (const event of record.events ?? []) {
+    for (const drawDefinition of event.drawDefinitions ?? []) {
+      for (const structure of drawDefinition.structures ?? []) {
+        for (const matchUp of structure.matchUps ?? []) {
+          if (matchUp.matchUpId === matchUpId) {
+            matchUp.schedule = { ...matchUp.schedule, scoredTime };
+            tournamentEngine.setState(record);
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+
 const timelineFor = (utcOffsetMinutes = 0, asOfMs?: number) =>
   buildRecoveryTimeline({
     tournamentRecord: tournamentEngine.getTournament().tournamentRecord as any,
@@ -84,12 +110,15 @@ describe('finish and duration ladders', () => {
       startTime: '09:00',
     });
 
+    // Entered 75 minutes after the start — a normal same-session entry.
+    expect(setScoredTime(target.matchUpId, `${DATE}T10:15:00.000Z`)).toBe(true);
+
     const appearance = allAppearances(timelineFor()).find((a) => a.matchUpId === target.matchUpId);
     expect(appearance).toBeTruthy();
-    // mocksEngine scores every matchUp, so the factory stamped scoredTime.
     expect(appearance!.finishSource).toEqual('scoredTime');
     // Duration is start → scoredTime, a proxy rather than the format average.
     expect(appearance!.durationSource).toEqual('scoredTime');
+    expect(appearance!.durationMinutes).toEqual(75);
   });
 
   it('projects from scheduledTime when nothing else is recorded, and says the duration is estimated', () => {
@@ -195,5 +224,61 @@ describe('doubles', () => {
     // which is what makes same-day singles+doubles load visible at all.
     expect(appearances.length).toEqual(4);
     expect(new Set(appearances.map((a) => a.participantId)).size).toEqual(4);
+  });
+});
+
+describe('late-entered scores', () => {
+  /**
+   * `scoredTime` records when the score was ENTERED, not when play ended. Usually
+   * within minutes — which is why it is the workhorse rung — but a score entered
+   * the next morning or corrected days later is not a finish proxy at all.
+   * Unbounded it produced a matchUp that "ran" for three days.
+   */
+  it('rejects a score stamped implausibly long after the start and projects instead', () => {
+    const { matchUps } = seed();
+    const target: any = matchUps[0];
+    tournamentEngine.addMatchUpScheduledDate({
+      matchUpId: target.matchUpId,
+      drawId: target.drawId,
+      scheduledDate: DATE,
+    });
+    tournamentEngine.addMatchUpStartTime({
+      matchUpId: target.matchUpId,
+      drawId: target.drawId,
+      startTime: '09:00',
+    });
+
+    // mocksEngine stamps scoredTime at the real clock, which is nowhere near the
+    // fabricated 2026-08-20 start — exactly the late-entry shape.
+    const appearance = allAppearances(timelineFor()).find((a) => a.matchUpId === target.matchUpId);
+    expect(appearance).toBeTruthy();
+    expect(appearance!.finishSource).toEqual('startTime');
+    expect(appearance!.durationSource).toEqual('estimated');
+    // Projected from the start by the format average, wrong by minutes rather
+    // than by days.
+    expect(appearance!.finishMs - appearance!.startMs).toEqual(appearance!.averageMinutes * 60_000);
+  });
+
+  it('still accepts a score stamped within the plausible window', () => {
+    const { matchUps } = seed();
+    const target: any = matchUps[0];
+    tournamentEngine.addMatchUpScheduledDate({
+      matchUpId: target.matchUpId,
+      drawId: target.drawId,
+      scheduledDate: DATE,
+    });
+    tournamentEngine.addMatchUpStartTime({
+      matchUpId: target.matchUpId,
+      drawId: target.drawId,
+      startTime: '09:00',
+    });
+    // Entered 100 minutes after the start — a normal same-session entry. The
+    // control that proves the bound is not simply rejecting every score.
+    expect(setScoredTime(target.matchUpId, `${DATE}T10:40:00.000Z`)).toBe(true);
+
+    const appearance = allAppearances(timelineFor()).find((a) => a.matchUpId === target.matchUpId);
+    expect(appearance!.finishSource).toEqual('scoredTime');
+    expect(appearance!.durationSource).toEqual('scoredTime');
+    expect(appearance!.durationMinutes).toEqual(100);
   });
 });

--- a/src/tests/queries/reports/recoveryTimelineLadders.test.ts
+++ b/src/tests/queries/reports/recoveryTimelineLadders.test.ts
@@ -1,0 +1,199 @@
+import { buildRecoveryTimeline, wasPlayed } from '@Query/reports/recoveryTimeline';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+import { DOUBLES_EVENT } from '@Constants/eventConstants';
+
+const DATE = '2026-08-20';
+
+/**
+ * The finish and duration ladders are the heart of the report: five rungs of
+ * decreasing fidelity for "when did this end", four for "how long did it run".
+ * Each rung needs its own exercise, because a rung that silently never fires is
+ * indistinguishable from one that works until the day the data shape changes.
+ */
+function seed({ doubles = false }: { doubles?: boolean } = {}) {
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [
+      {
+        ...(doubles && { eventType: DOUBLES_EVENT }),
+        eventName: doubles ? 'Doubles' : 'Singles',
+        matchUpFormat: 'SET3-S:6/TB7',
+        drawSize: 4,
+      },
+    ],
+    completeAllMatchUps: true,
+    startDate: DATE,
+    endDate: DATE,
+    setState: true,
+    nonRandom: 1,
+  });
+  const matchUps = tournamentEngine.allTournamentMatchUps({}).matchUps ?? [];
+  return { matchUps };
+}
+
+const timelineFor = (utcOffsetMinutes = 0, asOfMs?: number) =>
+  buildRecoveryTimeline({
+    tournamentRecord: tournamentEngine.getTournament().tournamentRecord as any,
+    utcOffsetMinutes,
+    asOfMs,
+  });
+
+/** Every appearance in the timeline, flattened. */
+const allAppearances = (timeline: ReturnType<typeof timelineFor>) => [...timeline.byParticipant.values()].flat();
+
+describe('wasPlayed', () => {
+  it('excludes the statuses where nobody took the court', () => {
+    for (const matchUpStatus of ['WALKOVER', 'DOUBLE_WALKOVER', 'CANCELLED']) {
+      expect(wasPlayed({ matchUpStatus })).toBe(false);
+    }
+  });
+
+  it('includes retirements and abandonments — time was spent on court', () => {
+    for (const matchUpStatus of ['RETIRED', 'ABANDONED', 'COMPLETED', 'DEAD_RUBBER']) {
+      expect(wasPlayed({ matchUpStatus })).toBe(true);
+    }
+  });
+
+  it('splits a default on score presence: mid-match disqualification vs no-show', () => {
+    // Nothing else in the record distinguishes them.
+    expect(wasPlayed({ matchUpStatus: 'DEFAULTED', score: { sets: [{ side1Score: 6 }] } })).toBe(true);
+    expect(wasPlayed({ matchUpStatus: 'DEFAULTED' })).toBe(false);
+    expect(wasPlayed({ matchUpStatus: 'DOUBLE_DEFAULT', score: { sets: [] } })).toBe(false);
+  });
+
+  it('treats an unknown or absent status as played', () => {
+    expect(wasPlayed({})).toBe(true);
+    expect(wasPlayed({ matchUpStatus: 'IN_PROGRESS' })).toBe(true);
+  });
+});
+
+describe('finish and duration ladders', () => {
+  it('falls to scoredTime when no endTime was recorded', () => {
+    const { matchUps } = seed();
+    const target: any = matchUps[0];
+    tournamentEngine.addMatchUpScheduledDate({
+      matchUpId: target.matchUpId,
+      drawId: target.drawId,
+      scheduledDate: DATE,
+    });
+    tournamentEngine.addMatchUpStartTime({
+      matchUpId: target.matchUpId,
+      drawId: target.drawId,
+      startTime: '09:00',
+    });
+
+    const appearance = allAppearances(timelineFor()).find((a) => a.matchUpId === target.matchUpId);
+    expect(appearance).toBeTruthy();
+    // mocksEngine scores every matchUp, so the factory stamped scoredTime.
+    expect(appearance!.finishSource).toEqual('scoredTime');
+    // Duration is start → scoredTime, a proxy rather than the format average.
+    expect(appearance!.durationSource).toEqual('scoredTime');
+  });
+
+  it('projects from scheduledTime when nothing else is recorded, and says the duration is estimated', () => {
+    const { matchUps } = seed();
+    const target: any = matchUps[0];
+    tournamentEngine.addMatchUpScheduledDate({
+      matchUpId: target.matchUpId,
+      drawId: target.drawId,
+      scheduledDate: DATE,
+    });
+    tournamentEngine.addMatchUpScheduledTime({
+      matchUpId: target.matchUpId,
+      drawId: target.drawId,
+      scheduledTime: '09:00',
+    });
+    // Remove the auto-stamped scoredTime so the ladder falls all the way through.
+    tournamentEngine.setMatchUpStatus({
+      outcome: { matchUpStatus: 'COMPLETED', winningSide: 1, score: undefined },
+      matchUpId: target.matchUpId,
+      drawId: target.drawId,
+    });
+
+    const appearance = allAppearances(timelineFor()).find((a) => a.matchUpId === target.matchUpId);
+    expect(appearance).toBeTruthy();
+    expect(appearance!.durationSource).toEqual('estimated');
+    // 90 for SET3-S:6/TB7 under POLICY_SCHEDULING_DEFAULT — the policy's
+    // prediction, not an observation, which is exactly why it is labelled.
+    expect(appearance!.durationMinutes).toEqual(90);
+  });
+
+  it('excludes a matchUp with no time information at all rather than guessing', () => {
+    const { matchUps } = seed();
+    // Nothing scheduled anywhere.
+    const timeline = timelineFor();
+    expect(timeline.totalCount).toEqual(0);
+    expect(allAppearances(timeline).length).toEqual(0);
+    expect(matchUps.length).toBeGreaterThan(0);
+  });
+
+  it('honours asOfMs so an in-progress tournament can be bounded', () => {
+    const { matchUps } = seed();
+    for (const matchUp of matchUps as any[]) {
+      tournamentEngine.addMatchUpScheduledDate({
+        matchUpId: matchUp.matchUpId,
+        drawId: matchUp.drawId,
+        scheduledDate: DATE,
+      });
+      tournamentEngine.addMatchUpScheduledTime({
+        matchUpId: matchUp.matchUpId,
+        drawId: matchUp.drawId,
+        scheduledTime: '09:00',
+      });
+    }
+    const unbounded = timelineFor();
+    expect(unbounded.totalCount).toBeGreaterThan(0);
+
+    // Bound to before the day began — nothing has started yet.
+    const bounded = timelineFor(0, Date.parse(`${DATE}T00:00:00.000Z`));
+    expect(bounded.totalCount).toEqual(0);
+  });
+
+  it('shifts the reported calendar day by the venue offset', () => {
+    const { matchUps } = seed();
+    const target: any = matchUps[0];
+    tournamentEngine.addMatchUpScheduledDate({
+      matchUpId: target.matchUpId,
+      drawId: target.drawId,
+      scheduledDate: DATE,
+    });
+    tournamentEngine.addMatchUpScheduledTime({
+      matchUpId: target.matchUpId,
+      drawId: target.drawId,
+      scheduledTime: '23:30',
+    });
+
+    // 23:30 local at UTC+0 is still DATE...
+    expect(allAppearances(timelineFor(0)).find((a) => a.matchUpId === target.matchUpId)!.scheduledDate).toEqual(DATE);
+    // ...and the arithmetic is offset-consistent: the wall clock is interpreted
+    // in the venue's frame, so the local date the operator saw is preserved.
+    expect(allAppearances(timelineFor(-300)).find((a) => a.matchUpId === target.matchUpId)!.scheduledDate).toEqual(
+      DATE,
+    );
+  });
+});
+
+describe('doubles', () => {
+  it('yields one appearance per individual, not per pair', () => {
+    const { matchUps } = seed({ doubles: true });
+    const target: any = matchUps[0];
+    tournamentEngine.addMatchUpScheduledDate({
+      matchUpId: target.matchUpId,
+      drawId: target.drawId,
+      scheduledDate: DATE,
+    });
+    tournamentEngine.addMatchUpStartTime({
+      matchUpId: target.matchUpId,
+      drawId: target.drawId,
+      startTime: '09:00',
+    });
+
+    const appearances = allAppearances(timelineFor()).filter((a) => a.matchUpId === target.matchUpId);
+    // Four individuals across two pairs — recovery is a property of a person,
+    // which is what makes same-day singles+doubles load visible at all.
+    expect(appearances.length).toEqual(4);
+    expect(new Set(appearances.map((a) => a.participantId)).size).toEqual(4);
+  });
+});

--- a/src/tests/tools/zonedTime.test.ts
+++ b/src/tests/tools/zonedTime.test.ts
@@ -1,0 +1,78 @@
+import { offsetMinutesAt, zonedParts, zonedWallClockToMs } from '@Tools/zonedTime';
+import { describe, expect, it } from 'vitest';
+
+const NY = 'America/New_York';
+
+// US DST 2026: forward 2026-03-08, back 2026-11-01.
+const WINTER = Date.parse('2026-01-15T12:00:00.000Z'); // EST, UTC-5
+const SUMMER = Date.parse('2026-07-15T12:00:00.000Z'); // EDT, UTC-4
+
+describe('offsetMinutesAt', () => {
+  it('returns the offset in force at that instant, not a fixed one', () => {
+    expect(offsetMinutesAt(WINTER, NY)).toEqual(-300);
+    expect(offsetMinutesAt(SUMMER, NY)).toEqual(-240);
+  });
+
+  it('returns undefined without a zone, or for one it cannot resolve', () => {
+    expect(offsetMinutesAt(WINTER)).toBeUndefined();
+    expect(offsetMinutesAt(WINTER, 'Not/AZone')).toBeUndefined();
+  });
+
+  it('handles a zone with no DST at all', () => {
+    expect(offsetMinutesAt(WINTER, 'UTC')).toEqual(0);
+    expect(offsetMinutesAt(SUMMER, 'UTC')).toEqual(0);
+  });
+});
+
+describe('zonedWallClockToMs', () => {
+  it('converts the same wall clock differently on either side of a DST change', () => {
+    const winter = zonedWallClockToMs({ date: '2026-01-15', time: '09:00', timeZone: NY });
+    const summer = zonedWallClockToMs({ date: '2026-07-15', time: '09:00', timeZone: NY });
+    expect(winter).toEqual(Date.parse('2026-01-15T14:00:00.000Z')); // 09:00 EST
+    expect(summer).toEqual(Date.parse('2026-07-15T13:00:00.000Z')); // 09:00 EDT
+
+    // This is the whole point: a single offset cannot produce both.
+    const fixed = (date: string) => zonedWallClockToMs({ date, time: '09:00', utcOffsetMinutes: -300 });
+    expect(fixed('2026-01-15')).toEqual(winter);
+    expect(fixed('2026-07-15')).not.toEqual(summer);
+  });
+
+  it('falls back to the fixed offset without a zone, and for an unknown zone', () => {
+    const expected = Date.parse('2026-07-15T13:00:00.000Z');
+    expect(zonedWallClockToMs({ date: '2026-07-15', time: '09:00', utcOffsetMinutes: -240 })).toEqual(expected);
+    // An unrecognised zone must degrade to the previous behaviour, not throw.
+    expect(
+      zonedWallClockToMs({ date: '2026-07-15', time: '09:00', utcOffsetMinutes: -240, timeZone: 'Not/AZone' }),
+    ).toEqual(expected);
+  });
+
+  it('returns null for missing or malformed input', () => {
+    expect(zonedWallClockToMs({ time: '09:00', timeZone: NY })).toBeNull();
+    expect(zonedWallClockToMs({ date: '2026-07-15', timeZone: NY })).toBeNull();
+    expect(zonedWallClockToMs({ date: '2026-07-15', time: 'noon', timeZone: NY })).toBeNull();
+    expect(zonedWallClockToMs({ date: 'not-a-date', time: '09:00', timeZone: NY })).toBeNull();
+  });
+
+  it('round-trips a wall clock through both directions on both sides of the change', () => {
+    for (const date of ['2026-01-15', '2026-07-15']) {
+      const ms = zonedWallClockToMs({ date, time: '09:00', timeZone: NY })!;
+      expect(zonedParts({ ms, timeZone: NY })).toEqual({ date, time: '09:00' });
+    }
+  });
+});
+
+describe('zonedParts', () => {
+  it('reports the venue-local clock per instant', () => {
+    expect(zonedParts({ ms: WINTER, timeZone: NY })).toEqual({ date: '2026-01-15', time: '07:00' });
+    expect(zonedParts({ ms: SUMMER, timeZone: NY })).toEqual({ date: '2026-07-15', time: '08:00' });
+  });
+
+  it('uses the fixed offset when no zone is supplied', () => {
+    expect(zonedParts({ ms: SUMMER, utcOffsetMinutes: -300 })).toEqual({ date: '2026-07-15', time: '07:00' });
+  });
+
+  it('rolls the calendar day when the offset crosses midnight', () => {
+    const ms = Date.parse('2026-07-16T02:00:00.000Z');
+    expect(zonedParts({ ms, timeZone: NY })).toEqual({ date: '2026-07-15', time: '22:00' });
+  });
+});

--- a/src/tools/zonedTime.ts
+++ b/src/tools/zonedTime.ts
@@ -1,0 +1,126 @@
+/**
+ * Venue-local wall clock ↔ UTC instant, correct across a DST boundary.
+ *
+ * A single `utcOffsetMinutes` is the offset at *one* moment. Applied to a
+ * tournament that spans a DST change it is wrong by an hour on the far side of
+ * the change — in the US that is the March and November weekends, which do host
+ * competition. The error is silent: times simply read an hour off, and a
+ * recovery figure derived from them is wrong by 60 minutes in a report whose
+ * whole purpose is to measure recovery in minutes.
+ *
+ * An IANA zone identifier (`America/New_York`) resolves the offset **per
+ * instant** instead, so both sides of the change convert correctly. `Intl` is
+ * built into Node and every browser, so this adds no dependency and keeps the
+ * factory pure.
+ *
+ * Callers that supply a fixed offset keep working unchanged — the offset path is
+ * still correct for a tournament that does not cross a transition, which is
+ * almost all of them.
+ */
+
+const MS_PER_MINUTE = 60_000;
+
+// `Intl.DateTimeFormat` construction is expensive relative to formatting, and a
+// timeline resolves thousands of instants against a handful of zones.
+const formatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function formatterFor(timeZone: string): Intl.DateTimeFormat | undefined {
+  const cached = formatterCache.get(timeZone);
+  if (cached) return cached;
+  try {
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      second: '2-digit',
+      minute: '2-digit',
+      month: '2-digit',
+      hour: '2-digit',
+      day: '2-digit',
+      year: 'numeric',
+      hourCycle: 'h23',
+      timeZone,
+    });
+    formatterCache.set(timeZone, formatter);
+    return formatter;
+  } catch {
+    // An unknown or malformed zone must not throw in a report. The caller falls
+    // back to its fixed offset, which is the previous behaviour rather than a
+    // new failure mode.
+    return undefined;
+  }
+}
+
+/** The zone's offset from UTC, in minutes, **at a specific instant** (local = UTC + offset). */
+export function offsetMinutesAt(ms: number, timeZone?: string): number | undefined {
+  if (!timeZone) return undefined;
+  const formatter = formatterFor(timeZone);
+  if (!formatter) return undefined;
+
+  const parts: Record<string, number> = {};
+  for (const { type, value } of formatter.formatToParts(new Date(ms))) {
+    if (type !== 'literal') parts[type] = Number(value);
+  }
+  if (!Number.isFinite(parts.year)) return undefined;
+
+  // Read the zone's wall clock back as though it were UTC; the difference from
+  // the true instant is the offset.
+  const asIfUtc = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second);
+  return Math.round((asIfUtc - ms) / MS_PER_MINUTE);
+}
+
+/**
+ * Venue-local `YYYY-MM-DD` + `HH:MM` → UTC ms.
+ *
+ * Converting local → UTC is circular: the offset depends on the instant, and the
+ * instant is what we are solving for. Resolved by interpreting the wall clock as
+ * UTC, taking the offset at that approximate instant, then re-reading the offset
+ * at the corrected one — which settles everywhere except inside the one
+ * ambiguous hour a fall-back transition repeats, where either reading is
+ * defensible and both are within an hour of the truth.
+ *
+ * Falls back to `utcOffsetMinutes` when no zone is supplied or the zone is not
+ * recognised.
+ */
+export function zonedWallClockToMs({
+  utcOffsetMinutes = 0,
+  timeZone,
+  date,
+  time,
+}: {
+  utcOffsetMinutes?: number;
+  timeZone?: string;
+  date?: string;
+  time?: string;
+}): number | null {
+  if (!date || !time) return null;
+  const match = /^(\d{1,2}):(\d{2})/.exec(time);
+  if (!match) return null;
+  const base = Date.parse(`${date}T00:00:00.000Z`);
+  if (Number.isNaN(base)) return null;
+
+  const naive = base + (Number(match[1]) * 60 + Number(match[2])) * MS_PER_MINUTE;
+
+  const firstOffset = offsetMinutesAt(naive, timeZone);
+  if (firstOffset === undefined) return naive - utcOffsetMinutes * MS_PER_MINUTE;
+
+  const approximate = naive - firstOffset * MS_PER_MINUTE;
+  const settledOffset = offsetMinutesAt(approximate, timeZone) ?? firstOffset;
+  return naive - settledOffset * MS_PER_MINUTE;
+}
+
+/** UTC ms → venue-local calendar date + wall clock, per-instant when a zone is supplied. */
+export function zonedParts({
+  utcOffsetMinutes = 0,
+  timeZone,
+  ms,
+}: {
+  utcOffsetMinutes?: number;
+  timeZone?: string;
+  ms: number;
+}): { date: string; time: string } {
+  const offset = offsetMinutesAt(ms, timeZone) ?? utcOffsetMinutes;
+  const shifted = new Date(ms + offset * MS_PER_MINUTE);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return {
+    date: `${shifted.getUTCFullYear()}-${pad(shifted.getUTCMonth() + 1)}-${pad(shifted.getUTCDate())}`,
+    time: `${pad(shifted.getUTCHours())}:${pad(shifted.getUTCMinutes())}`,
+  };
+}


### PR DESCRIPTION
Phases C1, C2, D and part of E of [`Mentat/planning/PARTICIPANT_RECOVERY_TIME_REPORT.md`], plus the `policyDefinitions` fix.

## Why these reports exist

The Inspector rest analysis (TMX #1326/#1346) scopes rest to **one calendar day by design**, which makes overnight turnaround structurally invisible — and the overnight rule carries the largest figure in the rulebook: **12 hours** between a junior's last matchUp of one day and the first of the next (USTA Friend at Court). Spanning days is the point.

## Policy schema

**`defaultTimes.overnightTimes`** — category-aware, because 12 hours is a *junior* rule and adult play has no equivalent. Resolved through the same precedence ladder as recovery (`getOvernightRecoveryTimes`). Absent means **"no rule configured"**, which consumers must report rather than substitute for — the contract `getMatchUpDailyLimits` already has.

**`recoveryTimes[].byPlayedMinutes`** — recovery keyed to how long the previous matchUp actually ran, as the long-standing USTA table states it (≤1 hr → 30 min, 1–1½ → 1 hr, beyond → 1½).

### byPlayedMinutes is opt-in on *both* sides, and neither half is incidental

It needs the policy to author bands **and** the caller to supply a measured duration.

1. Applied to an *estimated* duration the banding is **circular** — the estimate is `averageMinutes`, drawn from the very policy being consulted, so the band is selected by the number the policy already predicted.
2. **No scheduler call site supplies `playedMinutes`, and none can.** Recovery is resolved per `matchUpFormat` cohort and fanned out to every matchUp in it (`getScheduledRoundsDetails.ts:137-167`) — one level coarser than the per-instance quantity a band needs. Honouring it would mean moving the resolver inside `matchUpIds.forEach`, invalidating `greatestAverageMinutes`, the `hashes` cohorting and `periodLength`. The codebase already knows: `processAlreadyScheduledMatchUps.ts:110` carries `// for the future when variable averageMinutes supported`.

So **scheduling stays bit-identical by construction rather than behind a feature flag** — no flag to mis-set, no behavioural fork to test twice.

## The two reports

One shared timeline core, so they cannot disagree — asserted directly by a test comparing who each reports as short-rested.

- **Expands every side to individuals.** Recovery is a property of a person, not of an entry; this is what makes same-day singles+doubles load visible at all.
- **Ports `wasPlayed` from TMX** rather than re-deriving it, adding `CANCELLED`. `completedMatchUpStatuses` is unusable here — it includes every walkover and default, so reusing it charges a player full recovery and estimated court time for a matchUp they never played.
- **Reports which rung produced each figure.** Five for finish, four for duration. `estimated` is the policy's prediction, not an observation, and the summary counts how many rows landed there — without that, an average built mostly from estimates reads as a finding.
- **Scopes same-day gaps to `recoveryMinutes` and cross-day gaps to `overnightMinutes`**, so the first matchUp of each day does not manufacture a 1260-minute recovery surplus.

The roll-up is **deliberately not a composite score**: a weighted index would invent an authority the data does not have and launder estimates into one confident number.

## `policyDefinitions` on `getScheduleTiming`

It read the attached policy and offered no way to substitute one, unlike `allEventMatchUps`, `getParticipantEntries` and the rest of the query surface. Now uses the established `policyDefinitions?.[TYPE] ?? appliedPolicies?.[TYPE]` precedence. Every existing caller omits it and resolves exactly as before — which matters, since this is on the auto-scheduler's hot path.

## Falsification

| Reverted | Result |
|---|---|
| required recovery zeroed | 2 deficit tests **red** |
| walkovers allowed through | exclusion test **red** |
| `policyDefinitions ?? attached` → attached | 2 override tests **red**, 2 controls green |
| `participantId` removed from Team Stats | 1 test **red** |

Every detector also carries a control asserting the *opposite* outcome (sufficient gap → no deficit; no override → attached policy; walkover removed → other matchUp still present), so none can be stuck on.

## Bundle-size re-baseline

The `.d.ts` budget tripped at +10.06%. Measured by building each commit rather than assuming:

```
baseline (#4505)              773,200
this branch, before reports   849,949   +9.92%
after the reports commit      850,994  +10.06%
```

This work contributes **1,045 bytes (0.13%)**; the other 9.9% accumulated across every PR since #4505 without a re-baseline. Re-baselining is the correct response to genuine-but-not-mine drift.

## Gates

`pnpm verify` — all 14 steps, exit 0. **11,361 tests** (baseline 11,325).