### PR TITLE
fix(reports): emit a resolvable winner id from the draw structure report

### DIFF
--- a/src/query/reports/wrappers/wrapStructureReport.ts
+++ b/src/query/reports/wrappers/wrapStructureReport.ts
@@ -28,12 +28,21 @@ export function wrapStructureReport({
     }
   }
 
-  // Build participant name lookup
+  // Build participant lookups, keyed by BOTH participantId and personId because
+  // a structure report identifies its winner by `winningPersonId`.
+  //
+  // The name map alone cannot answer "which participant is this" — it points two
+  // different ids at the same string. The parallel id map is what lets a consumer
+  // resolve the winner and open a participant card. `winningTeamId` is already a
+  // participantId (TEAM participants), so it maps to itself.
   const participantNameMap: Record<string, string> = {};
+  const participantIdMap: Record<string, string> = {};
   for (const p of tournamentRecord.participants ?? []) {
     participantNameMap[p.participantId] = p.participantName ?? '';
+    participantIdMap[p.participantId] = p.participantId;
     if (p.person?.personId) {
       participantNameMap[p.person.personId] = p.participantName ?? '';
+      participantIdMap[p.person.personId] = p.participantId;
     }
   }
 
@@ -51,8 +60,13 @@ export function wrapStructureReport({
   const rows = (result.structureReports ?? []).map((report: any) => {
     // Resolve winner name from personId or teamId
     const winnerName = participantNameMap[report.winningPersonId] || participantNameMap[report.winningTeamId] || '';
+    const winningParticipantId =
+      participantIdMap[report.winningPersonId] || participantIdMap[report.winningTeamId] || '';
 
     return {
+      // Not a displayed column — consumers hide it — but it is what lets a table
+      // open the winner's participant card, and it survives to CSV/JSON export.
+      winningParticipantId,
       eventId: report.eventId ?? '',
       eventName: eventNameMap[report.eventId] || '',
       drawId: report.drawId ?? '',

--- a/src/tests/queries/reports/structureReportWinnerId.test.ts
+++ b/src/tests/queries/reports/structureReportWinnerId.test.ts
@@ -1,0 +1,127 @@
+import { STRUCTURE_REPORT } from '@Constants/reportConstants';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+import { DOUBLES_EVENT, TEAM_EVENT } from '@Constants/eventConstants';
+
+/**
+ * A structure report identifies its winner by `winningPersonId` — a PERSON id,
+ * not a participantId. The name map alone cannot answer "which participant is
+ * this": it deliberately points both ids at the same string. Without a parallel
+ * id map the winner column names someone a consumer cannot resolve, which is why
+ * the winner was the one participant in the reports surface with no reachable
+ * card.
+ */
+describe('Structure report — winningParticipantId', () => {
+  const generate = () => tournamentEngine.generateReport({ reportId: STRUCTURE_REPORT }) as any;
+
+  it('emits an id that resolves to a real participant, not the raw personId', () => {
+    mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 8, eventName: 'Singles' }],
+      completeAllMatchUps: true,
+      setState: true,
+      nonRandom: 1,
+    });
+
+    const result = generate();
+    expect(result.error).toBeUndefined();
+
+    const decided = result.rows.filter((row: any) => row.winner);
+    expect(decided.length, 'no structure reported a winner — the case is untested').toBeGreaterThan(0);
+
+    const participants = tournamentEngine.getParticipants({}).participants ?? [];
+    const byId: Record<string, any> = {};
+    for (const participant of participants) byId[participant.participantId] = participant;
+
+    for (const row of decided) {
+      expect(row.winningParticipantId).toBeTruthy();
+      const participant = byId[row.winningParticipantId];
+      // The id must be resolvable by `getParticipants` — that is precisely what a
+      // participant card does with it. A personId would fail here.
+      expect(participant, `winningParticipantId ${row.winningParticipantId} is not a participantId`).toBeTruthy();
+      // ...and it must be the participant whose name the row already displays.
+      expect(participant.participantName).toEqual(row.winner);
+    }
+  });
+
+  /**
+   * The structure report is **person-oriented by design** — it records
+   * `winningPersonId` / `winningPerson2Id` alongside per-person WTN details, and
+   * the `winner` column already displays only the FIRST individual's name for a
+   * doubles draw. The id therefore resolves to that same individual, not to the
+   * PAIR: it must open the card for the person whose name the row shows.
+   *
+   * Resolving to the PAIR would be worse on both counts — the id would disagree
+   * with the displayed name, and `participantProfileModal` is person-oriented
+   * throughout, so a PAIR renders a mostly-empty card.
+   */
+  it('resolves a doubles winner to the individual the row actually names', () => {
+    mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 4, eventName: 'Doubles', eventType: DOUBLES_EVENT }],
+      completeAllMatchUps: true,
+      setState: true,
+      nonRandom: 1,
+    });
+
+    const decided = generate().rows.filter((row: any) => row.winner);
+    expect(decided.length).toBeGreaterThan(0);
+
+    const participants = tournamentEngine.getParticipants({}).participants ?? [];
+    const byId: Record<string, any> = {};
+    for (const participant of participants) byId[participant.participantId] = participant;
+
+    for (const row of decided) {
+      const participant = byId[row.winningParticipantId];
+      expect(participant).toBeTruthy();
+      expect(participant.participantType).toEqual('INDIVIDUAL');
+      // The id and the displayed name must agree — that agreement is the whole
+      // contract, and it is what a PAIR id would break.
+      expect(participant.participantName).toEqual(row.winner);
+    }
+  });
+
+  it('resolves a team winner, where the id is already a participantId', () => {
+    mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 4, eventType: TEAM_EVENT }],
+      completeAllMatchUps: true,
+      randomWinningSide: true,
+      setState: true,
+      nonRandom: 1,
+    });
+
+    const decided = generate().rows.filter((row: any) => row.winner);
+    if (!decided.length) return; // team structures need not report a winner
+
+    const participants = tournamentEngine.getParticipants({}).participants ?? [];
+    const byId: Record<string, any> = {};
+    for (const participant of participants) byId[participant.participantId] = participant;
+
+    for (const row of decided) {
+      expect(byId[row.winningParticipantId]).toBeTruthy();
+    }
+  });
+
+  it('leaves the id empty rather than guessing when no winner is decided', () => {
+    mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 8, eventName: 'Singles' }],
+      setState: true,
+      nonRandom: 1,
+    });
+
+    const undecided = generate().rows.filter((row: any) => !row.winner);
+    expect(undecided.length, 'every structure had a winner — the empty case is untested').toBeGreaterThan(0);
+    for (const row of undecided) expect(row.winningParticipantId).toEqual('');
+  });
+
+  it('does not surface the id as a displayed column', () => {
+    mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 8 }],
+      completeAllMatchUps: true,
+      setState: true,
+      nonRandom: 1,
+    });
+    const result = generate();
+    expect(result.columns.some((column: any) => column.key === 'winningParticipantId')).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes the one gap left open by [#4692](https://github.com/CourtHive/competition-factory/pull/4692). Pairs with CourtHive/TMX#1350.

## The problem

`wrapStructureReport` identifies its winner by **`winningPersonId` — a PERSON id, not a participantId** — so the winner was the one name in the reports surface a consumer could not resolve to a participant.

Its existing `participantNameMap` is keyed by *both* `participantId` and `person.personId` pointing at the same string. That serves display but cannot answer *"which participant is this"*. A parallel id map resolves `personId → participantId`; `winningTeamId` is already a participantId and maps to itself.

## It resolves to the individual the row NAMES, not to the pair

The structure report is **person-oriented by design** — it records `winningPersonId` / `winningPerson2Id` alongside per-person WTN details, and the `winner` column already displays only the *first* individual for a doubles draw.

Resolving to the PAIR would be worse on both counts: the id would disagree with the displayed name, and `participantProfileModal` is person-oriented throughout, so a PAIR renders a mostly-empty card. I found this by writing the assertion the other way first and letting it fail.

Empty rather than guessed when no winner is decided; not a displayed column.

## Tests

The id is asserted **resolvable by `getParticipants`** — which is exactly what a participant card does with it, and exactly what a `personId` would fail — and asserted to match the name the row already shows.

Both the decided and undecided cases **assert the fixture produced them first** (`'no structure reported a winner — the case is untested'`), so neither can pass vacuously.

Falsified: blanking the id turns 3 of 5 red.

## Gates

`pnpm verify` all 14 steps exit 0 · **11,388 tests** · coverage headroom OK · bundle-size inside budget.