### PR TITLE
docs: capture the eight changes shipped since the last docs publish

### DIFF
--- a/documentation/docs/concepts/scheduling-policy.mdx
+++ b/documentation/docs/concepts/scheduling-policy.mdx
@@ -7,7 +7,8 @@ title: Scheduling Policy
 A **Scheduling Policy** defines the foundational parameters that govern how tournaments are scheduled, including:
 
 - Average matchUp duration times for different formats
-- Mandated recovery times between matches
+- Mandated recovery times between matches, optionally banded by how long the previous matchUp ran
+- Minimum overnight rest between the last matchUp of one day and the first of the next
 - Daily match limits per player
 - Venue and court modification restrictions
 

--- a/documentation/docs/governors/matchup-governor.md
+++ b/documentation/docs/governors/matchup-governor.md
@@ -401,13 +401,17 @@ const { matchUps } = engine.getCompetitionMatchUps({
 
 ## getEventMatchUpFormatTiming
 
-Returns format timing configuration for an event.
+Returns format timing configuration for an event. When `categoryType` is not supplied it is resolved from the event's own category.
 
 ```js
-const { timing } = engine.getEventMatchUpFormatTiming({
+const { eventMatchUpFormatTiming } = engine.getEventMatchUpFormatTiming({
   eventId, // required
+  matchUpFormats, // optional - can be retrieved from policy
+  categoryType, // optional - falls back to the event's category when not supplied
 });
 ```
+
+See [queryGovernor.getEventMatchUpFormatTiming](/docs/governors/query-governor#geteventmatchupformattiming) for category resolution details.
 
 ---
 
@@ -502,10 +506,18 @@ const { matchUpFormat } = engine.getMatchUpFormat({
 Returns timing parameters for a matchUp format.
 
 ```js
-const { timing } = engine.getMatchUpFormatTiming({
-  matchUpFormat, // required
-});
+const { averageMinutes, recoveryMinutes, typeChangeRecoveryMinutes, overnightMinutes, recoveryFromPlayedMinutes } =
+  engine.getMatchUpFormatTiming({
+    matchUpFormat, // required
+    eventType, // optional - defaults to SINGLES
+    categoryName, // optional
+    categoryType, // optional
+    policyDefinitions, // optional - evaluate against a policy not attached to the record
+    playedMinutes, // optional - measured duration; keys byPlayedMinutes bands
+  });
 ```
+
+See [queryGovernor.getMatchUpFormatTiming](/docs/governors/query-governor#getmatchupformattiming) for the full parameter and return reference.
 
 ---
 

--- a/documentation/docs/governors/query-governor.md
+++ b/documentation/docs/governors/query-governor.md
@@ -1080,10 +1080,14 @@ Requires an array of `matchUpFormats` either be defined in scoring policy that i
 ```js
 const { eventMatchUpFormatTiming } = engine.getEventMatchUpFormatTiming({
   matchUpFormats, // optional - can be retrieved from policy
-  categoryType, // optional - categoryType is not part of CODES or event attributes, but can be defined in a policy
+  categoryType, // optional - falls back to the event's category when not supplied
   eventId,
 });
 ```
+
+**Category resolution.** When `categoryType` is not supplied it is resolved from the event — `event.category.categoryType`, falling back to `event.category.subType`. An explicitly-passed value still wins.
+
+This matters because timing figures are category-dependent: `POLICY_SCHEDULING_DEFAULT` gives ADULT and WHEELCHAIR doubles 30 minutes of recovery and JUNIOR doubles 60. Callers that relied on the previous behaviour — where an unsupplied `categoryType` meant the event's category was ignored — will now see junior figures for junior events.
 
 ---
 
@@ -1314,16 +1318,37 @@ const { matchUpFormat, structureDefaultMatchUpFormat, drawDefaultMatchUpFormat, 
 Searches for policy definitions or extensions to determine the `averageMinutes` and `recoveryMinutes` for a given `matchUpFormat`. Extensions are considered to be overrides of policy definitions.
 
 ```js
-const { averageMinutes, recoveryMinutes } = engine.getMatchUpFormatTiming({
-  defaultAverageMinutes, // optional setting if no matching definition found
-  defaultRecoveryMinutes, // optional setting if no matching definition found
-  matchUpFormat,
-  categoryName, // optional
-  categoryType, // optional
-  eventType, // optional - defaults to SINGLES; SINGLES, DOUBLES
-  eventId, // optional - prioritizes policy definition attached to event before tournament record
-});
+const { averageMinutes, recoveryMinutes, typeChangeRecoveryMinutes, overnightMinutes, recoveryFromPlayedMinutes } =
+  engine.getMatchUpFormatTiming({
+    defaultAverageMinutes, // optional setting if no matching definition found
+    defaultRecoveryMinutes, // optional setting if no matching definition found
+    matchUpFormat,
+    categoryName, // optional
+    categoryType, // optional
+    eventType, // optional - defaults to SINGLES; SINGLES, DOUBLES
+    eventId, // optional - prioritizes policy definition attached to event before tournament record
+    policyDefinitions, // optional - evaluate against a policy not attached to the record
+    playedMinutes, // optional - measured duration of the previous matchUp; keys byPlayedMinutes bands
+  });
 ```
+
+**Returns:**
+
+| Field                       | Meaning                                                                                     |
+| --------------------------- | ------------------------------------------------------------------------------------------- |
+| `averageMinutes`            | Expected duration for the format                                                            |
+| `recoveryMinutes`           | Rest required after a matchUp of this format                                                |
+| `typeChangeRecoveryMinutes` | Rest required when the participant crosses singles ↔ doubles                                |
+| `overnightMinutes`          | Minimum rest across a day boundary; `undefined` when no rule is configured                  |
+| `recoveryFromPlayedMinutes` | `true` when `recoveryMinutes` came from a `byPlayedMinutes` band rather than the flat table |
+
+`policyDefinitions` supplies a scheduling policy in place of whatever is attached to the tournamentRecord, following the same `policyDefinitions ?? appliedPolicies` precedence used across the query surface. It lets a caller ask "what would this look like under a different policy" without mutating the record. Omitted, resolution is exactly as before.
+
+`playedMinutes` selects a [`byPlayedMinutes`](/docs/policies/scheduling#duration-banded-recovery) band. It is opt-in on **both** sides — the policy must author bands and the caller must supply a duration it actually **measured**. Applied to an estimated duration the banding would be circular, since the estimate is `averageMinutes` drawn from the very policy being consulted. No scheduler call site supplies it, so scheduling behaviour is unchanged by construction.
+
+:::caution `overnightMinutes` absent means "no rule"
+`undefined` is not zero. Adult play carries no equivalent to the junior twelve-hour overnight rule, so an absent value must be reported as _unconstrained_ rather than substituted with a figure of the caller's own. This matches the contract `getMatchUpDailyLimits` already has.
+:::
 
 ---
 

--- a/documentation/docs/governors/report-governor.md
+++ b/documentation/docs/governors/report-governor.md
@@ -68,24 +68,28 @@ const byCategory = Object.groupBy(ready, (r) => r.category);
 
 **Registered Reports:**
 
-| Report ID                        | Name                   | Category     | Requires            |
-| -------------------------------- | ---------------------- | ------------ | ------------------- |
-| `entries.entryStatus`            | Entry Status Report    | Entries      | Events              |
-| `structure.drawReport`           | Draw Structure Report  | Draws        | Events              |
-| `matchUp.results`                | Match Results          | MatchUps     | Completed draws     |
-| `matchUp.statusSummary`          | MatchUp Status Summary | MatchUps     | Completed draws     |
-| `matchUp.competitiveness`        | Match Competitiveness  | MatchUps     | Completed draws     |
-| `participant.results`            | Participant Results    | Participants | Completed draws     |
-| `participant.seedingPerformance` | Seeding Performance    | Participants | Seeded participants |
-| `participant.teamStats`          | Team Statistics        | Participants | Team participants   |
-| `venue.utilization`              | Venue Utilization      | Scheduling   | Venues              |
-| `scheduling.callTimingVariance`  | Call Timing Variance   | Scheduling   | Venues              |
-| `audit.mutationLog`              | Mutation Log           | Audit        | Server audit trail  |
-| `audit.drawRevisions`            | Draw Revision History  | Audit        | Server audit trail  |
-| `audit.schedulingChurn`          | Scheduling Churn       | Audit        | Server audit trail  |
-| `audit.positionChanges`          | Position Changes       | Audit        | Server audit trail  |
+| Report ID                        | Name                      | Category     | Requires            |
+| -------------------------------- | ------------------------- | ------------ | ------------------- |
+| `entries.entryStatus`            | Entry Status Report       | Entries      | Events              |
+| `structure.drawReport`           | Draw Structure Report     | Draws        | Events              |
+| `matchUp.results`                | Match Results             | MatchUps     | Completed draws     |
+| `matchUp.statusSummary`          | MatchUp Status Summary    | MatchUps     | Completed draws     |
+| `matchUp.competitiveness`        | Match Competitiveness     | MatchUps     | Completed draws     |
+| `participant.results`            | Participant Results       | Participants | Completed draws     |
+| `participant.seedingPerformance` | Seeding Performance       | Participants | Seeded participants |
+| `participant.teamStats`          | Team Statistics           | Participants | Team participants   |
+| `venue.utilization`              | Venue Utilization         | Scheduling   | Venues              |
+| `scheduling.callTimingVariance`  | Call Timing Variance      | Scheduling   | Venues              |
+| `participant.recoveryTime`       | Participant Recovery Time | Scheduling   | Scheduled matchUps  |
+| `participant.experience`         | Participant Experience    | Participants | Scheduled matchUps  |
+| `audit.mutationLog`              | Mutation Log              | Audit        | Server audit trail  |
+| `audit.drawRevisions`            | Draw Revision History     | Audit        | Server audit trail  |
+| `audit.schedulingChurn`          | Scheduling Churn          | Audit        | Server audit trail  |
+| `audit.positionChanges`          | Position Changes          | Audit        | Server audit trail  |
 
 Reports with `source: 'server'` require data from the server audit trail and cannot be generated from the tournament record alone.
+
+"Scheduled matchUps" means at least one matchUp carries a `scheduledTime`, `startTime`, or `calledAt`. Without one of those anchors every matchUp is undatable and the two timeline reports would return zero rows, so `computableNow` is `false` rather than producing an empty table.
 
 ---
 
@@ -186,6 +190,45 @@ const json = JSON.stringify(result, null, 2);
 // Only column keys should be rendered in UI; extra fields are for CSV/JSON export
 ```
 
+**Report-specific parameters:**
+
+Most reports take no parameters. The two timeline reports — [Participant Recovery Time](#participant-recovery-time-report) and [Participant Experience](#participant-experience-report) — accept these:
+
+```ts
+{
+  timeZone?: string;            // IANA zone, e.g. 'America/New_York' — preferred
+  utcOffsetMinutes?: number;    // venue offset from UTC (local = UTC + offset); default 0
+  policyDefinitions?: PolicyDefinitions;  // evaluate against a policy not attached to the record
+  asOfMs?: number;              // ignore matchUps starting after this instant
+}
+```
+
+:::warning Prefer `timeZone` over `utcOffsetMinutes`
+`utcOffsetMinutes` is the offset at **one** moment. Applied to a tournament that spans a daylight-saving transition it is wrong by an hour on the far side of it — silently, in a report whose entire subject is minutes. A participant finishing 22:00 and starting 08:00 across a spring-forward actually rested **nine** hours; a fixed offset reports ten.
+
+Supplying an IANA `timeZone` resolves the offset per instant instead. `utcOffsetMinutes` remains the fallback when no zone is given or the zone is not recognised, so existing callers are unaffected and an unknown zone degrades to previous behaviour rather than throwing.
+:::
+
+`policyDefinitions` answers "what would this tournament look like under a _different_ scheduling policy" without mutating the record. It follows the usual precedence — a supplied policy wins over the one attached to the tournament.
+
+**Row identifiers not present in `columns`:**
+
+Several reports emit ids that are deliberately absent from `columns`. Consumers hide them, but they are what lets a table resolve the participant behind a displayed name — to open a participant card — or navigate from a row to its matchUp, and they survive to CSV/JSON export.
+
+| Report                          | Identifier fields                                                                                                   |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `structure.drawReport`          | `winningParticipantId`                                                                                              |
+| `matchUp.results`               | `side1ParticipantId`, `side2ParticipantId`, `winningParticipantId`, `eventId`, `drawId`, `structureId`, `matchUpId` |
+| `matchUp.competitiveness`       | `side1ParticipantId`, `side2ParticipantId`, `eventId`, `drawId`, `structureId`, `matchUpId`                         |
+| `scheduling.callTimingVariance` | `side1ParticipantId`, `side2ParticipantId`, `eventId`, `drawId`, `structureId`, `matchUpId`                         |
+| `participant.teamStats`         | `participantId`                                                                                                     |
+| `participant.recoveryTime`      | `participantId`, `eventId`, `drawId`, `structureId`, `matchUpId`                                                    |
+| `participant.experience`        | `participantId`                                                                                                     |
+
+A doubles side yields its **PAIR** id; a consumer hydrates individuals from that, so a partner can still be opened individually. `structure.drawReport` is the exception — it resolves to the **individual the row actually names**, because the report is person-oriented throughout and its winner column already shows only the first individual of a pair. An id resolving to the PAIR would disagree with the name displayed beside it.
+
+Where no value can be determined — an undecided structure winner, a side with no participant — the field is an empty string rather than a guess.
+
 **Error handling:**
 
 ```js
@@ -256,6 +299,162 @@ result.rows.slice(0, 5).forEach((r) => {
 ```
 
 The report is listed (`computableNow: true`) whenever the tournament has venues; rows populate once matchUps are called to court. Until then the report is empty and `summary.scheduledButUncalled` reflects scheduled matchUps still awaiting a call.
+
+---
+
+## Participant Recovery Time Report
+
+`reportId: 'participant.recoveryTime'` — one row per **individual participant per matchUp played**, in chronological order, across every day of the tournament.
+
+The live schedule Inspector scopes its rest analysis to a single calendar day by design, which makes overnight turnaround invisible — and the overnight rule carries the largest figure in the rulebook. Spanning days is the point of this report.
+
+**Columns:**
+
+| Key                        | Title          | Meaning                                             |
+| -------------------------- | -------------- | --------------------------------------------------- |
+| `participantName`          | Participant    | The individual, not the entry                       |
+| `scheduledDate`            | Date           | Venue-local date                                    |
+| `matchNumber`              | #              | Ordinal within that participant's day               |
+| `eventName` / `roundName`  | Event / Round  | Where the matchUp sits                              |
+| `startTime` / `finishTime` | Start / Finish | Venue-local wall clock                              |
+| `durationMinutes`          | On Court       | Time on court                                       |
+| `durationSource`           | Duration From  | Which rung produced `durationMinutes`               |
+| `recoveryReceived`         | Recovery       | Minutes since the previous matchUp **the same day** |
+| `recoveryRequired`         | Required       | What the policy required after that matchUp         |
+| `recoveryDeficit`          | Deficit        | `required - received`, floored at 0                 |
+| `overnightReceived`        | Overnight      | Minutes since the **previous day's** last finish    |
+| `overnightRequired`        | Overnight Req  | Overnight minimum for the participant's category    |
+| `waitMinutes`              | Wait           | Planned `scheduledTime` → actual `calledAt`         |
+| `finishSource`             | Finish From    | Which rung produced `finishTime`                    |
+
+**Same-day and cross-day gaps are scoped separately.** A same-day gap is measured against `recoveryMinutes`; a cross-day gap against `overnightMinutes`. Measuring one against the other would manufacture a huge surplus or deficit on every first matchUp of the day.
+
+Recovery is a property of the matchUp just **completed** — the scheduler reads it the same way. When a participant crosses singles ↔ doubles, the previous matchUp's `typeChangeRecoveryMinutes` applies instead, which is generally the larger figure.
+
+**Provenance: an inferred number must never read as a measured one.**
+
+`finishSource`, strongest rung first:
+
+| Value           | Derived from                                       |
+| --------------- | -------------------------------------------------- |
+| `endTime`       | An explicit end time                               |
+| `scoredTime`    | When a score was first entered                     |
+| `startTime`     | Start + the policy's `averageMinutes` (projection) |
+| `calledAt`      | Call to court + `averageMinutes` (projection)      |
+| `scheduledTime` | Planned time + `averageMinutes` (projection)       |
+
+`scoredTime` carries the load in practice rather than `endTime`: clients write an end time only on an explicit operator action, while the factory auto-captures `scoredTime` on the first meaningful score. A late-entered score pushes the anchor _after_ the true finish, so recovery is understated — the conservative direction, reporting a player as less rested rather than more. `scoredTime` is bounded to twelve hours past the start; beyond that it is treated as a later correction rather than a finish, and the ladder falls through to a projection.
+
+`durationSource`:
+
+| Value        | Derived from                                                  |
+| ------------ | ------------------------------------------------------------- |
+| `measured`   | Start → end                                                   |
+| `scoredTime` | Start → score entry                                           |
+| `calledAt`   | Call to court → score entry                                   |
+| `estimated`  | The policy's `averageMinutes` — **not an observation at all** |
+
+**Which matchUps count.** Walkovers, double walkovers, and cancellations are excluded — charging a participant full recovery and estimated court time for a matchUp they never played would corrupt every figure downstream. A default is included only when it carries a score, because a default with a score was played up to the point of the default and one without is a no-show; nothing else in the record distinguishes them.
+
+Rows are sorted worst experience first — largest deficit, then longest wait — because an operator opening this report is looking for who was treated worst, not for row one.
+
+**Summary:**
+
+```ts
+{
+  appearances: number;                  // rows, i.e. individual-matchUp pairs
+  participants: number;
+  shortRecoveryCount: number;           // rows with a deficit above zero
+  worstRecoveryDeficit: number;
+  estimatedDurationCount: number;
+  estimatedDurationPercentage: number;  // how much of this report is prediction
+  utcOffsetMinutes: number;
+  timeZone?: string;
+}
+```
+
+`estimatedDurationPercentage` is not decoration. Without it, an average built mostly from estimates reads as a finding.
+
+**Example:**
+
+```js
+const result = tournamentEngine.generateReport({
+  reportId: 'participant.recoveryTime',
+  parameters: { timeZone: 'America/New_York' },
+});
+
+console.log(`${result.summary.shortRecoveryCount} short rests`);
+console.log(`${result.summary.estimatedDurationPercentage}% of durations are estimates`);
+
+result.rows.slice(0, 5).forEach((r) => {
+  console.log(`${r.participantName} ${r.scheduledDate}: got ${r.recoveryReceived}, needed ${r.recoveryRequired}`);
+});
+```
+
+---
+
+## Participant Experience Report
+
+`reportId: 'participant.experience'` — one row per **individual participant**, rolled up across the whole tournament. Built on the same timeline core as the recovery report, so the two can never disagree.
+
+**Columns:**
+
+| Key                    | Title         | Meaning                                                    |
+| ---------------------- | ------------- | ---------------------------------------------------------- |
+| `participantName`      | Participant   |                                                            |
+| `daysPlayed`           | Days          | Distinct days played                                       |
+| `matchesPlayed`        | Matches       |                                                            |
+| `busiestDayMatches`    | Busiest Day   | Most matchUps in a single day                              |
+| `courtMinutes`         | On Court      | Total time on court                                        |
+| `estimatedPct`         | Estimated %   | Share of this participant's durations that are projections |
+| `shortRecoveryCount`   | Short Rests   | Same-day gaps below requirement                            |
+| `worstRecoveryDeficit` | Worst Deficit |                                                            |
+| `shortOvernightCount`  | Short Nights  | Nights below the overnight minimum                         |
+| `worstOvernight`       | Worst Night   | Shortest overnight turnaround received                     |
+| `meanWaitMinutes`      | Mean Wait     | Undefined rather than zero when nothing was called         |
+| `maxWaitMinutes`       | Max Wait      |                                                            |
+| `longestDayMinutes`    | Longest Day   | First **expected** time → last finish                      |
+
+`longestDayMinutes` is anchored to when the participant was first _expected_, not when they first played. Being told 09:00 and first walking on at 20:00 is eleven hours of the experience that a first-start anchor erases.
+
+Wait is reported as mean and max rather than a standard deviation: a participant consistently called 15 minutes late had a predictable tournament and one swinging −30/+180 had a chaotic one at the same mean, and operators read minutes rather than sigma.
+
+:::info Deliberately not a composite score
+There is no weighted "experience index". One would invent an authority the data does not have and launder estimated durations into a single confident number. These are sortable counts; the operator decides what "worst" means. If a band is ever wanted, derive it from `worstRecoveryDeficit` alone — the one quantity with a rulebook behind it.
+:::
+
+**Summary:**
+
+```ts
+{
+  participants: number;
+  appearances: number;
+  participantsWithShortRecovery: number;
+  participantsWithShortOvernight: number;
+  estimatedDurationPercentage: number;
+  utcOffsetMinutes: number;
+  timeZone?: string;
+}
+```
+
+**Example:**
+
+```js
+const result = tournamentEngine.generateReport({
+  reportId: 'participant.experience',
+  parameters: { timeZone: 'America/New_York' },
+});
+
+console.log(`${result.summary.participantsWithShortOvernight} participants had a short night`);
+
+// Who had the hardest tournament
+const worst = [...result.rows].sort((a, b) => b.worstRecoveryDeficit - a.worstRecoveryDeficit)[0];
+console.log(`${worst.participantName}: ${worst.matchesPlayed} matches over ${worst.daysPlayed} days`);
+```
+
+:::tip Overnight requires a configured rule
+`overnightRequired`, `shortOvernightCount`, and `worstOvernight` depend on `defaultTimes.overnightTimes` in the scheduling policy. Where no rule is configured for a participant's category — adult play carries no equivalent to the junior twelve-hour rule — the requirement is absent and nothing is flagged. Absent means **"no rule configured"**, which a consumer must report rather than substituting a figure of its own. See [Scheduling Policy](/docs/policies/scheduling#overnight-recovery).
+:::
 
 ---
 
@@ -785,6 +984,25 @@ reports.flightReports.forEach((flight) => {
 - Finishing position ranges indicate placement (e.g., winner: 1, loser: 2 for finals)
 - Custom extensions can be extracted using extensionProfiles accessor patterns
 - Reports include only structures that have been generated (excludes planned but not created)
+
+**Identifying the winner:**
+
+`structureReports` identifies a winner by `winningPersonId` — a **person** id — alongside `winningTeamId` for team structures. A person id cannot be passed to `getParticipants`, so it does not on its own answer "which participant is this".
+
+The wrapped `structure.drawReport` row therefore also carries `winningParticipantId`, resolved from whichever of the two is present, and it is what a consumer should use to open a participant card:
+
+```js
+const result = tournamentEngine.generateReport({ reportId: 'structure.drawReport' });
+
+const row = result.rows[0];
+if (row.winningParticipantId) {
+  const { participants } = tournamentEngine.getParticipants({
+    participantFilters: { participantIds: [row.winningParticipantId] },
+  });
+}
+```
+
+It resolves to the **individual the row names**, not to the pair — see the identifier table under [`generateReport`](#generatereport) — and is an empty string when no winner has been decided, rather than a guess.
 
 ---
 

--- a/documentation/docs/policies/scheduling.md
+++ b/documentation/docs/policies/scheduling.md
@@ -50,6 +50,20 @@ The **Scheduling Policy** (`POLICY_TYPE_SCHEDULING`) controls scheduling behavio
           DOUBLES?: number;
           TEAM?: number;
         };
+        byPlayedMinutes?: Array<{                 // Recovery banded by measured duration
+          upTo?: number;                          // Band ceiling; omit for the catch-all
+          minutes: number;
+        }>;
+      }>;
+      overnightTimes?: Array<{                    // Rest across a day boundary
+        categoryNames?: string[];
+        categoryTypes?: string[];                 // 12 hours is a JUNIOR rule
+        minutes: {
+          default: number;                        // 0 means "no rule"
+          SINGLES?: number;
+          DOUBLES?: number;
+          TEAM?: number;
+        };
       }>;
     };
 
@@ -444,6 +458,72 @@ console.log(timing.averageMinutes); // 90 (from defaultTimes)
 console.log(timing.recoveryMinutes); // 60 (from defaultTimes)
 ```
 
+### Evaluate Against a Policy That Is Not Attached
+
+`policyDefinitions` substitutes a scheduling policy for whatever is attached to the tournamentRecord, so a caller can ask "what would this tournament look like under a different policy" without mutating it. A supplied policy wins; omitted, resolution is exactly as before.
+
+```js
+const timing = tournamentEngine.getMatchUpFormatTiming({
+  matchUpFormat: 'SET3-S:6/TB7',
+  eventType: 'DOUBLES',
+  policyDefinitions: strictJuniorSchedulingPolicy, // not attached to the record
+});
+```
+
+This is what the [Participant Recovery Time](/docs/governors/report-governor#participant-recovery-time-report) and [Participant Experience](/docs/governors/report-governor#participant-experience-report) reports use to evaluate a completed tournament against a policy other than the one it ran under.
+
+---
+
+## Overnight Recovery
+
+`defaultTimes.overnightTimes` sets the minimum rest between the **last matchUp of one day and the first of the next**. It differs from `recoveryTimes` in two ways that matter:
+
+1. **It is not per-format.** An overnight rule is a property of the day boundary, not of what was played — the USTA _Friend at Court_ states it as a flat 12 hours for junior divisions regardless of format. So there is no `matchUpFormat` axis.
+2. **It is category-dependent.** The 12-hour figure is a _junior_ rule; adult play carries no equivalent constraint. That is why the default policy pairs a JUNIOR entry with an unconstrained catch-all rather than stating one flat figure.
+
+```js
+defaultTimes: {
+  overnightTimes: [
+    { categoryTypes: ['JUNIOR'], minutes: { default: 720 } }, // 12 hours
+    { minutes: { default: 0 } },                              // everyone else: no rule
+  ],
+}
+```
+
+Precedence mirrors recovery: event scheduling extension → tournament scheduling → the attached or supplied policy → the caller's default.
+
+:::caution Absent means "no rule", not zero
+Where nothing is configured, `getMatchUpFormatTiming` returns `overnightMinutes: undefined`. A consumer must report that as _unconstrained_ rather than substituting a figure of its own — the same contract `getMatchUpDailyLimits` already has. Reports built on it flag nothing for a category with no rule, which is the correct outcome, not a gap.
+:::
+
+## Duration-Banded Recovery
+
+Some sanctioning bodies scale rest by how long the previous matchUp **actually ran** rather than by its format. The long-standing USTA table gives 30 minutes after a match under an hour, an hour after one to one-and-a-half, and ninety minutes beyond that. Expressed as an ordered band list on a recovery-times entry:
+
+```js
+recoveryTimes: [
+  {
+    categoryTypes: ['JUNIOR'],
+    minutes: { default: 60 },
+    byPlayedMinutes: [
+      { upTo: 60, minutes: 30 },
+      { upTo: 90, minutes: 60 },
+      { minutes: 90 }, // catch-all — no `upTo`
+    ],
+  },
+];
+```
+
+Bands may be authored in any order; the catch-all always sorts last. A matched band overrides the flat `minutes` figure, and `getMatchUpFormatTiming` reports `recoveryFromPlayedMinutes: true` when it did.
+
+:::info Opt-in on both sides
+A band applies only when the policy authors `byPlayedMinutes` **and** the caller supplies a `playedMinutes` it actually measured.
+
+Applied to an _estimated_ duration the banding is circular: the estimate is `averageMinutes`, drawn from the very policy being consulted, so the band would be selected by the number the policy already predicted.
+
+No scheduler call site supplies `playedMinutes`, and none can — recovery is resolved once per matchUpFormat cohort and fanned out to every matchUp in it, one level coarser than the per-instance quantity a band needs. **Scheduling behaviour is therefore unchanged by construction rather than behind a feature flag.** The report layer is the intended consumer, where every duration is retrospective and its provenance is known per row.
+:::
+
 ---
 
 ## Venue Modification Protection
@@ -585,6 +665,7 @@ import { POLICY_SCHEDULING_DEFAULT } from 'tods-competition-factory';
 // - 30 minutes recovery for doubles adults
 // - 60 minutes recovery for all juniors
 // - 120 minutes for wheelchair matches
+// - 12 hours overnight recovery for juniors; no overnight rule for adults
 // - 2 singles + 2 doubles per day, max 3 total
 // - Specific times for 20+ common formats
 ```


### PR DESCRIPTION
The site was last published 2026-08-22 (gh-pages `bc3fca571`, from master `bde75624b`). Master has taken 8 commits since; three are dependency chores and one is the 6.30.0 release, leaving five that carry public surface. None of it was documented — and one item shipped inside 6.30.0 itself, because the previous backfill (#4685) was authored before it landed.

All four source changes documented here are now released in **6.31.0**.

## Reports (#4692, #4693)

- `participant.recoveryTime` and `participant.experience` registered in the reports table, each with a full section: columns, summary shape, and the condition gating `computableNow` — a matchUp carrying `scheduledTime`, `startTime` or `calledAt`. Without an anchor both reports return zero rows, so they are reported as not computable rather than producing an empty table.
- The provenance ladders are documented as ladders. `finishSource` and `durationSource` exist so an inferred figure never reads as a measured one, and `estimatedDurationPercentage` exists so an average built mostly from projections cannot pass as a finding. Recorded with the reasoning, along with the twelve-hour bound on `scoredTime` and the walkover/cancellation exclusion — a default counts only when it carries a score.
- Report-specific `generateReport` parameters, which had no home anywhere: `timeZone`, `utcOffsetMinutes`, `policyDefinitions`, `asOfMs`. The DST caveat is stated in the direction that matters — prefer the IANA zone, because a fixed offset is the offset at *one* moment and misreports rest by an hour across a transition, in a report whose entire subject is minutes.
- One table for every row identifier absent from `columns`, across all seven reports that emit them, plus the pair-vs-individual distinction and why `structure.drawReport` is the deliberate exception.

## Scheduling policy (#4692)

- `defaultTimes.overnightTimes` — why it is category-shaped rather than flat (12 hours is a junior rule; adult play has no equivalent), and that absent means *"no rule configured"* rather than zero.
- `recoveryTimes[].byPlayedMinutes` — the duration bands, and why they are opt-in on both sides: applied to an estimate the banding is circular, and no scheduler call site can supply a measured duration, so scheduling stays bit-identical by construction rather than behind a flag.
- `getMatchUpFormatTiming` gained `policyDefinitions` and `playedMinutes` and now returns `overnightMinutes` and `recoveryFromPlayedMinutes`. Three doc sites described the old signature; two of them also described a `{ timing }` return the method has never had.

## Scheduling (#4686, shipped in 6.30.0)

- `getEventMatchUpFormatTiming` resolves `categoryType` from the event's own category when none is passed. Recorded as a behaviour change, since junior doubles now takes 60 minutes of recovery where it silently took the adult 30.
- Deleted the claim that *"categoryType is not part of CODES or event attributes"*. `Category.categoryType` is a declared attribute; the same false comment was removed from source in #4686 and would otherwise have republished.

## Verification

Docusaurus builds with no broken links or anchors — evidence rather than silence: the detector was falsified, and a deliberately planted bad anchor does warn. markdownlint and prettier clean. Every claim was checked against source rather than against commit messages; that caught an under-listed identifier set on Call Timing Variance, which already carried location ids.

`pnpm verify` was not run: the diff is entirely markdown under `documentation/docs/`, outside the package build, so bundle-size/surface/publint cannot be affected.

## Deliberately out of scope

The seeded directive-avoidance **resolution** defect noted in #4688 — `positionSeeds.ts` re-reads `getAppliedPolicies({ drawDefinition })` and ignores the `appliedPolicies` already threaded in, so a policy supplied via `generateDrawDefinition({ policyDefinitions })` never reaches seeded avoidance. `policies/avoidance.md` keeps its current claim, uncaveated, pending a dedicated workstream.