### PR TITLE
docs: correct the three stale facts in the documentation README

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -26,8 +26,18 @@ This command generates static content into the `build` directory and can be serv
 
 ## Deployment
 
+From the repository root:
+
 ```console
-GIT_USER=CourtHive USE_SSH=true pnpm docpub
+pnpm docs:publish
 ```
 
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+That is the canonical form and the one to reach for — it wraps the underlying command, so there are no environment variables to remember:
+
+```console
+cd documentation && GIT_USER=CourtHive USE_SSH=true pnpm docpub
+```
+
+Either builds the website and pushes it to the `gh-pages` branch, which is what GitHub Pages serves. Note the script is `docpub`, not `deploy`.
+
+This README is not part of the built site, so changing it does not require a republish.

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,6 +1,6 @@
 # Website
 
-This website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern static website generator.
+This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
 
 ## Installation
 
@@ -14,7 +14,7 @@ pnpm install
 pnpm start
 ```
 
-This command starts a local development server and open up a browser window. Most changes are reflected live without having to restart the server.
+This command starts a local development server on port 3030 and opens a browser window. Most changes are reflected live without having to restart the server.
 
 ## Build
 
@@ -27,7 +27,7 @@ This command generates static content into the `build` directory and can be serv
 ## Deployment
 
 ```console
-GIT_USER=CourtHive USE_SSH=true pnpm deploy
+GIT_USER=CourtHive USE_SSH=true pnpm docpub
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.


### PR DESCRIPTION
Found by running each documented command against `documentation/package.json` rather than reading past them.

| Documented | Actual |
| --- | --- |
| `pnpm deploy` | **`pnpm docpub`** — the documented command does not exist and fails outright |
| "Docusaurus 2", `v2.docusaurus.io` | `@docusaurus/core` **3.10.2** |
| `pnpm start` (implied :3000) | `docusaurus start --port **3030**` |

The deploy line is the one that costs something: this session hit it while performing the 2026-08-24 republish and had to read `package.json` to find the working form. Anyone following the README to publish the site gets an error instead.

`pnpm install` and `pnpm build` check out exactly as documented.

Markdown-only, outside the package build.