### PR TITLE
docs: state the matchUpDailyLimits no-limit contract

### DIFF
--- a/documentation/docs/governors/matchup-governor.md
+++ b/documentation/docs/governors/matchup-governor.md
@@ -441,11 +441,14 @@ const { contextIds } = engine.getMatchUpContextIds({
 
 ## getMatchUpDailyLimits
 
-Returns daily participation limits for matchUps.
+Returns daily participation limits for matchUps. `undefined` when no scheduling policy is attached.
 
 ```js
-const { limits } = engine.getMatchUpDailyLimits();
+const { matchUpDailyLimits } = engine.getMatchUpDailyLimits();
 ```
+
+See [queryGovernor.getMatchUpDailyLimits](/docs/governors/query-governor#getmatchupdailylimits) for
+the `undefined`-means-no-limit contract.
 
 ---
 

--- a/documentation/docs/governors/query-governor.md
+++ b/documentation/docs/governors/query-governor.md
@@ -1402,12 +1402,25 @@ const { competitiveBands } = engine.getMatchUpsStats({
 
 ## getMatchUpDailyLimits
 
-Returns player daily match limits for singles/doubles/total matches.
+Returns the tournament-wide daily match limits for singles/doubles/total matches.
 
 ```js
-const { matchUpDailyLimits } = tournamentId.getMatchUpDailyLimits();
-const { DOUBLES, SINGLES, total } = matchUpDailyLimits;
+const { matchUpDailyLimits } = engine.getMatchUpDailyLimits({
+  tournamentId, // optional - select one tournament in a multi-tournament context
+});
+
+// `matchUpDailyLimits` is undefined when no scheduling policy is attached
+const { DOUBLES, SINGLES, total } = matchUpDailyLimits ?? {};
 ```
+
+:::caution `undefined` means "no limit configured"
+Unlike its sibling `getMatchUpFormatTiming`, this method does **not** fall back to
+`POLICY_SCHEDULING_DEFAULT`. An unpoliced tournament returns `undefined` rather than the fixture's
+`{ SINGLES: 2, DOUBLES: 2, total: 3 }`, and a consumer must report that as _no limit configured_
+rather than substituting one — inventing a constraint would make the scheduler refuse placements
+under a rule the tournament never adopted. Rationale and the full asymmetry in
+[Scheduling Policy → Retrieving Daily Limits](/docs/policies/scheduling#retrieving-daily-limits).
+:::
 
 ---
 

--- a/documentation/docs/policies/scheduling.md
+++ b/documentation/docs/policies/scheduling.md
@@ -409,13 +409,40 @@ const participantLimitsPolicy = {
 ### Retrieving Daily Limits
 
 ```js
-const { matchUpDailyLimits } = tournamentEngine.getMatchUpDailyLimits({
-  participantId: 'player-id',
-});
+const { matchUpDailyLimits } = tournamentEngine.getMatchUpDailyLimits();
 
 console.log(matchUpDailyLimits);
-// { SINGLES: 2, DOUBLES: 2, total: 3 }
+// { SINGLES: 2, DOUBLES: 2, total: 3 }   — when a scheduling policy is attached
+// undefined                              — when none is
 ```
+
+The method returns the **tournament-wide** limits and takes no `participantId`; per-participant
+overrides live in the policy's `matchUpDailyLimits` array and are applied by the scheduler, not
+returned here. In a multi-tournament context it accepts an optional `tournamentId`.
+
+:::caution `undefined` means "no limit configured" — do not substitute your own
+
+`getMatchUpDailyLimits` resolves `tournamentDailyLimits || policy.defaultDailyLimits` and **does not
+fall back to `POLICY_SCHEDULING_DEFAULT`**. A tournament with no scheduling policy attached therefore
+gets `undefined`, not `{ SINGLES: 2, DOUBLES: 2, total: 3 }` — even though that is what the fixture
+would have supplied.
+
+**This is deliberate, and it is an asymmetry with its own sibling.** `getMatchUpFormatTiming` _does_
+substitute the fixture, so the same unpoliced tournament gets real per-format averages and recovery
+times while getting no daily limits at all.
+
+The distinction is between an estimate and a rule. An average match duration is a **guess at a
+quantity** — substituting one makes a schedule approximately right instead of flatly wrong. A daily
+limit is a **constraint** — substituting one would make the scheduler refuse to place a
+participant's third matchUp, enforcing a rule the tournament never adopted. A default is not a
+detection.
+
+So a consumer must render "no limit configured" rather than defaulting to 3. TMX's Inspector rest
+rows do this correctly: they report the ordinal ("match #3 today") and omit the limit clause entirely
+when none is configured.
+
+The same contract governs [`overnightMinutes`](#overnight-recovery).
+:::
 
 ---
 


### PR DESCRIPTION
## The contract

`getMatchUpDailyLimits` resolves `tournamentDailyLimits || policy.defaultDailyLimits` and **does not** fall back to `POLICY_SCHEDULING_DEFAULT`. An unpoliced tournament gets `undefined`, not `{ SINGLES: 2, DOUBLES: 2, total: 3 }`.

Its sibling `getMatchUpFormatTiming` **does** substitute the fixture (`getMatchUpFormatTiming.ts:79`), so the same tournament gets real per-format averages and recovery times while getting no daily limits at all. `scheduleProfileRounds.ts:133` is the consumer, so automated scheduling applies no limit for such a tournament.

That asymmetry had been reasoned through in Mentat's tracker and written down nowhere a consumer would look.

## Documented, not "fixed"

It is deliberate. An average duration is a **guess at a quantity** — substituting one makes a schedule approximately right instead of flatly wrong. A daily limit is a **constraint** — substituting one would make the scheduler refuse a participant's third matchUp under a rule the tournament never adopted. A default is not a detection.

Adopting the fixture for symmetry would silently change automated scheduling output for every existing unpoliced tournament, in the "refuses to schedule" direction. That is a behaviour change wanting its own release note, not a docs pass.

## Closes a forward reference

Two lines shipped in #4694 already read *"the same contract `getMatchUpDailyLimits` already has"* — true, but unverifiable, because the contract was undocumented. Now it resolves.

## Three example errors at the same sites

All would mislead on copy-paste:

| File | Was | Actual |
| --- | --- | --- |
| `policies/scheduling.md` | `getMatchUpDailyLimits({ participantId })` | not a parameter — takes `{ tournamentRecords, tournamentId }`, returns tournament-wide limits |
| `query-governor.md` | `tournamentId.getMatchUpDailyLimits()` | `engine.` |
| `matchup-governor.md` | `const { limits } =` | `const { matchUpDailyLimits } =` |

The scheduling example also printed the fixture values unconditionally — precisely the false impression the asymmetry creates.

## Verification

Docusaurus builds with no broken links or anchors; markdownlint and prettier clean.

⚠️ **Toolchain conflict worth knowing:** prettier rewrites `*emphasis*` → `_emphasis_`, while markdownlint MD049 enforces whichever style appears *first* in the file. Introducing asterisk emphasis turns **pre-existing** underscore lines red even though neither line is wrong alone — it surfaced here at `scheduling.md:549`, a line from #4694 that lints clean on master. Run prettier *before* `lint:md`. Noted in the commit body so the next person does not chase it.

Needs a republish after merge (site content, unlike #4696).