### PR TITLE
docs: make pnpm lint:md green

### DIFF
--- a/documentation/docs/concepts/unified-identity.md
+++ b/documentation/docs/concepts/unified-identity.md
@@ -50,7 +50,7 @@ the id is the entire payload, and an entry without one carries no identity at al
 **Independent of the event grain.** A record acquired wholesale from one organisation can
 still carry events sanctioned by others, so neither flag can be inferred from the other.
 
-### Writing
+### Writing — tournament grain
 
 ```js
 // upsert — the copy-back case, where an id is acquired after the record exists
@@ -102,7 +102,7 @@ Every id attribute is independently optional for exactly that reason: populate o
 grains the origin actually models. An origin that does model events supplies `eventId`
 too.
 
-### Writing
+### Writing — draw grain
 
 ```js
 engine.addDrawOtherId({

--- a/documentation/docs/engines/subscriptions.md
+++ b/documentation/docs/engines/subscriptions.md
@@ -104,7 +104,7 @@ These topics are additive; existing subscribers are unaffected.
 };
 ```
 
-A subscriber that only needs to know *which* event or structure changed — cache eviction, fan-out routing, a read-model projection — should not have to hydrate the matchUp to find out.
+A subscriber that only needs to know _which_ event or structure changed — cache eviction, fan-out routing, a read-model projection — should not have to hydrate the matchUp to find out.
 
 `eventId` and `structureId` are populated best-effort rather than being required of every call site. A stored matchUp carries no `structureId` (only an inContext one does), so a notice emitted from a mutation that holds only a `drawDefinition` resolves it from the draw. Likewise a caller that supplies `event` rather than `eventId` still produces a populated `eventId`. Both are also populated for **propagated** matchUps — the downstream matchUps a result advances into — so a subscriber sees the same attribution on the matchUp a winner moves to as on the one that was scored.
 

--- a/documentation/docs/migration-6.0.0.md
+++ b/documentation/docs/migration-6.0.0.md
@@ -19,7 +19,7 @@ In 5.x and earlier, `generateDynamicRatings` with `considerGames: true` normalis
 
 Ratings computed with `considerGames: true` **will change** as a result. The new values are correct; the old ones were not.
 
-### What to do
+### What to do — dynamic ratings
 
 - **If you never set `considerGames: true`** (the default is `false`) — nothing changes. You are not affected.
 - **If you do set `considerGames: true`** — there is no code change. Re-run `generateDynamicRatings` and **re-baseline** any stored rating values against the new output. Do not attempt to reconcile old and new values numerically; treat the pre-6.0.0 values as incorrect and replace them.
@@ -37,7 +37,7 @@ const { modifications } = scaleEngine.generateDynamicRatings({
 
 `modifyParticipant` previously read and wrote a non-canonical lowercase `person.birthdate`. In 6.0.0 it reads and writes the canonical camelCase **`person.birthDate`**, matching the rest of the factory type surface.
 
-### What to do
+### What to do — `person.birthDate`
 
 Rename every read and write of the lowercase field:
 


### PR DESCRIPTION
`pnpm lint:md` has been **failing on master**. It is not part of the `verify` CI job, so nothing caught it — all four documentation PRs merged today passed CI with this red underneath.

None of the three failures come from today's PRs; the `subscriptions.md` one landed with #4685 on 2026-08-22 and the others are older. Fixed rather than attributed — this session has been editing this tree all day, and the failure-ownership rule is explicit.

| File | Rule | Fix |
| --- | --- | --- |
| `engines/subscriptions.md:107` | MD049 | `*which*` → `_which_`, matching the file's established style |
| `migration-6.0.0.md` | MD024 | two `### What to do` → "— dynamic ratings" / "— `person.birthDate`" |
| `concepts/unified-identity.md` | MD024 | two `### Writing` → "— tournament grain" / "— draw grain" |

The MD024 renames are an improvement beyond the lint: duplicate headings were getting silent `#what-to-do-1` / `#writing-1` anchors from Docusaurus. I verified nothing linked to the old anchors before renaming.

**Worth knowing about the toolchain:** prettier rewrites `*x*` → `_x_`, but only in files it is run over, while MD049 enforces whichever emphasis style appears *first* in each file. A stray asterisk therefore survives prettier and fails `lint:md` — and because `lint:md` is not in CI, it fails silently until someone runs it locally.

**Suggested follow-up (not in this PR):** add `lint:md` to the `verify` job, or this will drift red again. Happy to open that separately.

Verification: `lint:md` green across all 188 files, `lint` and `check-types` green, Docusaurus builds with no broken links or anchors.