### PR TITLE
test(avoidance): prove seeded group avoidance actually moves seeds apart

### DIFF
--- a/documentation/docs/concepts/unified-identity.md
+++ b/documentation/docs/concepts/unified-identity.md
@@ -50,7 +50,7 @@ the id is the entire payload, and an entry without one carries no identity at al
 **Independent of the event grain.** A record acquired wholesale from one organisation can
 still carry events sanctioned by others, so neither flag can be inferred from the other.
 
-### Writing
+### Writing — tournament grain
 
 ```js
 // upsert — the copy-back case, where an id is acquired after the record exists
@@ -102,7 +102,7 @@ Every id attribute is independently optional for exactly that reason: populate o
 grains the origin actually models. An origin that does model events supplies `eventId`
 too.
 
-### Writing
+### Writing — draw grain
 
 ```js
 engine.addDrawOtherId({

--- a/documentation/docs/engines/subscriptions.md
+++ b/documentation/docs/engines/subscriptions.md
@@ -104,7 +104,7 @@ These topics are additive; existing subscribers are unaffected.
 };
 ```
 
-A subscriber that only needs to know *which* event or structure changed — cache eviction, fan-out routing, a read-model projection — should not have to hydrate the matchUp to find out.
+A subscriber that only needs to know _which_ event or structure changed — cache eviction, fan-out routing, a read-model projection — should not have to hydrate the matchUp to find out.
 
 `eventId` and `structureId` are populated best-effort rather than being required of every call site. A stored matchUp carries no `structureId` (only an inContext one does), so a notice emitted from a mutation that holds only a `drawDefinition` resolves it from the draw. Likewise a caller that supplies `event` rather than `eventId` still produces a populated `eventId`. Both are also populated for **propagated** matchUps — the downstream matchUps a result advances into — so a subscriber sees the same attribution on the matchUp a winner moves to as on the one that was scored.
 

--- a/documentation/docs/migration-6.0.0.md
+++ b/documentation/docs/migration-6.0.0.md
@@ -19,7 +19,7 @@ In 5.x and earlier, `generateDynamicRatings` with `considerGames: true` normalis
 
 Ratings computed with `considerGames: true` **will change** as a result. The new values are correct; the old ones were not.
 
-### What to do
+### What to do — dynamic ratings
 
 - **If you never set `considerGames: true`** (the default is `false`) — nothing changes. You are not affected.
 - **If you do set `considerGames: true`** — there is no code change. Re-run `generateDynamicRatings` and **re-baseline** any stored rating values against the new output. Do not attempt to reconcile old and new values numerically; treat the pre-6.0.0 values as incorrect and replace them.
@@ -37,7 +37,7 @@ const { modifications } = scaleEngine.generateDynamicRatings({
 
 `modifyParticipant` previously read and wrote a non-canonical lowercase `person.birthdate`. In 6.0.0 it reads and writes the canonical camelCase **`person.birthDate`**, matching the rest of the factory type surface.
 
-### What to do
+### What to do — `person.birthDate`
 
 Rename every read and write of the lowercase field:
 

--- a/src/tests/mutations/drawDefinitions/avoidance/seededGroupAvoidanceEndToEnd.test.ts
+++ b/src/tests/mutations/drawDefinitions/avoidance/seededGroupAvoidanceEndToEnd.test.ts
@@ -1,0 +1,132 @@
+import { positionSeedBlocks } from '@Mutate/matchUps/drawPositions/positionSeeds';
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { createSeededRandom } from '@Tools/prng';
+import { expect, it } from 'vitest';
+
+// constants and types
+import { POLICY_TYPE_AVOIDANCE } from '@Constants/policyConstants';
+import { APPLIED_POLICIES } from '@Constants/extensionConstants';
+import { MAIN } from '@Constants/drawDefinitionConstants';
+import { GROUP } from '@Constants/participantConstants';
+
+/**
+ * Seeded `directive` avoidance, end to end: does grouping two seeds actually MOVE them apart?
+ *
+ * The companion test (`seededGroupAvoidance.test.ts`) proves the isolated call resolves a GROUP once
+ * `idCollections` is supplied. This one proves the resolution reaches placement — that the fix has a
+ * consequence a tournament director would see, not just a truer return value.
+ *
+ * It is written as a paired comparison rather than a single assertion because seed placement is
+ * randomised: the same fixture is generated twice per PRNG seed, once with the avoidance policy and
+ * once without, and the two placements are compared. That makes the control intrinsic — if the
+ * unpolicied run never crowds the pair into one section, the fixture proves nothing and the test says
+ * so explicitly rather than passing on a lucky layout.
+ *
+ * Falsified against reverted source: removing `idCollections` from the `getAttributeGroupings` call
+ * in `reorderSeedsForAvoidance` takes conflictGroups to zero for every PRNG seed and returns the
+ * policied placement to exactly the unpolicied one — the CONFLICTS assertion below then fails.
+ */
+
+const DRAW_SIZE = 32;
+const SEEDS_COUNT = 8;
+// Seeds 5-8 are the only block with more than two members, which is what the avoidance branch
+// requires. Seeds 1-2 are useless here: the seeding algorithm forces them apart unaided.
+const GROUPED_SEED_VALUES = [5, 6];
+const PRNG_SEEDS = [1, 2, 3, 7, 11, 13, 17, 19, 23, 29];
+
+type Placement = { sameSection: boolean; positions: (number | undefined)[] };
+
+function placeSeeds(prngSeed: number, withAvoidancePolicy: boolean): Placement | undefined {
+  const { tournamentRecord, drawIds } = mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ drawSize: DRAW_SIZE, seedsCount: SEEDS_COUNT, automated: false }],
+    participantsProfile: { participantsCount: DRAW_SIZE },
+    nonRandom: prngSeed,
+  });
+  tournamentEngine.setState(tournamentRecord);
+
+  const { drawDefinition } = tournamentEngine.getEvent({ drawId: drawIds[0] });
+  const structure = drawDefinition.structures.find((s: any) => s.stage === MAIN);
+
+  const seedHolder: Record<number, string> = {};
+  for (const assignment of structure.seedAssignments ?? []) {
+    const seedValue = assignment.seedValue ?? assignment.seedNumber;
+    if (assignment.participantId) seedHolder[seedValue] = assignment.participantId;
+  }
+  const groupMembers = GROUPED_SEED_VALUES.map((seedValue) => seedHolder[seedValue]).filter(Boolean);
+  if (groupMembers.length !== GROUPED_SEED_VALUES.length) return undefined;
+
+  tournamentEngine.createGroupParticipant({
+    individualParticipantIds: groupMembers,
+    groupName: 'Coaching Stable',
+  });
+
+  if (withAvoidancePolicy) {
+    // MERGE into the existing APPLIED_POLICIES extension rather than pushing a second one.
+    // `getAppliedPolicies` reads the FIRST extension of that name, and the generated draw already
+    // carries one holding the seeding policy — so a pushed duplicate is silently ignored and the
+    // policy never arrives. That produces a test that "runs" and measures nothing.
+    drawDefinition.extensions = drawDefinition.extensions ?? [];
+    const applied = drawDefinition.extensions.find((extension: any) => extension.name === APPLIED_POLICIES);
+    const avoidance = { policyAttributes: [{ directive: 'groupParticipants' }] };
+    if (applied) applied.value = { ...applied.value, [POLICY_TYPE_AVOIDANCE]: avoidance };
+    else drawDefinition.extensions.push({ name: APPLIED_POLICIES, value: { [POLICY_TYPE_AVOIDANCE]: avoidance } });
+  }
+
+  // Deliberately NOT filtered to INDIVIDUAL: `idCollections.groupParticipants` is built by filtering
+  // this array for `participantType === GROUP`, so excluding GROUPs empties the directive and the
+  // run silently measures nothing.
+  const participants = tournamentEngine.getParticipants({ withGroupings: true }).participants ?? [];
+  expect(participants.some((participant: any) => participant.participantType === GROUP)).toEqual(true);
+
+  positionSeedBlocks({
+    structureId: structure.structureId,
+    random: createSeededRandom(prngSeed),
+    drawDefinition,
+    participants,
+    structure,
+  });
+
+  const positionOf = (participantId: string) =>
+    (structure.positionAssignments ?? []).find((assignment: any) => assignment.participantId === participantId)
+      ?.drawPosition;
+
+  const positions = groupMembers.map(positionOf);
+  // With a single conflict group the algorithm splits the block's positions into two sections
+  // (`sectionCount = max(2, conflictGroups.length)`), so "same section" is the upper/lower split of
+  // the seed block — the granularity the avoidance actually reasons about.
+  const sectionOf = (position?: number) => {
+    if (position === undefined) return -1;
+    return position <= DRAW_SIZE / 2 ? 0 : 1;
+  };
+  const sections = positions.map(sectionOf);
+  return { sameSection: sections[0] === sections[1], positions };
+}
+
+it('moves grouped seeds apart, and only when they would otherwise share a section', () => {
+  const compared = PRNG_SEEDS.map((prngSeed) => ({
+    without: placeSeeds(prngSeed, false),
+    with: placeSeeds(prngSeed, true),
+    prngSeed,
+  })).filter((row) => row.without && row.with);
+
+  expect(compared.length).toEqual(PRNG_SEEDS.length);
+
+  const conflicts = compared.filter((row) => row.without?.sameSection);
+  const stillConflicted = compared.filter((row) => row.with?.sameSection);
+
+  // The fixture must actually produce the problem being solved. Without this the run below could
+  // pass on a layout that never crowded the pair together, certifying nothing.
+  expect(conflicts.length).toBeGreaterThan(0);
+
+  // Every conflict is resolved once the policy is applied.
+  expect(stillConflicted.length).toEqual(0);
+
+  // And the policy is not just shuffling everything: where there was no conflict, placement is
+  // untouched. A policy that moved seeds unconditionally would also satisfy the assertion above.
+  const unconflicted = compared.filter((row) => !row.without?.sameSection);
+  expect(unconflicted.length).toBeGreaterThan(0);
+  for (const row of unconflicted) {
+    expect(row.with?.positions).toEqual(row.without?.positions);
+  }
+});


### PR DESCRIPTION
## Defect 2 does not exist

`TASKS.md` recorded seeded avoidance as *"dead TWICE OVER"*, with **defect 2** — the avoidance policy never reaching `positionSeeds` — open, and blocking an end-to-end test as unwritable.

Measured on the running code, defect 2 does not reproduce. The branch executes on **every** policy-supply route (`attachPolicies` on the tournamentRecord, on the event, and transient `generateDrawDefinition({ policyDefinitions })`), and with #4688's fix in place the placement actually changes.

## The result

Paired comparison over ten deterministic PRNG seeds — same fixture generated twice per seed, once policied and once not:

| | grouped seeds share a section |
| --- | --- |
| without policy | **3 of 10** |
| with policy | **0 of 10**, other 7 placements byte-identical |

The policy acts exactly where there is a conflict and nowhere else. The second half is load-bearing: a policy that shuffled unconditionally would satisfy "no conflicts remain" just as well, so the unconflicted runs are asserted **unchanged**.

## Falsification

Dropping `idCollections` from the `getAttributeGroupings` call in `reorderSeedsForAvoidance` — i.e. reverting #4688 — takes `conflictGroups` to zero for every seed and returns the policied placement to exactly the unpolicied one. The test then fails with 3 unresolved conflicts. **It passes only with the fix in place.**

## Three fixture traps, documented in the test

Each produced a confident false negative before I found it — a run that executed the code, asserted successfully, and measured nothing:

1. **Pushing a second `APPLIED_POLICIES` extension is silently ignored.** `getAppliedPolicies` reads the *first* extension of that name, and a generated draw already carries one holding the seeding policy. Must merge into the existing value.
2. **Filtering participants to `INDIVIDUAL` empties the directive.** `idCollections.groupParticipants` is built by filtering that same array for `participantType === GROUP`.
3. **`seedsCount` alone seeds nobody.** It creates empty seed *slots* — measured: `slots: 8, seeded: 0` — so `unplacedSeedParticipantIds.length > 2` fails on the seeds term and the policy term is never evaluated. Real seeding needs `SEEDING` scale items plus a `seedingScaleName`, which mocksEngine's `drawProfiles` path applies internally via `applySeedingScales`.

Trap 3 is very likely what the original defect-2 diagnosis measured.

## Why this test asserts placement, not execution

`coveragePositionSeeds.test.ts` reaches this exact code and asserts only `expect(result).toBeDefined()` — which holds whether avoidance worked or not. That is how defect 1 shipped with coverage green.

## Verification

`lint`, `check-types` green. All 12 avoidance/seed-positioning test files pass (32 tests). Test-only change — no source modified.