### PR TITLE
fix(schedule): suppress time modifiers once a matchUp's start is settled

### DIFF
--- a/src/query/matchUp/getMatchUpScheduleDetails.ts
+++ b/src/query/matchUp/getMatchUpScheduleDetails.ts
@@ -46,6 +46,31 @@ type GetMatchUpScheduleDetailsArgs = {
   publishStatus?: any;
   event?: Event;
 };
+/**
+ * Whether a matchUp's start is still an open question.
+ *
+ * A `FOLLOWED_BY` or `AFTER_REST` / `NOT_BEFORE` annotation is a promise about
+ * *when this matchUp may begin*. Once that is settled the annotation is not
+ * merely redundant — on a published order of play it is misinformation, telling
+ * a player and a referee that a match is waiting on something that has already
+ * happened.
+ *
+ * Two settling signals, both local to the matchUp:
+ *
+ *   - **Called to court.** A match that has been called IS on court; "followed
+ *     by" is moot for it whatever else on that court did or did not finish.
+ *   - **Any score at all.** A single game is enough, and the partial case is the
+ *     one that matters: that is the state a live match sits in for an hour while
+ *     the annotation goes on claiming it has not begun. A completed status
+ *     settles it too, walkovers included — resolved is resolved.
+ */
+function startIsSettled(matchUp: any): boolean {
+  if (matchUp?.schedule?.calledAt) return true;
+  if (matchUp?.matchUpStatus && completedMatchUpStatuses.includes(matchUp.matchUpStatus)) return true;
+  if (matchUp?.winningSide) return true;
+  return !!matchUp?.score?.sets?.length;
+}
+
 export function getMatchUpScheduleDetails(params: GetMatchUpScheduleDetailsArgs) {
   let event = params.event;
   let matchUpType: any = params.matchUpType;
@@ -186,7 +211,18 @@ function buildFullSchedule({
   const courtAnnotation = firstClass.courtAnnotation ?? timeItemMap.get(COURT_ANNOTATION);
   const allocatedCourts = firstClass.allocatedCourts ?? timeItemMap.get(ALLOCATE_COURTS);
   const scheduledTime = firstClass.scheduledTime ?? timeItemMap.get(SCHEDULED_TIME);
-  const timeModifiers = firstClass.timeModifiers ?? timeItemMap.get(TIME_MODIFIERS);
+  // SUPPRESSED, never cleared: the stored value is the operator's stated intent
+  // and stays exactly where they put it. Hiding it here rather than deleting it
+  // on score entry means the reverse case needs no rule of its own — remove the
+  // score and the annotation is simply visible again, because the condition that
+  // hid it has lapsed. It also means no score-entry path can forget: hydration is
+  // downstream of the draw view, the schedule, the relay and every import.
+  //
+  // Read-side only. The write path (`matchUpTimeModifiers`, used by
+  // `mutate/matchUps/schedule/scheduledTime.ts`) reads storage directly, so
+  // adding and removing modifiers still operates on the real value.
+  const storedTimeModifiers = firstClass.timeModifiers ?? timeItemMap.get(TIME_MODIFIERS);
+  const timeModifiers = startIsSettled(matchUp) ? undefined : storedTimeModifiers;
   let scheduledDate = firstClass.scheduledDate ?? timeItemMap.get(SCHEDULED_DATE);
   const endDate = firstClass.endDate ?? timeItemMap.get(END_DATE);
   const official = firstClass.official ?? timeItemMap.get(ASSIGN_OFFICIAL);

--- a/src/tests/queries/scheduling/timeModifierSuppression.test.ts
+++ b/src/tests/queries/scheduling/timeModifierSuppression.test.ts
@@ -1,0 +1,158 @@
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+// constants
+import { SINGLE_ELIMINATION } from '@Constants/drawDefinitionConstants';
+import { COMPLETED, TO_BE_PLAYED, WALKOVER } from '@Constants/matchUpStatusConstants';
+import { FOLLOWED_BY } from '@Constants/timeItemConstants';
+import { SUCCESS } from '@Constants/resultConstants';
+
+/**
+ * A `FOLLOWED_BY` / `AFTER_REST` / `NOT_BEFORE` annotation is a promise about
+ * *when a matchUp may begin*. Once that is settled the annotation is not merely
+ * redundant — on a published order of play it is misinformation, telling a player
+ * and a referee that a match is waiting on something that has already happened.
+ *
+ * It is **suppressed at hydration, never cleared**. The stored value is the
+ * operator's stated intent and stays where they put it, which is what lets the
+ * reverse case work without a rule of its own: remove the score and the
+ * annotation is simply visible again, because the condition that hid it lapsed.
+ */
+
+const START_DATE = '2026-06-15';
+
+function setup() {
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ drawType: SINGLE_ELIMINATION, drawSize: 8 }],
+    setState: true,
+    startDate: START_DATE,
+  });
+  const { matchUps } = tournamentEngine.allTournamentMatchUps();
+  const matchUp = matchUps.find((m: any) => m.roundNumber === 1);
+  const { matchUpId, drawId } = matchUp;
+
+  tournamentEngine.addMatchUpScheduleItems({
+    matchUpId,
+    drawId,
+    schedule: { scheduledDate: START_DATE, scheduledTime: '10:00', timeModifiers: [FOLLOWED_BY] },
+  });
+
+  return { matchUpId, drawId };
+}
+
+/** The hydrated view — what every consumer and every notice subscriber sees. */
+function hydratedModifiers(matchUpId: string) {
+  const { matchUp }: any = tournamentEngine.findMatchUp({ matchUpId, inContext: true });
+  return matchUp?.schedule?.timeModifiers;
+}
+
+/**
+ * The value as it sits in the record, reached without going through hydration.
+ *
+ * `findMatchUp` hydrates even without `inContext`, so it reports the suppressed
+ * view and cannot answer "is it still there?". Walking the drawDefinition is the
+ * only read that can distinguish suppressed from deleted — which is the entire
+ * claim being made here.
+ */
+function storedModifiers(matchUpId: string, drawId: string) {
+  const { drawDefinition }: any = tournamentEngine.getEvent({ drawId });
+  const structures = drawDefinition?.structures ?? [];
+  for (const structure of structures) {
+    const found = (structure.matchUps ?? []).find((m: any) => m.matchUpId === matchUpId);
+    if (found) return found.schedule?.timeModifiers;
+  }
+  return undefined;
+}
+
+/**
+ * Complete the matchUp with a score its format accepts.
+ *
+ * `6-1` alone is rejected as invalid for the default format, and a rejected
+ * mutation leaves the matchUp TO_BE_PLAYED — which would let a suppression
+ * assertion pass for the wrong reason. The result is asserted, not assumed.
+ */
+function complete(matchUpId: string, drawId: string) {
+  const { outcome } = mocksEngine.generateOutcomeFromScoreString({
+    scoreString: '6-1 6-1',
+    matchUpStatus: COMPLETED,
+    winningSide: 1,
+  });
+  const result: any = tournamentEngine.setMatchUpStatus({ outcome, matchUpId, drawId });
+  expect(result).toMatchObject(SUCCESS);
+}
+
+describe('timeModifiers survive until the start is settled', () => {
+  it('hydrates the annotation while the matchUp has not begun', () => {
+    const { matchUpId } = setup();
+    expect(hydratedModifiers(matchUpId)).toEqual([FOLLOWED_BY]);
+  });
+
+  it('suppresses once the matchUp is called to court', () => {
+    const { matchUpId, drawId } = setup();
+    // `addMatchUpScheduleItems` reports success and silently ignores calledAt —
+    // `setMatchUpCalledAt` is the mutation that actually writes it.
+    const result: any = tournamentEngine.setMatchUpCalledAt({
+      calledAt: '2026-06-15T14:00:00.000Z',
+      matchUpId,
+      drawId,
+    });
+    expect(result).toMatchObject(SUCCESS);
+    expect(hydratedModifiers(matchUpId)).toBeUndefined();
+  });
+
+  it('suppresses on a PARTIAL score — the state a live match sits in for an hour', () => {
+    const { matchUpId, drawId } = setup();
+    const result: any = tournamentEngine.setMatchUpStatus({
+      matchUpId,
+      drawId,
+      outcome: { score: { sets: [{ side1Score: 3, side2Score: 2 }] } },
+    });
+    expect(result).toMatchObject(SUCCESS);
+    // Still TO_BE_PLAYED — this is the live-match state, not a completed one.
+    const { matchUp }: any = tournamentEngine.findMatchUp({ matchUpId, drawId });
+    expect(matchUp.winningSide).toBeUndefined();
+    expect(hydratedModifiers(matchUpId)).toBeUndefined();
+  });
+
+  it('suppresses on a completed score', () => {
+    const { matchUpId, drawId } = setup();
+    complete(matchUpId, drawId);
+    expect(hydratedModifiers(matchUpId)).toBeUndefined();
+  });
+
+  it('suppresses on a walkover — resolved is resolved, even with nobody on court', () => {
+    const { matchUpId, drawId } = setup();
+    const result: any = tournamentEngine.setMatchUpStatus({
+      matchUpId,
+      drawId,
+      outcome: { matchUpStatus: WALKOVER, winningSide: 1 },
+    });
+    expect(result).toMatchObject(SUCCESS);
+    expect(hydratedModifiers(matchUpId)).toBeUndefined();
+  });
+});
+
+describe('suppression is a view, not a deletion', () => {
+  it('leaves the stored value untouched, so the write path still sees the intent', () => {
+    const { matchUpId, drawId } = setup();
+    complete(matchUpId, drawId);
+
+    expect(hydratedModifiers(matchUpId)).toBeUndefined();
+    expect(storedModifiers(matchUpId, drawId)).toEqual([FOLLOWED_BY]);
+  });
+
+  it('shows the annotation again when the score is removed — no rule of its own', () => {
+    const { matchUpId, drawId } = setup();
+    complete(matchUpId, drawId);
+    expect(hydratedModifiers(matchUpId)).toBeUndefined();
+
+    const reset: any = tournamentEngine.setMatchUpStatus({
+      matchUpId,
+      drawId,
+      outcome: { score: undefined, winningSide: undefined, matchUpStatus: TO_BE_PLAYED },
+    });
+    expect(reset).toMatchObject(SUCCESS);
+    expect(hydratedModifiers(matchUpId)).toEqual([FOLLOWED_BY]);
+  });
+});


### PR DESCRIPTION
## The problem

A `FOLLOWED_BY` or `AFTER_REST` / `NOT_BEFORE` annotation is a promise about **when a matchUp may begin**. Once that question is settled the annotation is not merely redundant — on a published order of play it is **misinformation**, telling a player and a referee that a match is waiting on something that has already happened.

Today they survive both being called to court and being scored.

## Two settling signals, both local to the matchUp

- **Called to court.** A match that has been called *is* on court; "followed by" is moot for it whatever else on that court did or did not finish.
- **Any score at all.** A single game is enough, and the **partial** case is the one that matters: that is the state a live match sits in for an hour while the annotation goes on claiming it has not begun. A completed status settles it too, walkovers included — resolved is resolved.

## Suppressed at hydration, never cleared

The stored value is the operator's stated intent and stays exactly where they put it. That single choice does most of the work:

- **The reverse case needs no rule of its own.** Remove the score and the annotation is visible again, because the condition that hid it lapsed. Clearing on score entry would have forced a decision about restoring consumed intent.
- **No score-entry path can forget.** Hydration is downstream of the draw view, the schedule, the relay and every import; a clear-on-write would have to be wired into each of them.
- **Fan-out is free.** Score entry and `setMatchUpCalledAt` already emit notices, and subscribers receive matchUps through hydration — so they get the suppressed shape with no new notice type and no new mutation. In CFS this fires the existing subscriptions unchanged.
- **Publishing inherits it.** `addMatchUpContext` applies embargo and `scheduleVisibilityFilters` to the hydrated schedule, downstream of this.

**Read-side only.** `matchUpTimeModifiers` — the write path used by `mutate/matchUps/schedule/scheduledTime.ts` — reads storage directly, so adding and removing modifiers still operates on the real value.

## Placement

`getMatchUpScheduleDetails` assembles `timeModifiers` and is reached from exactly one caller (`addMatchUpContext`), so this is one function rather than a pattern to spread. Everything the rule needs was already in scope there: `matchUp.matchUpStatus` (already tested against `completedMatchUpStatuses`), `matchUp.score`, and `schedule.calledAt`.

## Stated consequence

The record keeps a `timeModifiers` value that no longer displays anywhere, and a TODS export will contain it. That is the price of non-destructive, and it is the right price.

## Verification

Seven tests, falsified in both directions — reverting the one-line suppression fails six of the seven. Full suite **11,396** green; `pnpm verify` clean end to end (generated, types, lint, attr-audit, coverage, coverage-headroom, server, audit, build, publint, runtime, shakeable, bundle-size, surface, pack).

Two test-side traps found on the way, both recorded in the test file because they will catch the next person:

- `addMatchUpScheduleItems` returns `{success: true}` while **silently ignoring `calledAt`** — `setMatchUpCalledAt` is the mutation that actually writes it.
- `findMatchUp` hydrates **even without `inContext`**, so proving the value still exists requires walking the drawDefinition; the obvious reader reports the suppressed view and cannot distinguish suppressed from deleted.

Every mutation result is asserted rather than assumed, because a rejected one leaves the matchUp `TO_BE_PLAYED` and would let a suppression assertion pass for the wrong reason — which is exactly what the first draft did with a `6-1` score the default format rejects.