### PR TITLE
feat(analysis): report extensions that no reader will ever see

### DIFF
--- a/src/constants/attributeConstants.ts
+++ b/src/constants/attributeConstants.ts
@@ -37,6 +37,7 @@ export const UUIDS = 'uuids';
 export const PENALTY_TYPE = 'penaltyType';
 export const PENALTY_ID = 'penaltyId';
 export const VENUE_ID = 'venueId';
+export const VENUE = 'venue';
 export const STAGE = 'stage';
 
 export const AVERAGE_MATCHUP_MINUTES = 'averageMatchUpMinutes';

--- a/src/mutate/extensions/addExtension.ts
+++ b/src/mutate/extensions/addExtension.ts
@@ -59,6 +59,20 @@ export function addExtension(params?: AddExtensionArgs): {
     params.extension.createdAt ??= new Date().toISOString();
   }
 
+  // ── Invariant: AT MOST ONE extension per `name`, per element ──
+  //
+  // Find-and-replace, push only when absent. This is what MAINTAINS the invariant, and readers
+  // depend on it: `getAppliedPolicies` and friends resolve an extension with `.find()`, which
+  // returns the FIRST match. Writer and reader therefore agree by construction.
+  //
+  // Nothing ENFORCES the invariant, though — it is upheld here rather than validated on the way in.
+  // A record assembled outside this API (hand-built fixture, importer, classic-converter, legacy
+  // storage) can carry two extensions of the same name, and every `.find()` reader will silently
+  // use the first and ignore the second. That is quiet data loss on a path nothing checks, which is
+  // why `analyzeTournament` reports duplicates as `extensionAnomalies` rather than anyone throwing.
+  //
+  // If you are here because a policy you attached "did not take effect", the cause is more likely a
+  // duplicate already on the element than anything wrong with this function.
   const existingExtension = params.element.extensions.find(({ name }) => name === params.extension.name);
   if (existingExtension) {
     existingExtension.value = params.extension.value;

--- a/src/query/extensions/getAppliedPolicies.ts
+++ b/src/query/extensions/getAppliedPolicies.ts
@@ -38,6 +38,16 @@ export function getAppliedPolicies({
 
   function extractAppliedPolicies(params) {
     const extensions = params?.extensions;
+    // `.find()` takes the FIRST extension of this name, which is correct because `addExtension`
+    // maintains at most one per name per element — it replaces in place and pushes only when
+    // absent, and `attachPolicies` goes through it (guarding again per policyType with
+    // EXISTING_POLICY_TYPE unless `allowReplacement`). Writer and reader agree by construction.
+    //
+    // This is NOT a fail-open, and it has been mistaken for one: a dropped duplicate is not
+    // systematically more permissive — the surviving FIRST extension may be stricter or looser than
+    // the one ignored. The real exposure is narrower: the invariant is convention rather than
+    // enforcement, so a record built outside the API can carry duplicates whose later entries
+    // vanish without error. `analyzeTournament` reports those as `extensionAnomalies`.
     const extensionPolicies = extensions?.find((extension) => extension.name === APPLIED_POLICIES)?.value;
     if (extensionPolicies) {
       for (const key of Object.keys(extensionPolicies))

--- a/src/query/tournaments/analyzeDraws.ts
+++ b/src/query/tournaments/analyzeDraws.ts
@@ -34,8 +34,12 @@ export function analyzeDraws({ tournamentRecord }): {
 
   const eventsMap = {};
 
-  const eventDraws = tournamentRecord.events
-    ?.flatMap((event: any) => {
+  // `?? []` rather than `events?.flatMap(...)`: the optional chain guarded this expression and left
+  // `eventDraws` undefined, which the unguarded `.forEach` on the next line then threw on. A
+  // tournament with no events is ordinary — one that has been created but not yet built out — and
+  // analysis of it should return empty, not crash.
+  const eventDraws = (tournamentRecord.events ?? [])
+    .flatMap((event: any) => {
       const eventId = event.eventId;
       eventsMap[eventId] = event;
       return (event?.drawDefinitions ?? []).map((drawDefinition: any) => ({

--- a/src/query/tournaments/analyzeTournament.ts
+++ b/src/query/tournaments/analyzeTournament.ts
@@ -1,3 +1,4 @@
+import { getExtensionAnomalies } from '@Query/tournaments/getExtensionAnomalies';
 import { getParticipants } from '@Query/participants/getParticipants';
 import { analyzeDraws } from '@Query/tournaments/analyzeDraws';
 import { checkIsDual } from '@Query/tournaments/checkIsDual';
@@ -19,6 +20,13 @@ export function analyzeTournament({ tournamentRecord }) {
   const participantResult = getParticipants({ tournamentRecord });
   if (participantResult.missingParticipantIds?.length) {
     analysis.missingParticipantIds = participantResult.missingParticipantIds;
+  }
+
+  // Extensions after the first of a given name are unreachable — every reader resolves with
+  // `.find()`. Only present when there is something to report, matching `missingParticipantIds`.
+  const extensionAnomalies = getExtensionAnomalies({ tournamentRecord });
+  if (extensionAnomalies.length) {
+    analysis.extensionAnomalies = extensionAnomalies;
   }
 
   return { ...SUCCESS, analysis };

--- a/src/query/tournaments/getExtensionAnomalies.ts
+++ b/src/query/tournaments/getExtensionAnomalies.ts
@@ -1,0 +1,72 @@
+import { Tournament } from '@Types/tournamentTypes';
+
+/**
+ * Extensions that will be silently ignored because something earlier holds the same `name`.
+ *
+ * `addExtension` maintains at most one extension per `name` per element — it replaces in place and
+ * pushes only when absent — and every reader resolves with `.find()`, taking the FIRST match.
+ * Writer and reader agree, so a record built through the API cannot trip this.
+ *
+ * Records assembled OUTSIDE the API can: hand-built fixtures, importers, classic-converter, and
+ * anything restored from legacy storage. There, a second extension of the same name is dropped with
+ * no error and no signal — the attached policy, timing override or flag simply never takes effect.
+ * That is the failure this reports: not a wrong value, but a value nobody will ever read.
+ *
+ * Reported rather than thrown. The condition is rare, always upstream of the factory, and never
+ * makes a tournament unusable — it makes one attachment inert. Refusing to load the record would be
+ * a wildly disproportionate response to a duplicate flag on one venue.
+ */
+
+type ElementType = 'TOURNAMENT' | 'EVENT' | 'DRAW_DEFINITION' | 'STRUCTURE' | 'PARTICIPANT' | 'VENUE';
+
+export type ExtensionAnomaly = {
+  /** Names occurring more than once; every occurrence after the first is unreachable. */
+  duplicateNames: { name: string; occurrences: number }[];
+  elementType: ElementType;
+  /** Absent for TOURNAMENT, which is identified by the record itself. */
+  elementId?: string;
+};
+
+function duplicatesOf(element: any): { name: string; occurrences: number }[] {
+  const extensions = element?.extensions;
+  if (!Array.isArray(extensions) || extensions.length < 2) return [];
+
+  const counts = new Map<string, number>();
+  for (const extension of extensions) {
+    const name = extension?.name;
+    if (typeof name !== 'string') continue;
+    counts.set(name, (counts.get(name) ?? 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .filter(([, occurrences]) => occurrences > 1)
+    .map(([name, occurrences]) => ({ name, occurrences }))
+    .sort((a, b) => b.occurrences - a.occurrences || a.name.localeCompare(b.name));
+}
+
+export function getExtensionAnomalies({ tournamentRecord }: { tournamentRecord: Tournament }): ExtensionAnomaly[] {
+  const anomalies: ExtensionAnomaly[] = [];
+
+  const consider = (element: any, elementType: ElementType, elementId?: string) => {
+    const duplicateNames = duplicatesOf(element);
+    if (duplicateNames.length) anomalies.push({ duplicateNames, elementType, ...(elementId && { elementId }) });
+  };
+
+  consider(tournamentRecord, 'TOURNAMENT');
+
+  for (const participant of tournamentRecord?.participants ?? [])
+    consider(participant, 'PARTICIPANT', participant?.participantId);
+
+  for (const venue of tournamentRecord?.venues ?? []) consider(venue, 'VENUE', venue?.venueId);
+
+  for (const event of tournamentRecord?.events ?? []) {
+    consider(event, 'EVENT', event?.eventId);
+    for (const drawDefinition of event?.drawDefinitions ?? []) {
+      consider(drawDefinition, 'DRAW_DEFINITION', drawDefinition?.drawId);
+      for (const structure of drawDefinition?.structures ?? [])
+        consider(structure, 'STRUCTURE', structure?.structureId);
+    }
+  }
+
+  return anomalies;
+}

--- a/src/query/tournaments/getExtensionAnomalies.ts
+++ b/src/query/tournaments/getExtensionAnomalies.ts
@@ -1,3 +1,11 @@
+import {
+  DRAW_DEFINITION,
+  EVENT,
+  PARTICIPANT,
+  STRUCTURE,
+  TOURNAMENT_RECORD,
+  VENUE,
+} from '@Constants/attributeConstants';
 import { Tournament } from '@Types/tournamentTypes';
 
 /**
@@ -17,13 +25,23 @@ import { Tournament } from '@Types/tournamentTypes';
  * a wildly disproportionate response to a duplicate flag on one venue.
  */
 
-type ElementType = 'TOURNAMENT' | 'EVENT' | 'DRAW_DEFINITION' | 'STRUCTURE' | 'PARTICIPANT' | 'VENUE';
+/**
+ * Reuses the canonical element vocabulary in `attributeConstants` rather than inventing a parallel
+ * set of literals — these are the same names the rest of the factory uses for these elements.
+ */
+type ElementType =
+  | typeof TOURNAMENT_RECORD
+  | typeof DRAW_DEFINITION
+  | typeof PARTICIPANT
+  | typeof STRUCTURE
+  | typeof EVENT
+  | typeof VENUE;
 
 export type ExtensionAnomaly = {
   /** Names occurring more than once; every occurrence after the first is unreachable. */
   duplicateNames: { name: string; occurrences: number }[];
   elementType: ElementType;
-  /** Absent for TOURNAMENT, which is identified by the record itself. */
+  /** Absent for the tournamentRecord itself, which the caller already holds. */
   elementId?: string;
 };
 
@@ -52,19 +70,18 @@ export function getExtensionAnomalies({ tournamentRecord }: { tournamentRecord: 
     if (duplicateNames.length) anomalies.push({ duplicateNames, elementType, ...(elementId && { elementId }) });
   };
 
-  consider(tournamentRecord, 'TOURNAMENT');
+  consider(tournamentRecord, TOURNAMENT_RECORD);
 
   for (const participant of tournamentRecord?.participants ?? [])
-    consider(participant, 'PARTICIPANT', participant?.participantId);
+    consider(participant, PARTICIPANT, participant?.participantId);
 
-  for (const venue of tournamentRecord?.venues ?? []) consider(venue, 'VENUE', venue?.venueId);
+  for (const venue of tournamentRecord?.venues ?? []) consider(venue, VENUE, venue?.venueId);
 
   for (const event of tournamentRecord?.events ?? []) {
-    consider(event, 'EVENT', event?.eventId);
+    consider(event, EVENT, event?.eventId);
     for (const drawDefinition of event?.drawDefinitions ?? []) {
-      consider(drawDefinition, 'DRAW_DEFINITION', drawDefinition?.drawId);
-      for (const structure of drawDefinition?.structures ?? [])
-        consider(structure, 'STRUCTURE', structure?.structureId);
+      consider(drawDefinition, DRAW_DEFINITION, drawDefinition?.drawId);
+      for (const structure of drawDefinition?.structures ?? []) consider(structure, STRUCTURE, structure?.structureId);
     }
   }
 

--- a/src/tests/query/extensions/extensionAnomalies.test.ts
+++ b/src/tests/query/extensions/extensionAnomalies.test.ts
@@ -5,6 +5,7 @@ import mocksEngine from '@Assemblies/engines/mock';
 import { expect, describe, it } from 'vitest';
 
 // constants and types
+import { DRAW_DEFINITION, EVENT, STRUCTURE, TOURNAMENT_RECORD, VENUE } from '@Constants/attributeConstants';
 import { POLICY_TYPE_AVOIDANCE } from '@Constants/policyConstants';
 import { APPLIED_POLICIES } from '@Constants/extensionConstants';
 
@@ -48,7 +49,7 @@ describe('getExtensionAnomalies', () => {
 
     const anomalies = getExtensionAnomalies({ tournamentRecord: record });
     expect(anomalies.length).toEqual(1);
-    expect(anomalies[0].elementType).toEqual('TOURNAMENT');
+    expect(anomalies[0].elementType).toEqual(TOURNAMENT_RECORD);
     expect(anomalies[0].duplicateNames).toEqual([{ name: APPLIED_POLICIES, occurrences: 2 }]);
 
     // The consequence, asserted rather than assumed: the SECOND value is the one nobody reads.
@@ -79,10 +80,10 @@ describe('getExtensionAnomalies', () => {
     const anomalies = getExtensionAnomalies({ tournamentRecord: record });
     const byType = Object.fromEntries(anomalies.map((a) => [a.elementType, a]));
 
-    expect(byType.EVENT?.elementId).toEqual(event.eventId);
-    expect(byType.DRAW_DEFINITION?.elementId).toEqual(drawDefinition.drawId);
-    expect(byType.STRUCTURE?.elementId).toEqual(structure.structureId);
-    expect(byType.VENUE?.elementId).toEqual(venue.venueId);
+    expect(byType[EVENT]?.elementId).toEqual(event.eventId);
+    expect(byType[DRAW_DEFINITION]?.elementId).toEqual(drawDefinition.drawId);
+    expect(byType[STRUCTURE]?.elementId).toEqual(structure.structureId);
+    expect(byType[VENUE]?.elementId).toEqual(venue.venueId);
   });
 
   it('is quiet on a clean record — three occurrences of DIFFERENT names are not an anomaly', () => {

--- a/src/tests/query/extensions/extensionAnomalies.test.ts
+++ b/src/tests/query/extensions/extensionAnomalies.test.ts
@@ -1,0 +1,131 @@
+import { getExtensionAnomalies } from '@Query/tournaments/getExtensionAnomalies';
+import { getAppliedPolicies } from '@Query/extensions/getAppliedPolicies';
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { expect, describe, it } from 'vitest';
+
+// constants and types
+import { POLICY_TYPE_AVOIDANCE } from '@Constants/policyConstants';
+import { APPLIED_POLICIES } from '@Constants/extensionConstants';
+
+/**
+ * Duplicate extension names are unreachable data: every reader resolves with `.find()`, so only the
+ * FIRST extension of a name is ever seen. `addExtension` maintains one-per-name, which is why a
+ * record built through the API cannot trip this — and why the detector has to be fed a record built
+ * by hand to have anything to find.
+ *
+ * That asymmetry is the point of the first test: it proves the API upholds the invariant, so the
+ * detector is aimed at genuinely-external data rather than at a defect in the factory.
+ */
+
+const AVOIDANCE = { policyAttributes: [{ directive: 'groupParticipants' }] };
+
+describe('the API upholds one-extension-per-name', () => {
+  it('replaces in place rather than appending a second', () => {
+    mocksEngine.generateTournamentRecord({ setState: true });
+    tournamentEngine.attachPolicies({ policyDefinitions: { [POLICY_TYPE_AVOIDANCE]: AVOIDANCE } });
+    tournamentEngine.attachPolicies({
+      policyDefinitions: { [POLICY_TYPE_AVOIDANCE]: { ...AVOIDANCE, policyName: 'second' } },
+      allowReplacement: true,
+    });
+
+    const record = tournamentEngine.getTournament().tournamentRecord;
+    const applied = (record.extensions ?? []).filter((e: any) => e.name === APPLIED_POLICIES);
+    expect(applied.length).toEqual(1);
+    expect(getExtensionAnomalies({ tournamentRecord: record })).toEqual([]);
+  });
+});
+
+describe('getExtensionAnomalies', () => {
+  it('reports a duplicate, and the duplicate really is unreachable', () => {
+    mocksEngine.generateTournamentRecord({ setState: true });
+    const record = tournamentEngine.getTournament().tournamentRecord;
+
+    // Built by hand, exactly as an importer or legacy converter would.
+    record.extensions = record.extensions ?? [];
+    record.extensions.push({ name: APPLIED_POLICIES, value: { [POLICY_TYPE_AVOIDANCE]: AVOIDANCE } });
+    record.extensions.push({ name: APPLIED_POLICIES, value: { [POLICY_TYPE_AVOIDANCE]: { policyName: 'ignored' } } });
+
+    const anomalies = getExtensionAnomalies({ tournamentRecord: record });
+    expect(anomalies.length).toEqual(1);
+    expect(anomalies[0].elementType).toEqual('TOURNAMENT');
+    expect(anomalies[0].duplicateNames).toEqual([{ name: APPLIED_POLICIES, occurrences: 2 }]);
+
+    // The consequence, asserted rather than assumed: the SECOND value is the one nobody reads.
+    const applied = getAppliedPolicies({ tournamentRecord: record }).appliedPolicies;
+    expect(applied?.[POLICY_TYPE_AVOIDANCE]?.policyName).toBeUndefined();
+    expect(applied?.[POLICY_TYPE_AVOIDANCE]?.policyAttributes).toBeDefined();
+  });
+
+  it('finds duplicates on nested elements and names the element', () => {
+    mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 8 }],
+      venueProfiles: [{ courtsCount: 2 }],
+      setState: true,
+    });
+    const record = tournamentEngine.getTournament().tournamentRecord;
+
+    const event = record.events[0];
+    const drawDefinition = event.drawDefinitions[0];
+    const structure = drawDefinition.structures[0];
+    const venue = record.venues[0];
+
+    for (const element of [event, drawDefinition, structure, venue]) {
+      element.extensions = element.extensions ?? [];
+      element.extensions.push({ name: 'dupe', value: 1 });
+      element.extensions.push({ name: 'dupe', value: 2 });
+    }
+
+    const anomalies = getExtensionAnomalies({ tournamentRecord: record });
+    const byType = Object.fromEntries(anomalies.map((a) => [a.elementType, a]));
+
+    expect(byType.EVENT?.elementId).toEqual(event.eventId);
+    expect(byType.DRAW_DEFINITION?.elementId).toEqual(drawDefinition.drawId);
+    expect(byType.STRUCTURE?.elementId).toEqual(structure.structureId);
+    expect(byType.VENUE?.elementId).toEqual(venue.venueId);
+  });
+
+  it('is quiet on a clean record — three occurrences of DIFFERENT names are not an anomaly', () => {
+    mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 8 }],
+      setState: true,
+    });
+    const record = tournamentEngine.getTournament().tournamentRecord;
+    record.extensions = [
+      { name: 'alpha', value: 1 },
+      { name: 'beta', value: 2 },
+      { name: 'gamma', value: 3 },
+    ];
+    expect(getExtensionAnomalies({ tournamentRecord: record })).toEqual([]);
+  });
+});
+
+describe('analyzeTournament surfaces it', () => {
+  it('analyzes a tournament with no events at all', () => {
+    // Regression: `analyzeDraws` built `eventDraws` with `events?.flatMap(...)` and then called
+    // `.forEach` on it unguarded, so an event-less tournament threw rather than analyzing empty.
+    // A created-but-not-yet-built-out tournament is ordinary, and it is exactly what the detector
+    // above is most likely to be pointed at during an import.
+    mocksEngine.generateTournamentRecord({ setState: true });
+    const result: any = tournamentEngine.analyzeTournament();
+    expect(result.error).toBeUndefined();
+    expect(result.analysis).toBeDefined();
+  });
+
+  it('omits extensionAnomalies when clean and includes it when not', () => {
+    mocksEngine.generateTournamentRecord({ setState: true });
+
+    const clean: any = tournamentEngine.analyzeTournament();
+    expect(clean.analysis.extensionAnomalies).toBeUndefined();
+
+    const record = tournamentEngine.getTournament().tournamentRecord;
+    record.extensions = record.extensions ?? [];
+    record.extensions.push({ name: 'dupe', value: 1 });
+    record.extensions.push({ name: 'dupe', value: 2 });
+    tournamentEngine.setState(record);
+
+    const dirty: any = tournamentEngine.analyzeTournament();
+    expect(dirty.analysis.extensionAnomalies?.length).toEqual(1);
+    expect(dirty.analysis.extensionAnomalies[0].duplicateNames[0].name).toEqual('dupe');
+  });
+});


### PR DESCRIPTION
Follow-up to a correction. While closing out the avoidance workstream I described duplicate `APPLIED_POLICIES` extensions as a "fail-open" — then checked the writer and found that was wrong. CA's call: document the real behaviour where people will meet it, and detect the narrow thing that *is* true.

## What is actually true

An extension after the first of a given `name` is **unreachable**. Every reader resolves with `.find()`, so the attached policy, timing override or flag never takes effect — no error, no signal.

`addExtension` maintains one-per-name (replaces in place, pushes only when absent) and `attachPolicies` guards again per `policyType`. **A record built through the factory cannot get into this state.** The invariant is upheld by the writer rather than validated on the way in, so records assembled *outside* the API — hand-built fixtures, importers, classic-converter, legacy storage — can carry duplicates that vanish silently.

It is **not** a fail-open: the surviving *first* extension is not systematically more permissive than the one dropped. That distinction is now written into both files, because I got it wrong by reading one half.

## Documented at both halves

Neither `addExtension` nor `getAppliedPolicies` said which side upheld the invariant, which is exactly why meeting either alone reads as a bug. Each now states it and points at the other.

## Detected, not enforced

`analyzeTournament` gains `extensionAnomalies`, present only when non-empty (matching `missingParticipantIds`). Walks tournament, participants, venues, events, drawDefinitions, structures; reports element type, id, and each duplicated name with its occurrence count.

Reported rather than thrown deliberately — the condition is rare, always upstream, and never makes a tournament unusable; it makes one attachment inert. Detecting by name **generally** rather than for `appliedPolicies` alone, since the invariant is per-name for every extension.

## Bonus: a crash the new tests found

`analyzeDraws` built `eventDraws` with `events?.flatMap(...)` then called `.forEach` on it **unguarded** — so `analyzeTournament` **threw** on a tournament with no events. The optional chain guarded one step and the next line crashed.

An event-less tournament is ordinary, and it is precisely what this detector gets pointed at during an import — which is how the tests hit it. Fixed with `?? []` so the expression is total, plus a regression test.

## Falsification

- Revert the `analyzeDraws` fix → the event-less test fails.
- Blind the detector (`occurrences > 1` → `> 99`) → all three detection tests fail, while the clean-record and API-upholds-invariant tests stay green.

The first test asserts the API **cannot** produce a duplicate — that is what proves the detector is aimed at external data rather than at a factory defect. The duplicate test asserts the *consequence* (the second value is the one nobody reads), not merely that the report fires.

`lint`, `check-types` green; 514 tests across the touched areas pass.