### PR TITLE
style: move the multi-line destructured import last

### DIFF
--- a/src/query/tournaments/getExtensionAnomalies.ts
+++ b/src/query/tournaments/getExtensionAnomalies.ts
@@ -1,3 +1,4 @@
+import { Tournament } from '@Types/tournamentTypes';
 import {
   DRAW_DEFINITION,
   EVENT,
@@ -6,7 +7,6 @@ import {
   TOURNAMENT_RECORD,
   VENUE,
 } from '@Constants/attributeConstants';
-import { Tournament } from '@Types/tournamentTypes';
 
 /**
  * Extensions that will be silently ignored because something earlier holds the same `name`.


### PR DESCRIPTION
Standards pass on what #4702 merged. One real violation.

Imports sort longest-first within a section, but **multi-line destructured imports go last** regardless of length. In `getExtensionAnomalies.ts` the `attributeConstants` import was first.

## The mechanism is worth noting, because it will recur

I wrote that import as a single line. **Prettier wrapped it** when it crossed 120 characters, which turned a correctly-ordered single-line import into a misplaced multi-line one — no human touched the import block.

Neither eslint nor prettier enforces this ordering, so the file was green under `lint`, `check-types`, `prettier` **and** the full `pnpm verify` while being wrong. Adding one more constant to any destructured import can silently move it out of position the same way.

This is the second import-ordering violation this session that survived every automated check (the other was in #4700). Both were caught only by reading the block. If that keeps happening, an eslint rule for it would be worth more than the manual passes.

## Verification

`pnpm verify` exits 0 across all 8 stages. No behaviour change — import order only.