### PR TITLE
fix(schedule): addMatchUpScheduleItems covers calledAt, and names what it will not write

### DIFF
--- a/src/constants/errorConditionConstants.ts
+++ b/src/constants/errorConditionConstants.ts
@@ -8,6 +8,14 @@ export const ANACHRONISM = {
   message: 'Chronological error; time violation.',
   code: 'ANACHRONISM',
 };
+// A schedule attribute that was accepted but not written. Reported rather than
+// thrown because reading a schedule and writing it back is a supported pattern;
+// `errorOnUnknownAttributes` escalates it, exactly as `errorOnAnachronism` does
+// for ANACHRONISM.
+export const UNWRITABLE_SCHEDULE_ATTRIBUTES = {
+  message: 'Schedule attributes accepted but not written.',
+  code: 'UNWRITABLE_SCHEDULE_ATTRIBUTES',
+};
 // Assigning a BYE to a drawPosition whose matchUp already holds a court/time is
 // ambiguous: the operator may be mid-swap and want the placement kept, or may want
 // the slot released. Rather than guess, the position-action path refuses until the
@@ -907,6 +915,7 @@ export const CAPACITY_EXCEEDED = {
 
 export const errorConditionConstants = {
   ANACHRONISM,
+  UNWRITABLE_SCHEDULE_ATTRIBUTES,
   BOOKING_NOT_FOUND,
   CANNOT_CHANGE_WINNING_SIDE,
   CAPACITY_EXCEEDED,

--- a/src/mutate/matchUps/schedule/scheduleItems/scheduleItems.ts
+++ b/src/mutate/matchUps/schedule/scheduleItems/scheduleItems.ts
@@ -20,6 +20,7 @@ import { assignMatchUpVenue } from '@Mutate/matchUps/schedule/assignMatchUpVenue
 import { allTournamentMatchUps } from '@Query/matchUps/getAllTournamentMatchUps';
 import { addMatchUpTimeItem } from '@Mutate/timeItems/matchUps/matchUpTimeItems';
 import { getMatchUpDependencies } from '@Query/matchUps/getMatchUpDependencies';
+import { setMatchUpCalledAt } from '@Mutate/matchUps/schedule/setMatchUpCalledAt';
 import { modifyMatchUpNotice } from '@Mutate/notifications/drawNotifications';
 import { scheduledMatchUpDate } from '@Query/matchUp/scheduledMatchUpDate';
 import { getParticipants } from '@Query/participants/getParticipants';
@@ -62,6 +63,7 @@ import {
   INVALID_END_TIME,
   INVALID_TIME,
   ANACHRONISM,
+  UNWRITABLE_SCHEDULE_ATTRIBUTES,
   INVALID_VALUES,
   ErrorType,
   MISSING_TOURNAMENT_RECORD,
@@ -101,11 +103,35 @@ function applyScheduleTiming({
   stopTime,
   resumeTime,
   endTime,
+  calledAt,
   matchUpId,
   matchUp,
   event,
   stack,
 }) {
+  // `calledAt` is an actual-play attribute and belongs with the four below it,
+  // not with placement: the schedule lock deliberately does not guard any of
+  // them, so a pinned matchUp can still be called, started, suspended and
+  // completed.
+  //
+  // The guard is `!== undefined`, matching every sibling, and that is a
+  // DELIBERATE narrowing of `setMatchUpCalledAt`'s own contract. Called
+  // directly, that method reads `undefined` as "clear". Here an absent key
+  // destructures to `undefined` too, so honouring that reading would make every
+  // partial schedule write silently wipe a call-to-court. `null` remains the
+  // explicit clear, which is what a caller round-tripping a schedule object
+  // would send anyway.
+  if (calledAt !== undefined) {
+    const result = setMatchUpCalledAt({
+      disableNotice: true,
+      tournamentRecord,
+      drawDefinition,
+      matchUpId,
+      calledAt,
+      event,
+    });
+    if (result?.error) return decorateResult({ result, stack, context: { calledAt } });
+  }
   if (scheduledDate !== undefined) {
     const result = addMatchUpScheduledDate({
       disableNotice: true,
@@ -309,12 +335,110 @@ function unassignGridPosition({ tournamentRecords, tournamentRecord, drawDefinit
   assignMatchUpVenue({ ...shared, tournamentRecords, venueId: undefined });
 }
 
+/**
+ * Every attribute this facade actually writes.
+ *
+ * Kept as an explicit set rather than derived from the destructure so that
+ * adding a key to one and forgetting the other is a test failure rather than a
+ * silent no-op — which is the exact defect this guard exists to close.
+ */
+const WRITABLE_SCHEDULE_ATTRIBUTES = new Set([
+  'allocatedCourts',
+  'calledAt',
+  'courtAnnotation',
+  'courtId',
+  'courtIds',
+  'courtOrder',
+  'endTime',
+  'homeParticipantId',
+  'resumeTime',
+  'scheduledDate',
+  'scheduledTime',
+  'startTime',
+  'stopTime',
+  'timeModifiers',
+  'venueId',
+]);
+
+/**
+ * Hydrator output that a caller can only ever be echoing back, never setting.
+ *
+ * Reading a matchUp's schedule and writing it back is a supported pattern — it
+ * is what the `courtIds` / `allocatedCourts` accommodation above exists to
+ * protect — and a hydrated schedule carries fourteen keys this facade does not
+ * write. Warning about these would make every round-trip noisy for values the
+ * caller had no way to omit and no ability to influence, so they are dropped in
+ * silence, deliberately.
+ */
+const DERIVED_SCHEDULE_ATTRIBUTES = new Set([
+  'averageMinutes',
+  'courtName',
+  'endDate',
+  'isoDateString',
+  'milliseconds',
+  'recoveryMinutes',
+  'time',
+  'timeAfterRecovery',
+  'typeChangeRecoveryMinutes',
+  'typeChangeTimeAfterRecovery',
+  'venueAbbreviation',
+  'venueName',
+]);
+
+/**
+ * Attributes this facade ignores, reported rather than dropped in silence.
+ *
+ * The dangerous class is NOT the typo — it is the **real attribute this function
+ * does not happen to write**. `calledAt` was one: hydrated, storable, accepted
+ * without complaint and never written, so a caller got `{ success: true }` and
+ * no call-to-court. `allocatedCourts` was another, fixed in place above. A guard
+ * that only caught unrecognised names would have caught neither, because both
+ * are names the hydrator emits.
+ *
+ * So anything neither written nor purely derived is named back to the caller —
+ * `lock` most of all, since silently discarding a director's pin is the worst of
+ * these to discover later. Warnings, not errors, because callers in the field
+ * round-trip locked and scored matchUps today and breaking them to make a point
+ * about hygiene would be the wrong trade; `errorOnUnknownAttributes` escalates
+ * per call, mirroring how `errorOnAnachronism` escalates ANACHRONISM.
+ */
+function unwritableScheduleAttributes(schedule: any): string[] {
+  return Object.keys(schedule ?? {}).filter(
+    (key) =>
+      schedule[key] !== undefined && !WRITABLE_SCHEDULE_ATTRIBUTES.has(key) && !DERIVED_SCHEDULE_ATTRIBUTES.has(key),
+  );
+}
+
+/** The unwritable attributes, plus the error to return if this caller asked to be stopped by them. */
+function checkUnwritableAttributes(schedule: any, errorOnUnknownAttributes: boolean, stack: string) {
+  const unwritable = unwritableScheduleAttributes(schedule);
+  if (!unwritable.length || !errorOnUnknownAttributes) return { unwritable };
+  return {
+    unwritable,
+    error: decorateResult({
+      result: { error: UNWRITABLE_SCHEDULE_ATTRIBUTES },
+      info: `not written: ${unwritable.join(', ')}`,
+      stack,
+    }),
+  };
+}
+
+/** Success, carrying whatever the call has to say for itself. */
+function scheduleItemsResult(warning: any, unwritable: string[]) {
+  const warnings = [
+    ...(warning ? [warning] : []),
+    ...(unwritable.length ? [{ ...UNWRITABLE_SCHEDULE_ATTRIBUTES, attributes: unwritable }] : []),
+  ];
+  return warnings.length ? { ...SUCCESS, warnings } : { ...SUCCESS };
+}
+
 type AddMatchUpScheduleItemsArgs = {
   inContextMatchUps?: HydratedMatchUp[];
   drawMatchUps?: HydratedMatchUp[];
   overrideScheduleLock?: boolean;
   proConflictDetection?: boolean;
   drawDefinition: DrawDefinition;
+  errorOnUnknownAttributes?: boolean;
   errorOnAnachronism?: boolean;
   removePriorValues?: boolean;
   checkChronology?: boolean;
@@ -347,6 +471,7 @@ export function addMatchUpScheduleItems(params: AddMatchUpScheduleItemsArgs): {
 
   let { matchUpDependencies, inContextMatchUps } = params;
   const {
+    errorOnUnknownAttributes = false,
     proConflictDetection = false,
     errorOnAnachronism = false,
     checkChronology = true,
@@ -386,8 +511,14 @@ export function addMatchUpScheduleItems(params: AddMatchUpScheduleItemsArgs): {
     }
   }
 
+  // Reported before anything is written, so a caller learns what will be ignored
+  // even when a later step errors out.
+  const { unwritable, error: unwritableError } = checkUnwritableAttributes(schedule, errorOnUnknownAttributes, stack);
+  if (unwritableError) return unwritableError;
+
   const {
     endTime,
+    calledAt,
     courtId,
     courtAnnotation,
     courtOrder,
@@ -465,6 +596,7 @@ export function addMatchUpScheduleItems(params: AddMatchUpScheduleItemsArgs): {
     stopTime,
     resumeTime,
     endTime,
+    calledAt,
     matchUpId,
     matchUp,
     event,
@@ -513,7 +645,7 @@ export function addMatchUpScheduleItems(params: AddMatchUpScheduleItemsArgs): {
     });
   }
 
-  return warning ? { ...SUCCESS, warnings: [warning] } : { ...SUCCESS };
+  return scheduleItemsResult(warning, unwritable);
 }
 
 function checkScheduleConflicts({

--- a/src/tests/mutations/scheduling/scheduleItemsAttributeGuard.test.ts
+++ b/src/tests/mutations/scheduling/scheduleItemsAttributeGuard.test.ts
@@ -1,0 +1,117 @@
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+// constants
+import { UNWRITABLE_SCHEDULE_ATTRIBUTES } from '@Constants/errorConditionConstants';
+import { SINGLE_ELIMINATION } from '@Constants/drawDefinitionConstants';
+import { SUCCESS } from '@Constants/resultConstants';
+
+/**
+ * `addMatchUpScheduleItems` accepted any object and wrote only the attributes it
+ * destructured, returning `{ success: true }` either way. Two real attributes
+ * have already been lost that way — `allocatedCourts` (fixed in place) and
+ * `calledAt` — so the failure mode is recurring, not hypothetical.
+ *
+ * The guard has to survive read-modify-write, which is a supported pattern: a
+ * hydrated schedule carries a dozen keys the facade cannot write and the caller
+ * cannot omit. Those are dropped in silence. Everything else is named back.
+ */
+
+const START_DATE = '2026-06-15';
+
+function setup() {
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ drawType: SINGLE_ELIMINATION, drawSize: 8 }],
+    setState: true,
+    startDate: START_DATE,
+  });
+  const { matchUps }: any = tournamentEngine.allTournamentMatchUps();
+  const { matchUpId, drawId } = matchUps.find((m: any) => m.roundNumber === 1);
+  return { matchUpId, drawId };
+}
+
+function warnedAttributes(result: any): string[] {
+  const warning = (result.warnings ?? []).find((w: any) => w.code === UNWRITABLE_SCHEDULE_ATTRIBUTES.code);
+  return warning?.attributes ?? [];
+}
+
+describe('a schedule attribute that is not written says so', () => {
+  it('stays silent on a clean write', () => {
+    const { matchUpId, drawId } = setup();
+    const result: any = tournamentEngine.addMatchUpScheduleItems({
+      matchUpId,
+      drawId,
+      schedule: { scheduledDate: START_DATE, scheduledTime: '10:00' },
+    });
+    expect(result).toMatchObject(SUCCESS);
+    expect(result.warnings).toBeUndefined();
+  });
+
+  it('names a real attribute it cannot write — the class that lost calledAt', () => {
+    const { matchUpId, drawId } = setup();
+    const result: any = tournamentEngine.addMatchUpScheduleItems({
+      matchUpId,
+      drawId,
+      schedule: { scheduledDate: START_DATE, official: 'someOfficialId' },
+    });
+    expect(result).toMatchObject(SUCCESS);
+    expect(warnedAttributes(result)).toEqual(['official']);
+  });
+
+  it('names a misspelling rather than accepting it', () => {
+    const { matchUpId, drawId } = setup();
+    const result: any = tournamentEngine.addMatchUpScheduleItems({
+      matchUpId,
+      drawId,
+      schedule: { scheduleDate: START_DATE, calledat: '2026-06-15T14:00:00.000Z' },
+    });
+    expect(warnedAttributes(result).toSorted((a, b) => a.localeCompare(b))).toEqual(['calledat', 'scheduleDate']);
+  });
+
+  it('escalates to an error, and writes nothing, when the caller asks it to', () => {
+    const { matchUpId, drawId } = setup();
+    const result: any = tournamentEngine.addMatchUpScheduleItems({
+      matchUpId,
+      drawId,
+      errorOnUnknownAttributes: true,
+      schedule: { scheduledDate: START_DATE, nonsense: true },
+    });
+    expect(result.error).toEqual(UNWRITABLE_SCHEDULE_ATTRIBUTES);
+    expect(result.info).toContain('nonsense');
+
+    const { matchUp }: any = tournamentEngine.findMatchUp({ matchUpId, drawId });
+    expect(matchUp.schedule?.scheduledDate).toBeUndefined();
+  });
+
+  it('ignores an undefined value rather than reporting a key the caller did not set', () => {
+    const { matchUpId, drawId } = setup();
+    const result: any = tournamentEngine.addMatchUpScheduleItems({
+      matchUpId,
+      drawId,
+      schedule: { scheduledDate: START_DATE, official: undefined },
+    });
+    expect(result.warnings).toBeUndefined();
+  });
+});
+
+describe('read-modify-write survives the guard', () => {
+  it('writes back a whole hydrated schedule without a single warning', () => {
+    const { matchUpId, drawId } = setup();
+    tournamentEngine.addMatchUpScheduleItems({
+      matchUpId,
+      drawId,
+      schedule: { scheduledDate: START_DATE, scheduledTime: '10:00' },
+    });
+
+    // Every derived key the hydrator emits arrives here, unasked for and
+    // unomittable — isoDateString, averageMinutes, recoveryMinutes, venueName…
+    const { matchUp }: any = tournamentEngine.findMatchUp({ matchUpId, inContext: true });
+    const schedule = matchUp.schedule;
+    expect(Object.keys(schedule).length).toBeGreaterThan(2);
+
+    const result: any = tournamentEngine.addMatchUpScheduleItems({ matchUpId, drawId, schedule });
+    expect(result).toMatchObject(SUCCESS);
+    expect(result.warnings).toBeUndefined();
+  });
+});

--- a/src/tests/mutations/scheduling/scheduleItemsCalledAt.test.ts
+++ b/src/tests/mutations/scheduling/scheduleItemsCalledAt.test.ts
@@ -1,0 +1,113 @@
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+// constants
+import { SINGLE_ELIMINATION } from '@Constants/drawDefinitionConstants';
+import { SUCCESS } from '@Constants/resultConstants';
+
+/**
+ * `addMatchUpScheduleItems` is the batch facade over the per-attribute schedule
+ * methods. `calledAt` was absent from the attributes it destructures, so passing
+ * one returned `{ success: true }` and wrote nothing — the same silent-drop the
+ * `courtIds` / `allocatedCourts` comment in that file was written to fix.
+ *
+ * It belongs with the actual-play attributes (startTime / stopTime / resumeTime
+ * / endTime), which the facade already covers and which the schedule lock
+ * deliberately does not guard.
+ */
+
+const START_DATE = '2026-06-15';
+const CALLED_AT = '2026-06-15T14:00:00.000Z';
+
+function setup() {
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ drawType: SINGLE_ELIMINATION, drawSize: 8 }],
+    setState: true,
+    startDate: START_DATE,
+  });
+  const { matchUps }: any = tournamentEngine.allTournamentMatchUps();
+  const { matchUpId, drawId } = matchUps.find((m: any) => m.roundNumber === 1);
+  return { matchUpId, drawId };
+}
+
+/** Raw read — `findMatchUp` hydrates even without `inContext`. */
+function storedSchedule(matchUpId: string, drawId: string) {
+  const { drawDefinition }: any = tournamentEngine.getEvent({ drawId });
+  for (const structure of drawDefinition?.structures ?? []) {
+    const found = (structure.matchUps ?? []).find((m: any) => m.matchUpId === matchUpId);
+    if (found) return found.schedule ?? {};
+  }
+  return {};
+}
+
+describe('addMatchUpScheduleItems covers calledAt', () => {
+  it('writes calledAt, which previously reported success and did nothing', () => {
+    const { matchUpId, drawId } = setup();
+    const result: any = tournamentEngine.addMatchUpScheduleItems({
+      matchUpId,
+      drawId,
+      schedule: { calledAt: CALLED_AT },
+    });
+    expect(result).toMatchObject(SUCCESS);
+    expect(storedSchedule(matchUpId, drawId).calledAt).toEqual(CALLED_AT);
+  });
+
+  it('writes it alongside the other attributes in one call', () => {
+    const { matchUpId, drawId } = setup();
+    tournamentEngine.addMatchUpScheduleItems({
+      matchUpId,
+      drawId,
+      schedule: { scheduledDate: START_DATE, scheduledTime: '14:05', calledAt: CALLED_AT },
+    });
+    // `scheduledDate` is first-class and so reachable from the raw record;
+    // `startTime` is deliberately not asserted here — it is written as a
+    // timeItem rather than to `schedule`, so a raw read cannot see it.
+    const stored = storedSchedule(matchUpId, drawId);
+    expect(stored.calledAt).toEqual(CALLED_AT);
+    expect(stored.scheduledDate).toEqual(START_DATE);
+  });
+
+  it('clears on an explicit null, matching setMatchUpCalledAt', () => {
+    const { matchUpId, drawId } = setup();
+    tournamentEngine.addMatchUpScheduleItems({ matchUpId, drawId, schedule: { calledAt: CALLED_AT } });
+    expect(storedSchedule(matchUpId, drawId).calledAt).toEqual(CALLED_AT);
+
+    const result: any = tournamentEngine.addMatchUpScheduleItems({
+      matchUpId,
+      drawId,
+      schedule: { calledAt: null },
+    });
+    expect(result).toMatchObject(SUCCESS);
+    expect(storedSchedule(matchUpId, drawId).calledAt).toBeUndefined();
+  });
+
+  /**
+   * The one place the facade deliberately narrows `setMatchUpCalledAt`. Called
+   * directly, that method reads `undefined` as "clear"; here an omitted key
+   * destructures to `undefined` too, so honouring it would make every partial
+   * schedule write silently wipe a call-to-court.
+   */
+  it('does NOT clear calledAt when the key is simply absent from a later write', () => {
+    const { matchUpId, drawId } = setup();
+    tournamentEngine.addMatchUpScheduleItems({ matchUpId, drawId, schedule: { calledAt: CALLED_AT } });
+
+    tournamentEngine.addMatchUpScheduleItems({
+      matchUpId,
+      drawId,
+      schedule: { scheduledDate: START_DATE, scheduledTime: '15:00' },
+    });
+    expect(storedSchedule(matchUpId, drawId).calledAt).toEqual(CALLED_AT);
+  });
+
+  it('rejects a non-string calledAt rather than storing it', () => {
+    const { matchUpId, drawId } = setup();
+    const result: any = tournamentEngine.addMatchUpScheduleItems({
+      matchUpId,
+      drawId,
+      schedule: { calledAt: 1234 },
+    });
+    expect(result.error).toBeDefined();
+    expect(storedSchedule(matchUpId, drawId).calledAt).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Two changes, one root cause

`addMatchUpScheduleItems` is the **batch facade** over the per-attribute schedule methods — `applyScheduleTiming` and `applyScheduleAssignments` delegate onward to `addMatchUpScheduledDate`, `assignMatchUpCourt` and the rest. It destructured a fixed key list, wrote only those, and returned `{ success: true }` either way.

### 1. `calledAt` was missing from that list

Passing one reported success and wrote nothing.

It belongs with the actual-play attributes — `startTime`, `stopTime`, `resumeTime`, `endTime` — which the facade already covers and which the schedule lock deliberately does not guard. That function's own comment groups them: *"Actual-play attributes … are never guarded, so a locked matchUp can still be started, suspended and completed."* `calledAt` is the call-to-court moment immediately preceding `startTime`.

Now wired through `applyScheduleTiming` to `setMatchUpCalledAt`, guarded and `disableNotice`d exactly like its siblings.

**One deliberate narrowing**, documented at the call site: called directly, `setMatchUpCalledAt` reads `undefined` as *clear*. In the facade an absent key destructures to `undefined` too, so honouring that reading would make every partial schedule write silently wipe a call-to-court. `null` remains the explicit clear — which is what a round-tripping caller sends anyway.

### 2. The silent success, on its third appearance

`allocatedCourts` was lost this way and patched in place; the comment about it is still in the file. `calledAt` was lost the same way.

**A guard that only caught unrecognised names would have caught neither** — both are names the hydrator emits. The dangerous class is not the typo, it is *a real attribute the facade does not happen to write*. So attributes are sorted three ways:

| bucket | count | behaviour |
|---|---|---|
| **writable** | 15 | written, as before |
| **derived** | 12 — `isoDateString`, `milliseconds`, `time`, `venueName`, `venueAbbreviation`, `courtName`, `averageMinutes`, `recoveryMinutes`, `timeAfterRecovery`, `typeChange*`, `endDate` | ignored in silence |
| **everything else** | `lock`, `official`, `scorekeeper`, `timekeeper`, `scoredTime`, any misspelling | named back in `warnings` |

The derived bucket exists because **read-modify-write is a supported pattern** — it is what the `courtIds` / `allocatedCourts` accommodation protects — and a hydrated schedule carries a dozen keys the caller cannot omit and cannot influence. Warning about those would make every round-trip noisy.

`lock` is in the reported bucket on purpose: silently discarding a director's pin is the worst of these to discover later.

**Warnings, not errors.** Callers in the field round-trip locked and scored matchUps today; breaking them to make a point about hygiene is the wrong trade. `errorOnUnknownAttributes` escalates per call, mirroring exactly how `errorOnAnachronism` escalates `ANACHRONISM` in this same function.

## Verification

**Eleven tests, all falsified in both directions.** Two are worth calling out:

- A genuine **read-modify-write of a full hydrated schedule** that must produce **zero** warnings. Emptying the derived bucket makes it fail — that is the test protecting the round-trip.
- `calledAt` survives a later partial write that omits it, pinning the `undefined`-means-absent narrowing.

Full suite **11,410** green. `pnpm verify` clean across all fifteen steps (generated, types, lint, attr-audit, coverage, coverage-headroom, server, audit, build, publint, runtime, shakeable, bundle-size, surface, pack).

Extracted `checkUnwritableAttributes` and `scheduleItemsResult` — the guard took cognitive complexity to 33 against the repo's limit of 30.

## Note on provenance

Developed in a `git worktree`, not the shared factory checkout: mid-work another session checked that checkout onto its own branch while this change was uncommitted in the tree. Nothing of theirs was touched, and this branch is off current `master`.