### PR TITLE
docs: cover the three user-facing changes queued for 6.32.0, and pin the published components

### DIFF
--- a/documentation/docs/governors/schedule-governor.md
+++ b/documentation/docs/governors/schedule-governor.md
@@ -1456,15 +1456,85 @@ engine.addMatchUpScheduleItems({
     venueId, // optional — assigned venue
     courtOrder, // optional — order on court
     homeParticipantId, // optional — home team participant
+    calledAt, // optional — ISO instant; call to court. `null` clears
     courtIds, // optional — for TEAM matchUps, allocate courts
     allocatedCourts, // optional — alias for courtIds; accepts the read-side shape
   },
   removePriorValues, // optional boolean — clear existing schedule timeItems first
   checkChronology, // optional boolean — defaults to true; validate time ordering
   errorOnAnachronism, // optional boolean — return error on chronological violations
+  errorOnUnknownAttributes, // optional boolean — error instead of warning on attributes that will not be written
   proConflictDetection, // optional boolean — detect pro scheduling conflicts
   disableNotice, // optional boolean — suppress modification notices
 });
+```
+
+### `calledAt`
+
+`calledAt` is an **actual-play** attribute and sits with `startTime` / `stopTime` /
+`resumeTime` / `endTime` — none of which a [schedule lock](#setmatchupschedulelock)
+guards, so a pinned matchUp can still be called to court, started, suspended and
+completed.
+
+Its `undefined` handling differs from `setMatchUpCalledAt`
+**deliberately**. Called directly, that method reads `undefined` as _clear_. Here an
+omitted key destructures to `undefined` too, so honouring that reading would make
+every partial schedule write silently wipe a call-to-court:
+
+```js
+engine.addMatchUpScheduleItems({ matchUpId, drawId, schedule: { calledAt: isoInstant } });
+
+// later, a re-time that says nothing about calledAt — the call survives
+engine.addMatchUpScheduleItems({ matchUpId, drawId, schedule: { scheduledTime: '15:00' } });
+
+// explicit clear
+engine.addMatchUpScheduleItems({ matchUpId, drawId, schedule: { calledAt: null } });
+```
+
+### Attributes that will not be written are reported
+
+The method writes the attributes it recognises and, before 6.32.0, silently ignored
+everything else while still returning `{ success: true }`. Two real attributes were
+lost that way — `allocatedCourts` (see below) and `calledAt`.
+
+Incoming keys are now sorted three ways:
+
+| bucket            | attributes                                                                                                                                                                                                                 | behaviour              |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| **written**       | `scheduledDate`, `scheduledTime`, `startTime`, `stopTime`, `resumeTime`, `endTime`, `calledAt`, `courtId`, `courtIds`, `allocatedCourts`, `venueId`, `courtOrder`, `courtAnnotation`, `timeModifiers`, `homeParticipantId` | applied                |
+| **derived**       | `isoDateString`, `milliseconds`, `time`, `venueName`, `venueAbbreviation`, `courtName`, `averageMinutes`, `recoveryMinutes`, `timeAfterRecovery`, `typeChangeRecoveryMinutes`, `typeChangeTimeAfterRecovery`, `endDate`    | ignored silently       |
+| **anything else** | `lock`, `official`, `scorekeeper`, `timekeeper`, `scoredTime`, misspellings                                                                                                                                                | returned in `warnings` |
+
+The **derived** bucket exists so that read-modify-write keeps working: a hydrated
+schedule carries a dozen keys the caller cannot omit and cannot influence, and
+warning about those would make every round-trip noisy.
+
+```js
+const { warnings } = engine.addMatchUpScheduleItems({
+  matchUpId,
+  drawId,
+  schedule: { scheduledDate, official: personId },
+});
+// warnings → [{ code: 'UNWRITABLE_SCHEDULE_ATTRIBUTES', attributes: ['official'] }]
+```
+
+`lock` is in the reported bucket on purpose — silently discarding a director's pin is
+the worst of these to discover later. Assign officials through the
+[officiating governor](./officiating-governor) and pin with
+[`setMatchUpScheduleLock`](#setmatchupschedulelock).
+
+Warnings rather than errors, because callers round-trip locked and scored matchUps
+today. Pass `errorOnUnknownAttributes: true` to make it a hard error instead — the
+same escalation `errorOnAnachronism` provides for chronology:
+
+```js
+const result = engine.addMatchUpScheduleItems({
+  matchUpId,
+  drawId,
+  errorOnUnknownAttributes: true,
+  schedule: { scheduledDate, nonsense: true },
+});
+// result.error → UNWRITABLE_SCHEDULE_ATTRIBUTES; nothing is written
 ```
 
 ### Court allocation: `courtIds` in, `allocatedCourts` out
@@ -1580,6 +1650,55 @@ Behavior:
 This is engine-generated state, not an input: it is treated as read-only by
 consumers and reflects the engine's own capture, not a value supplied by the
 caller.
+
+---
+
+## `timeModifiers` are suppressed once a matchUp's start is settled
+
+A `FOLLOWED_BY` or `AFTER_REST` / `NOT_BEFORE` annotation is a promise about **when a
+matchUp may begin**. Once that question is settled the annotation is not merely
+redundant — on a published order of play it is misinformation, telling a player and a
+referee that a match is waiting on something that has already happened.
+
+From **6.32.0**, hydration omits `schedule.timeModifiers` once either of two local
+signals says the start is settled:
+
+- **Called to court** — `schedule.calledAt` is present. A match that has been called
+  _is_ on court; "followed by" is moot for it whatever else on that court did or did
+  not finish.
+- **Any score at all** — a single game is enough, and the partial case is the one that
+  matters: that is the state a live match sits in for an hour while the annotation
+  goes on claiming it has not begun. A completed status settles it too, walkovers
+  included.
+
+### Suppressed, never cleared
+
+The stored value is untouched. That is what makes the behaviour reversible without a
+rule of its own:
+
+```js
+engine.addMatchUpScheduleItems({ matchUpId, drawId, schedule: { timeModifiers: ['FOLLOWED_BY'] } });
+
+engine.setMatchUpStatus({ matchUpId, drawId, outcome }); // any score
+engine.findMatchUp({ matchUpId, inContext: true }).matchUp.schedule.timeModifiers; // undefined
+
+engine.setMatchUpStatus({ matchUpId, drawId, outcome: { score: undefined, winningSide: undefined } });
+engine.findMatchUp({ matchUpId, inContext: true }).matchUp.schedule.timeModifiers; // ['FOLLOWED_BY']
+```
+
+Consequences worth knowing:
+
+- **Read-side only.** The write path reads storage directly, so adding and removing
+  modifiers still operates on the real value — a UI that renders annotation controls
+  from a _hydrated_ matchUp will show none on a settled matchUp, which is intended.
+- **Subscribers get it for free.** Score entry and `setMatchUpCalledAt` already emit
+  notices, and subscribers receive matchUps through hydration, so no new notice type
+  and no new mutation are involved.
+- **Publishing inherits it.** Embargo and `scheduleVisibilityFilters` are applied to
+  the hydrated schedule, downstream of this.
+- **The record still carries the value.** A TODS export will contain a
+  `timeModifiers` entry that no longer displays anywhere. That is the price of not
+  destroying an operator's stated intent.
 
 ---
 

--- a/documentation/docs/governors/tournament-governor.md
+++ b/documentation/docs/governors/tournament-governor.md
@@ -105,6 +105,34 @@ const { analysis } = engine.analyzeTournament();
 
 **Returns:** Tournament-level metrics including events, participants, draws, and matchUps.
 
+### `extensionAnomalies`
+
+From **6.32.0**, the analysis reports extensions that no reader will ever see.
+
+An extension after the first of a given `name` is **unreachable** — every reader
+resolves with `.find()` — so the attached policy, timing override or flag simply never
+takes effect, with no error and no signal.
+
+```js
+const { analysis } = engine.analyzeTournament();
+analysis.extensionAnomalies;
+// [{ element: 'venue', elementId: 'venue-1', name: 'scheduleTiming', count: 3 }]
+```
+
+Present **only when there is something to report**, matching how
+`missingParticipantIds` behaves — so its absence is the ordinary case, not a
+failure to look.
+
+Records built through the factory cannot reach this state: `addExtension` maintains
+one-per-name (it replaces in place and pushes only when absent) and `attachPolicies`
+guards again per `policyType`. The invariant is upheld by the writer rather than
+validated on the way in, which is precisely why records assembled **outside** the API
+— hand-built fixtures, importers, `classic-converter`, legacy storage — can carry
+duplicates that vanish silently. This reports them rather than throwing: the condition
+is rare and always upstream of the factory.
+
+`analyzeDraws` reports the same anomalies for draw-level extensions.
+
 ---
 
 ## copyTournamentRecord

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -21,7 +21,7 @@
     "@mdx-js/react": "^3.1.1",
     "@types/react": "19.2.18",
     "clsx": "2.1.1",
-    "courthive-components": "3.14.4",
+    "courthive-components": "3.15.1",
     "leaflet": "^1.9.4",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",

--- a/documentation/pnpm-lock.yaml
+++ b/documentation/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: 2.1.1
         version: 2.1.1
       courthive-components:
-        specifier: 3.14.4
-        version: 3.14.4(@tiptap/pm@3.30.2)(leaflet@1.9.4)(tods-competition-factory@6.30.0)
+        specifier: 3.15.1
+        version: 3.15.1(@tiptap/pm@3.30.2)(leaflet@1.9.4)(tods-competition-factory@6.30.0)
       leaflet:
         specifier: ^1.9.4
         version: 1.9.4
@@ -2461,8 +2461,8 @@ packages:
       typescript:
         optional: true
 
-  courthive-components@3.14.4:
-    resolution: {integrity: sha512-SajkfKmPRIIswm5E92aVmfBl8QUcgEJ7BbjP3b5JiZUuuL+zDt+OX2S/TkT6h5YtrAKex41J+fauLCgslEicNw==}
+  courthive-components@3.15.1:
+    resolution: {integrity: sha512-c5M+W8jHCzvc9T9fZDAiWlrRjsf1BeGxroqwyk/sUqtzd4bBHXBSjgHm17uPZRJ+EbBqyREq2/5V9Ex8L7JNGw==}
     engines: {node: '>=22'}
     peerDependencies:
       leaflet: ^1.9.4
@@ -9265,7 +9265,7 @@ snapshots:
       parse-json: 5.2.0
       path-type: 4.0.0
 
-  courthive-components@3.14.4(@tiptap/pm@3.30.2)(leaflet@1.9.4)(tods-competition-factory@6.30.0):
+  courthive-components@3.15.1(@tiptap/pm@3.30.2)(leaflet@1.9.4)(tods-competition-factory@6.30.0):
     dependencies:
       '@tiptap/core': 3.30.2(@tiptap/pm@3.30.2)
       '@tiptap/extension-color': 3.30.2(@tiptap/extension-text-style@3.30.2(@tiptap/core@3.30.2(@tiptap/pm@3.30.2)))


### PR DESCRIPTION
Everything on `master` since `v6.31.0` that a consumer can observe — none of which arrived with documentation.

## `timeModifiers` are suppressed once a matchUp's start is settled (#4701)

New section in the schedule governor covering the two settling signals (`calledAt` present; any score at all, partial included), and the **suppressed-never-cleared** property that makes score removal restore the annotation without needing a rule of its own.

States the four consequences rather than leaving them to be discovered: read-side only so the write path still sees the real value; subscribers get it through hydration with no new notice type; publishing inherits it via the existing embargo filter; and the record still carries a `timeModifiers` value that no longer displays anywhere, which a TODS export will contain.

## `addMatchUpScheduleItems` covers `calledAt`, and reports what it will not write (#4705)

- `calledAt` documented as an actual-play attribute, with the **deliberate divergence** from `setMatchUpCalledAt` on `undefined` spelled out and shown in code — an omitted key must not clear a call-to-court.
- The three attribute buckets as a table (written / derived-and-ignored / reported), including *why* the derived bucket exists: read-modify-write is supported, and a hydrated schedule carries a dozen keys the caller cannot omit.
- `errorOnUnknownAttributes` as the opt-in escalation, alongside the `errorOnAnachronism` precedent.

## `analyzeTournament` reports `extensionAnomalies` (#4702)

Why a second extension of a given `name` is unreachable (`.find()`), why records built through the factory cannot reach that state (`addExtension` maintains one-per-name, `attachPolicies` guards per `policyType`), and therefore why the anomalies only ever come from records assembled outside the API — fixtures, importers, `classic-converter`, legacy storage. Notes that it is present only when non-empty, matching `missingParticipantIds`.

## Dependency

Takes `documentation`'s `courthive-components` pin to the published **3.15.1**. Renovate's #4703 had just moved it `3.14.3 → 3.14.4`, two minors behind the registry. Lockfile synced.

## Not included

The remaining commits since `v6.31.0` are tests (#4699, #4700), style (#4704), and docs corrections that already shipped (#4694, #4696, #4697, #4698) — no consumer-visible surface.

## Verification

`pnpm lint:md` clean across all 188 files.