### PR TITLE
docs(reports): mark the factory copy of wasPlayed authoritative

### DIFF
--- a/src/query/reports/recoveryTimeline.ts
+++ b/src/query/reports/recoveryTimeline.ts
@@ -78,8 +78,24 @@ export type DurationSource = 'measured' | 'scoredTime' | 'calledAt' | 'estimated
  * default, so reusing it charges a player full recovery, a daily ordinal and
  * estimated court time for a matchUp they never played.
  *
- * `CANCELLED` is present here and absent from the TMX set only because it falls
- * outside that module's domain — a cancelled matchUp plainly put nobody on court.
+ * ── THIS COPY IS AUTHORITATIVE (decided 2026-08-25) ──
+ *
+ * The predicate exists in two places: here and TMX `participantRest.ts`. They were
+ * briefly out of step — `CANCELLED` was added here first — and TMX has since adopted
+ * it, so the two sets are now IDENTICAL. Neither copy had been marked as the source
+ * of truth, which is what allowed the drift.
+ *
+ * **Change this one first.** A change here is a change to what the whole ecosystem
+ * counts as "played"; TMX follows. If you find the two disagreeing again, the factory
+ * is right by default and the divergence is the bug.
+ *
+ * One divergence IS deliberate and should not be "fixed": TMX's finish-anchor
+ * plausibility check tolerates a missing start, because a draw-view score entry
+ * leaves no start while its stamp is the only evidence the match happened. The
+ * equivalent here (`isPlausibleFinish`) returns false without a start, because it
+ * computes a DURATION and cannot measure one from nothing. Same idea, different
+ * question — do not align them.
+ *
  * `RETIRED` and `ABANDONED` are deliberately absent from this set: both mean time
  * was spent on court.
  */


### PR DESCRIPTION
Comment-only. Two facts about `wasPlayed` lived solely in a Mentat in-flight claim that is about to be archived, and would have been lost with it.

## The existing comment had gone false

It read: *"`CANCELLED` is present here and absent from the TMX set."*

TMX adopted `CANCELLED` on 2026-08-25 — `participantRest.ts:213`, verified in source. The two sets are now **identical**, so the comment described a difference that no longer exists.

## The authority decision was unrecorded

The predicate exists in two places — here and TMX — and **neither was marked as the source of truth.** That is exactly what let them drift.

The TMX session that adopted `CANCELLED` (in response to a cross-session note from this one) decided **the factory wins**, and that changes land here first. That decision was written into an in-flight claim, which is the wrong home for a durable cross-repo contract. It now sits at the definition, where anyone about to edit either copy will meet it.

## One divergence that must NOT be aligned

Recorded so a future reader doesn't "tidy" it:

- **TMX's** finish-anchor plausibility check tolerates a missing start — a draw-view score entry leaves no start, while its stamp is the only evidence the match happened.
- **`isPlausibleFinish` here** returns false without a start, because it computes a **duration** and cannot measure one from nothing.

Same idea, different question.

## Verification

`pnpm verify` exits 0 across all 8 stages. No behaviour change.