### PR TITLE
docs(reports): record that TMX now enforces the wasPlayed agreement

### DIFF
--- a/src/query/reports/recoveryTimeline.ts
+++ b/src/query/reports/recoveryTimeline.ts
@@ -89,6 +89,20 @@ export type DurationSource = 'measured' | 'scoredTime' | 'calledAt' | 'estimated
  * counts as "played"; TMX follows. If you find the two disagreeing again, the factory
  * is right by default and the divergence is the bug.
  *
+ * **And TMX now checks.** `TMX/src/pages/tournament/tabs/scheduleViews/wasPlayedConformance.test.ts`
+ * runs the Participant Recovery report over one matchUp per status and asserts its own
+ * copy reaches the same verdict this one does. So a change here that TMX has not
+ * followed does not drift quietly for a release — it turns that suite red on the next
+ * factory bump, which is the whole reason it exists: this paragraph asked the next
+ * editor to keep the two in step, and asking is what failed the first time.
+ *
+ * Two things that suite pins, worth knowing before editing the sets below. A
+ * `DOUBLE_DEFAULT` never reaches the score-discriminated branch in practice —
+ * `setMatchUpStatus` keeps the status and drops the sets, so it answers `false`
+ * whatever the caller passed. And the verdict is asserted through a non-UTC venue
+ * zone, because whether a matchUp was played is a property of its status and score
+ * and must never acquire a dependency on the clock.
+ *
  * One divergence IS deliberate and should not be "fixed": TMX's finish-anchor
  * plausibility check tolerates a missing start, because a draw-view score entry
  * leaves no start while its stamp is the only evidence the match happened. The


### PR DESCRIPTION
Follow-up to #4707, which marked this copy of `wasPlayed` authoritative.

That block already said the factory copy wins and asked the next editor to keep TMX in step. **Asking is exactly what failed the first time** — the two drifted by `CANCELLED` while both files carried comments requesting agreement. A comment is not a gate.

TMX now checks. [`wasPlayedConformance.test.ts`](https://github.com/CourtHive/TMX/blob/main/src/pages/tournament/tabs/scheduleViews/wasPlayedConformance.test.ts) (TMX #1362, merged) drives the Participant Recovery report over one matchUp per status and asserts its own copy reaches the same verdict this one does. So a change here that TMX has not followed turns that suite red on the next factory bump, rather than drifting quietly for a release.

It is behavioural rather than a source comparison because it has to be: `wasPlayed` is not exported from the package entry, the published tarball ships `dist` only (`files: ['dist']`), and TMX's CI strips the `link:` overrides — so a test reading the sibling checkout would assert against code TMX does not ship against. Verified non-vacuous over there by reintroducing the historical drift: dropping `CANCELLED` from TMX's set turns exactly one case red, the one named for it.

The comment also records two things that suite pins, both easy to get wrong by reading the predicate instead of the record:

- **A `DOUBLE_DEFAULT` never reaches the score-discriminated branch.** `setMatchUpStatus` keeps the status and drops the sets, so it answers `false` whatever the caller passed. That is a property of the engine, not of the rule.
- **The verdict is asserted through a non-UTC venue zone**, so `wasPlayed` cannot quietly acquire a dependency on the clock — it is a property of status and score only.

Comment-only; no behaviour change. `pnpm verify` green (exit 0), including the coverage-headroom gate.