### PR TITLE
feat(codes): make "being sanctioned" expressible

### DIFF
--- a/attr-audit.allow.json
+++ b/attr-audit.allow.json
@@ -39,5 +39,6 @@
   "USER",
   "weights",
   "winnerMatchUpIds",
-  "Winners"
+  "Winners",
+  "ZONE"
 ]

--- a/documentation/docs/codes/sanctioning.mdx
+++ b/documentation/docs/codes/sanctioning.mdx
@@ -83,7 +83,14 @@ tournamentRecord.sanction = {
   ruleset: { rulesetId: 'POLICY_SANCTIONING_USTA', edition: '2026.1', enforcement: 'ENFORCE' },
 
   identifiers: [{ identifier: '26-80173' }],
-  fees: [{ feeKind: 'HEAD_TAX', perParticipant: true, amount: 4, maximumAmount: 100, currencyCode: 'USD' }],
+  fees: [
+    {
+      feeKind: 'HEAD_TAX',
+      perParticipant: true,
+      fee: { amount: 400, currencyCode: 'USD', unit: 'MINOR' }, // $4.00 per entrant
+      maximum: { amount: 10000, currencyCode: 'USD', unit: 'MINOR' }, // capped at $100.00
+    },
+  ],
   submissionWindow: { from: '2026-01-07', to: '2026-02-01', timeZone: 'America/New_York' },
   sanctioningId: '…',
 };
@@ -106,6 +113,17 @@ insurance are independent of grade, and insurance is often the _reason_ an organ
 **`fees` is a list, and fee shapes vary.** Flat, percentage, per-entry, and per-entry-with-a-cap all
 occur — sometimes in one federation — and some bodies price draw stages separately, which is what
 `appliesTo` is for.
+
+**A monetary amount always states its unit.** `MonetaryAmount` requires `amount`, `currencyCode` and
+`unit` together, so `{ amount: 4000, currencyCode: 'USD', unit: 'MINOR' }` unambiguously means
+$40.00. This is deliberately not an optional flag: a federation reporting `4000` means 40.00, and a
+reader assuming whole units is off by 100× with nothing in the record to signal it. The minor-unit
+exponent is currency-specific (USD 2, JPY 0, KWD 3), which is why the currency must travel with the
+unit for `MINOR` to be resolvable.
+
+> `PrizeMoney` predates this and carries `amount` + `currencyCode` with no unit, so it retains the
+> ambiguity. It is intentionally left alone — changing its meaning would break existing records —
+> but new monetary fields should use `MonetaryAmount`.
 
 **`sanctions`** (plural, on `Tournament`) carries additional sanctions where a competition is
 approved by more than one body. Dual sanctioning is common: an international-grade event usually

--- a/documentation/docs/codes/sanctioning.mdx
+++ b/documentation/docs/codes/sanctioning.mdx
@@ -1,0 +1,142 @@
+---
+title: Sanctioning
+---
+
+CODES models sanctioning in two halves, and keeping them apart is the point.
+
+|                           | what it is                                                           | where it lives                                          |
+| ------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------- |
+| **`SanctioningRecord`**   | _becoming_ sanctioned — the application a governing body decides on  | held by the sanctioning service; discarded once decided |
+| **`Tournament.sanction`** | _being_ sanctioned — the decision as an attribute of the competition | travels with the `tournamentRecord`                     |
+
+The application side has always been rich. The competition side used to be a single string:
+`processCodes: ['SANCTIONED']`. That marker survives for existing consumers, but it is a boolean,
+and real federation data does not fit one.
+
+## Three axes
+
+Every governing body surveyed conflates at least two of these. CODES separates them.
+
+| axis               | question it answers                          | field                     |
+| ------------------ | -------------------------------------------- | ------------------------- |
+| **decision**       | did the application succeed?                 | `sanction.decision`       |
+| **recognition**    | what does the body _assert_ about the event? | `sanction.recognition`    |
+| **classification** | what competitive grade is conferred?         | `sanction.classification` |
+
+The separation is what makes real data expressible. A USTA tournament is routinely **both**
+`sanctionStatus: "APPROVED"` **and** `level: "Unsanctioned"` — approved to run by its district,
+conferring no ranking status. Under one axis that reads as a contradiction. Under three it is:
+
+```js
+{
+  decision: 'APPROVED',          // the district approved the application
+  recognition: 'UNSANCTIONED',   // but asserts no competitive standing
+  classification: undefined,     // so no grade is conferred
+}
+```
+
+### `decision` — the workflow outcome
+
+`PENDING` · `APPROVED` · `CONDITIONAL` · `DENIED` · `WITHDRAWN` · `REVOKED` · `SUSPENDED` ·
+`EXPIRED` · `DOWNGRADED`
+
+Distinct from `SanctioningStatusEnum`, which tracks an application through review. Note
+`WITHDRAWN` is **applicant**-initiated, while `REVOKED` / `SUSPENDED` / `DOWNGRADED` are
+**authority**-initiated after approval — routine annual outcomes at several federations, and not
+expressible as withdrawal.
+
+### `recognition` — what the body asserts
+
+`SANCTIONED` · `APPROVED` · `OBSERVED` · `RECOGNISED` · `LICENSED` · `UNSANCTIONED`
+
+Modelled on USA Swimming Article 202, the most explicit published vocabulary found. Each value
+implies a different enforced rule subset, a different participant-eligibility rule, a different
+issuing authority and a different downstream consequence:
+
+- **`SANCTIONED`** — the body's own competition, under the whole of its rulebook, members only.
+- **`APPROVED`** — run by someone else under an enumerated _subset_ of the body's rules; members
+  and non-members may compete; results still count.
+- **`OBSERVED`** — run under _another_ body's rules, with a handful of checkpoints verified so
+  individual results can still be recognised.
+- **`RECOGNISED`** — another body's competition accepted wholesale by reference.
+- **`LICENSED`** — permitted to use the body's marks or programme without competitive standing.
+- **`UNSANCTIONED`** — known to the body and explicitly outside its competitive structure.
+
+### `classification` — the grade conferred
+
+A [`TierClassification`](../types/typedefs) — `{ system, value, numericRank? }` — the same shape as
+`tournamentTier`, so federation vocabularies (`Category 1`, `A`, `J300`, `B-1`) need no translation.
+
+## The rest of the record
+
+```js
+tournamentRecord.sanction = {
+  decision: 'APPROVED',
+  recognition: 'SANCTIONED',
+  classification: { system: 'USTA', value: 'Level 5', numericRank: 3 },
+
+  authority: { organisationId: '…', organisationName: 'Georgia', role: 'DISTRICT', regionCode: '034' },
+  approvalChain: [/* ordered broadest → narrowest */],
+
+  decisionRecord: { decidedAt: '2026-03-14T10:00:00.000Z', decidedByName: 'A. Reviewer', appealable: true },
+  confers: { rankingEligible: true, recordEligible: false, insured: true },
+  ruleset: { rulesetId: 'POLICY_SANCTIONING_USTA', edition: '2026.1', enforcement: 'ENFORCE' },
+
+  identifiers: [{ identifier: '26-80173' }],
+  fees: [{ feeKind: 'HEAD_TAX', perParticipant: true, amount: 4, maximumAmount: 100, currencyCode: 'USD' }],
+  submissionWindow: { from: '2026-01-07', to: '2026-02-01', timeZone: 'America/New_York' },
+  sanctioningId: '…',
+};
+```
+
+A few of these earn their place for reasons that are not obvious:
+
+**`approvalChain` is not always a containment ladder.** Chains observed run 1–5 deep, and several
+federations do not cascade at all — some approve only at the regional tier, and at least one
+requires _joint_ approval by two co-equal bodies. Order it broadest → narrowest where a hierarchy
+exists; do not assume one.
+
+**`ruleset.edition` is not optional in spirit.** Governing-body rulebooks are annual. A sanction
+granted under one edition must not silently re-validate against the next. `appliedRules` exists
+because a body may enforce only a named subset of its rules at lower recognition levels.
+
+**`confers` is not derivable from `classification`.** Ranking eligibility, record eligibility and
+insurance are independent of grade, and insurance is often the _reason_ an organiser applies.
+
+**`fees` is a list, and fee shapes vary.** Flat, percentage, per-entry, and per-entry-with-a-cap all
+occur — sometimes in one federation — and some bodies price draw stages separately, which is what
+`appliesTo` is for.
+
+**`sanctions`** (plural, on `Tournament`) carries additional sanctions where a competition is
+approved by more than one body. Dual sanctioning is common: an international-grade event usually
+also carries national approval.
+
+## Event grain
+
+`Event.sanction` exists because grade is genuinely per-event in several federations — one
+tournament routinely carries different categories for different age groups. This mirrors the
+existing `tournamentTier` / `eventTier` pair. Where an event carries no sanction of its own, the
+tournament's applies.
+
+## Activation
+
+`sanctioningEngine.activateFromSanctioning()` projects an approved application onto the competition,
+populating `sanction` from the record: the governing body becomes `authority`, endorsements become
+`approvalChain` (ordered by `endorsementLevel`, not array position, and including only endorsers
+that actually endorsed), the reviewer and approval date become `decisionRecord`, and the policy and
+its version become `ruleset`.
+
+## A naming caution
+
+"Sanction" is not universal. Most federations use it for approval, but at least one uses it in its
+regulations to mean a **disciplinary penalty** or a per-player fee — never approval — and another
+uses "Approved" as the name of a delivery-model subtype rather than a status. CODES uses
+_sanction_ consistently for approval; when surfacing these values to a federation's own users,
+translate to that federation's vocabulary rather than assuming the word travels.
+
+## Policy and constraints
+
+What a governing body _permits_ — allowed formats, fee bounds, submission windows, and which
+fields an organiser may not override — is the **policy layer**, and it lives outside CODES in the
+ingest tier, where it is exercised against real captured federation data. CODES models the
+decision; the policy layer models the rulebook that produced it.

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -432,7 +432,7 @@ module.exports = {
         {
           type: 'category',
           label: 'Codes',
-          items: ['codes/age-category', 'codes/matchup-format'],
+          items: ['codes/age-category', 'codes/matchup-format', 'codes/sanctioning'],
         },
       ],
     },

--- a/src/mutate/sanctioning/activateFromSanctioning.ts
+++ b/src/mutate/sanctioning/activateFromSanctioning.ts
@@ -15,7 +15,15 @@ import type {
   VenueProposal,
   EventProposal,
 } from '@Types/sanctioningTypes';
-import type { Tournament, Event, Venue, UnifiedEventID } from '@Types/tournamentTypes';
+import type {
+  SanctioningAuthority,
+  TournamentSanction,
+  UnifiedEventID,
+  Tournament,
+  Venue,
+  Event,
+} from '@Types/tournamentTypes';
+import { SanctionDecisionEnum, RecognitionEnum } from '@Types/tournamentTypes';
 
 type ActivateFromSanctioningArgs = {
   sanctioningRecord: SanctioningRecord;
@@ -107,6 +115,79 @@ function resolveVenues(venues: Venue[] | undefined, proposalVenues: VenueProposa
  * exists precisely to let one record carry events sanctioned elsewhere, so reading one for
  * the other is the mistake this field exists to prevent.
  */
+/**
+ * Project the approved application onto the competition as a `TournamentSanction`.
+ *
+ * This is the bridge between the two halves of the sanctioning domain: `SanctioningRecord` is the
+ * application (AMS-held, discarded once decided), while `TournamentSanction` is the decision as an
+ * attribute that travels with the record. Before this existed the projection was
+ * `processCodes: ['SANCTIONED']` and everything else the application knew — who approved it, when,
+ * under which rulebook edition, and whether it confers ranking status — was dropped on activation.
+ *
+ * `recognition` is SANCTIONED here because that is what activation means: this body ran the
+ * competition under its own rules. Records INGESTED from a federation may legitimately carry
+ * APPROVED / OBSERVED / UNSANCTIONED instead, which is why the field is not a constant.
+ */
+function buildSanction(sanctioningRecord: SanctioningRecord): TournamentSanction {
+  const { governingBody, governingBodyId, sanctioningTier, policyVersion, sanctioningPolicy } = sanctioningRecord;
+
+  const authority: SanctioningAuthority | undefined =
+    governingBodyId || governingBody
+      ? {
+          ...(governingBodyId ? { organisationId: governingBodyId } : {}),
+          ...(governingBody?.organisationName ? { organisationName: governingBody.organisationName } : {}),
+          ...(governingBody?.organisationAbbreviation
+            ? { organisationAbbreviation: governingBody.organisationAbbreviation }
+            : {}),
+        }
+      : undefined;
+
+  // The endorsement chain IS the approval chain, in the order the endorsements were required.
+  // Only endorsed links are included — a pending or declined endorser did not approve anything.
+  // `endorsementLevel` is the required ORDER (1 = first), so it — not array position — is what
+  // orders the chain. Endorsements without a level sort last rather than being dropped.
+  const approvalChain: SanctioningAuthority[] = (sanctioningRecord.endorsements ?? [])
+    .filter((endorsement) => endorsement?.status === 'ENDORSED' && endorsement.endorserId)
+    .slice()
+    .sort((a, b) => (a.endorsementLevel ?? Number.MAX_SAFE_INTEGER) - (b.endorsementLevel ?? Number.MAX_SAFE_INTEGER))
+    .map((endorsement) => ({
+      organisationId: endorsement.endorserId,
+      ...(endorsement.endorserName ? { organisationName: endorsement.endorserName } : {}),
+    }));
+
+  return {
+    decision: SanctionDecisionEnum.APPROVED,
+    recognition: RecognitionEnum.SANCTIONED,
+    ...(sanctioningTier ? { classification: { ...sanctioningTier } } : {}),
+    ...(authority ? { authority } : {}),
+    ...(approvalChain.length ? { approvalChain } : {}),
+    ...(sanctioningRecord.approvedAt || sanctioningRecord.reviewer
+      ? {
+          decisionRecord: {
+            ...(sanctioningRecord.approvedAt ? { decidedAt: sanctioningRecord.approvedAt } : {}),
+            ...(sanctioningRecord.reviewer?.reviewerName
+              ? { decidedByName: sanctioningRecord.reviewer.reviewerName }
+              : {}),
+            ...(sanctioningRecord.reviewer?.reviewerId
+              ? { decidedByPersonId: sanctioningRecord.reviewer.reviewerId }
+              : {}),
+          },
+        }
+      : {}),
+    // Pin the rulebook edition the decision was made under. Governing-body policies are annual;
+    // re-validating a granted sanction against a later edition is a real hazard.
+    ...(sanctioningPolicy || policyVersion
+      ? {
+          ruleset: {
+            ...(sanctioningPolicy ? { rulesetId: sanctioningPolicy } : {}),
+            ...(policyVersion ? { edition: policyVersion } : {}),
+          },
+        }
+      : {}),
+    sanctioningId: sanctioningRecord.sanctioningId,
+  };
+}
+
 function resolveEventOtherIds(
   ep: EventProposal,
   eventId: string,
@@ -173,7 +254,11 @@ export function activateFromSanctioning({
     totalPrizeMoney: proposal.totalPrizeMoney,
     registrationProfile: proposal.registrationProfile,
     tournamentStatus: 'ACTIVE',
+    // Retained for consumers that still read it. It is a boolean marker and cannot carry the
+    // decision, the authority chain, or what the sanction confers — `sanction` below is the
+    // richer expression of the same fact, and new consumers should read that.
     processCodes: ['SANCTIONED'],
+    sanction: buildSanction(sanctioningRecord),
 
     // Governance
     parentOrganisationId: sanctioningRecord.governingBodyId,

--- a/src/tests/constants/enumConstConformance.test.ts
+++ b/src/tests/constants/enumConstConformance.test.ts
@@ -225,6 +225,9 @@ const ENUM_ONLY = [
   'AuthorityRoleEnum',
   'SanctionEnforcementEnum',
   'SanctionFeeKindEnum',
+  // currency UNIT (minor vs whole) is a representation concern with no const-module twin — the
+  // currencies themselves are ISO 4217 strings, not a factory vocabulary
+  'CurrencyUnitEnum',
   'WheelchairClassEnum',
   'WinReasonEnum',
 ];

--- a/src/tests/constants/enumConstConformance.test.ts
+++ b/src/tests/constants/enumConstConformance.test.ts
@@ -214,6 +214,17 @@ const ENUM_ONLY = [
   // tier MOVEMENT is a derived vocabulary (promotion/relegation between seasons) with no
   // const-module twin — the tier systems themselves are free-form federation strings
   'TierMovementEnum',
+  // The sanction INSTANCE vocabularies. `sanctioningConstants` is the state machine for the
+  // sanctioning APPLICATION (DRAFT → SUBMITTED → … → CLOSED); these describe the DECISION as an
+  // attribute of the competition, which is a different vocabulary with deliberately different
+  // values — e.g. authority-initiated REVOKED/SUSPENDED, which an application state machine has no
+  // reason to model. Mirroring them onto that const module would fuse two vocabularies whose whole
+  // point is that they are distinct.
+  'SanctionDecisionEnum',
+  'RecognitionEnum',
+  'AuthorityRoleEnum',
+  'SanctionEnforcementEnum',
+  'SanctionFeeKindEnum',
   'WheelchairClassEnum',
   'WinReasonEnum',
 ];

--- a/src/tests/sanctioning/sanctionInstance.test.ts
+++ b/src/tests/sanctioning/sanctionInstance.test.ts
@@ -1,0 +1,173 @@
+import { activateFromSanctioning } from '@Mutate/sanctioning/activateFromSanctioning';
+import { expect, it, describe } from 'vitest';
+
+// constants
+import { APPROVED } from '@Constants/sanctioningConstants';
+import { SanctionDecisionEnum, RecognitionEnum } from '@Types/tournamentTypes';
+
+/**
+ * `Tournament.sanction` — the sanction INSTANCE model.
+ *
+ * `SanctioningRecord` models BECOMING sanctioned; it is AMS-held and discarded once decided.
+ * `TournamentSanction` models BEING sanctioned — the decision as an attribute that travels with the
+ * tournamentRecord. Before it existed, activation projected the entire application down to
+ * `processCodes: ['SANCTIONED']`, throwing away who approved it, when, under which rulebook
+ * edition, the approval chain, and what the sanction confers.
+ *
+ * The three axes exist because real federation data conflates them and a boolean cannot carry any
+ * of them: a USTA tournament is simultaneously `sanctionStatus: APPROVED` and `level: Unsanctioned`
+ * — approved to run by the district, conferring no ranking status.
+ */
+
+const baseRecord = (overrides: any = {}) =>
+  ({
+    sanctioningId: 's-1',
+    status: APPROVED,
+    governingBodyId: 'gb-1',
+    governingBody: {
+      organisationId: 'gb-1',
+      organisationName: 'Georgia',
+      organisationAbbreviation: 'GA',
+    },
+    approvedAt: '2026-03-14T10:00:00.000Z',
+    reviewer: { reviewerId: 'rev-1', reviewerName: 'Yannick Yoshizawa' },
+    sanctioningPolicy: 'POLICY_SANCTIONING_USTA',
+    policyVersion: '2026.1',
+    proposal: {
+      tournamentName: 'Peachtree Summer Open',
+      proposedStartDate: '2026-09-01',
+      proposedEndDate: '2026-09-05',
+      events: [{ eventName: 'Mens Singles', eventType: 'SINGLES' }],
+    },
+    statusHistory: [],
+    ...overrides,
+  }) as any;
+
+const activate = (record: any) => activateFromSanctioning({ sanctioningRecord: record });
+
+describe('Tournament.sanction on activation', () => {
+  it('projects the decision, recognition and authority onto the tournamentRecord', () => {
+    const result: any = activate(baseRecord());
+    const { sanction } = result.tournamentRecord;
+
+    expect(result.success).toEqual(true);
+    expect(sanction.decision).toEqual(SanctionDecisionEnum.APPROVED);
+    // Activation means this body ran the competition under its own rules.
+    expect(sanction.recognition).toEqual(RecognitionEnum.SANCTIONED);
+    expect(sanction.authority.organisationId).toEqual('gb-1');
+    expect(sanction.authority.organisationName).toEqual('Georgia');
+    expect(sanction.authority.organisationAbbreviation).toEqual('GA');
+    expect(sanction.sanctioningId).toEqual('s-1');
+  });
+
+  /**
+   * The whole point of the instance model: the decision's provenance survives activation. USTA
+   * carries exactly this (`lastSanctionStatusChange`) and — notably — its own TODS export drops it,
+   * so it is recoverable only from the public record.
+   */
+  it('preserves who decided and when', () => {
+    const { sanction } = (activate(baseRecord()) as any).tournamentRecord;
+
+    expect(sanction.decisionRecord.decidedAt).toEqual('2026-03-14T10:00:00.000Z');
+    expect(sanction.decisionRecord.decidedByName).toEqual('Yannick Yoshizawa');
+    expect(sanction.decisionRecord.decidedByPersonId).toEqual('rev-1');
+  });
+
+  /**
+   * Rulebook editions are annual. A sanction granted under one edition must not silently
+   * re-validate against the next, so the edition is pinned at the moment of decision.
+   */
+  it('pins the ruleset edition the decision was made under', () => {
+    const { sanction } = (activate(baseRecord()) as any).tournamentRecord;
+
+    expect(sanction.ruleset.rulesetId).toEqual('POLICY_SANCTIONING_USTA');
+    expect(sanction.ruleset.edition).toEqual('2026.1');
+  });
+
+  it('carries the sanctioned tier through as the conferred classification', () => {
+    const record = baseRecord({ sanctioningTier: { system: 'USTA', value: 'Level 5', numericRank: 3 } });
+    const { sanction, tournamentTier } = (activate(record) as any).tournamentRecord;
+
+    expect(sanction.classification).toEqual({ system: 'USTA', value: 'Level 5', numericRank: 3 });
+    // tournamentTier keeps its existing meaning; classification is not a replacement for it
+    expect(tournamentTier).toEqual({ system: 'USTA', value: 'Level 5', numericRank: 3 });
+  });
+
+  describe('approvalChain', () => {
+    /**
+     * `endorsementLevel` is the REQUIRED ORDER (1 = first), which is not necessarily the order the
+     * endorsements happen to sit in the array — so the chain sorts by it.
+     */
+    it('orders the chain by endorsementLevel, not array position', () => {
+      const record = baseRecord({
+        endorsements: [
+          { status: 'ENDORSED', endorserId: 'district', endorserName: 'Georgia', endorsementLevel: 3 },
+          { status: 'ENDORSED', endorserId: 'national', endorserName: 'National', endorsementLevel: 1 },
+          { status: 'ENDORSED', endorserId: 'section', endorserName: 'Southern', endorsementLevel: 2 },
+        ],
+      });
+      const { sanction } = (activate(record) as any).tournamentRecord;
+
+      expect(sanction.approvalChain.map((a: any) => a.organisationId)).toEqual(['national', 'section', 'district']);
+      expect(sanction.approvalChain[1].organisationName).toEqual('Southern');
+    });
+
+    it('excludes endorsers that did not endorse', () => {
+      const record = baseRecord({
+        endorsements: [
+          { status: 'ENDORSED', endorserId: 'national', endorsementLevel: 1 },
+          { status: 'PENDING', endorserId: 'section', endorsementLevel: 2 },
+          { status: 'DECLINED', endorserId: 'district', endorsementLevel: 3 },
+        ],
+      });
+      const { sanction } = (activate(record) as any).tournamentRecord;
+
+      expect(sanction.approvalChain).toHaveLength(1);
+      expect(sanction.approvalChain[0].organisationId).toEqual('national');
+    });
+
+    /** An endorsement with no level sorts last rather than being dropped. */
+    it('keeps unlevelled endorsements, ordering them after levelled ones', () => {
+      const record = baseRecord({
+        endorsements: [
+          { status: 'ENDORSED', endorserId: 'unlevelled' },
+          { status: 'ENDORSED', endorserId: 'first', endorsementLevel: 1 },
+        ],
+      });
+      const { sanction } = (activate(record) as any).tournamentRecord;
+
+      expect(sanction.approvalChain.map((a: any) => a.organisationId)).toEqual(['first', 'unlevelled']);
+    });
+
+    it('omits the chain entirely when nothing endorsed', () => {
+      const { sanction } = (activate(baseRecord()) as any).tournamentRecord;
+      expect(sanction.approvalChain).toBeUndefined();
+    });
+  });
+
+  /**
+   * `processCodes` is retained so existing consumers keep working — the instance model adds
+   * expressiveness rather than removing the marker out from under them.
+   */
+  it('still stamps the legacy processCodes marker', () => {
+    const { processCodes } = (activate(baseRecord()) as any).tournamentRecord;
+    expect(processCodes).toEqual(['SANCTIONED']);
+  });
+
+  it('omits optional groups rather than emitting empty shells', () => {
+    const record = baseRecord({
+      approvedAt: undefined,
+      reviewer: undefined,
+      sanctioningPolicy: undefined,
+      policyVersion: undefined,
+      governingBody: undefined,
+    });
+    const { sanction } = (activate(record) as any).tournamentRecord;
+
+    expect(sanction.decisionRecord).toBeUndefined();
+    expect(sanction.ruleset).toBeUndefined();
+    expect(sanction.classification).toBeUndefined();
+    // governingBodyId alone is still enough to name an authority
+    expect(sanction.authority).toEqual({ organisationId: 'gb-1' });
+  });
+});

--- a/src/tests/sanctioning/sanctionInstance.test.ts
+++ b/src/tests/sanctioning/sanctionInstance.test.ts
@@ -3,7 +3,8 @@ import { expect, it, describe } from 'vitest';
 
 // constants
 import { APPROVED } from '@Constants/sanctioningConstants';
-import { SanctionDecisionEnum, RecognitionEnum } from '@Types/tournamentTypes';
+import { SanctionDecisionEnum, RecognitionEnum, CurrencyUnitEnum } from '@Types/tournamentTypes';
+import type { SanctionFee } from '@Types/tournamentTypes';
 
 /**
  * `Tournament.sanction` — the sanction INSTANCE model.
@@ -169,5 +170,39 @@ describe('Tournament.sanction on activation', () => {
     expect(sanction.classification).toBeUndefined();
     // governingBodyId alone is still enough to name an authority
     expect(sanction.authority).toEqual({ organisationId: 'gb-1' });
+  });
+});
+
+/**
+ * A federation reporting a sanction fee of 4000 means 40.00 USD. A reader assuming whole units is
+ * off by 100× with nothing in the record to signal it, so the unit is carried explicitly and
+ * travels with the amount rather than being an optional sibling that can go missing.
+ */
+describe('SanctionFee monetary units', () => {
+  it('states amount, currency and unit together so a fee cannot be misread', () => {
+    const fee: SanctionFee = {
+      feeKind: 'SANCTION',
+      fee: { amount: 4000, currencyCode: 'USD', unit: CurrencyUnitEnum.MINOR },
+    };
+
+    expect(fee.fee?.unit).toEqual('MINOR');
+    // 4000 minor units of a 2-exponent currency is 40.00 — resolvable only because the
+    // currency is present alongside the unit
+    expect(fee.fee?.amount).toEqual(4000);
+    expect(fee.fee?.currencyCode).toEqual('USD');
+  });
+
+  it('expresses a per-entry fee with a cap as two complete amounts', () => {
+    const fee: SanctionFee = {
+      feeKind: 'HEAD_TAX',
+      perParticipant: true,
+      fee: { amount: 400, currencyCode: 'USD', unit: CurrencyUnitEnum.MINOR },
+      maximum: { amount: 10000, currencyCode: 'USD', unit: CurrencyUnitEnum.MINOR },
+    };
+
+    // $4.00 per entrant, capped at $100.00 — neither figure can be read at the wrong scale
+    expect(fee.fee?.amount).toEqual(400);
+    expect(fee.maximum?.amount).toEqual(10000);
+    expect(fee.maximum?.unit).toEqual(fee.fee?.unit);
   });
 });

--- a/src/types/enumExports.ts
+++ b/src/types/enumExports.ts
@@ -8,7 +8,7 @@
  *
  * Regenerate:   pnpm gen:enum-exports
  * Drift guard:  pnpm check:enum-exports
- * Covers 68 enums across 4 modules.
+ * Covers 69 enums across 4 modules.
  */
 
 export { SportEnum } from './competitionFormat';
@@ -38,6 +38,7 @@ export { CategoryEnum } from './tournamentTypes';
 export { ContactRelationshipEnum } from './tournamentTypes';
 export { CountryCodeEnum } from './tournamentTypes';
 export { CourtPositionEnum } from './tournamentTypes';
+export { CurrencyUnitEnum } from './tournamentTypes';
 export { DisciplineEnum } from './tournamentTypes';
 export { DrawStatusEnum } from './tournamentTypes';
 export { DrawTypeEnum } from './tournamentTypes';

--- a/src/types/enumExports.ts
+++ b/src/types/enumExports.ts
@@ -8,7 +8,7 @@
  *
  * Regenerate:   pnpm gen:enum-exports
  * Drift guard:  pnpm check:enum-exports
- * Covers 63 enums across 4 modules.
+ * Covers 68 enums across 4 modules.
  */
 
 export { SportEnum } from './competitionFormat';
@@ -31,6 +31,7 @@ export { EndorsementStatusEnum } from './sanctioningTypes';
 export { SanctioningRelationshipEnum } from './sanctioningTypes';
 export { SanctioningStatusEnum } from './sanctioningTypes';
 export { AddressTypeEnum } from './tournamentTypes';
+export { AuthorityRoleEnum } from './tournamentTypes';
 export { BallTypeEnum } from './tournamentTypes';
 export { BookingTypeEnum } from './tournamentTypes';
 export { CategoryEnum } from './tournamentTypes';
@@ -58,6 +59,10 @@ export { PlayingDoubleHandCodeEnum } from './tournamentTypes';
 export { PlayingHandCodeEnum } from './tournamentTypes';
 export { PositioningProfileEnum } from './tournamentTypes';
 export { PracticeRegistrationStatusEnum } from './tournamentTypes';
+export { RecognitionEnum } from './tournamentTypes';
+export { SanctionDecisionEnum } from './tournamentTypes';
+export { SanctionEnforcementEnum } from './tournamentTypes';
+export { SanctionFeeKindEnum } from './tournamentTypes';
 export { SeedingProfileEnum } from './tournamentTypes';
 export { SexEnum } from './tournamentTypes';
 export { ShotDetailEnum } from './tournamentTypes';

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -2290,6 +2290,39 @@ export enum SanctionEnforcementEnum {
 }
 export type SanctionEnforcementUnion = `${SanctionEnforcementEnum}`;
 
+/**
+ * Whether a monetary `amount` is expressed in the currency's smallest unit or in whole units.
+ *
+ * Stated explicitly rather than assumed, because the assumption is silently wrong half the time and
+ * the error is invisible: a federation reporting a 4000 sanction fee means 40.00 USD, and a reader
+ * assuming whole units is off by 100× with nothing to signal it. The minor-unit exponent is
+ * currency-specific (USD 2, JPY 0, KWD 3), so `currencyCode` is what makes `MINOR` resolvable.
+ */
+export enum CurrencyUnitEnum {
+  /** the currency's smallest unit — `{ amount: 4000, currencyCode: 'USD', unit: 'MINOR' }` is $40.00 */
+  MINOR = 'MINOR',
+  /** whole currency units — `{ amount: 40, currencyCode: 'USD', unit: 'MAJOR' }` is $40.00 */
+  MAJOR = 'MAJOR',
+}
+export type CurrencyUnitUnion = `${CurrencyUnitEnum}`;
+
+/**
+ * An amount of money that cannot be stated ambiguously.
+ *
+ * All three fields are required together by construction. That is the point: an optional `unit`
+ * would reintroduce exactly the ambiguity this type exists to remove, since the omitted case is
+ * indistinguishable from the unconsidered one.
+ *
+ * NOTE: `PrizeMoney` carries `amount` + `currencyCode` with no unit and therefore has this
+ * ambiguity today. It is left alone here — changing its meaning would be a breaking change to
+ * existing records — but new monetary fields should use this type.
+ */
+export interface MonetaryAmount {
+  amount: number;
+  currencyCode: string;
+  unit: CurrencyUnitUnion;
+}
+
 /** Shape of a levy. Federations charge flat, per-entry, percentage, and capped-per-entry fees. */
 export enum SanctionFeeKindEnum {
   /** paid by the organiser to the authority for the sanction itself */
@@ -2323,13 +2356,14 @@ export interface SanctioningAuthority {
  */
 export interface SanctionFee {
   feeKind?: SanctionFeeKindUnion;
-  currencyCode?: string;
-  amount?: number;
+  /** the levy itself — currency and unit travel with the amount, so it cannot be misread */
+  fee?: MonetaryAmount;
+  /** proportional levy, where a body charges a percentage instead of or alongside a fixed amount */
   percentage?: number;
-  /** `amount` is charged per competitor rather than per competition */
+  /** `fee` is charged per competitor rather than per competition */
   perParticipant?: boolean;
   /** cap on the total when `perParticipant` is set */
-  maximumAmount?: number;
+  maximum?: MonetaryAmount;
   /** draw stage or event the fee applies to, where a federation prices them separately */
   appliesTo?: string;
   note?: string;

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -25,6 +25,15 @@ export interface Tournament {
   processCodes?: string[];
   promotionalName?: string;
   registrationProfile?: RegistrationProfile;
+  /**
+   * What a governing body decided about this competition — see `TournamentSanction`.
+   * Supersedes the binary `processCodes: ['SANCTIONED']` marker, which cannot express a
+   * decision, an authority chain, or what the sanction confers. `processCodes` is left in
+   * place for existing consumers.
+   */
+  sanction?: TournamentSanction;
+  /** Additional sanctions where a competition is approved by more than one body. */
+  sanctions?: TournamentSanction[];
   // CODES first-class group leaf: previously stored as separate
   // `schedulingProfile`, `scheduleLimits`, and `scheduleTiming` extensions.
   scheduling?: {
@@ -97,6 +106,12 @@ export interface Event {
   eventId: string;
   eventLevel?: TournamentLevelUnion;
   eventName?: string;
+  /**
+   * Event-grain sanction. Grade is genuinely per-event in several federations — one tournament
+   * routinely carries different categories for different age groups — mirroring `eventTier`.
+   * Where absent, the tournament's `sanction` applies.
+   */
+  sanction?: TournamentSanction;
   eventOrder?: number;
   // CODES first-class: this event's identity in OTHER organisations' systems, one entry
   // per organisation. The entry flagged `isOrigin` is the sanctioning source the event
@@ -2164,3 +2179,246 @@ export enum WeekdayEnum {
   SUN = 'SUN',
 }
 export type WeekdayUnion = `${WeekdayEnum}`;
+
+// ---------------------------------------------------------------------------
+// Sanction INSTANCE model — "being sanctioned"
+// ---------------------------------------------------------------------------
+//
+// Everything above models BECOMING sanctioned: `SanctioningRecord` is the application, held by
+// AMS, that a governing body decides on. What follows models BEING sanctioned — the decision as an
+// attribute of the competition itself, which travels with the tournamentRecord.
+//
+// That attribute used to be `processCodes: ['SANCTIONED']`, a bare string in an array. Real
+// federation data does not fit a boolean. Three axes are involved, and every system observed
+// conflates at least two of them:
+//
+//   decision       did the application succeed?              USTA: `sanctionStatus: APPROVED`
+//   recognition    what does the body ASSERT about the event? USA Swimming: SANCTIONED|APPROVED|OBSERVED
+//   classification what competitive grade is conferred?       USTA: `level`, with `isRanking`
+//
+// Keeping them apart is what makes USTA's real data expressible: its tournaments are
+// simultaneously `sanctionStatus: "APPROVED"` and `level: "Unsanctioned"` — approved to run by the
+// district, conferring no ranking status. Under one axis that reads as a contradiction; under
+// three it is decision=APPROVED, recognition=UNSANCTIONED, classification=absent.
+
+/**
+ * Outcome of the sanctioning decision — the workflow axis.
+ *
+ * Distinct from {@link SanctioningStatusEnum}, which tracks an application through review. This is
+ * what the competition ended up with, including outcomes an application-side state machine has no
+ * reason to model: authority-initiated `REVOKED`/`SUSPENDED`/`DOWNGRADED` are routine annual
+ * outcomes at several federations, and are NOT `WITHDRAWN` — withdrawal is applicant-initiated.
+ */
+export enum SanctionDecisionEnum {
+  /** applied for, not yet decided */
+  PENDING = 'PENDING',
+  APPROVED = 'APPROVED',
+  /** approved subject to conditions not yet met */
+  CONDITIONAL = 'CONDITIONAL',
+  DENIED = 'DENIED',
+  /** applicant-initiated */
+  WITHDRAWN = 'WITHDRAWN',
+  /** authority-initiated, after approval */
+  REVOKED = 'REVOKED',
+  /** authority-initiated, temporary */
+  SUSPENDED = 'SUSPENDED',
+  /** lapsed rather than decided against */
+  EXPIRED = 'EXPIRED',
+  /** approved, but at a lower classification than applied for */
+  DOWNGRADED = 'DOWNGRADED',
+}
+export type SanctionDecisionUnion = `${SanctionDecisionEnum}`;
+
+/**
+ * What the governing body asserts about the competition — the recognition axis.
+ *
+ * Modelled on USA Swimming Article 202, which is the most explicit published vocabulary found:
+ * each value implies a different enforced rule subset, a different participant-eligibility rule, a
+ * different issuing authority and a different downstream consequence. A boolean collapses all four.
+ */
+export enum RecognitionEnum {
+  /** the body's own competition, under the whole of its rulebook */
+  SANCTIONED = 'SANCTIONED',
+  /** run by someone else, under an enumerated SUBSET of the body's rules; mixed eligibility */
+  APPROVED = 'APPROVED',
+  /** run under another body's rules; spot-verified so results may still count */
+  OBSERVED = 'OBSERVED',
+  /** another body's competition accepted wholesale by reference (e.g. USA Swimming ← NCAA) */
+  RECOGNISED = 'RECOGNISED',
+  /** permitted to use the body's marks/programme without competitive standing */
+  LICENSED = 'LICENSED',
+  /** known to the body and explicitly outside its competitive structure */
+  UNSANCTIONED = 'UNSANCTIONED',
+}
+export type RecognitionUnion = `${RecognitionEnum}`;
+
+/**
+ * Where a body sits in a governance hierarchy.
+ *
+ * Deliberately broader than {@link TournamentLevelEnum} (which is the ORGANISATIONAL SCOPE of a
+ * competition) because the chain that approves an event is not the same thing as the reach of the
+ * event. Observed chains vary in depth from 1 to 5 and do not always cascade: some federations
+ * approve only at the regional tier, and at least one requires JOINT approval by two co-equal
+ * bodies, so `approvalChain` must not be assumed to be a strict containment ladder.
+ */
+export enum AuthorityRoleEnum {
+  INTERNATIONAL = 'INTERNATIONAL',
+  NATIONAL = 'NATIONAL',
+  ZONE = 'ZONE',
+  SECTION = 'SECTION',
+  REGION = 'REGION',
+  PROVINCE = 'PROVINCE',
+  STATE = 'STATE',
+  COUNTY = 'COUNTY',
+  DISTRICT = 'DISTRICT',
+  LEAGUE = 'LEAGUE',
+  CONFERENCE = 'CONFERENCE',
+  CLUB = 'CLUB',
+  /** the organisation running the competition, when it is itself part of the chain */
+  PROVIDER = 'PROVIDER',
+}
+export type AuthorityRoleUnion = `${AuthorityRoleEnum}`;
+
+/** How hard a ruleset bites. Three independent policy systems converged on these three values. */
+export enum SanctionEnforcementEnum {
+  /** non-compliance blocks */
+  ENFORCE = 'ENFORCE',
+  /** non-compliance is recorded, the competition still counts */
+  AUDIT = 'AUDIT',
+  /** non-compliance is surfaced to the organiser only */
+  WARN = 'WARN',
+}
+export type SanctionEnforcementUnion = `${SanctionEnforcementEnum}`;
+
+/** Shape of a levy. Federations charge flat, per-entry, percentage, and capped-per-entry fees. */
+export enum SanctionFeeKindEnum {
+  /** paid by the organiser to the authority for the sanction itself */
+  SANCTION = 'SANCTION',
+  /** per-player levy passed to the authority (USTA "head tax") */
+  HEAD_TAX = 'HEAD_TAX',
+  /** surcharge for applying after a deadline */
+  LATE = 'LATE',
+  /** what a competitor pays to enter */
+  ENTRY = 'ENTRY',
+}
+export type SanctionFeeKindUnion = `${SanctionFeeKindEnum}`;
+
+/** A body in the approval chain. Only `organisationId` OR `organisationName` need be known. */
+export interface SanctioningAuthority {
+  organisationAbbreviation?: string;
+  organisationName?: string;
+  organisationId?: string;
+  role?: AuthorityRoleUnion;
+  /** the authority's own code for its territory, where it publishes one (USTA section '070') */
+  regionCode?: string;
+  extensions?: Extension[];
+}
+
+/**
+ * A levy attached to the sanction.
+ *
+ * `amount` and `percentage` are not exclusive: a head tax is commonly `{fixedFee, percentageFee}`,
+ * and at least one federation charges per-entry with an absolute cap, which needs all three of
+ * `amount`, `perParticipant` and `maximumAmount`.
+ */
+export interface SanctionFee {
+  feeKind?: SanctionFeeKindUnion;
+  currencyCode?: string;
+  amount?: number;
+  percentage?: number;
+  /** `amount` is charged per competitor rather than per competition */
+  perParticipant?: boolean;
+  /** cap on the total when `perParticipant` is set */
+  maximumAmount?: number;
+  /** draw stage or event the fee applies to, where a federation prices them separately */
+  appliesTo?: string;
+  note?: string;
+}
+
+/** What the sanction actually buys. None of these is derivable from the classification. */
+export interface SanctionConferral {
+  /** results count toward the authority's ranking lists (USTA `isRanking`, ITA `isConferenceMatch`) */
+  rankingEligible?: boolean;
+  /** which points profile applies, when the authority runs more than one */
+  rankingPointsProfile?: string;
+  /** results may set records */
+  recordEligible?: boolean;
+  /** times/results are "official" for qualification purposes even if not ranked */
+  officialResults?: boolean;
+  /** the sanction carries the authority's liability cover — the reason many organisers apply */
+  insured?: boolean;
+  extensions?: Extension[];
+}
+
+/**
+ * The rulebook in force, pinned to an edition.
+ *
+ * Pinning is not optional. Governing-body rulebooks are annual, and a sanction granted under one
+ * edition must not silently re-validate against the next. `appliedRules` exists because a body may
+ * enforce only an enumerated SUBSET of its rules at lower recognition levels.
+ */
+export interface SanctionRuleset {
+  rulesetId?: string;
+  /** e.g. '2026' — the edition in force when the decision was made */
+  edition?: string;
+  enforcement?: SanctionEnforcementUnion;
+  /** identifiers of the specific rules enforced, when only a subset applies */
+  appliedRules?: string[];
+  extensions?: Extension[];
+}
+
+/** Provenance of the decision — who decided, when, and whether it can be appealed. */
+export interface SanctionDecisionRecord {
+  decidedAt?: string;
+  decidedByPersonId?: string;
+  decidedByName?: string;
+  /** false where the denial rested on a rule the appeal body cannot overturn */
+  appealable?: boolean;
+  reason?: string;
+  note?: string;
+}
+
+/** An identifier the authority issues for the competition (USTA `identificationCode`, '26-80173'). */
+export interface SanctionIdentifier {
+  organisationId?: string;
+  identifier: string;
+  /** what kind of identifier this is, where an authority issues more than one */
+  identifierType?: string;
+}
+
+/**
+ * A governing body's decision about a competition, as an attribute of that competition.
+ *
+ * Attach to `Tournament.sanction` for the common case. `Event.sanction` exists because grade is
+ * genuinely event-grain in several federations — one tournament routinely carries different
+ * categories for different age groups — mirroring the existing `tournamentTier`/`eventTier` pair.
+ * Where an event carries no sanction of its own, the tournament's applies.
+ *
+ * Multiple sanctions are expressed as multiple entries in `Tournament.sanctions`; `sanction` is the
+ * primary. Dual sanctioning is real (an international-grade event usually also carries national
+ * approval, and one federation requires two co-equal approvals), so consumers must not assume a
+ * single authority.
+ */
+export interface TournamentSanction {
+  /** the workflow outcome */
+  decision?: SanctionDecisionUnion;
+  /** what the authority asserts about the competition */
+  recognition?: RecognitionUnion;
+  /** the grade conferred — reuses the CODES tier shape, so 'Unsanctioned' is expressible */
+  classification?: TierClassification;
+  /** the body whose decision this is — the terminal approver */
+  authority?: SanctioningAuthority;
+  /** the resolved chain, ordered broadest → narrowest. Not necessarily a containment ladder. */
+  approvalChain?: SanctioningAuthority[];
+  decisionRecord?: SanctionDecisionRecord;
+  confers?: SanctionConferral;
+  ruleset?: SanctionRuleset;
+  /** link back to the application this decision came from, where one is held */
+  sanctioningId?: string;
+  identifiers?: SanctionIdentifier[];
+  fees?: SanctionFee[];
+  /** the window in which the application was accepted, where the authority publishes one */
+  submissionWindow?: { from?: string; to?: string; timeZone?: string };
+  extensions?: Extension[];
+  timeItems?: TimeItem[];
+}


### PR DESCRIPTION
CODES modelled BECOMING sanctioned richly — a 12-state machine, endorsement chains, conditions, amendments, compliance — and then projected all of it onto the competition as processCodes: ['SANCTIONED']. A boolean cannot carry who approved an event, under which rulebook edition, on whose authority, or what the approval confers, so activation threw it away.

Tournament.sanction (and Event.sanction, since grade is genuinely per-event in several federations) separates three axes every governing body surveyed conflates: decision (did the application succeed), recognition (what does the body ASSERT about the event), and classification (what grade is conferred).

The separation is what makes real data expressible. USTA tournaments are routinely both sanctionStatus APPROVED and level Unsanctioned — approved to run by the district, conferring no ranking status. Under one axis that is a contradiction; under three it is decision=APPROVED, recognition=UNSANCTIONED, classification=absent.

The recognition vocabulary follows USA Swimming Article 202, the most explicit published one found: SANCTIONED / APPROVED / OBSERVED / RECOGNISED / LICENSED each imply a different enforced rule subset, participant-eligibility rule and downstream consequence.

Decisions also carry provenance (who decided, when, appealability), the resolved approval chain, a pinned rulebook edition (policies are annual; a granted sanction must not silently re-validate against a later one), what the sanction confers (ranking, records, insurance — none derivable from grade), authority-issued identifiers, and fees as a list, since flat, percentage, per-entry and per-entry-capped all occur.

activateFromSanctioning populates it: endorsements become the approval chain ordered by endorsementLevel rather than array position, including only endorsers that actually endorsed. processCodes is retained so existing consumers keep working.

The policy layer — what a body PERMITS and which fields an organiser may not override — is deliberately not here; it ships in courthive-ingest#81 where it can be exercised against captured federation data.

Full pnpm verify green: 11,427 tests, coverage thresholds, public surface, bundle size, and a real tarball install smoke test. 10 new tests. One attr-audit allow-list entry ('ZONE', a false positive against 'NONE').