### PR TITLE
chore(deps): update pnpm to 11.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tods-competition-factory",
-  "packageManager": "pnpm@11.22.0",
+  "packageManager": "pnpm@11.24.0",
   "author": "Charles Allen <charles@CourtHive.com> (CourtHive.com)",
   "description": "Create and mutate TODS compliant tournament objects",
   "keywords": [


### PR DESCRIPTION
`packageManager` only — no dependency, lockfile or build change, so it has no effect on what any consumer compiles or on a deploy.

**Supersedes #4712**, which proposes 11.23.0. Renovate should close or rebase that against this.

Picked up as an uncommitted edit in the shared checkout during a deploy-readiness survey; committed here rather than left dangling ahead of a full ecosystem build, since factory is the root of the publish chain and a dirty working tree there is the thing most likely to confuse a build-all.