### PR TITLE
feat(codes): give prize money a finishing-position shape

### DIFF
--- a/documentation/docs/codes/sanctioning.mdx
+++ b/documentation/docs/codes/sanctioning.mdx
@@ -128,6 +128,23 @@ unit for `MINOR` to be resolvable.
 > `MonetaryAmount` for the same reason, and the validator reports amounts it cannot compare rather
 > than folding them in.
 
+**A total is not a schedule.** `totalPrizeMoney` and `Event.prizeMoney` say what was offered;
+`prizeMoneyAwards` (on `Event`, and on `Tournament` where a body publishes one ladder for the whole
+competition) says what each finishing position was worth — the Grand Slam model of per-round
+payouts, generalised. Competitions commonly award money the way they award ranking points, by how
+far you got, so `PrizeMoneyAward.finishingPosition` reuses the key `finishingPositionRanges` already
+uses in the ranking-points policies, and "R16 was worth 200 points and 480,000" becomes one join
+rather than two vocabularies.
+
+> Two traps. **A `roundCode` is not a finishing position and the two run in opposite directions** —
+> a "Round 1" rung is what a first-round _loser_ received, the _last_ position, and which position
+> that is depends on the draw size (128 in a 128 draw, 16 in a 16 draw). **A ladder is never
+> summed.** Each rung is what one competitor received, so the outlay is
+> `amount × competitors finishing in that range`; adding the rungs understates a 128-draw purse
+> threefold. This is why awards are a separate field from `prizeMoney`, and why `PrizeMoney`
+> declares `finishingPosition?: never` — passing a ladder where a list of totals is expected is a
+> compile error rather than a silently wrong sum.
+
 **`sanctions`** (plural, on `Tournament`) carries additional sanctions where a competition is
 approved by more than one body. Dual sanctioning is common: an international-grade event usually
 also carries national approval.

--- a/src/tests/sanctioning/prizeMoney.test.ts
+++ b/src/tests/sanctioning/prizeMoney.test.ts
@@ -3,8 +3,13 @@ import { activateFromSanctioning } from '@Mutate/sanctioning/activateFromSanctio
 import { validateProposal } from '@Validators/sanctioning/validateProposal';
 import { expect, it, describe } from 'vitest';
 
-// constants
+// constants and types
+import type { PrizeMoneyAward, Tournament, Event } from '@Types/tournamentTypes';
+import { POLICY_TYPE_RANKING_POINTS } from '@Constants/policyConstants';
 import { APPROVED } from '@Constants/sanctioningConstants';
+
+// Fixtures
+import { POLICY_RANKING_POINTS_ATP } from '@Fixtures/policies/POLICY_RANKING_POINTS_ATP';
 
 /**
  * Prize money.
@@ -140,5 +145,203 @@ describe('event prize money reaches the activated event', () => {
   it('leaves the field absent when the proposal named none', () => {
     const result: any = activateFromSanctioning({ sanctioningRecord: record() });
     expect(result.tournamentRecord.events[0].prizeMoney).toBeUndefined();
+  });
+});
+
+/**
+ * Prize money BY FINISHING POSITION.
+ *
+ * `PrizeMoney` states a total. `PrizeMoneyAward` states the ladder — what each finishing position
+ * was actually worth — which is how competitions commonly award it and which CODES previously
+ * dropped.
+ *
+ * The ladders below follow the Grand Slam model of per-round payouts, in the form such ladders are
+ * published: comma-formatted strings keyed by round code. Realistic shapes rather than convenient
+ * ones, so the traps this type exists to prevent are actually exercised.
+ */
+describe('prizeMoneyAwards', () => {
+  /** A Grand Slam singles main draw: drawSize 128, eight rungs. */
+  const mainDrawLadder = [
+    { roundCode: '1', roundName: 'Round 1', money: '140,000' },
+    { roundCode: '2', roundName: 'Round 2', money: '190,000' },
+    { roundCode: '3', roundName: 'Round 3', money: '290,000' },
+    { roundCode: '4', roundName: 'Round 4', money: '480,000' },
+    { roundCode: 'Q', roundName: 'Quarter-Finals', money: '780,000' },
+    { roundCode: 'S', roundName: 'Semi-Finals', money: '1,450,000' },
+    { roundCode: 'F', roundName: 'Final', money: '2,800,000' },
+    { roundCode: 'W', roundName: 'Winner', money: '5,500,000' },
+  ];
+
+  /** A small event in the same tournament: drawSize 16, five rungs, the SAME `roundCode` values. */
+  const smallDrawLadder = [
+    { roundCode: '1', roundName: 'Round 1', money: '40,000' },
+    { roundCode: 'Q', roundName: 'Quarter-Finals', money: '120,000' },
+    { roundCode: 'S', roundName: 'Semi-Finals', money: '250,000' },
+    { roundCode: 'F', roundName: 'Final', money: '500,000' },
+    { roundCode: 'W', roundName: 'Winner', money: '1,000,000' },
+  ];
+
+  /** A qualifying draw: drawSize 128, three rungs, and none for the players who come through. */
+  const qualifyingLadder = [
+    { roundCode: '1', roundName: 'Round 1', money: '32,000' },
+    { roundCode: '2', roundName: 'Round 2', money: '48,000' },
+    { roundCode: '3', roundName: 'Round 3', money: '66,000' },
+  ];
+
+  /**
+   * What an adapter has to do, reduced to its two decisions — because both are places the data
+   * lies about itself:
+   *
+   *   1. `"1,450,000"` is a comma-formatted STRING. `Number('1,450,000')` is `NaN`, and a silent
+   *      `NaN` in a money field is the worst available outcome.
+   *   2. A row keyed 'Round 1' is what a first-round LOSER got, which is the LAST finishing
+   *      position — and which position that is depends on the DRAW SIZE, not on the round.
+   */
+  const toAwards = (rows: typeof mainDrawLadder, drawSize: number): PrizeMoneyAward[] => {
+    const finalRounds: Record<string, number> = { W: 1, F: 2, S: 4, Q: 8 };
+    return rows.map((row) => {
+      const roundNumber = Number.parseInt(row.roundCode, 10);
+      const finishingPosition = finalRounds[row.roundCode] ?? drawSize / 2 ** (roundNumber - 1);
+      const amount = Number(row.money.replaceAll(',', ''));
+      return {
+        amount,
+        currencyCode: 'USD',
+        unit: 'MAJOR' as const,
+        finishingPosition,
+        roundName: row.roundName,
+        roundCode: row.roundCode,
+      };
+    });
+  };
+
+  it('parses the published string rather than Number()-ing it into NaN', () => {
+    expect(Number('1,450,000')).toBeNaN();
+    expect(toAwards(mainDrawLadder, 128).find((a) => a.roundCode === 'S')?.amount).toEqual(1450000);
+  });
+
+  it('maps the eight published rows onto the eight finishing positions of a 128 draw', () => {
+    const awards = toAwards(mainDrawLadder, 128);
+
+    expect(awards.map((a) => a.finishingPosition)).toEqual([128, 64, 32, 16, 8, 4, 2, 1]);
+    expect(awards.map((a) => a.amount)).toEqual([140000, 190000, 290000, 480000, 780000, 1450000, 2800000, 5500000]);
+    // the authority's own vocabulary survives beside the position, so the mapping stays auditable
+    expect(awards.at(-1)).toEqual({
+      amount: 5500000,
+      currencyCode: 'USD',
+      unit: 'MAJOR',
+      finishingPosition: 1,
+      roundName: 'Winner',
+      roundCode: 'W',
+    });
+  });
+
+  /**
+   * The trap the type exists to name. Same tournament, same `roundCode: '1'` — and a round-keyed
+   * model cannot tell these two apart.
+   */
+  it('resolves the SAME roundCode to different positions at different draw sizes', () => {
+    const large = toAwards(mainDrawLadder, 128).find((a) => a.roundCode === '1');
+    const small = toAwards(smallDrawLadder, 16).find((a) => a.roundCode === '1');
+
+    expect(large?.finishingPosition).toEqual(128);
+    expect(small?.finishingPosition).toEqual(16);
+    expect(small?.finishingPosition).not.toEqual(large?.finishingPosition);
+  });
+
+  /** A qualifying ladder's top rung is NOT position 1 — the qualifiers are paid from the main draw. */
+  it('does not invent a winner rung for a qualifying ladder', () => {
+    const awards = toAwards(qualifyingLadder, 128);
+
+    expect(awards.map((a) => a.finishingPosition)).toEqual([128, 64, 32]);
+    expect(awards.some((a) => a.finishingPosition === 1)).toEqual(false);
+  });
+
+  /**
+   * The reason for reusing the key: the ranking-points policy already describes these same eight
+   * outcomes, so points and money become one join rather than two vocabularies. If this ever
+   * fails, the two models have diverged and the join is silently wrong.
+   */
+  it('uses the same keys the ATP ranking-points policy uses for a Grand Slam', () => {
+    const profiles = POLICY_RANKING_POINTS_ATP[POLICY_TYPE_RANKING_POINTS].awardProfiles;
+    const grandSlamSingles: any = profiles.find((p: any) => p.profileName === 'Grand Slam Singles');
+    const pointKeys = Object.keys(grandSlamSingles.finishingPositionRanges).map(Number);
+    const moneyKeys = toAwards(mainDrawLadder, 128).map((a) => a.finishingPosition);
+
+    expect([...pointKeys].toSorted((a, b) => a - b)).toEqual([...moneyKeys].toSorted((a, b) => a - b));
+    // "R16 was worth 200 points and $480,000" — expressible because the key is shared
+    expect(grandSlamSingles.finishingPositionRanges[16]).toEqual(200);
+    expect(moneyKeys.indexOf(16)).toBeGreaterThan(-1);
+  });
+
+  /**
+   * A ladder is not a list of totals. Each rung is what ONE competitor received, so the outlay is
+   * `amount × competitors finishing in that range` — and the naive sum understates the purse by
+   * more than threefold. This is why awards are a separate field from
+   * `prizeMoney` and why `sumAgainstBound` must never be handed one.
+   */
+  it('must not be summed as if each rung were a total', () => {
+    const awards = toAwards(mainDrawLadder, 128);
+    // positions 65-128 all won the same 140,000; position 2 is one player; position 1 is one player
+    const competitorsAt = (finishingPosition: number) => (finishingPosition <= 2 ? 1 : finishingPosition / 2);
+    const outlay = awards.reduce((total, a) => total + a.amount * competitorsAt(a.finishingPosition), 0);
+    const naive = awards.reduce((total, a) => total + a.amount, 0);
+
+    expect(outlay).toEqual(37840000);
+    expect(naive).toEqual(11630000);
+    expect(naive).not.toEqual(outlay);
+
+    // the existing total-comparison helper produces exactly that wrong figure, correctly
+    // denominated — which is what makes it dangerous rather than obviously broken. The compiler
+    // now refuses the call outright (`PrizeMoney.finishingPosition?: never`); before that
+    // discriminant existed, structural typing accepted a ladder here in silence.
+    // @ts-expect-error — a ladder is not a list of totals and may not be summed as one
+    expect(sumAgainstBound(awards, USD(0)).comparable).toEqual(naive);
+  });
+
+  it('hangs the ladder off the event, which is the grain it is published at', () => {
+    const event: Event = {
+      eventId: 'e-ms',
+      prizeMoneyAwards: toAwards(mainDrawLadder, 128),
+      prizeMoney: [USD(37840000)],
+    };
+
+    expect(event.prizeMoneyAwards).toHaveLength(8);
+    // one tournament, several ladders — none derivable from another
+    const qualifying: Event = { eventId: 'e-mq', prizeMoneyAwards: toAwards(qualifyingLadder, 128) };
+    expect(qualifying.prizeMoneyAwards).toHaveLength(3);
+  });
+
+  it('also sits at tournament grain, beside the total it explains', () => {
+    // 2,800,000 is DERIVED from the ladder (8x40k + 4x120k + 2x250k + 500k + 1000k) rather than
+    // asserted — the same `amount × competitors` arithmetic as above, checked a second time at a
+    // different draw size.
+    const tournament: Tournament = {
+      tournamentId: 't-uso',
+      totalPrizeMoney: [USD(2800000)],
+      prizeMoneyAwards: toAwards(smallDrawLadder, 16),
+    };
+    const competitorsAt = (finishingPosition: number) => (finishingPosition <= 2 ? 1 : finishingPosition / 2);
+    const outlay = (tournament.prizeMoneyAwards ?? []).reduce(
+      (total, a) => total + a.amount * competitorsAt(a.finishingPosition),
+      0,
+    );
+
+    expect(tournament.prizeMoneyAwards?.map((a) => a.finishingPosition)).toEqual([16, 8, 4, 2, 1]);
+    expect(outlay).toEqual(tournament.totalPrizeMoney?.[0].amount);
+  });
+
+  /**
+   * `unit` is required, and this is the assertion that keeps it that way. Publishers disagree on
+   * scale — whole units and minor units both occur — so an award without a declared one is off by
+   * 100x with nothing to signal it.
+   */
+  it('will not type-check an award that omits its unit', () => {
+    // @ts-expect-error — `unit` is required by MonetaryAmount and must stay required here
+    const missingUnit: PrizeMoneyAward = { amount: 140000, currencyCode: 'USD', finishingPosition: 128 };
+    expect(missingUnit.amount).toEqual(140000);
+
+    // @ts-expect-error — `finishingPosition` is what makes this an award rather than a total
+    const missingPosition: PrizeMoneyAward = { amount: 140000, currencyCode: 'USD', unit: 'MAJOR' };
+    expect(missingPosition.amount).toEqual(140000);
   });
 });

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -22,6 +22,18 @@ export interface Tournament {
   parentOrganisationId?: string;
   parentOrganisation?: Organisation;
   participants?: Participant[];
+  /**
+   * What each finishing position was worth, where an authority publishes ONE ladder for the whole
+   * competition rather than one per event. The counterpart to `totalPrizeMoney`, at the same
+   * grain: without it a reader can find the total at tournament level but must go to the events
+   * for the shape, and for a single-event competition there are no events to go to.
+   *
+   * NOT an aggregation of `Event.prizeMoneyAwards`. A ladder cannot be summed or merged across
+   * events — see `PrizeMoneyAward` — so this holds only what the source itself stated at
+   * tournament grain. Where an event carries its own ladder, the event's ladder governs that
+   * event; this one never overrides it.
+   */
+  prizeMoneyAwards?: PrizeMoneyAward[];
   processCodes?: string[];
   promotionalName?: string;
   registrationProfile?: RegistrationProfile;
@@ -115,6 +127,14 @@ export interface Event {
    * around it with an ad-hoc extension.
    */
   prizeMoney?: PrizeMoney[];
+  /**
+   * What each finishing position in this event was worth — the ladder behind `prizeMoney`.
+   *
+   * Event grain because that is the grain ladders are published at. A main draw, its qualifying,
+   * and a smaller-draw event in the same tournament each carry their own — different rung counts
+   * at different draw sizes, none of them derivable from another.
+   */
+  prizeMoneyAwards?: PrizeMoneyAward[];
   /**
    * Event-grain sanction. Grade is genuinely per-event in several federations — one tournament
    * routinely carries different categories for different age groups — mirroring `eventTier`.
@@ -1875,12 +1895,86 @@ export interface RegistrationEntryFee {
  * `unit` — the sum is otherwise meaningless.
  */
 export interface PrizeMoney extends MonetaryAmount {
+  /**
+   * Never set. Declared as `never` so a {@link PrizeMoneyAward}`[]` — a ladder, where every entry
+   * carries a `finishingPosition` — cannot be passed where a list of TOTALS is expected. Without
+   * it TypeScript's structural typing accepts the substitution silently, and `sumAgainstBound`
+   * returns a confident, correctly-denominated, wrong number. See `PrizeMoneyAward`.
+   */
+  finishingPosition?: never;
   createdAt?: Date | string;
   extensions?: Extension[];
   isMock?: boolean;
   notes?: string;
   timeItems?: TimeItem[];
   updatedAt?: Date | string;
+}
+
+/**
+ * What ONE finishing position was worth.
+ *
+ * `PrizeMoney` states a total; a `PrizeMoneyAward[]` states the ladder that produced it.
+ * Competitions commonly award money the way they award ranking points — by how far you got — and
+ * CODES could previously record only the sum, or drop the ladder entirely. A single tournament
+ * routinely carries several ladders that are not derivable from one another: a main draw, its
+ * qualifying, and smaller-draw events each publish their own.
+ *
+ * `finishingPosition` carries the SAME semantics as `finishingPositionRanges` in the
+ * ranking-points policies (`AwardProfile`, `types/rankingTypes.ts`): the MAXIMUM finishing position
+ * of the range the award covers. In a 128 draw the first-round losers finish 65th-128th, so their
+ * rung is `128`; semi-finalists finish 3rd-4th, so theirs is `4`. A Grand Slam singles ladder
+ * therefore lands on 1, 2, 4, 8, 16, 32, 64, 128 — the exact keys `grandSlamSingles` already uses
+ * in `POLICY_RANKING_POINTS_ATP`, because they describe the same eight outcomes. That is the point
+ * of reusing the key: "R16 was worth 200 points and 480,000" becomes one join rather than two
+ * vocabularies.
+ *
+ * Position rather than round, for the reason the points policies chose it: round-robins,
+ * consolations and playoffs have no clean "round you lost in", so a round-keyed model cannot
+ * express them at all.
+ *
+ * ## `roundCode` is NOT `finishingPosition`, and they run in opposite directions
+ *
+ * A "Round 1" rung is what a first-round LOSER received — the LAST finishing position, not the
+ * first. Code that maps round one to position one inverts the whole ladder and pays the champion
+ * the qualifier's cheque, with nothing in the data to signal it. Nor is the mapping fixed: the same
+ * round code is position 128 in a 128 draw and position 16 in a 16 draw, so a round number means
+ * nothing without the draw size. That is precisely why the position is what gets stored — and why
+ * `roundName` / `roundCode` are kept beside it, so the conversion stays auditable instead of lost.
+ *
+ * The top rung is not always position 1, either. A qualifying ladder's last rung is what the losers
+ * of the final qualifying round received; the players who came through are paid from the MAIN
+ * draw's ladder, so a qualifying ladder may carry no rung at position 1 at all.
+ *
+ * ## A ladder is not a list of totals — never sum one
+ *
+ * Each rung is what ONE competitor at that position received. A tournament's outlay is the sum of
+ * `amount x (competitors finishing in that range)`. For a 128 draw whose eight rungs run 140,000 /
+ * 190,000 / 290,000 / 480,000 / 780,000 / 1,450,000 / 2,800,000 / 5,500,000, adding the rungs gives
+ * 11,630,000 while the actual outlay is 37,840,000 — the naive figure is not the purse, nor
+ * anything else. This is why awards get their own field instead of being folded into `prizeMoney`.
+ *
+ * That is enforced rather than merely documented. `PrizeMoney` declares `finishingPosition?: never`
+ * for this single purpose, so passing a ladder where a list of totals is expected is a compile
+ * error — structural typing would otherwise accept the substitution in silence, and
+ * `sumAgainstBound` would return a confident, wrong, correctly-denominated number.
+ *
+ * As with `PrizeMoney`, `unit` is required and load-bearing. Publishers disagree on scale and on
+ * formatting: whole units as a comma-formatted STRING (which `Number()`s to `NaN`), whole units as
+ * an integer, and minor units as an integer all occur. Parsing is the producer's job; declaring the
+ * scale is this type's.
+ */
+export interface PrizeMoneyAward extends MonetaryAmount {
+  /**
+   * Maximum finishing position of the range this award covers — `1` winner, `2` finalist,
+   * `4` semi-finalist, `128` first-round loser in a 128 draw. A position, never a round number.
+   */
+  finishingPosition: number;
+  /** the authority's own label for the rung, where it publishes one (`'Quarter-Finals'`) */
+  roundName?: string;
+  /** the authority's own code for the rung, where it publishes one (`'Q'`, `'W'`, `'1'`) */
+  roundCode?: string;
+  extensions?: Extension[];
+  notes?: string;
 }
 
 export interface UnifiedTournamentID {


### PR DESCRIPTION
CODES could state what a competition offered in total. It could not state what reaching the quarter-finals was worth. `PrizeMoney` is an amount, not a schedule, so a per-round payout structure collapsed into a single figure or was dropped — and the second is worse, because nothing recorded that it happened.

## The shape already existed, for points

`PrizeMoneyAward` is not a new shape. `finishingPositionRanges` in the ranking-points policies is already finishing-position → value, and a Grand Slam singles ladder lands on the exact eight keys `grandSlamSingles` uses, because they describe the same eight outcomes. Reusing the key is the point: *"R16 was worth 200 points and 480,000"* becomes one join rather than two vocabularies.

`finishingPosition` carries the same semantics as its counterpart — the **maximum** of the range the award covers, so SF is `4` and R64 is `64`.

## Grain

- **`Event.prizeMoneyAwards`** — where ladders are published. A main draw, its qualifying, and a smaller-draw event in the same tournament each carry their own, at different rung counts and draw sizes, none derivable from another.
- **`Tournament.prizeMoneyAwards`** — the counterpart to the existing `totalPrizeMoney`. Without it a reader finds the total at tournament grain but must go to the events for its shape, and a single-event competition has no events to go to. Explicitly **not** an aggregation: ladders cannot be summed or merged.

## Two traps, documented on the type and locked in the spec

**A `roundCode` is not a finishing position, and the two run in opposite directions.** A "Round 1" rung is what a first-round *loser* received — the *last* position — and which position that is depends on the draw size, not the round: the same round code is position 128 in a 128 draw and position 16 in a 16 draw. A qualifying ladder may carry no rung at position 1 at all, because the players who come through are paid from the main draw. Code that maps round one to position one inverts the ladder and pays the champion the qualifier's cheque.

**A ladder is never summed.** Each rung is what *one* competitor received, so the outlay is `amount × competitors finishing in that range`. For a 128 draw whose rungs run 140,000 to 5,500,000, adding them gives 11,630,000 against an actual outlay of 37,840,000.

## The second rule is enforced, not just documented

Probed it first, and it was not. Because `PrizeMoneyAward extends MonetaryAmount` and every field `PrizeMoney` adds is optional, a `PrizeMoneyAward[]` was **structurally assignable to `PrizeMoney[]`** and compiled clean — so `sumAgainstBound` would have accepted a ladder in silence and returned a correctly-denominated wrong number, precisely the failure class #4711 hardened this model against.

`PrizeMoney` now declares `finishingPosition?: never` for this single purpose, making the substitution a compile error at no cost, since no existing `PrizeMoney` carries that field. The spec proves it with `@ts-expect-error`, so `tsc` fails if the guard ever stops firing.

`unit` stays required and load-bearing: publishers disagree on scale and formatting — whole units as a comma-formatted string that `Number()`s to `NaN`, whole units as an integer, and minor units all occur.

## Scope

Types, spec and docs only. No mutation surface, no query surface, no UI.

## Verification

`pnpm verify` exit 0 — all 15 steps, including coverage, build, publint, runtime, shakeable, bundle-size, surface and pack. 11,449 tests pass (baseline 11,440 + 9 new).

Both detectors were falsified with planted errors before being trusted, and so was the new spec: planting the exact round-to-position inversion the type exists to prevent fails 4 of the 9.