### PR TITLE
fix(codes): revive the dead schema validator and bring the schema back to the types

### DIFF
--- a/src/global/schema/tournament.schema.json
+++ b/src/global/schema/tournament.schema.json
@@ -159,6 +159,48 @@
           "items": {
             "$ref": "#/definitions/Venue"
           }
+        },
+        "activeDates": {
+          "type": "array",
+          "items": {
+            "type": ["string", "object"]
+          }
+        },
+        "factory": {
+          "type": "object"
+        },
+        "linkedTournamentIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "prizeMoneyAwards": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PrizeMoneyAward"
+          }
+        },
+        "sanction": {
+          "type": "object"
+        },
+        "sanctions": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "scheduling": {
+          "type": "object"
+        },
+        "tournamentTier": {
+          "type": "object"
+        },
+        "weekdays": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": ["tournamentId"],
@@ -206,7 +248,9 @@
     "Event": {
       "type": "object",
       "properties": {
-        "flightProfile": { "type": "object" },
+        "flightProfile": {
+          "type": "object"
+        },
         "createdAt": {
           "type": ["string", "object"],
           "format": "date-time"
@@ -346,6 +390,45 @@
         },
         "wheelchairClass": {
           "$ref": "#/definitions/WheelchairClassEnum"
+        },
+        "activeDates": {
+          "type": "array",
+          "items": {
+            "type": ["string", "object"]
+          }
+        },
+        "competitionFormat": {
+          "type": "string"
+        },
+        "prizeMoney": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PrizeMoney"
+          }
+        },
+        "prizeMoneyAwards": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PrizeMoneyAward"
+          }
+        },
+        "sanction": {
+          "type": "object"
+        },
+        "eventOtherIds": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "eventTier": {
+          "type": "object"
+        },
+        "weekdays": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": ["eventId"],
@@ -496,10 +579,18 @@
     "DrawDefinition": {
       "type": "object",
       "properties": {
-        "flightProfile": { "type": "object" },
-        "lineUps": { "type": "object" },
-        "draftState": { "type": "object" },
-        "competitionState": { "type": "object" },
+        "flightProfile": {
+          "type": "object"
+        },
+        "lineUps": {
+          "type": "object"
+        },
+        "draftState": {
+          "type": "object"
+        },
+        "competitionState": {
+          "type": "object"
+        },
         "createdAt": {
           "type": ["string", "object"],
           "format": "date-time"
@@ -633,7 +724,9 @@
     "Entry": {
       "type": "object",
       "properties": {
-        "roundTarget": { "type": "integer" },
+        "roundTarget": {
+          "type": "integer"
+        },
         "createdAt": {
           "type": ["string", "object"],
           "format": "date-time"
@@ -888,8 +981,12 @@
     "MatchUp": {
       "type": "object",
       "properties": {
-        "delegatedOutcome": { "type": "object" },
-        "disableAutoCalc": { "type": "boolean" },
+        "delegatedOutcome": {
+          "type": "object"
+        },
+        "disableAutoCalc": {
+          "type": "boolean"
+        },
         "createdAt": {
           "type": ["string", "object"],
           "format": "date-time"
@@ -1823,7 +1920,9 @@
     "Structure": {
       "type": "object",
       "properties": {
-        "roundTarget": { "type": "integer" },
+        "roundTarget": {
+          "type": "integer"
+        },
         "createdAt": {
           "type": ["string", "object"],
           "format": "date-time"
@@ -1942,9 +2041,15 @@
     "PositionAssignment": {
       "type": "object",
       "properties": {
-        "tally": { "type": "object" },
-        "subOrder": { "type": "integer" },
-        "disableLinks": { "type": "boolean" },
+        "tally": {
+          "type": "object"
+        },
+        "subOrder": {
+          "type": "integer"
+        },
+        "disableLinks": {
+          "type": "boolean"
+        },
         "createdAt": {
           "type": ["string", "object"],
           "format": "date-time"
@@ -3149,20 +3254,36 @@
     "LogisticsOption": {
       "type": "object",
       "properties": {
-        "address": { "type": "string" },
-        "description": { "type": "string" },
-        "email": { "type": "string" },
+        "address": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
         "extensions": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Extension"
           }
         },
-        "name": { "type": "string" },
-        "notes": { "type": "string" },
-        "phone": { "type": "string" },
-        "priceRange": { "type": "string" },
-        "url": { "type": "string" }
+        "name": {
+          "type": "string"
+        },
+        "notes": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "priceRange": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
       },
       "required": ["name"],
       "additionalProperties": false
@@ -3170,11 +3291,21 @@
     "SocialEvent": {
       "type": "object",
       "properties": {
-        "date": { "type": "string" },
-        "description": { "type": "string" },
-        "location": { "type": "string" },
-        "name": { "type": "string" },
-        "time": { "type": "string" }
+        "date": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "time": {
+          "type": "string"
+        }
       },
       "required": ["name"],
       "additionalProperties": false
@@ -3182,10 +3313,18 @@
     "Sponsor": {
       "type": "object",
       "properties": {
-        "logoUrl": { "type": "string" },
-        "name": { "type": "string" },
-        "tier": { "type": "string" },
-        "websiteUrl": { "type": "string" }
+        "logoUrl": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tier": {
+          "type": "string"
+        },
+        "websiteUrl": {
+          "type": "string"
+        }
       },
       "required": ["name"],
       "additionalProperties": false
@@ -3193,9 +3332,15 @@
     "DocumentLink": {
       "type": "object",
       "properties": {
-        "description": { "type": "string" },
-        "name": { "type": "string" },
-        "url": { "type": "string" }
+        "description": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
       },
       "required": ["name"],
       "additionalProperties": false
@@ -3203,9 +3348,15 @@
     "RegistrationEntryFee": {
       "type": "object",
       "properties": {
-        "amount": { "type": "number" },
-        "category": { "type": "string" },
-        "currencyCode": { "type": "string" },
+        "amount": {
+          "type": "number"
+        },
+        "category": {
+          "type": "string"
+        },
+        "currencyCode": {
+          "type": "string"
+        },
         "eventType": {
           "type": "string",
           "enum": ["SINGLES", "DOUBLES", "TEAM", "HYBRID"]
@@ -3254,9 +3405,13 @@
         },
         "currencyCode": {
           "type": "string"
+        },
+        "unit": {
+          "type": "string",
+          "enum": ["MINOR", "MAJOR"]
         }
       },
-      "required": ["amount", "currencyCode"],
+      "required": ["amount", "currencyCode", "unit"],
       "additionalProperties": false
     },
     "UnifiedTournamentId": {
@@ -3409,8 +3564,12 @@
     "Court": {
       "type": "object",
       "properties": {
-        "disabled": { "type": "boolean" },
-        "discipline": { "$ref": "#/definitions/DisciplineEnum" },
+        "disabled": {
+          "type": "boolean"
+        },
+        "discipline": {
+          "$ref": "#/definitions/DisciplineEnum"
+        },
         "createdAt": {
           "type": ["string", "object"],
           "format": "date-time"
@@ -3639,6 +3798,41 @@
         }
       },
       "required": ["organisationId", "venueId"],
+      "additionalProperties": false
+    },
+    "PrizeMoneyAward": {
+      "type": "object",
+      "properties": {
+        "amount": {
+          "type": "number"
+        },
+        "currencyCode": {
+          "type": "string"
+        },
+        "unit": {
+          "type": "string",
+          "enum": ["MINOR", "MAJOR"]
+        },
+        "finishingPosition": {
+          "type": "number"
+        },
+        "roundName": {
+          "type": "string"
+        },
+        "roundCode": {
+          "type": "string"
+        },
+        "notes": {
+          "type": "string"
+        },
+        "extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Extension"
+          }
+        }
+      },
+      "required": ["amount", "currencyCode", "unit", "finishingPosition"],
       "additionalProperties": false
     }
   }

--- a/src/tests/global/schemaValidation.test.ts
+++ b/src/tests/global/schemaValidation.test.ts
@@ -31,13 +31,23 @@ const schema = JSON.parse(
 const validate = ajv.compile(schema);
 
 const sourcePath = './src/tests/testHarness';
-const filenames: any[] = fs.readdirSync(sourcePath).filter(
-  (filename) => filename.indexOf('.tods.json') > 0 && filename.indexOf('.8') === undefined, // we don't want to validate TODS v0.8
-);
+// `.includes`, not `indexOf(...) === undefined`. `indexOf` returns a NUMBER, so the old
+// `filename.indexOf('.8') === undefined` was always false and `filenames` was always EMPTY —
+// `it.each([])` registers no tests and vitest does not complain, so this suite reported green
+// while validating none of the 16 TODS files. The read path below was wrong too
+// (`src/global/testHarness`, which does not exist), so either bug alone was fatal.
+const filenames: any[] = fs
+  .readdirSync(sourcePath)
+  .filter((filename) => filename.includes('.tods.json') && !filename.includes('.8')); // TODS v0.8 is not validated
+
+// Guard the guard: if the glob ever goes empty again, fail loudly instead of silently passing.
+it('finds TODS files to validate', () => {
+  expect(filenames.length).toBeGreaterThan(0);
+});
 
 it.each(filenames)('can validate all tods files in testHarness directory', (filename) => {
   const data = JSON.parse(
-    fs.readFileSync(`./src/global/testHarness/${filename}`, {
+    fs.readFileSync(`${sourcePath}/${filename}`, {
       encoding: 'utf8',
     }),
   );

--- a/src/tests/testHarness/assignTieMatchUpParticipantSub.tods.json
+++ b/src/tests/testHarness/assignTieMatchUpParticipantSub.tods.json
@@ -344,10 +344,7 @@
       "participantId": "64013fa7-f884-473a-ac26-a68bb4e9ac6b",
       "participantRole": "COMPETITOR",
       "participantName": "Pevensie/Pendejo",
-      "individualParticipantIds": [
-        "6632cdda-93c0-4d24-8372-2abc50d057b0",
-        "ca5b79f2-1d6f-4597-9ad5-2ea8b88c8063"
-      ],
+      "individualParticipantIds": ["6632cdda-93c0-4d24-8372-2abc50d057b0", "ca5b79f2-1d6f-4597-9ad5-2ea8b88c8063"],
       "participantType": "PAIR",
       "timeItems": []
     },
@@ -355,10 +352,7 @@
       "participantId": "b1f3c3bf-a405-4020-90ef-c437f252376e",
       "participantRole": "COMPETITOR",
       "participantName": "Veblen/Shaftoe",
-      "individualParticipantIds": [
-        "a43d7b32-1333-4ed3-9762-c3cd97ffd7d5",
-        "bd6fc460-9c6c-4a4b-a384-905a46104a32"
-      ],
+      "individualParticipantIds": ["a43d7b32-1333-4ed3-9762-c3cd97ffd7d5", "bd6fc460-9c6c-4a4b-a384-905a46104a32"],
       "participantType": "PAIR",
       "timeItems": []
     },
@@ -366,10 +360,7 @@
       "participantId": "b11583d5-0424-4893-aaaf-5cf388eb66a4",
       "participantRole": "COMPETITOR",
       "participantName": "Frank/Jovovich",
-      "individualParticipantIds": [
-        "320e6c40-f7d9-48d2-903b-247a7e4eba97",
-        "76b1df61-59fb-4bfe-a9a6-90eac71c2977"
-      ],
+      "individualParticipantIds": ["320e6c40-f7d9-48d2-903b-247a7e4eba97", "76b1df61-59fb-4bfe-a9a6-90eac71c2977"],
       "participantType": "PAIR",
       "timeItems": []
     },
@@ -377,10 +368,7 @@
       "participantId": "a030e9f1-b897-4c02-a776-54c742b9c964",
       "participantRole": "COMPETITOR",
       "participantName": "Banks/Bonaparte",
-      "individualParticipantIds": [
-        "bb87127b-7bab-4969-9230-9a3bbe342a0d",
-        "d751478d-f02b-49ca-9f22-f7577a10dba0"
-      ],
+      "individualParticipantIds": ["bb87127b-7bab-4969-9230-9a3bbe342a0d", "d751478d-f02b-49ca-9f22-f7577a10dba0"],
       "participantType": "PAIR",
       "timeItems": []
     },
@@ -388,10 +376,7 @@
       "participantId": "7d27e09f-b4e1-4954-b175-1533912734ae",
       "participantRole": "COMPETITOR",
       "participantName": "Eyre/Lem",
-      "individualParticipantIds": [
-        "3584ccb8-5b35-4b72-85cf-e749db48d055",
-        "32b181af-0f31-4b97-881b-4e9caa4180de"
-      ],
+      "individualParticipantIds": ["3584ccb8-5b35-4b72-85cf-e749db48d055", "32b181af-0f31-4b97-881b-4e9caa4180de"],
       "participantType": "PAIR",
       "timeItems": []
     },
@@ -428,10 +413,7 @@
     {
       "participantType": "PAIR",
       "participantRole": "COMPETITOR",
-      "individualParticipantIds": [
-        "ca5b79f2-1d6f-4597-9ad5-2ea8b88c8063",
-        "a43d7b32-1333-4ed3-9762-c3cd97ffd7d5"
-      ],
+      "individualParticipantIds": ["ca5b79f2-1d6f-4597-9ad5-2ea8b88c8063", "a43d7b32-1333-4ed3-9762-c3cd97ffd7d5"],
       "participantId": "2356ee4b-2c65-4cae-8774-06861d8a8d26",
       "participantName": "Pendejo/Veblen"
     },
@@ -925,8 +907,7 @@
               "endTime": "20:00"
             }
           ],
-          "onlineResources": [],
-          "venueId": "e8e4c0b0-216c-426f-bba2-18e16caa74b8"
+          "onlineResources": []
         },
         {
           "courtId": "6b79a823-06f9-43c3-8a10-1dc52f9fde9e",
@@ -977,8 +958,7 @@
               "endTime": "20:00"
             }
           ],
-          "onlineResources": [],
-          "venueId": "e8e4c0b0-216c-426f-bba2-18e16caa74b8"
+          "onlineResources": []
         },
         {
           "courtId": "774bd4e7-56c0-4d52-90bf-5bb0d0cef81c",
@@ -1029,8 +1009,7 @@
               "endTime": "20:00"
             }
           ],
-          "onlineResources": [],
-          "venueId": "e8e4c0b0-216c-426f-bba2-18e16caa74b8"
+          "onlineResources": []
         },
         {
           "courtId": "820d306d-70a0-4349-bdd4-025aaec137c4",
@@ -1081,8 +1060,7 @@
               "endTime": "20:00"
             }
           ],
-          "onlineResources": [],
-          "venueId": "e8e4c0b0-216c-426f-bba2-18e16caa74b8"
+          "onlineResources": []
         },
         {
           "courtId": "956b1d55-91ec-45d8-b2ac-a4b4d9e77980",
@@ -1133,8 +1111,7 @@
               "endTime": "20:00"
             }
           ],
-          "onlineResources": [],
-          "venueId": "e8e4c0b0-216c-426f-bba2-18e16caa74b8"
+          "onlineResources": []
         },
         {
           "courtId": "88e89e70-ac4d-4a26-818d-5197f2297a48",
@@ -1185,8 +1162,7 @@
               "endTime": "20:00"
             }
           ],
-          "onlineResources": [],
-          "venueId": "e8e4c0b0-216c-426f-bba2-18e16caa74b8"
+          "onlineResources": []
         }
       ]
     }
@@ -1278,10 +1254,7 @@
               ]
             },
             {
-              "matchUpFormatCodes": [
-                "SET3-S:4NOAD-F:TB7",
-                "SET3-S:4/TB7-F:TB10"
-              ],
+              "matchUpFormatCodes": ["SET3-S:4NOAD-F:TB7", "SET3-S:4/TB7-F:TB10"],
               "averageTimes": [
                 {
                   "categoryNames": [],
@@ -1303,11 +1276,7 @@
               ]
             },
             {
-              "matchUpFormatCodes": [
-                "SET3-S:4/TB5NOAD@3",
-                "SET1-S:6/TB5NOAD@5",
-                "SET3-S:4/TB7@3"
-              ],
+              "matchUpFormatCodes": ["SET3-S:4/TB5NOAD@3", "SET1-S:6/TB5NOAD@5", "SET3-S:4/TB7@3"],
               "averageTimes": [
                 {
                   "categoryNames": [],
@@ -1329,12 +1298,7 @@
               ]
             },
             {
-              "matchUpFormatCodes": [
-                "SET1-S:5/TB5NOAD@4",
-                "SET1-S:T20",
-                "SET1-S:6/TB7",
-                "SET1-S:6NOAD"
-              ],
+              "matchUpFormatCodes": ["SET1-S:5/TB5NOAD@4", "SET1-S:T20", "SET1-S:6/TB7", "SET1-S:6NOAD"],
               "averageTimes": [
                 {
                   "categoryNames": [],
@@ -1345,12 +1309,7 @@
               ]
             },
             {
-              "matchUpFormatCodes": [
-                "SET1-S:4/TB7",
-                "SET1-S:4/TB5@3",
-                "SET3-S:TB10",
-                "SET1-S:4NOAD"
-              ],
+              "matchUpFormatCodes": ["SET1-S:4/TB7", "SET1-S:4/TB5@3", "SET3-S:TB10", "SET1-S:4NOAD"],
               "averageTimes": [
                 {
                   "categoryNames": [],
@@ -1374,10 +1333,7 @@
           ],
           "matchUpRecoveryTimes": [
             {
-              "matchUpFormatCodes": [
-                "SET5-S:6/TB7-F:6/TB10",
-                "SET3-S:6/TB7@5-F:TB10"
-              ],
+              "matchUpFormatCodes": ["SET5-S:6/TB7-F:6/TB10", "SET3-S:6/TB7@5-F:TB10"],
               "recoveryTimes": [
                 {
                   "categoryNames": [],
@@ -1388,11 +1344,7 @@
               ]
             },
             {
-              "matchUpFormatCodes": [
-                "SET3-S:6/TB7",
-                "SET3-S:6/TB7-F:TB10",
-                "SET3-S:6/TB7-F:TB7"
-              ],
+              "matchUpFormatCodes": ["SET3-S:6/TB7", "SET3-S:6/TB7-F:TB10", "SET3-S:6/TB7-F:TB7"],
               "recoveryTimes": [
                 {
                   "categoryTypes": ["ADULT", "WHEELCHAIR"],

--- a/src/tests/testHarness/tallyPolicy.tods.json
+++ b/src/tests/testHarness/tallyPolicy.tods.json
@@ -158,7 +158,6 @@
                         "loser": [1, 4],
                         "winner": [1, 4]
                       },
-                      "losers": [],
                       "matchUpStatus": "COMPLETED",
                       "matchUpStatusCodes": [],
                       "matchUpType": "DOUBLES",
@@ -167,7 +166,6 @@
                       "sides": [],
                       "tieMatchUps": [],
                       "updatedAt": "2024-10-26T20:18:00.294Z",
-                      "winners": [],
                       "timeItems": [
                         {
                           "createdAt": "2024-10-22T14:30:53.622Z",
@@ -220,7 +218,6 @@
                         "loser": [1, 4],
                         "winner": [1, 4]
                       },
-                      "losers": [],
                       "matchUpStatus": "COMPLETED",
                       "matchUpStatusCodes": [],
                       "matchUpType": "DOUBLES",
@@ -229,7 +226,6 @@
                       "sides": [],
                       "tieMatchUps": [],
                       "updatedAt": "2024-10-26T20:17:48.090Z",
-                      "winners": [],
                       "timeItems": [
                         {
                           "createdAt": "2024-10-22T14:30:59.755Z",
@@ -282,7 +278,6 @@
                         "loser": [1, 4],
                         "winner": [1, 4]
                       },
-                      "losers": [],
                       "matchUpStatus": "COMPLETED",
                       "matchUpStatusCodes": [],
                       "matchUpType": "DOUBLES",
@@ -291,7 +286,6 @@
                       "sides": [],
                       "tieMatchUps": [],
                       "updatedAt": "2024-10-26T21:44:20.922Z",
-                      "winners": [],
                       "timeItems": [
                         {
                           "createdAt": "2024-10-22T14:31:10.251Z",
@@ -344,7 +338,6 @@
                         "loser": [1, 4],
                         "winner": [1, 4]
                       },
-                      "losers": [],
                       "matchUpStatus": "COMPLETED",
                       "matchUpStatusCodes": [],
                       "matchUpType": "DOUBLES",
@@ -353,7 +346,6 @@
                       "sides": [],
                       "tieMatchUps": [],
                       "updatedAt": "2024-10-26T22:59:27.002Z",
-                      "winners": [],
                       "timeItems": [
                         {
                           "createdAt": "2024-10-22T14:31:13.072Z",
@@ -406,7 +398,6 @@
                         "loser": [1, 4],
                         "winner": [1, 4]
                       },
-                      "losers": [],
                       "matchUpStatus": "COMPLETED",
                       "matchUpStatusCodes": [],
                       "matchUpType": "DOUBLES",
@@ -415,7 +406,6 @@
                       "sides": [],
                       "tieMatchUps": [],
                       "updatedAt": "2024-10-26T00:36:02.089Z",
-                      "winners": [],
                       "timeItems": [
                         {
                           "createdAt": "2024-10-22T14:35:18.967Z",
@@ -468,7 +458,6 @@
                         "loser": [1, 4],
                         "winner": [1, 4]
                       },
-                      "losers": [],
                       "matchUpStatus": "COMPLETED",
                       "matchUpStatusCodes": [],
                       "matchUpType": "DOUBLES",
@@ -477,7 +466,6 @@
                       "sides": [],
                       "tieMatchUps": [],
                       "updatedAt": "2024-10-26T00:36:14.065Z",
-                      "winners": [],
                       "timeItems": [
                         {
                           "createdAt": "2024-10-22T14:35:15.892Z",
@@ -771,7 +759,6 @@
       "tennisOfficialIds": [],
       "processCodes": [],
       "weekdays": [],
-      "onlineResources": [],
       "isMock": true
     }
   ],
@@ -4924,11 +4911,9 @@
       }
     }
   ],
-  "registrationProfile": [
-    {
-      "entriesClose": "2024-10-21T00:00:00.000Z"
-    }
-  ],
+  "registrationProfile": {
+    "entriesClose": "2024-10-21T00:00:00.000Z"
+  },
   "season": "a8ead796-829a-4be3-aced-5e5431e04d5d",
   "startDate": "2024-10-25T00:00:00.000Z",
   "totalPrizeMoney": [],


### PR DESCRIPTION
`tournament.schema.json` is the third declaration of CODES, after the TypeScript types and the docs. It had drifted far enough that it **accepted exactly what the types forbid and rejected what they require**: `PrizeMoney` has no `unit`, so a record carrying the field made required in #4711 *failed* validation while a record omitting it *passed*.

## Why nobody knew: the detector was dead

`schemaValidation.test.ts` validated **0 of the 16** TODS files in `testHarness`. Two independent bugs, either fatal on its own:

- `filename.indexOf('.8') === undefined` is always false — `indexOf` returns a number — so the file list was always empty. `it.each([])` registers no tests and vitest does not complain, so the suite reported green having checked nothing.
- It read from `./src/global/testHarness/`, which does not exist. The files are in `./src/tests/testHarness/`.

The suite ran 9 tests (the mocksEngine profiles) and looked healthy. **It now runs 26.** A guard test asserts the glob is non-empty, so the same silent-emptiness failure fails loudly instead of passing.

Both directions were falsified before being trusted: planting a bogus `Event` property fails validation, and breaking the glob fires the guard.

## Schema parity restored

| | |
|---|---|
| `PrizeMoney` | gains `unit`, and requires it — matching #4711 |
| `PrizeMoneyAward` | defined; `prizeMoneyAwards` added on `Event` and `Tournament` — matching #4716. `unit` and `finishingPosition` both required, and records omitting either are rejected |
| `Event` (`additionalProperties: false`) | was missing **eight** declared fields, so every one was a hard validation failure: `activeDates`, `competitionFormat`, `prizeMoney`, `prizeMoneyAwards`, `sanction`, `eventOtherIds`, `eventTier`, `weekdays` |
| `Tournament` (permissive) | was missing **nine**, which failed silently rather than loudly: `activeDates`, `factory`, `linkedTournamentIds`, `prizeMoneyAwards`, `sanction`, `sanctions`, `scheduling`, `tournamentTier`, `weekdays` |

## The judgement call

Reviving the validator surfaced four stale artifacts in two legacy fixtures — a denormalised `venueId` on courts (the `venueId` the scheduling code reads is on a schedule *cell*, not a court), `onlineResources` on an event, `winners`/`losers` on matchUps, and a `registrationProfile` that was an array where the type says object, the only one of ten fixtures shaped that way. All are declared in **neither** the types nor the schema, and read by nothing.

**The data is corrected rather than the schema loosened.** The opposite reading is defensible — `Tournament` and `Venue` are already `additionalProperties: true`, and CODES is a superset standard consumers extend — but making `Event`/`Court`/`MatchUp` permissive too would blunt the validator this PR exists to restore. Happy to flip it if the project prefers the permissive reading; it is a smaller change than this one.

## Review note

The two fixture diffs are mostly prettier collapsing arrays. Those files had never been formatted, and lint-staged's `*` glob normalises anything staged. `.prettierignore` already records this same annoyance for lockfiles.

## Verification

`pnpm verify` green — all 15 steps. Suite **11,449 → 11,466** (16 TODS files + the guard).