### PR TITLE
docs(codes): state the schema's additionalProperties convention, and enforce it

### DIFF
--- a/src/global/schema/tournament.schema.json
+++ b/src/global/schema/tournament.schema.json
@@ -204,7 +204,8 @@
         }
       },
       "required": ["tournamentId"],
-      "additionalProperties": true
+      "additionalProperties": true,
+      "$comment": "OPEN, and this is a KNOWN GAP rather than a decision — closing it is blocked, not declined. Measured 2026-08-28 against the 16 TODS fixtures: 13 records carry `venueIds`, 6 carry `deleted`, and `dualMatchMetadata`, `associatedOrganisations`, `rootOrganisationId`, `tournamentExternalId` and a nested `tournamentRecord` each appear. Closing this definition today fails 14 of 16 fixtures. Each undeclared field must first be resolved as either a real CODES concept (declare it in `types/tournamentTypes.ts` AND here) or as legacy data (correct the fixtures), after which this should become `false` to match the other 51."
     },
     "Extension": {
       "type": "object",
@@ -218,7 +219,8 @@
         "value": {}
       },
       "required": ["name", "value"],
-      "additionalProperties": true
+      "additionalProperties": true,
+      "$comment": "OPEN, deliberately and permanently. Extensions are CODES' escape hatch: `value` is unconstrained by design, and callers attach their own keys. This is the one exception that is not a backlog item."
     },
     "TimeItem": {
       "type": "object",
@@ -2508,7 +2510,9 @@
         "notes": {
           "type": "string"
         }
-      }
+      },
+      "$comment": "OPEN, and this is a KNOWN GAP rather than a decision — closing it is blocked, not declined. Measured 2026-08-28 against the 16 TODS fixtures: records carry `createdAt`, `updatedAt` and a nested `parentOrganisation`. Closing this definition today fails 14 of 16 fixtures. Each undeclared field must first be resolved as either a real CODES concept (declare it in `types/tournamentTypes.ts` AND here) or as legacy data (correct the fixtures), after which this should become `false` to match the other 51.",
+      "additionalProperties": true
     },
     "Participant": {
       "type": "object",
@@ -3559,7 +3563,8 @@
         }
       },
       "required": ["venueId"],
-      "additionalProperties": true
+      "additionalProperties": true,
+      "$comment": "OPEN, and this is a KNOWN GAP rather than a decision — closing it is blocked, not declined. Measured 2026-08-28 against the 16 TODS fixtures: 7 records carry `parentOrganisation`, which `Venue` does not declare. Closing this definition today fails 14 of 16 fixtures. Each undeclared field must first be resolved as either a real CODES concept (declare it in `types/tournamentTypes.ts` AND here) or as legacy data (correct the fixtures), after which this should become `false` to match the other 51."
     },
     "Court": {
       "type": "object",
@@ -3835,5 +3840,6 @@
       "required": ["amount", "currencyCode", "unit", "finishingPosition"],
       "additionalProperties": false
     }
-  }
+  },
+  "$comment": "CONVENTION: every object definition states `additionalProperties` EXPLICITLY, and the default is `false`. 51 of 55 definitions are closed. A closed definition is what makes a CODES field added to the TypeScript types but never mirrored here a LOUD failure rather than a silent one — the drift fixed in #4718 went unnoticed for exactly this reason on the open definitions. Four definitions are open; each carries a `$comment` saying why. `codesSchemaConvention.test.ts` enforces both halves: no definition may omit the keyword, and the open set may not grow without updating that test."
 }

--- a/src/tests/global/codesSchemaConvention.test.ts
+++ b/src/tests/global/codesSchemaConvention.test.ts
@@ -1,0 +1,65 @@
+import { expect, it, describe } from 'vitest';
+import fs from 'fs-extra';
+
+/**
+ * The CODES schema convention, enforced.
+ *
+ * `tournament.schema.json` is the THIRD declaration of CODES, after the TypeScript types and the
+ * docs, and it drifted far enough (#4718) to accept what the types forbid and reject what they
+ * require. A CLOSED definition is what turns that drift into a loud failure: add a field to the
+ * types, forget the schema, and validation fails. On an OPEN definition the same mistake is silent —
+ * which is precisely why `Tournament`'s nine missing fields went unnoticed while `Event`'s eight
+ * did not.
+ *
+ * So the convention is: every object definition states `additionalProperties` EXPLICITLY, and the
+ * default is `false`. These tests exist so the convention cannot quietly erode — a new definition
+ * that omits the keyword, or an existing one flipped open, fails here rather than years later.
+ */
+const schema = JSON.parse(fs.readFileSync('./src/global/schema/tournament.schema.json', { encoding: 'utf8' }));
+
+/**
+ * The ONLY definitions permitted to be open, and why. Adding to this list is a deliberate act that
+ * must be justified in the definition's own `$comment` — which the third test checks for.
+ *
+ * `Extension` is permanent: extensions are CODES' escape hatch and `value` is unconstrained by
+ * design. The other three are KNOWN GAPS, not decisions — real records carry fields CODES does not
+ * declare (`venueIds`, `deleted`, `Venue.parentOrganisation`, …), so closing them today fails 14 of
+ * the 16 TODS fixtures. Each undeclared field has to be resolved as a real CODES concept or as
+ * legacy data first. Shrinking this list is the goal; growing it needs a reason.
+ */
+const PERMITTED_OPEN = new Set(['Extension', 'Organisation', 'Tournament', 'Venue']);
+
+const objectDefinitions = Object.entries<any>(schema.definitions).filter(([, def]) => def?.properties);
+
+describe('CODES schema convention', () => {
+  it('has definitions to check', () => {
+    expect(objectDefinitions.length).toBeGreaterThan(50);
+  });
+
+  /** The literal "undocumented state": a definition that says nothing about its own stance. */
+  it('every object definition declares additionalProperties explicitly', () => {
+    const silent = objectDefinitions.filter(([, def]) => def.additionalProperties === undefined).map(([name]) => name);
+
+    expect(silent).toEqual([]);
+  });
+
+  it('only the permitted definitions are open', () => {
+    const open = objectDefinitions.filter(([, def]) => def.additionalProperties === true).map(([name]) => name);
+
+    expect([...open].toSorted((a, b) => a.localeCompare(b, 'en'))).toEqual(
+      [...PERMITTED_OPEN].toSorted((a, b) => a.localeCompare(b, 'en')),
+    );
+  });
+
+  /** An exception without a stated reason is how this became undocumented the first time. */
+  it('every open definition explains itself in a $comment', () => {
+    const unexplained = [...PERMITTED_OPEN].filter((name) => !schema.definitions[name]?.$comment);
+
+    expect(unexplained).toEqual([]);
+  });
+
+  it('states the convention at the top of the schema', () => {
+    expect(schema.$comment).toBeTruthy();
+    expect(schema.$comment).toContain('additionalProperties');
+  });
+});


### PR DESCRIPTION
Follow-up to #4718, which left the schema's strictness as an **undocumented state**.

## It is not the even split it looked like

Enumerating all 55 object definitions in `tournament.schema.json`:

| stance | count | which |
|---|---|---|
| `additionalProperties: false` | **51** | the convention |
| `additionalProperties: true` | 3 | `Extension`, `Tournament`, `Venue` |
| **keyword absent entirely** | 1 | `Organisation` |

`Organisation` saying nothing while 51 definitions state their stance explicitly is the tell that this was never a policy — it is accumulated drift.

**And the drift has consequences.** A CLOSED definition turns a CODES field added to the types but never mirrored here into a *loud* failure; an OPEN one hides it. That is precisely why `Tournament`'s nine missing fields were silent in #4718 while `Event`'s eight were not.

## Closing the open three is blocked, not declined

Measured against the 16 TODS fixtures — making `Tournament`/`Venue`/`Organisation` strict fails **14 of 16**, exposing 11 undeclared fields:

`venueIds` (13 records) · `deleted` (6) · `Venue.parentOrganisation` (7) · `Organisation.createdAt` / `updatedAt` / nested `parentOrganisation` · `dualMatchMetadata` · `associatedOrganisations` · `rootOrganisationId` · `tournamentExternalId` · a nested `tournamentRecord`

Each must first be resolved as a real CODES concept (declared in the types **and** here) or as legacy data (fixtures corrected). That is a discovery task, and this PR records it as one rather than starting it.

## What this does instead

- **Top-level `$comment`** stating the convention and why closed matters.
- **A `$comment` on each open definition.** `Extension` is permanent and deliberate — it is CODES' escape hatch and `value` is unconstrained by design. The other three say **KNOWN GAP**, carry the measured field list, and say what closing them requires.
- **`Organisation` gains an explicit `additionalProperties: true`.** The value is unchanged — absent already meant permissive — but it no longer stays silent.
- **`codesSchemaConvention.test.ts`** makes the convention enforceable rather than aspirational: no definition may omit the keyword, the open set must equal the documented allow-list, and every open definition must carry a `$comment` justifying itself.

Documentation alone decays — that is how this became undocumented in the first place. The test is the part that keeps it true.

## Verification

All three guards falsified with planted breakage — dropping the keyword, flipping a closed definition open, and deleting an exception's justification each fail their own test and only their own.

`pnpm verify` green, all 15 steps. Suite **11,466 → 11,471**.