### PR TITLE
fix(scales): centralize scale-value resolution and repair six silent defects

### DIFF
--- a/documentation/docs/concepts/scaleItems.md
+++ b/documentation/docs/concepts/scaleItems.md
@@ -883,6 +883,38 @@ const scaleAttributes = {
 };
 ```
 
+## Reading a scale value as a number
+
+Scale values are not consistently numeric across data sources, and getting the
+coercion wrong is silent rather than loud. Use the exported helper rather than
+writing the extraction by hand:
+
+```js
+import { resolveScaleValueNumber, hasScaleValueNumber } from 'tods-competition-factory';
+
+resolveScaleValueNumber({ utrRating: '12.48' }, { scaleName: 'UTR' }); // 12.48
+resolveScaleValueNumber({ utrRating: '' }, { scaleName: 'UTR' }); // undefined
+resolveScaleValueNumber(0); // 0
+```
+
+Three properties matter, and each corresponds to a defect this helper exists to
+prevent:
+
+- **Values may be strings.** Ingested records commonly store `'12.48'` rather
+  than `12.48`, so a `typeof value === 'number'` test silently discards every
+  real rating while passing every generated fixture.
+- **An empty string is not zero.** Records carry `''` for a participant with no
+  rating on that scale. `Number('')` is `0`, and `0` on a scale declared
+  `[1, 16]` is below the floor — an invented rating rather than a missing one.
+  Always coerce with `Number.parseFloat` plus a `NaN` guard.
+- **Zero is a legitimate rating.** `PSA`, `SQUASH_LEVELS`, `ITTF` and `BWF` all
+  declare `0` inside their valid range. Truthiness tests (`if (value)`,
+  `value || fallback`) therefore erase a real competitor — use
+  `hasScaleValueNumber` to ask whether a value is present.
+
+The helper returns `undefined` rather than a fallback; choosing a default is the
+caller's decision and belongs where its consequences are visible.
+
 ## Related Documentation
 
 - **[Accessors](./accessors)** - Accessing nested scale values

--- a/src/assemblies/generators/participants/generateLineUps.ts
+++ b/src/assemblies/generators/participants/generateLineUps.ts
@@ -1,3 +1,4 @@
+import { resolveScaleValueNumber } from '@Query/scales/resolveScaleValue';
 import { isMatchUpEventType } from '@Helpers/matchUpEventTypes/isMatchUpEventType';
 import { resolveTieFormat } from '@Query/hierarchical/tieFormats/resolveTieFormat';
 import { getPairedParticipant } from '@Query/participant/getPairedParticipant';
@@ -7,7 +8,6 @@ import { validateTieFormat } from '@Validators/validateTieFormat';
 import { getParticipantId } from '@Functions/global/extractors';
 import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
 import { generateRange } from '@Tools/arrays';
-import { isNumeric } from '@Tools/math';
 
 // constants and types
 import { CollectionAssignment, DrawDefinition, Event, TieFormat, Tournament } from '@Types/tournamentTypes';
@@ -102,11 +102,14 @@ export function generateLineUps(params: GenerateLineUpsArgs): ResultType & {
 
     if (Array.isArray(matchUpTypeScales)) {
       const scaleValue = matchUpTypeScales.find((scale) => scale.scaleName === scaleName)?.scaleValue;
-      if (isNumeric(scaleValue)) {
-        return scaleValue;
-      } else if (accessor && typeof scaleValue === 'object') return scaleValue[accessor];
+      // Returned the raw accessor value, so an unrated player's '' reached the
+      // comparator, where `'' - 11.2` coerces to 0 and floats them to the top of
+      // an ascending lineup. Resolve, then fall back explicitly.
+      const resolved = resolveScaleValueNumber(scaleValue, { accessor, scaleName });
+      if (resolved !== undefined) return resolved;
     }
-    return 0;
+    // No usable value: sink rather than lead, in either sort direction.
+    return sortOrder === DESCENDING ? Number.NEGATIVE_INFINITY : Number.POSITIVE_INFINITY;
   };
 
   const sortMethod = (a, b, matchUpType) => {

--- a/src/assemblies/generators/scales/generateDynamicRatings.ts
+++ b/src/assemblies/generators/scales/generateDynamicRatings.ts
@@ -1,3 +1,4 @@
+import { resolveScaleValueNumber } from '@Query/scales/resolveScaleValue';
 import { checkRequiredParameters } from '@Helpers/parameters/checkRequiredParameters';
 import { addDynamicRatings } from '@Mutate/participants/scaleItems/addDynamicRatings';
 import { getParticipantScaleItem } from '@Query/participant/getParticipantScaleItem';
@@ -222,9 +223,14 @@ function resolveParticipantScaleItem({
 
   let resolvedScaleItem = dynamicScaleItem ?? scaleItem;
   if (!dynamicScaleItem && scaleItem && isEloNative) {
-    const sv = scaleItem.scaleValue;
-    const sourceRating = sourceAccessor && typeof sv === 'object' ? sv[sourceAccessor] : sv;
-    if (sourceRating != null) {
+    // `sourceRating != null` admitted the empty string that real records carry
+    // for an unrated player, and `('' - 1) * 3000 / 15` is -200 — an ELO 200
+    // points below the declared floor, written back as the participant's rating.
+    const sourceRating = resolveScaleValueNumber(scaleItem.scaleValue, {
+      accessor: sourceAccessor,
+      scaleName: ratingType,
+    });
+    if (sourceRating !== undefined) {
       resolvedScaleItem = {
         ...scaleItem,
         scaleName: outputScaleName,
@@ -264,9 +270,11 @@ function resolveSourceDynamicItem({
 
   if (!sourceItem) return undefined;
 
-  const sv = sourceItem.scaleValue;
-  const sourceRating = sourceAccessor && typeof sv === 'object' ? sv[sourceAccessor] : sv;
-  if (sourceRating != null) {
+  const sourceRating = resolveScaleValueNumber(sourceItem.scaleValue, {
+    accessor: sourceAccessor,
+    scaleName: ratingType,
+  });
+  if (sourceRating !== undefined) {
     return {
       ...sourceItem,
       scaleName: outputScaleName,

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,6 +112,13 @@ export type { DisciplineProfile } from './fixtures/disciplines/disciplineProfile
 // PURE STATS — usable without an engine instance.
 export { computeRatingDistributionStats } from './query/formatWizard/distributionStats';
 
+// SCALE VALUES — the single implementation of "turn a scaleValue into a number".
+// Exported because consumers were each writing their own and disagreeing: real
+// records store ratings as strings ('12.48'), carry '' for an unrated player,
+// and legitimately carry 0 on scales whose range includes it. Getting any of
+// those three wrong is silent and produces a fabricated or missing rating.
+export { resolveScaleValueNumber, hasScaleValueNumber } from './query/scales/resolveScaleValue';
+
 // READ MODEL — the TODS→SQL-rows builder toolkit (single source for cast() +
 // the CFS incremental producer). See query/readModel/index.ts.
 export * as readModel from './query/readModel';

--- a/src/mutate/drawDefinitions/draft/initializeDraft.ts
+++ b/src/mutate/drawDefinitions/draft/initializeDraft.ts
@@ -1,3 +1,4 @@
+import { resolveScaleValueNumber } from '@Query/scales/resolveScaleValue';
 import { getParticipantScaleItem } from '@Query/participant/getParticipantScaleItem';
 import { getPositionAssignments } from '@Query/drawDefinition/positionsGetter';
 import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
@@ -180,7 +181,13 @@ function sortByTierMethod({
       participantId,
     });
     const raw = scaleItem?.scaleValue;
-    const numeric = resolveNumericScale(raw);
+    // Shared helper rather than a local copy: this file used to carry its own
+    // `resolveNumericScale`, one of eight independent implementations that
+    // disagreed about strings, '' and 0.
+    const numeric = resolveScaleValueNumber(raw, {
+      accessor: scaleAttributes?.accessor,
+      scaleName: scaleAttributes?.scaleName,
+    });
     if (numeric === undefined) {
       withoutScale.push(participantId);
     } else {
@@ -194,33 +201,6 @@ function sortByTierMethod({
 
   // Participants with scale values first (sorted), then those without
   return [...withScale.map((e) => e.participantId), ...withoutScale];
-}
-
-/**
- * Extract a numeric value from a scaleValue that may be a primitive or an object.
- * For object values (e.g. DUPR: { duprRating: 4.5, reliabilityScore: 80 }),
- * the accessor-resolved value is already in scaleValue when scaleAttributes.accessor
- * is provided. If not, we try to find the first numeric property.
- */
-function resolveNumericScale(raw: any): number | undefined {
-  if (raw == null) return undefined;
-  if (typeof raw === 'number') return raw;
-  if (typeof raw === 'string') {
-    const n = Number.parseFloat(raw);
-    return Number.isNaN(n) ? undefined : n;
-  }
-  if (typeof raw === 'object') {
-    // Accessor was already applied by participantScaleItem if available.
-    // Fallback: find the first numeric property value.
-    for (const val of Object.values(raw)) {
-      if (typeof val === 'number') return val;
-      if (typeof val === 'string') {
-        const n = Number.parseFloat(val);
-        if (!Number.isNaN(n)) return n;
-      }
-    }
-  }
-  return undefined;
 }
 
 /**

--- a/src/query/event/getScaledEntries.ts
+++ b/src/query/event/getScaledEntries.ts
@@ -1,3 +1,4 @@
+import { resolveScaleValueNumber, hasScaleValueNumber } from '@Query/scales/resolveScaleValue';
 import { getParticipantScaleItem } from '@Query/participant/getParticipantScaleItem';
 
 // constants and types
@@ -53,9 +54,18 @@ export function getScaledEntries({
     })
     .filter((scaledEntry) => {
       const scaleValue = scaledEntry.scaleValue;
-      // if a custom sort method is not provided, filter out entries with non-float values
-      if (!scaleSortMethod && (Number.isNaN(scaleValue) || !Number.parseFloat(scaleValue))) return false;
-      return scaleValue;
+      if (scaleSortMethod) return scaleValue;
+      // Was: `Number.isNaN(scaleValue) || !Number.parseFloat(scaleValue)`.
+      // Two defects. `!Number.parseFloat(v)` is a TRUTHINESS test, so a
+      // legitimate 0 was dropped — and PSA / SQUASH_LEVELS / ITTF / BWF all
+      // declare 0 inside their valid range, so a player on zero points could
+      // never be seeded. And an object-valued scaleValue (the shape returned
+      // when no accessor is supplied) parsed to NaN, silently emptying the
+      // whole result rather than reporting anything.
+      return hasScaleValueNumber(scaleValue, {
+        accessor: processingAttributes?.accessor,
+        scaleName: processingAttributes?.scaleName,
+      });
     })
     .sort(
       scaleSortMethod ||
@@ -75,6 +85,13 @@ export function getScaledEntries({
   }
 
   function scaleItemValue(scaleItem) {
-    return Number.parseFloat(scaleItem.scaleValue || (sortDescending ? -1 : 1e5));
+    // `scaleItem.scaleValue || fallback` would map a legitimate 0 to the
+    // fallback and sort that player to the wrong end; resolve first, then
+    // apply the fallback only when there is genuinely no value.
+    const resolved = resolveScaleValueNumber(scaleItem?.scaleValue, {
+      accessor: processingAttributes?.accessor,
+      scaleName: processingAttributes?.scaleName,
+    });
+    return resolved ?? (sortDescending ? -1 : 1e5);
   }
 }

--- a/src/query/matchUp/getMatchUpRatingDelta.ts
+++ b/src/query/matchUp/getMatchUpRatingDelta.ts
@@ -1,3 +1,4 @@
+import { resolveScaleValueNumber } from '@Query/scales/resolveScaleValue';
 import { signedRatingDelta } from './resolveDeltaBand';
 import ratingsParameters from '@Fixtures/ratings/ratingsParameters';
 
@@ -48,8 +49,10 @@ function scaleValueForParticipant({
   const rating = participant?.ratings?.[type]?.find((entry: any) => entry.scaleName === scaleName);
   const ranking = participant?.rankings?.[type]?.find((entry: any) => entry.scaleName === scaleName);
   const scaleValue = (rating ?? ranking)?.scaleValue;
-  const value = valueAccessor ? scaleValue?.[valueAccessor] : scaleValue;
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+  // A `typeof === 'number'` gate here rejected every ingested rating, which are
+  // stored as strings, and the caller treats `undefined` as "missing data, not a
+  // caller mistake" — so a fully rated draw reported no deltas and raised nothing.
+  return resolveScaleValueNumber(scaleValue, { accessor: valueAccessor, scaleName });
 }
 
 /**

--- a/src/query/matchUps/getPredictiveAccuracy.ts
+++ b/src/query/matchUps/getPredictiveAccuracy.ts
@@ -1,3 +1,4 @@
+import { resolveScaleValueNumber } from '@Query/scales/resolveScaleValue';
 import { isMatchUpEventType } from '@Helpers/matchUpEventTypes/isMatchUpEventType';
 import { allTournamentMatchUps } from '@Query/matchUps/getAllTournamentMatchUps';
 import { checkScoreHasValue } from '@Query/matchUp/checkScoreHasValue';
@@ -243,8 +244,16 @@ function getSideValues({
           if (exclude) exclusionValues.push(exclusionValue);
           scaleValues.push(scaleValue);
 
-          if (pValue && !Number.isNaN(Number(value))) {
-            value += pValue;
+          // `value` started at 0 and `+=` was applied to the RAW value. With
+          // string ratings that concatenates: 0 + '12.48' -> '012.48', then
+          // + '11.20' -> '012.4811.20' -> NaN. One individual per side survived
+          // by accident; every DOUBLES matchUp — two individuals — produced NaN,
+          // so the whole doubles predictive-accuracy result was garbage. The old
+          // guard tested the accumulator rather than the incoming value, so it
+          // never fired. Resolve each contribution to a number before adding.
+          const numericValue = resolveScaleValueNumber(pValue, { accessor: valueAccessor, scaleName });
+          if (numericValue !== undefined && value !== undefined) {
+            value += numericValue;
           } else {
             value = undefined;
           }

--- a/src/query/participant/getConvertedRating.ts
+++ b/src/query/participant/getConvertedRating.ts
@@ -1,4 +1,5 @@
 import { getRatingConvertedFromELO, getRatingConvertedToELO } from '@Generators/scales/eloConversions';
+import { resolveScaleValueNumber } from '@Query/scales/resolveScaleValue';
 import { checkRequiredParameters } from '@Helpers/parameters/checkRequiredParameters';
 import ratingsParameters from '@Fixtures/ratings/ratingsParameters';
 
@@ -41,8 +42,17 @@ export function getConvertedRating(params: GetConvertedRatingArgs) {
 
   const sourceRatingType = sourceRatingObject?.scaleName;
 
-  const accessor = ratingsParameters[sourceRatingObject?.scaleName]?.accessor;
-  const sourceRating = (accessor && sourceRatingObject.scaleValue[accessor]) || sourceRatingObject?.scaleValue;
+  // The previous form was `(accessor && scaleValue[accessor]) || scaleValue`.
+  // The `||` made an empty-string rating — which real records carry for a
+  // player with no rating on that scale — fall through to the whole OBJECT.
+  // `{...} - 1` is NaN, NaN survives convertRange, and `parseFloat('NaN') || 0`
+  // then produced 0, which on an inverted scale is `40 - 0` — the WORST possible
+  // WTN, invented silently. The same `||` also swallowed a legitimate 0, which
+  // PSA / SQUASH_LEVELS / ITTF / BWF all declare inside their valid range.
+  const sourceRating = resolveScaleValueNumber(sourceRatingObject?.scaleValue, {
+    scaleName: sourceRatingObject?.scaleName,
+  });
+  if (sourceRating === undefined) return { error: INVALID_VALUES };
   const eloValue = getRatingConvertedToELO({ sourceRatingType, sourceRating });
   const convertedRating = getRatingConvertedFromELO({
     targetRatingType: targetRatingType,

--- a/src/query/scales/getAvgWTN.ts
+++ b/src/query/scales/getAvgWTN.ts
@@ -1,5 +1,7 @@
+import { resolveScaleValueNumber, hasScaleValueNumber } from './resolveScaleValue';
 import { getDetailsWTN } from './getDetailsWTN';
 
+import { WTN } from '@Constants/ratingConstants';
 import { HydratedMatchUp } from '@Types/hydrated';
 
 type GetAvgWTNArgs = {
@@ -27,17 +29,22 @@ export function getAvgWTN({ eventType, matchUps, eventId, drawId }: GetAvgWTNArg
       return participants;
     }, {});
   const eventParticipants = Object.values(mappedParticipants);
+  // `getDetailsWTN` returns the value exactly as stored, which for ingested
+  // records is a STRING. Accumulating those with `+=` concatenates instead of
+  // adding ('0' + '4.13' + '5.20' -> '04.135.20'), so avgWTN came out NaN for
+  // any field of two or more rated players — and that NaN reaches published
+  // structure reports via structureReport.ts. Normalize once, here.
   const wtnRatings = eventParticipants
     .map((participant) => getDetailsWTN({ participant, eventType }))
-    .filter(({ wtnRating }) => wtnRating);
+    .filter(({ wtnRating }) => hasScaleValueNumber(wtnRating, { scaleName: WTN }));
 
   const pctNoRating = ((eventParticipants.length - wtnRatings.length) / eventParticipants.length) * 100;
 
   const wtnTotals = wtnRatings.reduce(
     (totals, wtnDetails) => {
       const { wtnRating, confidence } = wtnDetails;
-      totals.totalWTN += wtnRating;
-      totals.totalConfidence += confidence;
+      totals.totalWTN += resolveScaleValueNumber(wtnRating, { scaleName: WTN }) ?? 0;
+      totals.totalConfidence += resolveScaleValueNumber(confidence) ?? 0;
       return totals;
     },
     { totalWTN: 0, totalConfidence: 0 },

--- a/src/query/scales/resolveScaleValue.ts
+++ b/src/query/scales/resolveScaleValue.ts
@@ -1,0 +1,100 @@
+import ratingsParameters from '@Fixtures/ratings/ratingsParameters';
+
+/**
+ * The single place a scale value is turned into a number.
+ *
+ * Before this existed there were eight independent implementations across the
+ * factory, TMX and courthive-components, and they disagreed in ways that
+ * produced silent, wrong output rather than errors. Two failure modes recurred,
+ * and every clause below exists to prevent one of them:
+ *
+ * **1. Rejecting real ratings.** Ingested records store scale values as
+ * STRINGS — verified against production: `{ utrRating: '12.48' }`. mocksEngine
+ * emits numbers, so a `typeof x === 'number'` gate passes every synthetic test
+ * and silently drops every real rating.
+ *
+ * **2. Inventing a rating from nothing.** The same records carry
+ * `{ utrRating: '' }` for a player with no rating on that scale. `Number('')`
+ * is `0`, and `0` on UTR's declared `[1, 16]` range is a full unit below the
+ * floor — the strongest or weakest player in the field, fabricated from an
+ * empty string. So coercion goes through `Number.parseFloat` with an explicit
+ * NaN guard, never `Number()`, `+value` or `parseInt`.
+ *
+ * And one rule that is easy to miss in both directions:
+ *
+ * **3. `0` is a legitimate rating.** `PSA [0,3000]`, `SQUASH_LEVELS [0,7000]`,
+ * `ITTF [0,20000]` and `BWF [0,150000]` all declare zero inside their valid
+ * range — a new player really is on zero points. Any truthiness test (`if
+ * (value)`, `value || fallback`, `!Number.parseFloat(value)`) therefore erases
+ * a real competitor. Callers that need "is a value present" must ask for
+ * `undefined`, not falsiness.
+ *
+ * Returns `undefined` — never a fallback — when no number can be resolved.
+ * Choosing a default is the caller's decision and belongs at the call site
+ * where the consequences are visible.
+ */
+
+type ResolveScaleValueParams = {
+  /** Explicit accessor, e.g. 'utrRating'. Wins over the scaleName lookup. */
+  accessor?: string;
+  /** Scale name, used to look the accessor up in `ratingsParameters`. */
+  scaleName?: string;
+};
+
+/** Coerce a primitive to a number without ever mapping '' or null to 0. */
+function primitiveToNumber(value: unknown): number | undefined {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : undefined;
+  if (typeof value !== 'string') return undefined;
+  if (!value.trim()) return undefined;
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function accessorsFor({ accessor, scaleName }: ResolveScaleValueParams): string[] {
+  const params = scaleName ? ratingsParameters[scaleName] : undefined;
+  const candidates = [accessor, params?.accessor, ...(params?.accessors ?? [])];
+  return candidates.filter((candidate): candidate is string => typeof candidate === 'string' && !!candidate);
+}
+
+/**
+ * Resolve a scaleValue to a number, or `undefined` when there isn't one.
+ *
+ * Accepts a primitive (`12.48`, `'12.48'`) or an accessor-keyed object
+ * (`{ utrRating: '12.48' }`, `{ duprRating: 4.5, reliabilityScore: 80 }`).
+ * For objects the accessor is resolved in order: the explicit `accessor`
+ * argument, then the scale's declared `accessor`/`accessors` from
+ * `ratingsParameters`, and only then the first property that yields a number.
+ * That last fallback is a convenience for unknown scales; prefer passing
+ * `scaleName` so a multi-property scale (WTN carries both `wtnRating` and
+ * `confidence`) cannot resolve to the wrong field.
+ */
+export function resolveScaleValueNumber(scaleValue: unknown, params: ResolveScaleValueParams = {}): number | undefined {
+  const primitive = primitiveToNumber(scaleValue);
+  if (primitive !== undefined) return primitive;
+  if (!scaleValue || typeof scaleValue !== 'object') return undefined;
+
+  const source = scaleValue as Record<string, unknown>;
+  for (const accessor of accessorsFor(params)) {
+    const resolved = primitiveToNumber(source[accessor]);
+    if (resolved !== undefined) return resolved;
+  }
+
+  // Unknown scale shape: take the first property that resolves. Arrays are not
+  // a scale value shape and are excluded so an index never reads as a rating.
+  if (Array.isArray(scaleValue)) return undefined;
+  for (const value of Object.values(source)) {
+    const resolved = primitiveToNumber(value);
+    if (resolved !== undefined) return resolved;
+  }
+  return undefined;
+}
+
+/**
+ * Whether a scale value carries a usable number.
+ *
+ * Use this instead of truthiness so a legitimate `0` is not mistaken for a
+ * missing rating — see rule 3 above.
+ */
+export function hasScaleValueNumber(scaleValue: unknown, params: ResolveScaleValueParams = {}): boolean {
+  return resolveScaleValueNumber(scaleValue, params) !== undefined;
+}

--- a/src/tests/queries/scales/resolveScaleValue.test.ts
+++ b/src/tests/queries/scales/resolveScaleValue.test.ts
@@ -1,0 +1,102 @@
+import { resolveScaleValueNumber, hasScaleValueNumber } from '@Query/scales/resolveScaleValue';
+import { expect, it, describe } from 'vitest';
+
+/**
+ * Every case here is tied to a defect this helper exists to prevent. The string
+ * and empty-string shapes are copied from production records (ITA regional
+ * championships), not invented: mocksEngine emits numbers, so a synthetic-only
+ * fixture cannot exercise either one.
+ */
+
+describe('resolveScaleValueNumber — primitives', () => {
+  it('returns a number unchanged', () => {
+    expect(resolveScaleValueNumber(12.48)).toBe(12.48);
+    expect(resolveScaleValueNumber(1500)).toBe(1500);
+  });
+
+  it('reads a NUMERIC STRING, which is how ingested records store ratings', () => {
+    expect(resolveScaleValueNumber('12.48')).toBe(12.48);
+    expect(resolveScaleValueNumber(' 12.48 ')).toBe(12.48);
+  });
+
+  it('PRESERVES a legitimate zero', () => {
+    // PSA, SQUASH_LEVELS, ITTF and BWF all declare 0 inside their valid range.
+    // Any truthiness test here erases a real competitor from seeding.
+    expect(resolveScaleValueNumber(0)).toBe(0);
+    expect(resolveScaleValueNumber('0')).toBe(0);
+    expect(hasScaleValueNumber(0)).toBe(true);
+  });
+
+  it('rejects an empty string rather than reading it as zero', () => {
+    for (const empty of ['', '   ', '\t']) {
+      expect(resolveScaleValueNumber(empty)).toBeUndefined();
+      expect(hasScaleValueNumber(empty)).toBe(false);
+    }
+  });
+
+  it('rejects nullish and non-numeric values without coercing them', () => {
+    for (const value of [null, undefined, 'unrated', 'N/A', true, false, {}, []]) {
+      expect(resolveScaleValueNumber(value)).toBeUndefined();
+    }
+  });
+
+  it('rejects NaN and Infinity', () => {
+    for (const value of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, 'Infinity']) {
+      expect(resolveScaleValueNumber(value)).toBeUndefined();
+    }
+  });
+});
+
+describe('resolveScaleValueNumber — object shapes', () => {
+  it('resolves via an explicit accessor', () => {
+    expect(resolveScaleValueNumber({ utrRating: '12.48' }, { accessor: 'utrRating' })).toBe(12.48);
+  });
+
+  it("resolves via the scale's declared accessor when none is passed", () => {
+    expect(resolveScaleValueNumber({ utrRating: '12.48' }, { scaleName: 'UTR' })).toBe(12.48);
+    expect(resolveScaleValueNumber({ wtnRating: 4.13, confidence: 90 }, { scaleName: 'WTN' })).toBe(4.13);
+  });
+
+  it('takes the RATING, not a sibling attribute, for a multi-property scale', () => {
+    // WTN carries both wtnRating and confidence. Resolving to confidence would
+    // be catastrophic and silent, so scaleName must win over property order.
+    const reordered = { confidence: 90, wtnRating: 4.13 };
+    expect(resolveScaleValueNumber(reordered, { scaleName: 'WTN' })).toBe(4.13);
+    expect(resolveScaleValueNumber({ reliabilityScore: 80, duprRating: 4.5 }, { scaleName: 'DUPR' })).toBe(4.5);
+  });
+
+  it('rejects an object whose accessor holds an empty string', () => {
+    // Real records use '' for a player with no rating on that scale.
+    expect(resolveScaleValueNumber({ utrRating: '' }, { scaleName: 'UTR' })).toBeUndefined();
+    expect(hasScaleValueNumber({ utrRating: '' }, { scaleName: 'UTR' })).toBe(false);
+  });
+
+  it('falls back to the first resolvable property for an unknown scale', () => {
+    expect(resolveScaleValueNumber({ someRating: '9.5' })).toBe(9.5);
+    expect(resolveScaleValueNumber({ label: 'unrated', someRating: 9.5 })).toBe(9.5);
+  });
+
+  it('never reads an array index as a rating', () => {
+    expect(resolveScaleValueNumber([12.48])).toBeUndefined();
+  });
+
+  it('returns undefined for an object with nothing numeric in it', () => {
+    expect(resolveScaleValueNumber({ utrRating: '', confidence: '' }, { scaleName: 'UTR' })).toBeUndefined();
+    expect(resolveScaleValueNumber({ note: 'unrated' })).toBeUndefined();
+  });
+});
+
+describe('resolveScaleValueNumber — the numeric path is unchanged', () => {
+  it('agrees with plain arithmetic for values that already worked', () => {
+    // Guards the migration: nothing that was correct before may move.
+    const cases: [unknown, number][] = [
+      [4.13, 4.13],
+      [0, 0],
+      [1500, 1500],
+      [-200, -200],
+    ];
+    for (const [input, expected] of cases) {
+      expect(resolveScaleValueNumber(input)).toBe(expected);
+    }
+  });
+});

--- a/src/tests/queries/scales/scaleValueDefects.test.ts
+++ b/src/tests/queries/scales/scaleValueDefects.test.ts
@@ -1,0 +1,220 @@
+import { getMatchUpRatingDelta } from '@Query/matchUp/getMatchUpRatingDelta';
+import { getConvertedRating } from '@Query/participant/getConvertedRating';
+import { getScaledEntries } from '@Query/event/getScaledEntries';
+import { getAvgWTN } from '@Query/scales/getAvgWTN';
+import { expect, it, describe } from 'vitest';
+
+// constants and types
+import { RATING, SEEDING } from '@Constants/scaleConstants';
+import { SINGLES } from '@Constants/matchUpTypes';
+
+/**
+ * Regression tests for a class of defect the suite had no coverage for: scale
+ * values arriving as STRINGS, as an EMPTY STRING, or as a legitimate ZERO.
+ *
+ * `mocksEngine` emits numbers, so every existing test exercised only the one
+ * shape that already worked. The shapes here are copied from production records
+ * (ITA regional championships): `{ utrRating: '12.48' }` for a rated player and
+ * `{ utrRating: '' }` for one with no rating on that scale.
+ *
+ * Each block names the wrong value the code produced before the fix, because
+ * "returns undefined" and "returns the worst possible rating" are both silent,
+ * and the second is far more dangerous.
+ */
+
+const utr = (utrRating: string | number) => ({ scaleValue: { utrRating }, scaleName: 'UTR' });
+
+function participantWithRating(participantId: string, utrRating: string | number) {
+  return { participantId, ratings: { [SINGLES]: [utr(utrRating)] } };
+}
+
+describe('getMatchUpRatingDelta — string ratings are not "missing data"', () => {
+  const matchUpFor = (a: string | number, b: string | number) => ({
+    matchUpType: SINGLES,
+    winningSide: 1,
+    sides: [
+      { sideNumber: 1, participant: participantWithRating('a', a) },
+      { sideNumber: 2, participant: participantWithRating('b', b) },
+    ],
+  });
+
+  it('resolves a delta from STRING ratings', () => {
+    // Before: undefined, and the caller documents undefined as "missing data,
+    // not a caller mistake" — so a fully rated draw reported nothing, silently.
+    const result: any = getMatchUpRatingDelta({
+      matchUp: matchUpFor('12.48', '10.05'),
+      scaleAccessor: 'utrRating',
+      scaleName: 'UTR',
+    });
+    // Sign is the module's own perspective convention; asserted here against
+    // the value the NUMERIC path produces for identical inputs, so this test
+    // pins "strings behave like numbers" rather than re-deriving the convention.
+    expect(result.signedDelta).toBeCloseTo(-2.43, 6);
+  });
+
+  it('gives string and number ratings the identical delta', () => {
+    const asStrings: any = getMatchUpRatingDelta({
+      matchUp: matchUpFor('12.48', '10.05'),
+      scaleAccessor: 'utrRating',
+      scaleName: 'UTR',
+    });
+    const asNumbers: any = getMatchUpRatingDelta({
+      matchUp: matchUpFor(12.48, 10.05),
+      scaleAccessor: 'utrRating',
+      scaleName: 'UTR',
+    });
+    expect(asStrings.signedDelta).toBeCloseTo(asNumbers.signedDelta, 10);
+  });
+
+  it('still reports no delta when a side genuinely has no rating', () => {
+    const result: any = getMatchUpRatingDelta({
+      matchUp: matchUpFor('12.48', ''),
+      scaleAccessor: 'utrRating',
+      scaleName: 'UTR',
+    });
+    expect(result.signedDelta).toBeUndefined();
+  });
+});
+
+describe('getConvertedRating — an empty rating must not become the worst rating', () => {
+  it('converts a STRING rating', () => {
+    const result: any = getConvertedRating({
+      ratings: { [SINGLES]: [utr('12.48')] },
+      targetRatingType: 'WTN',
+      matchUpType: SINGLES,
+    });
+    expect(result.error).toBeUndefined();
+    expect(typeof result.convertedRating).toBe('number');
+  });
+
+  it('REFUSES an empty-string rating instead of returning the worst possible WTN', () => {
+    // Before: the `||` fallback passed the whole object into the conversion,
+    // producing NaN -> `|| 0` -> `40 - 0` = WTN 40, the worst on the scale,
+    // reported as a successful conversion.
+    const result: any = getConvertedRating({
+      ratings: { [SINGLES]: [utr('')] },
+      targetRatingType: 'WTN',
+      matchUpType: SINGLES,
+    });
+    expect(result.convertedRating).toBeUndefined();
+    expect(result.error).toBeDefined();
+  });
+
+  it('agrees between the string and number representations', () => {
+    const asString: any = getConvertedRating({
+      ratings: { [SINGLES]: [utr('12.48')] },
+      targetRatingType: 'WTN',
+      matchUpType: SINGLES,
+    });
+    const asNumber: any = getConvertedRating({
+      ratings: { [SINGLES]: [utr(12.48)] },
+      targetRatingType: 'WTN',
+      matchUpType: SINGLES,
+    });
+    expect(asString.convertedRating).toBeCloseTo(asNumber.convertedRating, 10);
+  });
+});
+
+describe('getScaledEntries — zero is a rating, not an absence', () => {
+  const buildRecord = (values: (number | string)[], scaleName: string) => {
+    const participants = values.map((scaleValue, index) => ({
+      participantId: `p${index}`,
+      participantType: 'INDIVIDUAL',
+      timeItems: [
+        {
+          itemType: `SCALE.${RATING}.${SINGLES}.${scaleName}`,
+          itemValue: scaleValue,
+        },
+      ],
+    }));
+    return {
+      tournamentRecord: { participants },
+      entries: values.map((_, index) => ({ participantId: `p${index}`, entryStatus: 'DIRECT_ACCEPTANCE' })),
+    };
+  };
+
+  it('keeps a participant on exactly ZERO points', () => {
+    // PSA declares range [0, 3000]; a new player really is on zero. Before, the
+    // `!Number.parseFloat(v)` truthiness test dropped them, and because
+    // autoSeeding runs through this they could never be seeded.
+    const { tournamentRecord, entries } = buildRecord([0, 500, 900, 1200], 'PSA');
+    const result: any = getScaledEntries({
+      scaleAttributes: { scaleType: RATING, scaleName: 'PSA', eventType: SINGLES },
+      tournamentRecord: tournamentRecord as any,
+      entries: entries as any,
+    });
+    expect(result.scaledEntries).toHaveLength(4);
+    expect(result.scaledEntries.map((e: any) => e.scaleValue)).toContain(0);
+  });
+
+  it('keeps STRING ratings and drops only the genuinely empty one', () => {
+    const { tournamentRecord, entries } = buildRecord(['12.48', '11.20', '10.05', ''], 'UTR');
+    const result: any = getScaledEntries({
+      scaleAttributes: { scaleType: RATING, scaleName: 'UTR', eventType: SINGLES },
+      tournamentRecord: tournamentRecord as any,
+      entries: entries as any,
+    });
+    expect(result.scaledEntries).toHaveLength(3);
+  });
+
+  it('sorts a zero to the correct end rather than to the fallback', () => {
+    const { tournamentRecord, entries } = buildRecord([0, 500, 1200], 'PSA');
+    const result: any = getScaledEntries({
+      scaleAttributes: { scaleType: RATING, scaleName: 'PSA', eventType: SINGLES },
+      tournamentRecord: tournamentRecord as any,
+      entries: entries as any,
+      sortDescending: true,
+    });
+    expect(result.scaledEntries.map((e: any) => e.scaleValue)).toEqual([1200, 500, 0]);
+  });
+
+  it('does not confuse a SEEDING scale with a RATING scale', () => {
+    const { tournamentRecord, entries } = buildRecord([0, 500], 'PSA');
+    const result: any = getScaledEntries({
+      scaleAttributes: { scaleType: SEEDING, scaleName: 'PSA', eventType: SINGLES },
+      tournamentRecord: tournamentRecord as any,
+      entries: entries as any,
+    });
+    expect(result.scaledEntries).toHaveLength(0);
+  });
+});
+
+describe('getAvgWTN — string ratings must average, not concatenate', () => {
+  const sideWith = (participantId: string, wtnRating: string | number) => ({
+    participant: {
+      participantId,
+      ratings: { [SINGLES]: [{ scaleName: 'WTN', scaleValue: { wtnRating, confidence: 90 } }] },
+    },
+  });
+
+  const matchUpsFor = (a: string | number, b: string | number) =>
+    [
+      {
+        drawId: 'd1',
+        matchUpFormat: 'SET3-S:6/TB7',
+        sides: [sideWith('a', a), sideWith('b', b)],
+      },
+    ] as any;
+
+  it('averages STRING ratings instead of producing NaN', () => {
+    // Before: totalWTN started at 0 and `+=` concatenated -> '04.135.20' -> NaN,
+    // and that NaN reaches published structure reports.
+    const result = getAvgWTN({ matchUps: matchUpsFor('4.13', '5.20'), eventType: SINGLES, drawId: 'd1' });
+    expect(Number.isNaN(result.avgWTN)).toBe(false);
+    expect(result.avgWTN).toBeCloseTo(4.665, 6);
+    expect(result.pctNoRating).toBe(0);
+  });
+
+  it('agrees between the string and number representations', () => {
+    const asStrings = getAvgWTN({ matchUps: matchUpsFor('4.13', '5.20'), eventType: SINGLES, drawId: 'd1' });
+    const asNumbers = getAvgWTN({ matchUps: matchUpsFor(4.13, 5.2), eventType: SINGLES, drawId: 'd1' });
+    expect(asStrings.avgWTN).toBeCloseTo(asNumbers.avgWTN, 10);
+    expect(asStrings.avgConfidence).toBeCloseTo(asNumbers.avgConfidence, 10);
+  });
+
+  it('counts an empty-string rating as unrated rather than averaging it in', () => {
+    const result = getAvgWTN({ matchUps: matchUpsFor('4.13', ''), eventType: SINGLES, drawId: 'd1' });
+    expect(result.avgWTN).toBeCloseTo(4.13, 6);
+    expect(result.pctNoRating).toBeCloseTo(50, 6);
+  });
+});


### PR DESCRIPTION
Found by running new code against **production ITA records** rather than `mocksEngine`. Six defects, none of which had test coverage, all of which fail silently.

## Why the suite missed all of them

`mocksEngine` emits clean numbers (`{ wtnRating: 4.13 }`). Real ingested records store:

- **strings** — `{ utrRating: '12.48' }`
- **an empty string** — `{ utrRating: '' }` for a participant with no rating on that scale
- **a legitimate zero** — `PSA [0,3000]`, `SQUASH_LEVELS [0,7000]`, `ITTF [0,20000]`, `BWF [0,150000]` all declare 0 inside their valid range

Every existing test exercised only the one shape that already worked. 11,471 tests, zero coverage of the other three.

## Centralization

There were **eight independent implementations** of "turn a scaleValue into a number" across factory, TMX and courthive-components, and they disagreed. This adds one — `resolveScaleValueNumber` / `hasScaleValueNumber` in `query/scales` — and **exports it from the package** so consumers stop mirroring it. `initializeDraft`'s private `resolveNumericScale` is deleted in favour of it.

## The six defects, with the wrong value each produced

| site | before |
|---|---|
| `getConvertedRating` | `(accessor && scaleValue[accessor]) \|\| scaleValue` let `''` fall through to the whole **object** → NaN → `\|\| 0` → `40 - 0` on an inverted scale = **the worst possible WTN**, returned as a success. Same `\|\|` swallowed a legitimate 0. |
| `getScaledEntries` | `!Number.parseFloat(v)` is a truthiness test → a participant on **exactly 0 points was dropped**, and since `autoSeeding` runs through this they could never be seeded. Sort fallback had the same flaw. |
| `getAvgWTN` | `totalWTN += wtnRating` **concatenated** strings (`'0' + '4.13' + '5.20'` = `'04.135.20'`) → `avgWTN` was **NaN** for any field of 2+ rated players, and that NaN reaches published structure reports. |
| `getMatchUpRatingDelta` | `typeof === 'number'` rejected every real rating; the caller documents `undefined` as *"missing data, not a caller mistake"*, so a fully rated draw reported no deltas and **raised nothing**. |
| `getPredictiveAccuracy` | doubles accumulator started at 0 and `+=` the raw value → concatenation. One individual per side survived by accident, two did not, so **every DOUBLES result was NaN**. The old guard tested the accumulator rather than the incoming value and never fired. |
| `generateDynamicRatings` | `sourceRating != null` admitted `''`, and `('' - 1) * 3000 / 15` = **-200** — an ELO below the declared floor, persisted. |
| `generateLineUps` | returned the raw accessor value, so `''` reached the comparator where `'' - 11.2` coerces to 0 and **floated an unrated player to the top of an ascending lineup**. |

## Blast radius

Factory is published to npm and consumed by **11 repos**. These are corrections, but they change output where it was previously wrong:

- **`getScaledEntries` is the highest-risk change** — it now returns entries it used to drop, which flows through `autoSeeding` → `generateSeedingScaleItems` → seeding → draw positions. Draws containing a 0-rated or string-rated participant **will seed differently than before**. That is the point, but it is a behaviour change.
- `getMatchUpRatingDelta` now returns `signedDelta` where it returned nothing — competitive-profile and deltaBand output appears where it was previously absent.
- `getAvgWTN` goes from NaN to a real number in structure reports.
- `getConvertedRating` no longer reports a fabricated worst-possible rating as a success; it now returns `INVALID_VALUES` for an unusable value.

**Nothing that was already correct moves** — the numeric path is asserted unchanged by explicit tests.

## Verification

- **27 new specs.** Falsified as a set: with the source changes reverted and the tests kept, **7 fail across all four modules**.
- `pnpm verify` green end to end (all 15 steps) — coverage statements 95.34% / branches 87.15%, `verify:surface` reports the two new exports as non-breaking additions.
- One flaky failure investigated rather than waved off: `tools/objects.test.ts` has a wall-clock assertion (`expected 113 to be less than 100`) that fired once under full-suite coverage load. Proven unrelated across three runs — green in isolation under coverage, green on a clean tree at full suite, green again with the fixes applied.

Docs: a "Reading a scale value as a number" section added to `concepts/scaleItems.md`.