### PR TITLE
fix(entries): make eligibility askable, and stop rejecting legal combined-rating pairs

### DIFF
--- a/src/assemblies/governors/eventGovernor/query.ts
+++ b/src/assemblies/governors/eventGovernor/query.ts
@@ -1,3 +1,4 @@
+export { getParticipantEligibility, getEligibleEvents } from '@Query/entries/getParticipantEligibility';
 export { getCategoryAgeDetails } from '@Query/event/getCategoryAgeDetails';
 export { getEventStructures } from '@Query/structure/structureGetter';
 export { getEventProperties } from '@Query/event/getEventProperties';

--- a/src/global/schema/tournament.schema.json
+++ b/src/global/schema/tournament.schema.json
@@ -530,6 +530,12 @@
         "categoryType": {
           "type": "string"
         },
+        "combinedRatingMax": {
+          "type": "number"
+        },
+        "combinedRatingMin": {
+          "type": "number"
+        },
         "ratingMax": {
           "type": "number"
         },
@@ -2492,6 +2498,9 @@
         "organisationType": {
           "$ref": "#/definitions/OrganisationTypeEnum"
         },
+        "role": {
+          "$ref": "#/definitions/AuthorityRoleEnum"
+        },
         "onlineResources": {
           "type": "array",
           "items": {
@@ -2958,6 +2967,24 @@
     "AddressTypeEnum": {
       "type": "string",
       "enum": ["HOME", "MAIL", "RESIDENTIAL", "VENUE", "WORK", "PRIMARY"]
+    },
+    "AuthorityRoleEnum": {
+      "type": "string",
+      "enum": [
+        "INTERNATIONAL",
+        "NATIONAL",
+        "ZONE",
+        "SECTION",
+        "REGION",
+        "PROVINCE",
+        "STATE",
+        "COUNTY",
+        "DISTRICT",
+        "LEAGUE",
+        "CONFERENCE",
+        "CLUB",
+        "PROVIDER"
+      ]
     },
     "BiographicalInformation": {
       "type": "object",

--- a/src/mutate/entries/addEventEntries.ts
+++ b/src/mutate/entries/addEventEntries.ts
@@ -1,9 +1,3 @@
-import {
-  CategoryRejection,
-  getEventDateRange,
-  getParticipantName,
-  validateParticipantCategory,
-} from './categoryValidation';
 import { isMatchUpEventType } from '@Helpers/matchUpEventTypes/isMatchUpEventType';
 import { getAppliedPolicies } from '@Query/extensions/getAppliedPolicies';
 import { addDrawEntries } from '@Mutate/drawDefinitions/addDrawEntries';
@@ -19,6 +13,13 @@ import { isUngrouped } from '@Query/entries/isUngrouped';
 import { coercedGender } from '@Helpers/coercedGender';
 import { isMixed } from '@Validators/isMixed';
 import { isAny } from '@Validators/isAny';
+
+import {
+  CategoryRejection,
+  getEventDateRange,
+  getParticipantName,
+  validateParticipantCategory,
+} from '@Query/entries/categoryValidation';
 
 // constants and types
 import {

--- a/src/query/entries/categoryValidation.ts
+++ b/src/query/entries/categoryValidation.ts
@@ -17,6 +17,17 @@ export interface RejectionReason {
   type: 'age' | 'rating';
   reason: string;
   details: AgeRejectionDetails | RatingRejectionDetails;
+  /**
+   * The data needed to decide was ABSENT — this is not a finding that the participant breaches a
+   * rule. A missing birthDate and an age outside the category range are both "not valid" to
+   * `addEventEntries`, which rejects either way, but they are opposite answers to a person asking
+   * whether they may enter: one is "no", the other is "nobody can tell yet".
+   *
+   * Consumed by {@link getParticipantEligibility}, which reports `indeterminate` rather than
+   * `eligible: false` when every reason carries this flag. Entry behaviour is deliberately
+   * unchanged — see that function.
+   */
+  indeterminate?: boolean;
 }
 
 export interface AgeRejectionDetails {
@@ -105,6 +116,17 @@ function isCombinedAgeCategory(category: Category): boolean {
 }
 
 /**
+ * Whether the category bounds the SUM of a pair's ratings rather than an individual's.
+ *
+ * The rating counterpart to {@link isCombinedAgeCategory}. Combined age announces itself through an
+ * `ageCategoryCode` (`C50-70`); combined rating has no code convention, so it is stated explicitly
+ * with `combinedRatingMin`/`combinedRatingMax`.
+ */
+function isCombinedRatingCategory(category: Category): boolean {
+  return category.combinedRatingMin !== undefined || category.combinedRatingMax !== undefined;
+}
+
+/**
  * Validate participant age against category constraints
  * Participant must be valid throughout the entire event period
  *
@@ -115,7 +137,7 @@ export function validateParticipantAge(
   category: Category,
   startDate: string,
   endDate: string,
-): { valid: boolean; reason?: string; details?: any } {
+): { valid: boolean; indeterminate?: boolean; reason?: string; details?: any } {
   // Skip validation for combined age categories (these are for pairs/teams, not individuals)
   if (isCombinedAgeCategory(category)) {
     return { valid: true };
@@ -147,6 +169,7 @@ export function validateParticipantAge(
   if (!birthDate && birthYear === undefined) {
     return {
       valid: false,
+      indeterminate: true,
       reason: 'Missing birthDate or birthYear',
       details: {
         requiredMin: effectiveAgeMin,
@@ -220,7 +243,17 @@ export function validateParticipantRating(
   category: Category,
   event: Event,
   tournamentRecord?: Tournament,
-): { valid: boolean; reason?: string; details?: any } {
+): { valid: boolean; indeterminate?: boolean; reason?: string; details?: any } {
+  // A combined bound constrains the PAIR, not either half of it, so an individual cannot be
+  // measured against it — a combined-7.0 category would otherwise reject the 4.0 half of a legal
+  // 3.0 + 4.0 pair. Skipped for the same reason combined AGE categories are skipped above.
+  //
+  // Only when no individual bound is also stated: a federation may legitimately cap the pair at 7.0
+  // AND bar anyone above 5.0 on their own, and that individual bound is still enforceable here.
+  if (isCombinedRatingCategory(category) && category.ratingMin === undefined && category.ratingMax === undefined) {
+    return { valid: true };
+  }
+
   // No rating restrictions
   if (!category.ratingMin && !category.ratingMax) {
     return { valid: true };
@@ -246,6 +279,7 @@ export function validateParticipantRating(
   if (!scaleItem?.scaleValue) {
     return {
       valid: false,
+      indeterminate: true,
       reason: `Missing ${category.ratingType} rating`,
       details: {
         ratingType: category.ratingType,
@@ -265,6 +299,7 @@ export function validateParticipantRating(
     if (extractedValue === undefined) {
       return {
         valid: false,
+        indeterminate: true,
         reason: `Cannot extract rating value from ${category.ratingType} scale item`,
         details: {
           ratingType: category.ratingType,
@@ -353,6 +388,7 @@ export function validateParticipantCategory(
         type: 'age',
         reason: ageValidation.reason!,
         details: ageValidation.details ?? {},
+        ...(ageValidation.indeterminate ? { indeterminate: true } : {}),
       });
     }
 
@@ -361,6 +397,7 @@ export function validateParticipantCategory(
         type: 'rating',
         reason: ratingValidation.reason!,
         details: ratingValidation.details ?? {},
+        ...(ratingValidation.indeterminate ? { indeterminate: true } : {}),
       });
     }
 

--- a/src/query/entries/getParticipantEligibility.ts
+++ b/src/query/entries/getParticipantEligibility.ts
@@ -1,0 +1,120 @@
+import { getEventDateRange, validateParticipantCategory } from '@Query/entries/categoryValidation';
+
+// constants and types
+import { MISSING_PARTICIPANT, MISSING_EVENT } from '@Constants/errorConditionConstants';
+import type { RejectionReason } from '@Query/entries/categoryValidation';
+import type { Event, Participant, Tournament } from '@Types/tournamentTypes';
+import type { ResultType } from '@Types/factoryTypes';
+
+export interface ParticipantEligibility {
+  /** the participant satisfies every category rule that could be evaluated */
+  eligible: boolean;
+  /**
+   * At least one rule could NOT be evaluated because the data it needs is absent — an unknown
+   * birthDate, an unrecorded rating. Distinct from `eligible: false`, which asserts a rule is
+   * BREACHED. When true, `eligible` is false and the honest reading is "cannot be determined".
+   */
+  indeterminate: boolean;
+  rejectionReasons: RejectionReason[];
+}
+
+/**
+ * Whether a participant may enter an event — asked, rather than attempted.
+ *
+ * The predicate itself is not new: `validateParticipantCategory` has evaluated age at both event
+ * ends, handled exact-DOB and calendar-year (`birthYear`) conventions, and expanded
+ * `ageCategoryCode` since it was written. It was reachable only through `addEventEntries`, so the
+ * one way to learn whether someone could enter was to try to enter them. A discovery surface
+ * evaluating one person against thousands of events with no intent to enter any of them cannot use
+ * a mutation.
+ *
+ * **This does not change who gets entered.** `addEventEntries` keeps its own behaviour exactly:
+ * a participant whose birthDate is unknown is still filtered out of the entry list there, while
+ * here the same participant reports `indeterminate`. That divergence is deliberate. The two call
+ * sites share a predicate and apply different policy to its output, because "we cannot tell" is
+ * correctly a refusal when writing an entry and correctly NOT a refusal when answering a question.
+ * `entryEligibility.test.ts` pins both halves so the asymmetry is not later tidied into a bug.
+ *
+ * Read-only: emits no notices and mutates nothing.
+ */
+export function getParticipantEligibility(params: {
+  participant: Participant;
+  event: Event;
+  tournamentRecord?: Tournament;
+}): ResultType & Partial<ParticipantEligibility> {
+  const { participant, event, tournamentRecord } = params ?? {};
+
+  if (!participant?.participantId) return { error: MISSING_PARTICIPANT };
+  if (!event?.eventId) return { error: MISSING_EVENT };
+
+  // An event with no category restricts nobody. Not a silent pass: there is genuinely no rule.
+  if (!event.category) return { eligible: true, indeterminate: false, rejectionReasons: [] };
+
+  const dateRange = getEventDateRange(event, tournamentRecord);
+  if ('error' in dateRange) return { error: dateRange.error };
+
+  const rejection = validateParticipantCategory(
+    participant,
+    event.category,
+    event,
+    dateRange.startDate,
+    dateRange.endDate,
+    tournamentRecord,
+  );
+
+  if (!rejection) return { eligible: true, indeterminate: false, rejectionReasons: [] };
+
+  const rejectionReasons = rejection.rejectionReasons;
+
+  // Indeterminate only when NOTHING was actually breached. A participant who is both over the age
+  // limit and missing a rating is ineligible, full stop — the missing rating cannot soften a
+  // breach that was established on other grounds.
+  const indeterminate = rejectionReasons.length > 0 && rejectionReasons.every((reason) => reason.indeterminate);
+
+  return { eligible: false, indeterminate, rejectionReasons };
+}
+
+export interface EventEligibility extends ParticipantEligibility {
+  eventId: string;
+}
+
+/**
+ * The same question across many events — "which of these can I enter".
+ *
+ * The bulk form exists because that is the shape callers actually need; asking per event means a
+ * caller re-resolves the participant and the tournament for every one of them.
+ *
+ * Events that cannot be evaluated at all (no resolvable date range, for instance) are returned as
+ * `indeterminate`, never dropped. A silently shortened list is indistinguishable from a list where
+ * those events were checked and found ineligible.
+ */
+export function getEligibleEvents(params: {
+  participant: Participant;
+  events: Event[];
+  tournamentRecord?: Tournament;
+}): ResultType & { eventEligibility?: EventEligibility[] } {
+  const { participant, events, tournamentRecord } = params ?? {};
+
+  if (!participant?.participantId) return { error: MISSING_PARTICIPANT };
+  if (!Array.isArray(events)) return { error: MISSING_EVENT };
+
+  const eventEligibility = events.map((event) => {
+    const result = getParticipantEligibility({ participant, event, tournamentRecord });
+    if (result.error || result.eligible === undefined) {
+      return {
+        eventId: event?.eventId,
+        eligible: false,
+        indeterminate: true,
+        rejectionReasons: [],
+      } as EventEligibility;
+    }
+    return {
+      eventId: event.eventId,
+      eligible: result.eligible,
+      indeterminate: !!result.indeterminate,
+      rejectionReasons: result.rejectionReasons ?? [],
+    };
+  });
+
+  return { eventEligibility };
+}

--- a/src/tests/mutations/coverageStatementGaps4.test.ts
+++ b/src/tests/mutations/coverageStatementGaps4.test.ts
@@ -27,7 +27,7 @@ import {
   getParticipantName,
   validateParticipantAge,
   validateParticipantRating,
-} from '@Mutate/entries/categoryValidation';
+} from '@Query/entries/categoryValidation';
 
 // constants
 import { INDIVIDUAL, PAIR } from '@Constants/participantConstants';

--- a/src/tests/queries/entries/participantEligibility.test.ts
+++ b/src/tests/queries/entries/participantEligibility.test.ts
@@ -1,0 +1,198 @@
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { describe, expect, it } from 'vitest';
+
+import { getParticipantEligibility, getEligibleEvents } from '@Query/entries/getParticipantEligibility';
+import { validateParticipantRating } from '@Query/entries/categoryValidation';
+import { INDIVIDUAL } from '@Constants/participantConstants';
+import { SINGLES_EVENT } from '@Constants/eventConstants';
+import { ANY } from '@Constants/genderConstants';
+
+/**
+ * Punch-list M3 and M4.
+ *
+ * The eligibility predicate was complete and tested, and reachable only by ATTEMPTING an entry.
+ * These tests cover the read-only query built on it, and — the part that matters most — pin the
+ * one place where the query and the mutation deliberately disagree.
+ */
+
+const seedU18 = ({ birthDate, birthYear }: { birthDate?: string; birthYear?: number } = {}) => {
+  const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+    eventProfiles: [
+      {
+        category: { categoryName: 'U18', ageMax: 17 },
+        eventName: 'U18 Singles',
+        eventType: SINGLES_EVENT,
+        gender: ANY,
+      },
+    ],
+    participantsProfile: { participantsCount: 4 },
+    startDate: '2026-06-01',
+    endDate: '2026-06-07',
+    nonRandom: 1,
+  });
+
+  const participant = tournamentRecord.participants.find((p: any) => p.participantType === INDIVIDUAL);
+  delete participant.person.birthDate;
+  if (birthDate) participant.person.birthDate = birthDate;
+  if (birthYear) participant.person.birthYear = birthYear;
+
+  tournamentEngine.setState(tournamentRecord);
+  return { tournamentRecord, participant, event: tournamentRecord.events[0] };
+};
+
+describe('getParticipantEligibility', () => {
+  it('reports eligible for a participant inside the age range', () => {
+    const { tournamentRecord, participant, event } = seedU18({ birthDate: '2010-03-04' });
+    const result: any = getParticipantEligibility({ participant, event, tournamentRecord });
+    expect(result.eligible).toBe(true);
+    expect(result.indeterminate).toBe(false);
+    expect(result.rejectionReasons).toEqual([]);
+  });
+
+  it('reports INELIGIBLE — not indeterminate — for a real age breach', () => {
+    const { tournamentRecord, participant, event } = seedU18({ birthDate: '2000-03-04' });
+    const result: any = getParticipantEligibility({ participant, event, tournamentRecord });
+    expect(result.eligible).toBe(false);
+    expect(result.indeterminate).toBe(false);
+    expect(result.rejectionReasons[0].type).toBe('age');
+  });
+
+  it('reports INDETERMINATE when the birth date is unknown', () => {
+    const { tournamentRecord, participant, event } = seedU18();
+    const result: any = getParticipantEligibility({ participant, event, tournamentRecord });
+    expect(result.eligible).toBe(false);
+    expect(result.indeterminate).toBe(true);
+    expect(result.rejectionReasons[0].indeterminate).toBe(true);
+    expect(result.rejectionReasons[0].reason).toContain('Missing birthDate');
+  });
+
+  it('an event with no category restricts nobody', () => {
+    const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+      eventProfiles: [{ eventName: 'Open', eventType: SINGLES_EVENT, gender: ANY }],
+      participantsProfile: { participantsCount: 2 },
+      nonRandom: 1,
+    });
+    const participant = tournamentRecord.participants.find((p: any) => p.participantType === INDIVIDUAL);
+    const event = tournamentRecord.events[0];
+    delete event.category;
+    const result: any = getParticipantEligibility({ participant, event, tournamentRecord });
+    expect(result.eligible).toBe(true);
+    expect(result.indeterminate).toBe(false);
+  });
+
+  it('is reachable through the engine and mutates nothing', () => {
+    const { tournamentRecord, participant, event } = seedU18({ birthDate: '2010-03-04' });
+    const before = JSON.stringify(tournamentRecord);
+    const result: any = tournamentEngine.getParticipantEligibility({ participant, event, tournamentRecord });
+    expect(result.eligible).toBe(true);
+    expect(JSON.stringify(tournamentRecord)).toEqual(before);
+  });
+});
+
+/**
+ * D1 — the deliberate divergence.
+ *
+ * "We cannot tell" is correctly a refusal when WRITING an entry and correctly not a refusal when
+ * ANSWERING a question. Both halves are asserted against the same participant so the asymmetry
+ * reads as intentional rather than as a bug somebody should reconcile.
+ *
+ * NOTE what the first test establishes, because it corrects an assumption this work was planned on:
+ * `addEventEntries` does NOT check categories by default. `enforceCategory` defaults to FALSE, so
+ * the unfiltered path enters anyone. The divergence only exists on the opt-in path — which is where
+ * it matters, and which is what the second test pins.
+ */
+describe('unknown birthDate: the query and the mutation deliberately disagree', () => {
+  it('addEventEntries does not enforce category by default — it enters the participant', () => {
+    const { participant, event } = seedU18();
+
+    tournamentEngine.addEventEntries({
+      participantIds: [participant.participantId],
+      eventId: event.eventId,
+    });
+
+    const { event: updated }: any = tournamentEngine.getEvent({ eventId: event.eventId });
+    const entered = (updated.entries ?? []).some((e: any) => e.participantId === participant.participantId);
+    expect(entered).toBe(true);
+  });
+
+  it('with enforceCategory, the query says indeterminate while the mutation still rejects', () => {
+    const { tournamentRecord, participant, event } = seedU18();
+
+    const eligibility: any = getParticipantEligibility({ participant, event, tournamentRecord });
+    expect(eligibility.eligible).toBe(false);
+    expect(eligibility.indeterminate).toBe(true);
+
+    // Same participant, same event, through the mutation: still filtered out, exactly as before.
+    const result: any = tournamentEngine.addEventEntries({
+      participantIds: [participant.participantId],
+      eventId: event.eventId,
+      enforceCategory: true,
+    });
+
+    const { event: updated }: any = tournamentEngine.getEvent({ eventId: event.eventId });
+    const entered = (updated.entries ?? []).some((e: any) => e.participantId === participant.participantId);
+    expect(entered).toBe(false);
+
+    // The rejection is reported on `context`, and it carries the SAME `indeterminate` flag the
+    // query keys off — one predicate, two policies, not two implementations.
+    const rejections = result.context?.categoryRejections ?? [];
+    expect(rejections.length).toBeGreaterThan(0);
+    expect(rejections[0].rejectionReasons[0].indeterminate).toBe(true);
+  });
+});
+
+describe('getEligibleEvents', () => {
+  it('answers across events and never silently drops one', () => {
+    const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+      eventProfiles: [
+        { category: { categoryName: 'U18', ageMax: 17 }, eventName: 'U18', eventType: SINGLES_EVENT, gender: ANY },
+        { category: { categoryName: 'O30', ageMin: 30 }, eventName: 'O30', eventType: SINGLES_EVENT, gender: ANY },
+      ],
+      participantsProfile: { participantsCount: 4 },
+      startDate: '2026-06-01',
+      endDate: '2026-06-07',
+      nonRandom: 1,
+    });
+    const participant = tournamentRecord.participants.find((p: any) => p.participantType === INDIVIDUAL);
+    participant.person.birthDate = '2010-03-04';
+    tournamentEngine.setState(tournamentRecord);
+
+    const result: any = getEligibleEvents({ participant, events: tournamentRecord.events, tournamentRecord });
+    expect(result.eventEligibility).toHaveLength(2);
+
+    const u18 = result.eventEligibility.find((e: any) => e.eventId === tournamentRecord.events[0].eventId);
+    const o30 = result.eventEligibility.find((e: any) => e.eventId === tournamentRecord.events[1].eventId);
+    expect(u18.eligible).toBe(true);
+    expect(o30.eligible).toBe(false);
+    expect(o30.indeterminate).toBe(false);
+  });
+});
+
+/**
+ * M4 — a combined bound constrains the PAIR, so an individual cannot be measured against it.
+ * Before this change a combined-7.0 category rejected the 4.0 half of a legal 3.0 + 4.0 pair.
+ */
+describe('combined rating categories', () => {
+  const event: any = { eventId: 'e', eventType: 'DOUBLES' };
+
+  it('does not reject an individual against a combined-only bound', () => {
+    const participant: any = { participantId: 'p', person: {} };
+    const category: any = { ratingType: 'NTRP', combinedRatingMax: 7.0 };
+    expect(validateParticipantRating(participant, category, event).valid).toBe(true);
+  });
+
+  it('still enforces an individual bound stated alongside a combined one', () => {
+    const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+      participantsProfile: { participantsCount: 2 },
+      nonRandom: 1,
+    });
+    const participant = tournamentRecord.participants.find((p: any) => p.participantType === INDIVIDUAL);
+    // No NTRP scale item exists for this participant, so an individual bound is INDETERMINATE
+    // rather than satisfied — which is itself the point: the combined bound did not suppress it.
+    const category: any = { ratingType: 'NTRP', combinedRatingMax: 7.0, ratingMax: 5.0 };
+    const result: any = validateParticipantRating(participant, category, event as any, tournamentRecord);
+    expect(result.valid).toBe(false);
+    expect(result.indeterminate).toBe(true);
+  });
+});

--- a/src/types/factoryEngineMethods.ts
+++ b/src/types/factoryEngineMethods.ts
@@ -270,6 +270,7 @@ export type FactoryEngineMethod =
   | 'getDrawParticipantRepresentativeIds'
   | 'getDrawStructures'
   | 'getDrawTypeCoercion'
+  | 'getEligibleEvents'
   | 'getEligibleVoluntaryConsolationParticipants'
   | 'getEntriesAndSeedsCount'
   | 'getEntryStatusReports'
@@ -317,6 +318,7 @@ export type FactoryEngineMethod =
   | 'getOfficialConflicts'
   | 'getOfficialEligibility'
   | 'getPairedParticipant'
+  | 'getParticipantEligibility'
   | 'getParticipantEventDetails'
   | 'getParticipantIdFinishingPositions'
   | 'getParticipantMembership'
@@ -938,6 +940,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'getDrawParticipantRepresentativeIds',
   'getDrawStructures',
   'getDrawTypeCoercion',
+  'getEligibleEvents',
   'getEligibleVoluntaryConsolationParticipants',
   'getEntriesAndSeedsCount',
   'getEntryStatusReports',
@@ -985,6 +988,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'getOfficialConflicts',
   'getOfficialEligibility',
   'getPairedParticipant',
+  'getParticipantEligibility',
   'getParticipantEventDetails',
   'getParticipantIdFinishingPositions',
   'getParticipantMembership',

--- a/src/types/methodSignatures.ts
+++ b/src/types/methodSignatures.ts
@@ -296,6 +296,7 @@ import type { bulkUpdatePublishedEventIds } from '@Query/event/bulkUpdatePublish
 import type { createOfficialRecord } from '@Mutate/officiating/createOfficialRecord';
 import type { deleteFlightAndFlightDraw } from '@Mutate/events/deleteFlightAndFlightDraw';
 import type { getCompetitionFormat } from '@Query/hierarchical/getCompetitionFormat';
+import type { getEligibleEvents, getParticipantEligibility } from '@Query/entries/getParticipantEligibility';
 import type { getEvaluationTemplate } from '@Query/officiating/getEvaluationTemplate';
 import type { getMatchUpScheduleDetails } from '@Query/matchUp/getMatchUpScheduleDetails';
 import type { getParticipantIdFinishingPositions } from '@Query/drawDefinition/finishingPositions';
@@ -838,6 +839,7 @@ export interface MethodSignatures {
   getDrawParticipantRepresentativeIds: EngineMethod<typeof getDrawParticipantRepresentativeIds>;
   getDrawStructures: EngineMethod<typeof getDrawStructures>;
   getDrawTypeCoercion: EngineMethod<typeof getDrawTypeCoercion>;
+  getEligibleEvents: EngineMethod<typeof getEligibleEvents>;
   getEligibleVoluntaryConsolationParticipants: EngineMethod<typeof getEligibleVoluntaryConsolationParticipants>;
   getEntriesAndSeedsCount: EngineMethod<typeof getEntriesAndSeedsCount>;
   getEntryStatusReports: EngineMethod<typeof getEntryStatusReports>;
@@ -884,6 +886,7 @@ export interface MethodSignatures {
   getOfficialConflicts: EngineMethod<typeof getOfficialConflicts>;
   getOfficialEligibility: EngineMethod<typeof getOfficialEligibility>;
   getPairedParticipant: EngineMethod<typeof getPairedParticipant>;
+  getParticipantEligibility: EngineMethod<typeof getParticipantEligibility>;
   getParticipantEventDetails: EngineMethod<typeof getParticipantEventDetails>;
   getParticipantIdFinishingPositions: EngineMethod<typeof getParticipantIdFinishingPositions>;
   getParticipantMembership: EngineMethod<typeof getParticipantMembership>;

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -102,6 +102,23 @@ export interface Organisation {
   organisationName: string;
   organisationId: string;
   notes?: string;
+  /**
+   * What KIND of body this is — authority, section, district, provider, club.
+   *
+   * `parentOrganisationId` gives the shape of a hierarchy but says nothing about what sits at each
+   * node, so a captured chain (National → Section → District → the club running the event) arrives
+   * as four indistinguishable organisations. Consumers were left inferring role from position, which
+   * fails on the chains that are not strict containment ladders — some bodies approve only at the
+   * regional tier, and at least one federation requires JOINT approval by two co-equal bodies.
+   *
+   * Reuses {@link AuthorityRoleEnum} rather than minting a parallel vocabulary. That enum was added
+   * for `SanctioningAuthority.role`, which closed this question INSIDE a sanction while leaving
+   * `Organisation` itself untyped — so the same body could state its role when it appeared in an
+   * approval chain and not when it appeared as `parentOrganisation`.
+   *
+   * Optional and never inferred: an organisation whose role nobody recorded is unknown, not a CLUB.
+   */
+  role?: AuthorityRoleUnion;
 }
 
 export interface Event {
@@ -214,6 +231,27 @@ export interface Category {
   ratingMax?: number;
   ratingMin?: number;
   ratingType?: string;
+  /**
+   * Bounds on the SUM of a pair's ratings, for events priced as a combined band —
+   * "NTRP 7.0 combined doubles", where a 3.0 and a 4.0 may enter together.
+   *
+   * Distinct from `ratingMin`/`ratingMax`, which bound an INDIVIDUAL. Modelling a combined event
+   * with `ratingMax: 7.0` does not merely lose information, it produces a wrong answer: the
+   * individual check rejects the 4.0 half of a legal 3.0 + 4.0 pair. `validateParticipantRating`
+   * therefore skips individual rating validation whenever a combined bound is stated, mirroring the
+   * skip already applied to combined AGE categories (`ageCategoryCode` matching `C##-##`).
+   *
+   * Both may legitimately be present: a federation can cap the pair at 7.0 *and* bar anyone above
+   * 5.0 individually. Where both are set the individual bounds still apply — the skip is keyed on
+   * `ratingType` being absent from the individual pair, not on the combined bound existing. See
+   * `validateParticipantRating`.
+   *
+   * NOT enforced at pair grain yet. Nothing sums a pair's ratings and compares it to these bounds;
+   * that belongs at entry time where both partners are known. Stating the bound is what stops the
+   * wrong rejection — enforcing it is a later change, deliberately not smuggled in here.
+   */
+  combinedRatingMax?: number;
+  combinedRatingMin?: number;
   subType?: string;
   timeItems?: TimeItem[];
   type?: CategoryUnion;


### PR DESCRIPTION
Punch-list **M3, M4, M5** from [`DESIGN_FLAWS_PUNCH_LIST.md`](https://github.com/CourtHive/Mentat/blob/main/planning/DESIGN_FLAWS_PUNCH_LIST.md). Spec: [`CODES_DISCOVERY_FIRST_CLASS_ADDITIONS.md`](https://github.com/CourtHive/Mentat/blob/main/planning/CODES_DISCOVERY_FIRST_CLASS_ADDITIONS.md) A4, A5, A7.

**M1/M2 are deliberately not here** — see the last section.

## M3 — the eligibility predicate was reachable only by attempting an entry

`validateParticipantCategory` is complete and tested: age at *both* event ends, exact-DOB and calendar-year (`birthYear`) conventions, `ageCategoryCode` expansion. Its only callers were `addEventEntries:227` and `:284`. A surface evaluating one person against thousands of events with no intent to enter any of them cannot use a mutation to do it.

`getParticipantEligibility` / `getEligibleEvents` expose it read-only. The file moves `mutate/entries` → `query/entries` — it is a pure predicate, and exporting a query from `src/mutate/` would misfile it permanently.

**The third state.** `RejectionReason` gains `indeterminate`, set where the data needed to decide is *absent* (unknown birthDate, unrecorded rating, unextractable scale value) and **not** where a rule is breached. A missing DOB and an age outside the range are both "not valid" to the mutation, which rejects either way — but they are opposite answers to a person asking whether they may enter: one is "no", the other is "nobody can tell yet". `indeterminate` requires *every* reason to be indeterminate, so an over-age participant who is also missing a rating is ineligible, full stop.

**Entry behaviour does not change.** The mutation and the query share one predicate and apply different policy to its output, because "we cannot tell" is correctly a refusal when *writing* an entry and correctly not a refusal when *answering a question*. The test asserts both halves against the same participant so the asymmetry cannot later be tidied into a bug.

> **That test also corrected an assumption this work was planned on.** `addEventEntries` does **not** check categories by default — `enforceCategory` defaults to `false`, so the default path enters anyone. The divergence exists only on the opt-in path. Both paths are now pinned. The first version of the test failed for exactly this reason, which is why it exists.

## M4 — a combined rating bound constrains the pair, not either half of it

Modelling "NTRP 7.0 combined doubles" as `ratingMax: 7.0` **rejected the 4.0 half of a legal 3.0 + 4.0 pair** — a wrong answer, not a missing feature.

`Category` gains `combinedRatingMin`/`combinedRatingMax`, and `validateParticipantRating` skips individual validation when only a combined bound is stated — mirroring the skip combined *age* categories (`C##-##`) have had all along. An individual bound stated alongside a combined one still applies.

Pair-grain enforcement is **not** included: stating the bound is what stops the wrong rejection; summing a pair belongs at entry time where both partners are known. Said so on the type rather than leaving it to be assumed closed.

## M5 — `Organisation.role`

`parentOrganisationId` gives a hierarchy's shape but says nothing about what sits at each node, so a captured chain (National → Section → District → the club running the event) arrived as four indistinguishable organisations. Reuses `AuthorityRoleEnum` from #4710, which closed this *inside* a sanction while leaving `Organisation` itself untyped.

> **Found while doing this, and left alone deliberately:** the schema declares `organisationType` → `OrganisationTypeEnum` (`NATIONAL_ASSOCIATION, SCHOOL, SECTION, AREA, DISTRICT, CLUB, OTHER`) that **does not exist on the TypeScript interface** — schema/type drift in the opposite direction to the kind #4718 fixed, and predating this change. Choosing between it and `role` is a modelling decision, not a cleanup. `role` is used here because M5's stated need was to distinguish an authority from a section from a district from a **PROVIDER**, and `OrganisationTypeEnum` has no PROVIDER at all.

## Schema

Kept level with the types per #4718:

- `Category` gains the two combined bounds — it is `additionalProperties: false`, so records carrying them would otherwise **fail validation**
- `Organisation` gains `role`
- `AuthorityRoleEnum` is **defined** — the `$ref` would otherwise have dangled. Checked: no dangling `$ref`s remain anywhere in the schema.

## Verification

`pnpm verify` green — all 15 steps, including `surface`, `coverage` and `pack`. Full suite: **11,481 passed**.

`factoryEngineMethods.ts` and `methodSignatures.ts` are generated; regenerated with `pnpm gen:*` rather than hand-edited (the first `verify` run caught the hand-edit).

## Why M1/M2 are held

They are `codes-monetary-model` by definition, and `ingest-slam-prize-money-producer` is mid-build against the **shared `factory/dist`**, which it rebuilt so `PrizeMoneyAward` would import. Landing a breaking money type under a session that depends on that dist is the collision ATC exists to prevent. Built in an isolated worktree for the same reason.

Also worth knowing before M1 starts: the 100× fee-render bug is **latent, not live** — TMX has no fee-entry UI, and the one source carrying minor units writes to `event.sanction.fees` (the M2 workaround). The two defects insulate each other, so **fixing M2 alone would activate M1.**