### PR TITLE
fix(scheduling): refuse a calledAt that precedes the tournament startDate

### DIFF
--- a/src/mutate/matchUps/schedule/setMatchUpCalledAt.ts
+++ b/src/mutate/matchUps/schedule/setMatchUpCalledAt.ts
@@ -1,16 +1,23 @@
+import { getTournamentTimeZone } from '@Query/tournaments/getTournamentTimeZone';
 import { modifyMatchUpNotice } from '@Mutate/notifications/drawNotifications';
 import { decorateResult } from '@Functions/global/decorateResult';
 import { findDrawMatchUp } from '@Acquire/findDrawMatchUp';
+import { extractDate } from '@Tools/dateTime';
+import { zonedParts } from '@Tools/zonedTime';
 
 // constants and types
+import { DrawDefinition, Event, Tournament } from '@Types/tournamentTypes';
+import { SUCCESS } from '@Constants/resultConstants';
 import {
+  INVALID_DATE,
   INVALID_VALUES,
   MATCHUP_NOT_FOUND,
   MISSING_DRAW_DEFINITION,
   MISSING_MATCHUP_ID,
 } from '@Constants/errorConditionConstants';
-import { DrawDefinition, Event, Tournament } from '@Types/tournamentTypes';
-import { SUCCESS } from '@Constants/resultConstants';
+
+/** UTC+14 (Kiritimati) is the furthest-ahead zone in use — no local day can open earlier than this. */
+const MAX_ZONE_OFFSET_AHEAD_MS = 14 * 60 * 60 * 1000;
 
 type SetMatchUpCalledAtArgs = {
   tournamentRecord?: Tournament;
@@ -22,6 +29,65 @@ type SetMatchUpCalledAtArgs = {
   matchUpId: string;
   event?: Event;
 };
+
+/**
+ * Whether a `calledAt` instant falls before the tournament's opening day.
+ *
+ * Calling a match to court is a physical act at the venue, so it cannot happen
+ * before the venue opens. `addMatchUpScheduledDate` already refuses a
+ * `scheduledDate` outside the tournament's range; a `calledAt` that predates the
+ * start is the same class of impossibility and was previously accepted without
+ * complaint.
+ *
+ * ── Why this needs a zone ──
+ *
+ * `startDate` is a bare venue-local calendar day; `calledAt` is a UTC instant.
+ * Comparing them without a zone compares two different things. In Sydney
+ * (UTC+10) a 09:00 call on opening day is 23:00 UTC on the PREVIOUS day, so a
+ * naive UTC-day comparison would reject a perfectly legitimate call — the
+ * failure mode is the exact opposite of the one being fixed, and worse, because
+ * it blocks the running desk. So the venue's zone resolves the instant to its
+ * real local day.
+ *
+ * ── When no zone can be resolved ──
+ *
+ * Many tournaments carry neither a `localTimeZone` nor a venue address, and
+ * there is then no exact answer to "which local day was that?" — only a bound.
+ * The furthest-ahead zone on earth is UTC+14, so local midnight opening the
+ * tournament can be no earlier than `startDate 00:00 UTC − 14h`. An instant
+ * before THAT is before the start in every zone that exists; an instant after it
+ * is opening day somewhere, and refusing it would risk blocking a real running
+ * desk — the worse of the two failures by far, since it stops play rather than
+ * admitting a bad row.
+ *
+ * That bound is the most this can soundly say without a zone, and it is
+ * deliberately weaker than the zoned check: an evening-before call in New York
+ * is caught only when the tournament names its zone. Setting `localTimeZone` is
+ * what upgrades this guard from "impossible anywhere" to "impossible here", and
+ * it is the same setting the rest of the venue time frame already depends on.
+ *
+ * `endDate` is deliberately NOT guarded. A match called near midnight on the
+ * final day legitimately runs past it, and the last day's play routinely spills
+ * over; there is no equivalent impossibility on that side.
+ */
+function calledBeforeTournamentStart({
+  tournamentRecord,
+  calledAt,
+}: {
+  tournamentRecord?: Tournament;
+  calledAt: string;
+}): boolean {
+  const startDate = extractDate(tournamentRecord?.startDate);
+  if (!startDate) return false;
+
+  const ms = Date.parse(calledAt);
+  if (Number.isNaN(ms)) return false; // rejected separately; never silently skipped
+
+  const { timeZone } = getTournamentTimeZone({ tournamentRecord });
+  if (timeZone) return zonedParts({ ms, timeZone }).date < startDate;
+
+  return ms < Date.parse(`${startDate}T00:00:00.000Z`) - MAX_ZONE_OFFSET_AHEAD_MS;
+}
 
 /**
  * Set or clear `matchUp.schedule.calledAt` — the ISO-string timestamp captured
@@ -40,6 +106,8 @@ type SetMatchUpCalledAtArgs = {
  *  - This is a CODES 5.0.0 NEW first-class attribute — no legacy timeItem
  *    mirror, no LEGACY/DUAL/NATIVE branching. The attribute is always
  *    written to `matchUp.schedule.calledAt`.
+ *  - A call to court cannot predate the tournament's first day. See
+ *    `calledBeforeTournamentStart`.
  */
 export function setMatchUpCalledAt(params: SetMatchUpCalledAtArgs) {
   const stack = 'setMatchUpCalledAt';
@@ -49,6 +117,27 @@ export function setMatchUpCalledAt(params: SetMatchUpCalledAtArgs) {
   if (!matchUpId) return decorateResult({ result: { error: MISSING_MATCHUP_ID }, stack });
   if (calledAt !== undefined && calledAt !== null && typeof calledAt !== 'string') {
     return decorateResult({ result: { error: INVALID_VALUES }, stack, info: 'calledAt must be an ISO string' });
+  }
+
+  if (typeof calledAt === 'string') {
+    // An unparseable stamp is rejected rather than stored: it cannot be checked
+    // against the tournament's start, so accepting one would leave a hole in the
+    // guard below that any bad caller could walk through.
+    if (Number.isNaN(Date.parse(calledAt))) {
+      return decorateResult({
+        result: { error: INVALID_DATE },
+        stack,
+        info: 'calledAt must be a parseable ISO string',
+      });
+    }
+    if (calledBeforeTournamentStart({ tournamentRecord, calledAt })) {
+      return decorateResult({
+        result: { error: INVALID_DATE },
+        info: 'calledAt cannot precede tournament startDate',
+        context: { calledAt, startDate: tournamentRecord?.startDate },
+        stack,
+      });
+    }
   }
 
   const { matchUp } = findDrawMatchUp({ drawDefinition, event, matchUpId });

--- a/src/tests/global/setMatchUpCalledAt.test.ts
+++ b/src/tests/global/setMatchUpCalledAt.test.ts
@@ -10,11 +10,20 @@ import { NATIVE } from '@Constants/schemaWriteModeConstants';
 const ISO_A = '2026-05-27T13:58:42.000Z';
 const ISO_B = '2026-05-27T14:05:00.000Z';
 
+// The stamps above are fixed, so the tournament they are written to has to be
+// running on that date: `setMatchUpCalledAt` refuses a call to court that
+// precedes `startDate`, and a mock left on its default (today) would put these
+// stamps months before the tournament opened.
+const START_DATE = '2026-05-27';
+const END_DATE = '2026-05-29';
+
 function seedTournament() {
   const result = mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ participantsCount: 8, drawSize: 8 }],
+    startDate: START_DATE,
+    endDate: END_DATE,
     inContext: true,
     setState: true,
-    drawProfiles: [{ participantsCount: 8, drawSize: 8 }],
   });
   const drawId = result.drawIds[0];
   const eventId = result.eventIds[0];

--- a/src/tests/mutations/scheduling/calledAtBeforeTournamentStart.test.ts
+++ b/src/tests/mutations/scheduling/calledAtBeforeTournamentStart.test.ts
@@ -1,0 +1,206 @@
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { describe, expect, it } from 'vitest';
+
+// constants
+import { INVALID_DATE, INVALID_VALUES } from '@Constants/errorConditionConstants';
+import { SINGLE_ELIMINATION } from '@Constants/drawDefinitionConstants';
+import { SUCCESS } from '@Constants/resultConstants';
+
+/**
+ * A matchUp cannot be called to court before the tournament opens.
+ *
+ * Found from the other end: a production tournament whose first day was still a
+ * day away displayed a call time on every matchUp in its draw. That particular
+ * symptom was a TMX rendering defect (a formatter that substituted "now" for an
+ * absent stamp), but it exposed that the factory itself would have accepted such
+ * a stamp without complaint — `setMatchUpCalledAt` validated only that the value
+ * was a string. `addMatchUpScheduledDate` has always refused a `scheduledDate`
+ * outside the tournament's range; a call to court predating the start is the
+ * same impossibility and is now refused the same way.
+ *
+ * `setMatchUpCalledAt` is the single write path — `addMatchUpScheduleItems`
+ * delegates to it — so both facades are exercised here.
+ */
+
+const START_DATE = '2026-06-15';
+const END_DATE = '2026-06-20';
+
+function setup({ localTimeZone }: { localTimeZone?: string } = {}) {
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ drawType: SINGLE_ELIMINATION, drawSize: 8 }],
+    endDate: END_DATE,
+    startDate: START_DATE,
+    setState: true,
+  });
+  // `generateTournamentRecord` does not thread `localTimeZone`, so it is set
+  // through the governor method a TD's Edit Dates modal would use.
+  if (localTimeZone) expect(tournamentEngine.setTournamentLocalTimeZone({ localTimeZone })).toEqual(SUCCESS);
+  const { matchUps }: any = tournamentEngine.allTournamentMatchUps();
+  const { matchUpId, drawId } = matchUps.find((m: any) => m.roundNumber === 1);
+  return { matchUpId, drawId };
+}
+
+/** Raw read — proves nothing was written, not merely that an error was returned. */
+function storedCalledAt(matchUpId: string, drawId: string) {
+  const { drawDefinition }: any = tournamentEngine.getEvent({ drawId });
+  for (const structure of drawDefinition?.structures ?? []) {
+    const found = (structure.matchUps ?? []).find((m: any) => m.matchUpId === matchUpId);
+    if (found) return found.schedule?.calledAt;
+  }
+  return undefined;
+}
+
+describe('calledAt cannot precede the tournament startDate', () => {
+  it('rejects a 21:02 call the evening before the start — the reported scenario, exactly', () => {
+    // The production sighting: a tournament whose first day was still a day away
+    // showed 21:02 against every matchUp. Stamped for real, that is what it would
+    // have been — 21:02 venue-local on 2026-06-14, the night before a 06-15 start.
+    const { matchUpId, drawId } = setup({ localTimeZone: 'America/New_York' });
+    const result: any = tournamentEngine.setMatchUpCalledAt({
+      calledAt: '2026-06-15T01:02:00.000Z', // 2026-06-14 21:02 in New York
+      matchUpId,
+      drawId,
+    });
+    expect(result.error).toEqual(INVALID_DATE);
+    expect(result.info).toContain('startDate');
+    expect(storedCalledAt(matchUpId, drawId)).toBeUndefined();
+  });
+
+  it('rejects a call stamped well before the tournament starts', () => {
+    const { matchUpId, drawId } = setup();
+    const result: any = tournamentEngine.setMatchUpCalledAt({
+      calledAt: '2026-05-01T14:00:00.000Z',
+      matchUpId,
+      drawId,
+    });
+    expect(result.error).toEqual(INVALID_DATE);
+    expect(storedCalledAt(matchUpId, drawId)).toBeUndefined();
+  });
+
+  it('rejects through addMatchUpScheduleItems too — the batch facade must not be a side door', () => {
+    const { matchUpId, drawId } = setup();
+    const result: any = tournamentEngine.addMatchUpScheduleItems({
+      schedule: { calledAt: '2026-06-01T14:00:00.000Z' },
+      matchUpId,
+      drawId,
+    });
+    expect(result.error).toEqual(INVALID_DATE);
+    expect(storedCalledAt(matchUpId, drawId)).toBeUndefined();
+  });
+
+  it('accepts a call on the opening day itself', () => {
+    const { matchUpId, drawId } = setup();
+    const calledAt = '2026-06-15T14:00:00.000Z';
+    expect(tournamentEngine.setMatchUpCalledAt({ calledAt, matchUpId, drawId })).toEqual(SUCCESS);
+    expect(storedCalledAt(matchUpId, drawId)).toEqual(calledAt);
+  });
+
+  it('accepts a call on a later tournament day', () => {
+    const { matchUpId, drawId } = setup();
+    const calledAt = '2026-06-18T14:00:00.000Z';
+    expect(tournamentEngine.setMatchUpCalledAt({ calledAt, matchUpId, drawId })).toEqual(SUCCESS);
+    expect(storedCalledAt(matchUpId, drawId)).toEqual(calledAt);
+  });
+
+  it('still clears with null, which carries no date to validate', () => {
+    const { matchUpId, drawId } = setup();
+    tournamentEngine.setMatchUpCalledAt({ calledAt: '2026-06-16T14:00:00.000Z', matchUpId, drawId });
+    expect(tournamentEngine.setMatchUpCalledAt({ calledAt: null, matchUpId, drawId })).toEqual(SUCCESS);
+    expect(storedCalledAt(matchUpId, drawId)).toBeUndefined();
+  });
+
+  it('rejects an unparseable stamp rather than storing one the guard cannot check', () => {
+    const { matchUpId, drawId } = setup();
+    const result: any = tournamentEngine.setMatchUpCalledAt({ calledAt: 'not-a-date', matchUpId, drawId });
+    expect(result.error).toEqual(INVALID_DATE);
+    expect(storedCalledAt(matchUpId, drawId)).toBeUndefined();
+  });
+
+  it('still rejects a non-string before it ever reaches the date guard', () => {
+    const { matchUpId, drawId } = setup();
+    const result: any = tournamentEngine.setMatchUpCalledAt({ calledAt: 1234, matchUpId, drawId });
+    expect(result.error).toEqual(INVALID_VALUES);
+  });
+});
+
+/**
+ * The zone half of the guard. `startDate` is a venue-local calendar day and
+ * `calledAt` is a UTC instant, so a comparison that ignores the zone gets the
+ * opening day wrong in both directions — and the direction that matters most is
+ * the FALSE REJECTION, which would block a real running desk.
+ */
+describe('the start-date comparison is made on the venue clock', () => {
+  it('accepts a Sydney morning call whose UTC day is still the day before the start', () => {
+    // 2026-06-15 09:00 in Sydney (UTC+10) is 2026-06-14T23:00Z. Compared as a
+    // UTC day that reads as the day BEFORE the tournament opens, yet it is
+    // 09:00 on opening morning at the venue and must be accepted.
+    const { matchUpId, drawId } = setup({ localTimeZone: 'Australia/Sydney' });
+    const calledAt = '2026-06-14T23:00:00.000Z';
+    expect(tournamentEngine.setMatchUpCalledAt({ calledAt, matchUpId, drawId })).toEqual(SUCCESS);
+    expect(storedCalledAt(matchUpId, drawId)).toEqual(calledAt);
+  });
+
+  it('rejects a Sydney call that is genuinely the evening before the start', () => {
+    // 2026-06-14T09:00Z is 19:00 on 2026-06-14 in Sydney — the night before.
+    const { matchUpId, drawId } = setup({ localTimeZone: 'Australia/Sydney' });
+    const result: any = tournamentEngine.setMatchUpCalledAt({
+      calledAt: '2026-06-14T09:00:00.000Z',
+      matchUpId,
+      drawId,
+    });
+    expect(result.error).toEqual(INVALID_DATE);
+    expect(storedCalledAt(matchUpId, drawId)).toBeUndefined();
+  });
+
+  it('accepts a New York evening call whose UTC day has already rolled to the next day', () => {
+    // 2026-06-15 21:02 in New York (UTC-4) is 2026-06-16T01:02Z — after the
+    // start either way, but it pins that the zone shift is applied, not assumed.
+    const { matchUpId, drawId } = setup({ localTimeZone: 'America/New_York' });
+    const calledAt = '2026-06-16T01:02:00.000Z';
+    expect(tournamentEngine.setMatchUpCalledAt({ calledAt, matchUpId, drawId })).toEqual(SUCCESS);
+    expect(storedCalledAt(matchUpId, drawId)).toEqual(calledAt);
+  });
+
+  it('rejects a New York call on the calendar day before the start', () => {
+    const { matchUpId, drawId } = setup({ localTimeZone: 'America/New_York' });
+    const result: any = tournamentEngine.setMatchUpCalledAt({
+      calledAt: '2026-06-14T18:00:00.000Z',
+      matchUpId,
+      drawId,
+    });
+    expect(result.error).toEqual(INVALID_DATE);
+  });
+
+  it('falls back to the UTC+14 bound when the tournament names no zone', () => {
+    // No localTimeZone and no venue address: the venue-local day is genuinely
+    // unknowable, so only a bound can be asserted. Local midnight opening the
+    // tournament is no earlier than 2026-06-14T10:00Z (UTC+14). An instant before
+    // that is before the start everywhere on earth and is refused; one after it is
+    // opening day SOMEWHERE and must be admitted, because refusing a real call to
+    // court stops play.
+    const { matchUpId, drawId } = setup();
+    const admissible = '2026-06-14T11:00:00.000Z'; // 2026-06-15 01:00 at UTC+14
+    expect(tournamentEngine.setMatchUpCalledAt({ calledAt: admissible, matchUpId, drawId })).toEqual(SUCCESS);
+
+    const impossibleAnywhere: any = tournamentEngine.setMatchUpCalledAt({
+      calledAt: '2026-06-14T09:00:00.000Z', // still 06-14 even at UTC+14
+      matchUpId,
+      drawId,
+    });
+    expect(impossibleAnywhere.error).toEqual(INVALID_DATE);
+  });
+
+  it('a zone turns the same evening-before stamp from admitted into refused', () => {
+    // The upgrade this guard gets from `localTimeZone`, pinned as a pair so the
+    // weakness of the zone-less bound is documented by behaviour, not by prose.
+    const eveningBefore = '2026-06-15T01:02:00.000Z'; // 2026-06-14 21:02 in New York
+
+    const zoneless = setup();
+    expect(tournamentEngine.setMatchUpCalledAt({ calledAt: eveningBefore, ...zoneless })).toEqual(SUCCESS);
+
+    const zoned = setup({ localTimeZone: 'America/New_York' });
+    const result: any = tournamentEngine.setMatchUpCalledAt({ calledAt: eveningBefore, ...zoned });
+    expect(result.error).toEqual(INVALID_DATE);
+  });
+});


### PR DESCRIPTION
## Why

Found from the other end. A production tournament whose first day was still a day away displayed a call time against **every** matchUp in its draw. That symptom was a client rendering defect (a formatter substituting "now" for an absent stamp — TMX #1387), but chasing it exposed that the factory would have *accepted* such a stamp without complaint: `setMatchUpCalledAt` validated only that the value was a string.

Calling a match to court is a physical act at the venue, so it cannot happen before the venue opens. `addMatchUpScheduledDate` has always refused a `scheduledDate` outside the tournament's range; this is the same class of impossibility.

## What changed

`setMatchUpCalledAt` refuses a `calledAt` preceding `tournamentRecord.startDate`. `addMatchUpScheduleItems` inherits it — it delegates to the same choke point, so the batch facade is not a side door (pinned by a test).

An **unparseable** stamp is refused too: it cannot be checked against the start date, so accepting one would leave a hole any caller could walk through.

## The comparison is venue-framed, and that is the load-bearing part

`startDate` is a bare venue-local calendar day; `calledAt` is a UTC instant. Comparing them directly compares two different things.

At UTC+10 a 09:00 call on opening day is 23:00 UTC on the *previous* day — a naive UTC-day comparison would reject a perfectly legitimate call. That is the opposite failure and the worse one, because refusing a real call to court stops play. So the venue zone (`getTournamentTimeZone` → `zonedParts`) resolves the instant to its real local day.

### When no zone can be resolved

Many tournaments carry neither a `localTimeZone` nor a venue address, and there is then no exact local day — only a bound. No zone is further ahead than UTC+14, so an instant before `startDate 00:00 UTC − 14h` is before the start *everywhere on earth*; anything after it is opening day somewhere and must be admitted.

**Worth knowing:** this makes the zone-less check deliberately weaker — an evening-before call is caught only once the tournament sets `localTimeZone`. Both halves are pinned as a pair, so the weakness is documented by behaviour rather than by prose. Failing open by that margin is the intended tradeoff: admitting one implausible row beats blocking a running desk.

`endDate` is **not** guarded — a match called near midnight on the final day legitimately runs past it.

## Test changes, stated rather than buried

`tests/global/setMatchUpCalledAt.test.ts` carried fixed `2026-05-27` stamps against a mock whose `startDate` defaults to today, putting them three months before the tournament opened. The new guard correctly rejects them. Its mock is pinned to those dates — **no assertion was changed**.

**Falsified:** stubbing the guard to `false` fails 7 of the 14 new tests.

## Verification

`pnpm verify` — all 14 steps, exit 0. Includes `verify:generated`, `attr-audit`, coverage, `verify:server` (9 jest suites), `build`, `publint`, `runtime`, `shakeable`, `bundle-size`, `surface`, `pack`.

**11522 passed** | 1 skipped (1115 files).