### PR TITLE
fix(codes): give the entry fee a unit and an event, and type what an organisation is

### DIFF
--- a/src/assemblies/governors/entriesGovernor/query.ts
+++ b/src/assemblies/governors/entriesGovernor/query.ts
@@ -1,2 +1,3 @@
+export { resolveEntryFee, getEntryFeeRange, isIndeterminateFee } from '@Query/entries/resolveEntryFee';
 export { getEntriesAndSeedsCount } from '@Query/entries/getEntriesAndSeedsCount';
 export { getMaxEntryPosition } from '@Query/entries/getMaxEntryPosition';

--- a/src/global/schema/tournament.schema.json
+++ b/src/global/schema/tournament.schema.json
@@ -2498,9 +2498,6 @@
         "organisationType": {
           "$ref": "#/definitions/OrganisationTypeEnum"
         },
-        "role": {
-          "$ref": "#/definitions/AuthorityRoleEnum"
-        },
         "onlineResources": {
           "type": "array",
           "items": {
@@ -2968,24 +2965,6 @@
       "type": "string",
       "enum": ["HOME", "MAIL", "RESIDENTIAL", "VENUE", "WORK", "PRIMARY"]
     },
-    "AuthorityRoleEnum": {
-      "type": "string",
-      "enum": [
-        "INTERNATIONAL",
-        "NATIONAL",
-        "ZONE",
-        "SECTION",
-        "REGION",
-        "PROVINCE",
-        "STATE",
-        "COUNTY",
-        "DISTRICT",
-        "LEAGUE",
-        "CONFERENCE",
-        "CLUB",
-        "PROVIDER"
-      ]
-    },
     "BiographicalInformation": {
       "type": "object",
       "properties": {
@@ -3382,15 +3361,28 @@
         "amount": {
           "type": "number"
         },
-        "category": {
+        "currencyCode": {
           "type": "string"
         },
-        "currencyCode": {
+        "unit": {
+          "type": "string",
+          "enum": ["MINOR", "MAJOR"]
+        },
+        "eventId": {
+          "type": "string"
+        },
+        "category": {
           "type": "string"
         },
         "eventType": {
           "type": "string",
           "enum": ["SINGLES", "DOUBLES", "TEAM", "HYBRID"]
+        },
+        "appliesFrom": {
+          "type": "string"
+        },
+        "appliesTo": {
+          "type": "string"
         },
         "extensions": {
           "type": "array",
@@ -3399,7 +3391,7 @@
           }
         }
       },
-      "required": ["amount", "currencyCode"],
+      "required": ["amount", "currencyCode", "unit"],
       "additionalProperties": false
     },
     "PrizeMoney": {

--- a/src/mutate/tournaments/tournamentDetails.ts
+++ b/src/mutate/tournaments/tournamentDetails.ts
@@ -3,7 +3,7 @@ import { addNotes, removeNotes } from '../base/addRemoveNotes';
 import { addNotice } from '@Global/state/globalState';
 
 // constants
-import { INVALID_TIME_ZONE, TOURNAMENT_CATEGORY_IN_USE } from '@Constants/errorConditionConstants';
+import { INVALID_TIME_ZONE, INVALID_VALUES, TOURNAMENT_CATEGORY_IN_USE } from '@Constants/errorConditionConstants';
 import { MODIFY_TOURNAMENT_DETAIL } from '@Constants/topicConstants';
 import { TOURNAMENT_RECORD } from '@Constants/attributeConstants';
 import { SUCCESS } from '@Constants/resultConstants';
@@ -160,9 +160,36 @@ export function setTournamentTier({ tournamentRecord, tournamentTier }) {
   return { ...SUCCESS };
 }
 
+/**
+ * Reject an entry fee that cannot be read at a known scale.
+ *
+ * `setRegistrationProfile` previously merged whatever object it was handed with no validation of any
+ * kind, so a fee with no `unit` — the exact ambiguity `MonetaryAmount` exists to remove — was stored
+ * without complaint and read back 100× wrong by any consumer that assumed whole units.
+ *
+ * Deliberately narrow. It checks the fields whose absence makes the amount UNREADABLE and nothing
+ * else: this is a previously ungated path, and a validator that fails closed on shapes callers have
+ * always been allowed to write would be a worse defect than the one it fixes.
+ *
+ * NOT the only write path, and deliberately so. `activateFromSanctioning` assigns
+ * `registrationProfile: proposal.registrationProfile` straight onto the record without coming
+ * through here, so a proposal authored before `unit` existed still activates. That hole is left
+ * open on purpose: an application mid-flight is the worst place to fail closed, and the read side
+ * (`resolveEntryFee`) reports such a fee as indeterminate rather than rendering it wrong. Close it
+ * when proposals are known to carry units.
+ */
+function invalidEntryFee(entryFees: any): boolean {
+  if (!Array.isArray(entryFees)) return false;
+  return entryFees.some(
+    (fee) => fee && typeof fee === 'object' && typeof fee.amount === 'number' && (!fee.currencyCode || !fee.unit),
+  );
+}
+
 export function setRegistrationProfile({ tournamentRecord, registrationProfile }) {
   const paramsCheck = requireParams({ tournamentRecord }, [TOURNAMENT_RECORD]);
   if (paramsCheck.error) return paramsCheck;
+
+  if (invalidEntryFee(registrationProfile?.entryFees)) return { error: INVALID_VALUES };
 
   if (registrationProfile && typeof registrationProfile === 'object') {
     tournamentRecord.registrationProfile = {

--- a/src/query/entries/resolveEntryFee.ts
+++ b/src/query/entries/resolveEntryFee.ts
@@ -1,0 +1,112 @@
+import type { RegistrationEntryFee } from '@Types/tournamentTypes';
+
+export interface ResolvedEntryFee {
+  amount: number;
+  currencyCode: string;
+  unit: string;
+}
+
+export interface IndeterminateEntryFee {
+  /** the fee cannot be stated at a known scale — render it as unknown, never as a number */
+  indeterminate: true;
+  reason: string;
+}
+
+/**
+ * Read a stored entry fee, refusing to guess its scale.
+ *
+ * `unit` is required on {@link RegistrationEntryFee} by construction, but records written before it
+ * existed still arrive over the wire without one, and a stored record is not a compile-time object.
+ * This is the read-side counterpart to that requirement: writes are strict, reads are tolerant, and
+ * the tolerance takes the shape of an explicit "cannot tell" rather than an assumption.
+ *
+ * **The unit is never inferred from magnitude.** "6000 is obviously minor units" is wrong on a real
+ * ¥6000 entry and on a genuine $6,000 pro-am, and both exist. A consumer that receives
+ * `indeterminate` should render "fee on request" or similar — anything but a figure that might be
+ * out by 100×.
+ *
+ * The same reasoning as `sumAgainstBound` in `comparePrizeMoney`: a reader that cannot evaluate must
+ * say so, because a confident wrong number is worse than an admitted gap.
+ */
+export function resolveEntryFee(fee?: RegistrationEntryFee | null): ResolvedEntryFee | IndeterminateEntryFee {
+  if (!fee || typeof fee !== 'object') {
+    return { indeterminate: true, reason: 'no fee' };
+  }
+  if (typeof fee.amount !== 'number' || Number.isNaN(fee.amount)) {
+    return { indeterminate: true, reason: 'amount is not a number' };
+  }
+  if (!fee.currencyCode) {
+    // An absent currency is unknown, not the reader's own. Defaulting it invents data.
+    return { indeterminate: true, reason: 'no currencyCode' };
+  }
+  if (!fee.unit) {
+    return { indeterminate: true, reason: 'no unit — scale unknown' };
+  }
+  return { amount: fee.amount, currencyCode: fee.currencyCode, unit: fee.unit };
+}
+
+/** True when `resolveEntryFee` could not state the fee at a known scale. */
+export function isIndeterminateFee(
+  resolved: ResolvedEntryFee | IndeterminateEntryFee,
+): resolved is IndeterminateEntryFee {
+  return (resolved as IndeterminateEntryFee).indeterminate === true;
+}
+
+export interface EntryFeeRange {
+  min: ResolvedEntryFee;
+  max: ResolvedEntryFee;
+  /** fees that could not be compared — present so a caller can disclose rather than hide them */
+  indeterminate: IndeterminateEntryFee[];
+  /** distinct `currencyCode`/`unit` pairs found beyond the one the range is denominated in */
+  incomparable: string[];
+}
+
+/**
+ * The lowest and highest of a set of fees — or nothing, when they cannot honestly be compared.
+ *
+ * A displayed price range ("$30–$155") is only meaningful if every contributing fee is denominated
+ * identically. Comparing across currencies picks the smaller NUMBER rather than the smaller VALUE:
+ * 40 EUR "beats" 45 USD on arithmetic that means nothing. So the range is computed only over the
+ * single most common `currencyCode`/`unit` pair, and everything else is REPORTED rather than folded
+ * in or dropped.
+ *
+ * Returns `undefined` when no fee can be resolved at all, so the caller renders nothing rather than
+ * a zero.
+ */
+export function getEntryFeeRange(fees?: RegistrationEntryFee[] | null): EntryFeeRange | undefined {
+  if (!Array.isArray(fees) || !fees.length) return undefined;
+
+  const resolved: ResolvedEntryFee[] = [];
+  const indeterminate: IndeterminateEntryFee[] = [];
+
+  for (const fee of fees) {
+    const result = resolveEntryFee(fee);
+    if (isIndeterminateFee(result)) indeterminate.push(result);
+    else resolved.push(result);
+  }
+
+  if (!resolved.length) return undefined;
+
+  // Group by denomination; the range is taken over the largest group so a single stray currency
+  // does not suppress an otherwise usable range.
+  const groups = new Map<string, ResolvedEntryFee[]>();
+  for (const entry of resolved) {
+    const key = `${entry.currencyCode}/${entry.unit}`;
+    const group = groups.get(key);
+    if (group) group.push(entry);
+    else groups.set(key, [entry]);
+  }
+
+  const sorted = [...groups.entries()].sort((a, b) => b[1].length - a[1].length || a[0].localeCompare(b[0]));
+  const [, chosen] = sorted[0];
+  const incomparable = sorted.slice(1).map(([key]) => key);
+
+  const ordered = [...chosen].sort((a, b) => a.amount - b.amount);
+
+  return {
+    min: ordered[0],
+    max: ordered[ordered.length - 1],
+    indeterminate,
+    incomparable,
+  };
+}

--- a/src/tests/constants/enumConstConformance.test.ts
+++ b/src/tests/constants/enumConstConformance.test.ts
@@ -228,6 +228,12 @@ const ENUM_ONLY = [
   // currency UNIT (minor vs whole) is a representation concern with no const-module twin — the
   // currencies themselves are ISO 4217 strings, not a factory vocabulary
   'CurrencyUnitEnum',
+  // what an Organisation IS (a school, a club, a national association), as distinct from
+  // AuthorityRoleEnum above, which is what part a body PLAYS in one approval chain. Brought into
+  // TypeScript from tournament.schema.json, where it was already declared; no const-module twin
+  // exists and minting one would create a second SECTION/DISTRICT/CLUB vocabulary beside the
+  // authority-role one.
+  'OrganisationTypeEnum',
   'WheelchairClassEnum',
   'WinReasonEnum',
 ];

--- a/src/tests/mutations/tournaments/registrationProfile.test.ts
+++ b/src/tests/mutations/tournaments/registrationProfile.test.ts
@@ -89,12 +89,15 @@ describe('registrationProfile', () => {
     expect(registrationProfile?.socialEvents?.[0].name).toBe('Welcome Dinner');
   });
 
+  // `unit` is required since RegistrationEntryFee began extending MonetaryAmount: an amount with no
+  // stated scale is readable at two scales 100x apart. The fixture below states it; the assertions
+  // are unchanged apart from the added round-trip check on `unit` itself.
   it('sets entry fees', () => {
     let result: any = tournamentEngine.setRegistrationProfile({
       registrationProfile: {
         entryFees: [
-          { amount: 50, currencyCode: 'USD', eventType: 'SINGLES' },
-          { amount: 75, currencyCode: 'USD', eventType: 'DOUBLES' },
+          { amount: 50, currencyCode: 'USD', unit: 'MAJOR', eventType: 'SINGLES' },
+          { amount: 75, currencyCode: 'USD', unit: 'MAJOR', eventType: 'DOUBLES' },
         ],
       },
     });
@@ -103,7 +106,15 @@ describe('registrationProfile', () => {
     let { registrationProfile } = tournamentEngine.getRegistrationProfile();
     expect(registrationProfile?.entryFees).toHaveLength(2);
     expect(registrationProfile?.entryFees?.[0].amount).toBe(50);
+    expect(registrationProfile?.entryFees?.[0].unit).toBe('MAJOR');
     expect(registrationProfile?.entryFees?.[1].eventType).toBe('DOUBLES');
+  });
+
+  it('refuses an entry fee whose scale is unstated', () => {
+    const result: any = tournamentEngine.setRegistrationProfile({
+      registrationProfile: { entryFees: [{ amount: 50, currencyCode: 'USD' }] },
+    });
+    expect(result.error).toBeDefined();
   });
 
   it('sets regulations and sponsors', () => {

--- a/src/tests/queries/entries/entryFeeResolution.test.ts
+++ b/src/tests/queries/entries/entryFeeResolution.test.ts
@@ -1,0 +1,133 @@
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { describe, expect, it } from 'vitest';
+
+import { getEntryFeeRange, isIndeterminateFee, resolveEntryFee } from '@Query/entries/resolveEntryFee';
+import { INVALID_VALUES } from '@Constants/errorConditionConstants';
+
+/**
+ * Punch-list M1.
+ *
+ * `RegistrationEntryFee` carried a bare amount + currencyCode, so `{ amount: 6000, currencyCode:
+ * 'USD' }` was readable as $60.00 or $6,000 with nothing to choose between them. Two shipped
+ * renderers assumed whole units, which is a 100× error on the federation surfaces that state minor
+ * units.
+ *
+ * These tests pin the two halves of the fix: writes require a unit, reads refuse to guess one.
+ */
+
+describe('resolveEntryFee — reads refuse to guess a scale', () => {
+  it('resolves a fully-stated fee', () => {
+    const result: any = resolveEntryFee({ amount: 6000, currencyCode: 'USD', unit: 'MINOR' });
+    expect(isIndeterminateFee(result)).toBe(false);
+    expect(result).toEqual({ amount: 6000, currencyCode: 'USD', unit: 'MINOR' });
+  });
+
+  it('reports INDETERMINATE for a fee with no unit rather than assuming one', () => {
+    // The pre-change shape. It must not resolve to either scale.
+    const result: any = resolveEntryFee({ amount: 6000, currencyCode: 'USD' } as any);
+    expect(isIndeterminateFee(result)).toBe(true);
+    expect(result.reason).toContain('unit');
+  });
+
+  it('does not invent a currency', () => {
+    const result: any = resolveEntryFee({ amount: 60, unit: 'MAJOR' } as any);
+    expect(isIndeterminateFee(result)).toBe(true);
+    expect(result.reason).toContain('currencyCode');
+  });
+
+  it('never infers the unit from magnitude — 6000 is not "obviously" minor units', () => {
+    // A genuine ¥6000 entry and a genuine $6,000 pro-am are both real; magnitude cannot separate
+    // them, so a resolver that tried would be confidently wrong on one of the two.
+    const yen: any = resolveEntryFee({ amount: 6000, currencyCode: 'JPY', unit: 'MAJOR' });
+    const usd: any = resolveEntryFee({ amount: 6000, currencyCode: 'USD', unit: 'MINOR' });
+    expect(yen.unit).toBe('MAJOR');
+    expect(usd.unit).toBe('MINOR');
+  });
+});
+
+describe('getEntryFeeRange — a range is only meaningful within one denomination', () => {
+  it('computes a range over fees denominated alike', () => {
+    const range: any = getEntryFeeRange([
+      { amount: 7500, currencyCode: 'USD', unit: 'MINOR' },
+      { amount: 9500, currencyCode: 'USD', unit: 'MINOR' },
+    ]);
+    expect(range.min.amount).toBe(7500);
+    expect(range.max.amount).toBe(9500);
+    expect(range.incomparable).toEqual([]);
+  });
+
+  it('does NOT pick the smaller number across currencies — it reports the mismatch', () => {
+    // 40 EUR is a smaller NUMBER than 45 USD but not a known smaller VALUE. The pre-change
+    // formatter sorted on amount alone and labelled the winner with its own currency.
+    const range: any = getEntryFeeRange([
+      { amount: 45, currencyCode: 'USD', unit: 'MAJOR' },
+      { amount: 45, currencyCode: 'USD', unit: 'MAJOR' },
+      { amount: 40, currencyCode: 'EUR', unit: 'MAJOR' },
+    ]);
+    expect(range.min.currencyCode).toBe('USD');
+    expect(range.incomparable).toEqual(['EUR/MAJOR']);
+  });
+
+  it('discloses unit-less fees rather than dropping them', () => {
+    const range: any = getEntryFeeRange([
+      { amount: 7500, currencyCode: 'USD', unit: 'MINOR' },
+      { amount: 9500, currencyCode: 'USD' } as any,
+    ]);
+    expect(range.min.amount).toBe(7500);
+    expect(range.indeterminate).toHaveLength(1);
+  });
+
+  it('returns undefined when nothing resolves, so a caller renders nothing rather than zero', () => {
+    expect(getEntryFeeRange([{ amount: 60 } as any])).toBeUndefined();
+    expect(getEntryFeeRange([])).toBeUndefined();
+  });
+});
+
+describe('setRegistrationProfile — writes are strict', () => {
+  const seed = () => {
+    const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+      participantsProfile: { participantsCount: 2 },
+      nonRandom: 1,
+    });
+    tournamentEngine.setState(tournamentRecord);
+    return tournamentRecord;
+  };
+
+  it('rejects an entry fee with no unit — the path previously validated nothing at all', () => {
+    seed();
+    const result: any = tournamentEngine.setRegistrationProfile({
+      registrationProfile: { entryFees: [{ amount: 6000, currencyCode: 'USD' }] },
+    });
+    expect(result.error).toEqual(INVALID_VALUES);
+  });
+
+  it('rejects an entry fee with no currencyCode', () => {
+    seed();
+    const result: any = tournamentEngine.setRegistrationProfile({
+      registrationProfile: { entryFees: [{ amount: 6000, unit: 'MINOR' }] },
+    });
+    expect(result.error).toEqual(INVALID_VALUES);
+  });
+
+  it('accepts a fully-stated fee and stores it', () => {
+    seed();
+    const result: any = tournamentEngine.setRegistrationProfile({
+      registrationProfile: {
+        entriesClose: '2026-06-01',
+        entryFees: [{ amount: 6000, currencyCode: 'USD', unit: 'MINOR', eventType: 'SINGLES' }],
+      },
+    });
+    expect(result.success).toBe(true);
+    const { tournamentRecord: stored }: any = tournamentEngine.getTournament();
+    expect(stored.registrationProfile.entryFees[0].unit).toBe('MINOR');
+  });
+
+  it('leaves a profile with no entryFees alone — the gate is narrow by design', () => {
+    seed();
+    const result: any = tournamentEngine.setRegistrationProfile({
+      registrationProfile: { entriesClose: '2026-06-01', dressCode: 'whites' },
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/types/enumExports.ts
+++ b/src/types/enumExports.ts
@@ -8,7 +8,7 @@
  *
  * Regenerate:   pnpm gen:enum-exports
  * Drift guard:  pnpm check:enum-exports
- * Covers 69 enums across 4 modules.
+ * Covers 70 enums across 4 modules.
  */
 
 export { SportEnum } from './competitionFormat';
@@ -51,6 +51,7 @@ export { LengthUnitEnum } from './tournamentTypes';
 export { LinkTypeEnum } from './tournamentTypes';
 export { MatchUpStatusEnum } from './tournamentTypes';
 export { OnlineResourceTypeEnum } from './tournamentTypes';
+export { OrganisationTypeEnum } from './tournamentTypes';
 export { ParticipantRoleEnum } from './tournamentTypes';
 export { ParticipantStatusEnum } from './tournamentTypes';
 export { ParticipantTypeEnum } from './tournamentTypes';

--- a/src/types/factoryEngineMethods.ts
+++ b/src/types/factoryEngineMethods.ts
@@ -273,6 +273,7 @@ export type FactoryEngineMethod =
   | 'getEligibleEvents'
   | 'getEligibleVoluntaryConsolationParticipants'
   | 'getEntriesAndSeedsCount'
+  | 'getEntryFeeRange'
   | 'getEntryStatusReports'
   | 'getEpisodes'
   | 'getEvaluations'
@@ -416,6 +417,7 @@ export type FactoryEngineMethod =
   | 'isComplete'
   | 'isCompletedStructure'
   | 'isEmbargoed'
+  | 'isIndeterminateFee'
   | 'isScheduleLocked'
   | 'isValid'
   | 'isValidForQualifying'
@@ -560,6 +562,7 @@ export type FactoryEngineMethod =
   | 'resetVoluntaryConsolationStructure'
   | 'resolveCourtId'
   | 'resolveDraftPositions'
+  | 'resolveEntryFee'
   | 'resolvePointValue'
   | 'resolveStatus'
   | 'resolveVenueId'
@@ -943,6 +946,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'getEligibleEvents',
   'getEligibleVoluntaryConsolationParticipants',
   'getEntriesAndSeedsCount',
+  'getEntryFeeRange',
   'getEntryStatusReports',
   'getEpisodes',
   'getEvaluations',
@@ -1086,6 +1090,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'isComplete',
   'isCompletedStructure',
   'isEmbargoed',
+  'isIndeterminateFee',
   'isScheduleLocked',
   'isValid',
   'isValidForQualifying',
@@ -1230,6 +1235,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'resetVoluntaryConsolationStructure',
   'resolveCourtId',
   'resolveDraftPositions',
+  'resolveEntryFee',
   'resolvePointValue',
   'resolveStatus',
   'resolveVenueId',

--- a/src/types/methodSignatures.ts
+++ b/src/types/methodSignatures.ts
@@ -511,6 +511,7 @@ import type { resetScorecard } from '@Mutate/matchUps/resetScorecard';
 import type { addOnlineResource } from '@Mutate/base/addOnlineResource';
 import type { addVenueOtherId } from '@Mutate/venues/addVenueOtherId';
 import type { publicFindParticipant } from '@Acquire/publicFindParticipant';
+import type { getEntryFeeRange, isIndeterminateFee, resolveEntryFee } from '@Query/entries/resolveEntryFee';
 import type { getMatchUpsMap } from '@Query/matchUps/getMatchUpsMap';
 import type { setEventDisplay } from '@Mutate/events/setEventDisplay';
 import type { setSubOrder } from '@Mutate/structures/setSubOrder';
@@ -842,6 +843,7 @@ export interface MethodSignatures {
   getEligibleEvents: EngineMethod<typeof getEligibleEvents>;
   getEligibleVoluntaryConsolationParticipants: EngineMethod<typeof getEligibleVoluntaryConsolationParticipants>;
   getEntriesAndSeedsCount: EngineMethod<typeof getEntriesAndSeedsCount>;
+  getEntryFeeRange: EngineMethod<typeof getEntryFeeRange>;
   getEntryStatusReports: EngineMethod<typeof getEntryStatusReports>;
   getEpisodes: EngineMethod<typeof getEpisodes>;
   getEvaluations: EngineMethod<typeof getEvaluations>;
@@ -974,6 +976,7 @@ export interface MethodSignatures {
   isComplete: EngineMethod<typeof isComplete>;
   isCompletedStructure: EngineMethod<typeof isCompletedStructure>;
   isEmbargoed: EngineMethod<typeof isEmbargoed>;
+  isIndeterminateFee: EngineMethod<typeof isIndeterminateFee>;
   isScheduleLocked: EngineMethod<typeof isScheduleLocked>;
   isValid: EngineMethod<typeof isValidMatchUpFormat>;
   isValidForQualifying: EngineMethod<typeof isValidForQualifying>;
@@ -1103,6 +1106,7 @@ export interface MethodSignatures {
   resetTieFormat: EngineMethod<typeof resetTieFormat>;
   resetVoluntaryConsolationStructure: EngineMethod<typeof resetVoluntaryConsolationStructure>;
   resolveDraftPositions: EngineMethod<typeof resolveDraftPositions>;
+  resolveEntryFee: EngineMethod<typeof resolveEntryFee>;
   resolvePointValue: EngineMethod<typeof resolvePointValue>;
   reverseScore: EngineMethod<typeof reverseScore>;
   scaledTeamAssignment: EngineMethod<typeof scaledTeamAssignment>;

--- a/src/types/sanctioningTypes.ts
+++ b/src/types/sanctioningTypes.ts
@@ -10,6 +10,7 @@ import type {
   MonetaryAmount,
   Organisation,
   PrizeMoney,
+  RegistrationEntryFee,
   RegistrationProfile,
   SurfaceCategoryUnion,
   TieFormat,
@@ -247,7 +248,14 @@ export interface TournamentProposal {
   // Financial
   totalPrizeMoney?: PrizeMoney[];
   entryFees?: EntryFee[];
-  sanctionFee?: PrizeMoney;
+  /**
+   * The levy the authority charges to sanction the competition.
+   *
+   * A {@link MonetaryAmount}, not `PrizeMoney`. `PrizeMoney` is an AWARD with provenance — money
+   * paid OUT to competitors — and it happened to carry the right primitive fields, which is why the
+   * mismatch went unnoticed. A sanction fee is money paid IN by the organiser.
+   */
+  sanctionFee?: MonetaryAmount;
 
   // Personnel
   officials?: OfficialProposal[];
@@ -346,13 +354,15 @@ export interface Coordinates {
   longitude: number;
 }
 
-export interface EntryFee {
-  amount: number;
-  currencyCode: string;
-  eventType?: EventTypeUnion;
-  category?: string;
-  extensions?: Extension[];
-}
+/**
+ * @deprecated Use {@link RegistrationEntryFee}, which this now aliases.
+ *
+ * `EntryFee` was a byte-identical duplicate of `RegistrationEntryFee` — same five fields, same
+ * meaning, two declarations. Retained as an alias rather than deleted because it is a PUBLIC export
+ * of this package: removing it would fail `verify:surface` and would not be a minor release.
+ * Remove in the next major if still unused.
+ */
+export type EntryFee = RegistrationEntryFee;
 
 export interface OfficialProposal {
   role: string;

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -103,23 +103,40 @@ export interface Organisation {
   organisationId: string;
   notes?: string;
   /**
-   * What KIND of body this is — authority, section, district, provider, club.
+   * What KIND of body this is — a national association, a school, a club.
    *
-   * `parentOrganisationId` gives the shape of a hierarchy but says nothing about what sits at each
-   * node, so a captured chain (National → Section → District → the club running the event) arrives
-   * as four indistinguishable organisations. Consumers were left inferring role from position, which
-   * fails on the chains that are not strict containment ladders — some bodies approve only at the
-   * regional tier, and at least one federation requires JOINT approval by two co-equal bodies.
+   * INTRINSIC to the organisation, and deliberately distinct from {@link SanctioningAuthority.role},
+   * which is POSITIONAL: what part a body plays in one particular approval chain. A school is a
+   * SCHOOL wherever it appears, and may occupy a CLUB-level rung in one federation's hierarchy and
+   * no rung at all in another's. Collapsing the two would make a body's identity depend on which
+   * chain you happened to read it from.
    *
-   * Reuses {@link AuthorityRoleEnum} rather than minting a parallel vocabulary. That enum was added
-   * for `SanctioningAuthority.role`, which closed this question INSIDE a sanction while leaving
-   * `Organisation` itself untyped — so the same body could state its role when it appeared in an
-   * approval chain and not when it appeared as `parentOrganisation`.
+   * Not a new vocabulary. `organisationType` has been declared in `tournament.schema.json` and
+   * documented on the public docs site all along; the TypeScript types were the only one of the
+   * three declarations missing it. This closes that gap rather than opening a fourth.
    *
-   * Optional and never inferred: an organisation whose role nobody recorded is unknown, not a CLUB.
+   * Optional and never inferred: an organisation whose type nobody recorded is unknown, not a CLUB.
    */
-  role?: AuthorityRoleUnion;
+  organisationType?: OrganisationTypeUnion;
 }
+
+/**
+ * What kind of body an {@link Organisation} is.
+ *
+ * Values mirror `OrganisationTypeEnum` in `tournament.schema.json`, which predates this type — the
+ * enum is being brought INTO TypeScript, not invented here, so the values are taken as given rather
+ * than improved. `OTHER` exists because the list is not exhaustive over every governing structure.
+ */
+export enum OrganisationTypeEnum {
+  NATIONAL_ASSOCIATION = 'NATIONAL_ASSOCIATION',
+  SCHOOL = 'SCHOOL',
+  SECTION = 'SECTION',
+  AREA = 'AREA',
+  DISTRICT = 'DISTRICT',
+  CLUB = 'CLUB',
+  OTHER = 'OTHER',
+}
+export type OrganisationTypeUnion = `${OrganisationTypeEnum}`;
 
 export interface Event {
   activeDates?: Date[] | string[]; // dates from startDate to endDate on which the tournament is active
@@ -1912,11 +1929,43 @@ export interface DocumentLink {
   url?: string;
 }
 
-export interface RegistrationEntryFee {
-  amount: number;
+/**
+ * What a competitor pays to enter.
+ *
+ * Extends {@link MonetaryAmount}, so `unit` is required and the amount cannot be read at the wrong
+ * scale. It previously carried a bare `amount` + `currencyCode`, which is the exact ambiguity
+ * `MonetaryAmount` was introduced to remove: a federation stating a `6000` entry fee means $60.00,
+ * and a reader assuming whole units is out by 100× with nothing in the record to signal it. That
+ * was not hypothetical — two captured federation surfaces state this same field at different
+ * scales, one in minor units and one in major.
+ *
+ * NOT a {@link SanctionFee}. A sanction fee is a levy the governing body collects from the
+ * organiser; this is the organiser's price to a competitor. Different payer, different setter,
+ * different lifecycle. `SanctionFeeKindEnum.ENTRY` exists for an authority-collected per-entry levy
+ * and is not a home for this.
+ *
+ * ## Which events a fee applies to
+ *
+ * Three selectors, most specific first: `eventId` > `category` > `eventType`. All are optional, and
+ * a fee with none applies to the whole tournament. `eventType` alone cannot distinguish a $75
+ * over-35 doubles from a $95 open doubles when both are on the same tournament, which is why
+ * `eventId` exists; `eventType` and `category` are kept because organisers genuinely do price "all
+ * doubles" once without enumerating events.
+ */
+export interface RegistrationEntryFee extends MonetaryAmount {
+  /** the specific event this fee buys entry to — the most specific selector */
+  eventId?: string;
   category?: string;
-  currencyCode: string;
   eventType?: EventTypeUnion;
+  /**
+   * Window in which this price is the one charged, for early-bird and late-entry pricing.
+   *
+   * Without it, an early rate and a late rate are two records with no stated relationship, and a
+   * consumer computing "what does this cost" has no way to exclude the one that has expired. Both
+   * ends optional: an early-bird rate with no `appliesFrom` has simply always been available.
+   */
+  appliesFrom?: string;
+  appliesTo?: string;
   extensions?: Extension[];
 }
 


### PR DESCRIPTION
Punch-list **M1**, plus a correction to **M5** from #4722. Companion PRs land the consumer half — see below.

## M1 — the one monetary field a competitor actually pays had no scale

`RegistrationEntryFee` carried a bare `amount` + `currencyCode`, so `{ amount: 6000, currencyCode: 'USD' }` was readable as **$60.00 or $6,000** with nothing to choose between them. That is the exact ambiguity `MonetaryAmount` was introduced to remove in #4710; #4711 swept `PrizeMoney` onto it and left this one behind.

It now extends `MonetaryAmount`, and gains `eventId` — `eventType` alone cannot distinguish a $75 over-35 doubles from a $95 open doubles when both sit on the same tournament. `appliesFrom`/`appliesTo` make early-bird and late pricing one list rather than two records with no stated relationship.

**The consumer sweep did not come back clean, unlike `PrizeMoney`'s.** Both shipped renderers assumed whole units, reproduced against the shipped formatter *before* the change:

```
{amount: 6000, currencyCode: USD, unit: MINOR}  →  USD $6,000.00   should be USD $60.00
[{45 USD}, {40 EUR}] cross-currency minimum     →  From EUR €40.00  picks the smaller *number*
{amount: 60} with no currencyCode               →  USD $60.00       currency invented
```

## Writes are strict, reads are tolerant

`setRegistrationProfile` previously merged **whatever object it was handed, with no validation of any kind**. It now rejects a fee whose scale cannot be read. `resolveEntryFee` is the read-side counterpart and reports `indeterminate` rather than assuming — the unit is **never** inferred from magnitude, because "6000 is obviously minor units" is wrong on a real ¥6000 entry *and* on a genuine $6,000 pro-am. Same reasoning as `sumAgainstBound` in `comparePrizeMoney`.

**Not the only write path, deliberately.** `activateFromSanctioning` assigns `registrationProfile` directly and still accepts a unit-less proposal. An application mid-flight is the worst place to fail closed, and the read side reports such a fee honestly. Recorded on the validator rather than left silent.

## `EntryFee` is aliased, not deleted

It was a byte-identical duplicate — but it is a **public export**, present in the published `.d.ts` and in `scripts/verify/baseline/surface.txt`, and `verify:surface` *hard-fails* on removal. Deleting it would also make this not a minor release. Aliased with `@deprecated`; delete in the next major.

`SanctioningProposal.sanctionFee` moves `PrizeMoney` → `MonetaryAmount`. `PrizeMoney` is an **award** — money paid out. A sanction fee is money paid **in**.

## M5 correction — `role` was the wrong call

`Organisation.role` shipped in #4722 and is **unreleased** (v6.33.0 is the latest tag; no tag contains `3fbc84219`), so it is corrected rather than lived with.

`organisationType` was already declared in `tournament.schema.json` **and** documented on the public docs site — the TypeScript types were the only one of three declarations missing it. `OrganisationTypeEnum` is now first-class and `Organisation` carries `organisationType`; `role` is removed.

The distinction that decides it: **what a body IS is intrinsic; what part it PLAYS in one approval chain is contextual.** A school is a SCHOOL wherever it appears, and may occupy a club-level rung in one hierarchy and none in another. The contextual axis already belongs to `SanctioningAuthority.role`, where #4710 correctly put it.

## Schema

Kept level with the types. `RegistrationEntryFee` gains `unit` (**required**), `eventId` and the windows, following the shape #4718 used for `PrizeMoney`. `Organisation.role` and the `AuthorityRoleEnum` definition I added in #4722 are removed again. No dangling `$ref`s remain.

## Two existing tests changed

Both pinned the old contract: `registrationProfile`'s fixture now states a unit (assertions unchanged, plus a round-trip check on `unit`), and `OrganisationTypeEnum` is registered enum-only in `enumConstConformance` — that guard forcing a decision when a new enum appears is it working as intended.

## Verification

`pnpm verify` green — all 15 steps. **`verify:surface`: no exports removed.** Full suite 11,535 passing.

## Companion PRs — these land together

- `courthive-components` — unit-aware fee badge
- `courthive-public` — unit-aware info tab
- `courthive-ingest` `2057ad1` — **M2**, entry fees off `event.sanction.fees`

**Sequencing matters here.** The 100× render was *latent* precisely because the minor-unit data was parked in `sanction.fees`, a field neither renderer reads. Landing the ingest repoint without the unit-aware renderers would have **activated** the bug.