### PR TITLE
feat(codes): give an event its own registration window and entry capacity

### DIFF
--- a/src/assemblies/governors/entriesGovernor/query.ts
+++ b/src/assemblies/governors/entriesGovernor/query.ts
@@ -1,3 +1,4 @@
+export { getEffectiveRegistrationProfile, getEventEntryFees } from '@Query/entries/getEffectiveRegistrationProfile';
 export { resolveEntryFee, getEntryFeeRange, isIndeterminateFee } from '@Query/entries/resolveEntryFee';
 export { getEntriesAndSeedsCount } from '@Query/entries/getEntriesAndSeedsCount';
 export { getMaxEntryPosition } from '@Query/entries/getMaxEntryPosition';

--- a/src/global/schema/tournament.schema.json
+++ b/src/global/schema/tournament.schema.json
@@ -207,6 +207,76 @@
       "additionalProperties": true,
       "$comment": "OPEN, and this is a KNOWN GAP rather than a decision — closing it is blocked, not declined. Measured 2026-08-28 against the 16 TODS fixtures: 13 records carry `venueIds`, 6 carry `deleted`, and `dualMatchMetadata`, `associatedOrganisations`, `rootOrganisationId`, `tournamentExternalId` and a nested `tournamentRecord` each appear. Closing this definition today fails 14 of 16 fixtures. Each undeclared field must first be resolved as either a real CODES concept (declare it in `types/tournamentTypes.ts` AND here) or as legacy data (correct the fixtures), after which this should become `false` to match the other 51."
     },
+    "EventRegistration": {
+      "type": "object",
+      "properties": {
+        "entriesOpen": {
+          "type": ["string", "object"],
+          "format": "date-time"
+        },
+        "entriesClose": {
+          "type": ["string", "object"],
+          "format": "date-time"
+        },
+        "withdrawalDeadline": {
+          "type": ["string", "object"],
+          "format": "date-time"
+        },
+        "entryFees": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RegistrationEntryFee"
+          }
+        },
+        "entryUrl": {
+          "type": "string"
+        },
+        "eligibilityNotes": {
+          "type": "string"
+        },
+        "extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Extension"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "EventEntryProfile": {
+      "type": "object",
+      "properties": {
+        "entriesLimit": {
+          "type": "number"
+        },
+        "targetDrawSize": {
+          "type": "number"
+        },
+        "selectionProcess": {
+          "$ref": "#/definitions/SelectionProcessEnum"
+        },
+        "selectionScaleName": {
+          "type": "string"
+        },
+        "wildcardCount": {
+          "type": "number"
+        },
+        "waitlistEnabled": {
+          "type": "boolean"
+        },
+        "extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Extension"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "SelectionProcessEnum": {
+      "type": "string",
+      "enum": ["FIRST_COME_FIRST_SERVED", "TOP_DOWN_BY_RANKING", "TOP_DOWN_BY_RATING", "MANUAL", "LOTTERY"]
+    },
     "Extension": {
       "type": "object",
       "properties": {
@@ -250,6 +320,12 @@
     "Event": {
       "type": "object",
       "properties": {
+        "registrationProfile": {
+          "$ref": "#/definitions/EventRegistration"
+        },
+        "entryProfile": {
+          "$ref": "#/definitions/EventEntryProfile"
+        },
         "flightProfile": {
           "type": "object"
         },

--- a/src/query/entries/getEffectiveRegistrationProfile.ts
+++ b/src/query/entries/getEffectiveRegistrationProfile.ts
@@ -1,0 +1,92 @@
+import type { Event, EventRegistration, RegistrationProfile, Tournament } from '@Types/tournamentTypes';
+
+/** The six fields an event may override. Anything else is tournament-wide by nature. */
+const OVERRIDABLE = [
+  'entriesOpen',
+  'entriesClose',
+  'withdrawalDeadline',
+  'entryFees',
+  'entryUrl',
+  'eligibilityNotes',
+] as const;
+
+export type EffectiveRegistrationProfile = Pick<RegistrationProfile, (typeof OVERRIDABLE)[number]>;
+
+/**
+ * The registration facts that actually apply to an event.
+ *
+ * **The cascade is FIELD BY FIELD, not object by object, and that distinction is the whole reason
+ * this function exists.** The obvious implementation —
+ *
+ * ```ts
+ * event.registrationProfile ?? tournamentRecord.registrationProfile
+ * ```
+ *
+ * — is wrong in a way that looks right: an event that overrides only `entriesClose` would silently
+ * lose the tournament's `entryUrl`, `entryFees` and every other field, because the whole object was
+ * replaced rather than merged. The failure is invisible at the call site and shows up as a missing
+ * registration link on one division.
+ *
+ * So every reader of a registration window must come through here rather than reaching for the
+ * fallback themselves. `Event.sanction` documents a similar inheritance, but that field is coarser —
+ * a sanction is taken whole — which is exactly why the finer rule is stated and enforced here
+ * instead of left to be inferred from the neighbouring one.
+ *
+ * Only the six overridable fields are returned. The tournament's logistics, sponsors and dress code
+ * are not event-scoped concepts and are read from `tournamentRecord.registrationProfile` directly.
+ *
+ * An `undefined` value on the event does NOT override — absent means "not stated here", never
+ * "explicitly nothing". A `null` is preserved, so a producer can still say "this event has no
+ * entry URL" when it means it.
+ */
+export function getEffectiveRegistrationProfile(params: {
+  event?: Event;
+  tournamentRecord?: Tournament;
+}): EffectiveRegistrationProfile {
+  const { event, tournamentRecord } = params ?? {};
+
+  const tournamentProfile: Partial<RegistrationProfile> = tournamentRecord?.registrationProfile ?? {};
+  const eventProfile: Partial<EventRegistration> = event?.registrationProfile ?? {};
+
+  const effective: Record<string, any> = {};
+  for (const field of OVERRIDABLE) {
+    const eventValue = (eventProfile as Record<string, any>)[field];
+    const tournamentValue = (tournamentProfile as Record<string, any>)[field];
+    effective[field] = eventValue === undefined ? tournamentValue : eventValue;
+  }
+
+  return effective as EffectiveRegistrationProfile;
+}
+
+/**
+ * Entry fees that apply to an event, narrowed by the fee's own selectors.
+ *
+ * A tournament-grain fee list can carry entries for several events, so "the fees on this record" is
+ * not the same question as "the fees for this event". Selectors are matched most-specific first:
+ * `eventId` > `category` > `eventType`. A fee with NO selector applies to every event — that is how
+ * a single tournament-wide price is stated.
+ *
+ * Returns only the most specific tier that matched, rather than everything that matched: a fee
+ * keyed to this exact `eventId` supersedes a blanket "all doubles" price, and returning both would
+ * leave the caller to re-derive precedence and get it wrong.
+ */
+export function getEventEntryFees(params: { event?: Event; tournamentRecord?: Tournament }) {
+  const { event, tournamentRecord } = params ?? {};
+  if (!event) return [];
+
+  const fees = getEffectiveRegistrationProfile({ event, tournamentRecord })?.entryFees ?? [];
+
+  const byEventId = fees.filter((fee) => fee?.eventId && fee.eventId === event.eventId);
+  if (byEventId.length) return byEventId;
+
+  const categoryName = event.category?.categoryName ?? event.category?.ageCategoryCode;
+  const byCategory = fees.filter((fee) => fee?.category && categoryName && fee.category === categoryName);
+  if (byCategory.length) return byCategory;
+
+  const byEventType = fees.filter((fee) => fee?.eventType && fee.eventType === event.eventType);
+  if (byEventType.length) return byEventType;
+
+  // No selector at all = tournament-wide. Fees selecting a DIFFERENT event are excluded here rather
+  // than returned as a fallback, which is why this is not simply `fees`.
+  return fees.filter((fee) => !fee?.eventId && !fee?.category && !fee?.eventType);
+}

--- a/src/tests/constants/enumConstConformance.test.ts
+++ b/src/tests/constants/enumConstConformance.test.ts
@@ -228,6 +228,11 @@ const ENUM_ONLY = [
   // currency UNIT (minor vs whole) is a representation concern with no const-module twin — the
   // currencies themselves are ISO 4217 strings, not a factory vocabulary
   'CurrencyUnitEnum',
+  // how an over-subscribed event chooses whom to accept. No const-module twin: the values are an
+  // EVENT-CONFIGURATION vocabulary consumed as a typed field, and the same strings already appear in
+  // captured federation records as `selectionProcessConstraints` — the authority's permitted SET,
+  // which is a different object from the organiser's chosen VALUE and must not be fused with it.
+  'SelectionProcessEnum',
   // what an Organisation IS (a school, a club, a national association), as distinct from
   // AuthorityRoleEnum above, which is what part a body PLAYS in one approval chain. Brought into
   // TypeScript from tournament.schema.json, where it was already declared; no const-module twin

--- a/src/tests/queries/entries/eventRegistration.test.ts
+++ b/src/tests/queries/entries/eventRegistration.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+
+import { getEffectiveRegistrationProfile, getEventEntryFees } from '@Query/entries/getEffectiveRegistrationProfile';
+import type { Event, Tournament } from '@Types/tournamentTypes';
+
+/**
+ * A2 and A3.
+ *
+ * The cascade test is the one that matters. `event.registrationProfile ?? tournament.registrationProfile`
+ * is the obvious implementation and it is wrong in a way that looks right — it replaces the whole
+ * object, so an event overriding one field silently loses every other. That is what these pin.
+ */
+
+const tournamentRecord = {
+  tournamentId: 't',
+  registrationProfile: {
+    entriesOpen: '2026-05-01',
+    entriesClose: '2026-06-01',
+    withdrawalDeadline: '2026-06-05',
+    entryUrl: 'https://example.test/enter',
+    eligibilityNotes: 'Members only',
+    entryFees: [{ amount: 5000, currencyCode: 'USD', unit: 'MAJOR' as const }],
+    // tournament-wide by nature — must NOT appear in the effective event profile
+    dressCode: 'whites',
+    sponsors: [{ name: 'Acme' }],
+  },
+} as unknown as Tournament;
+
+describe('getEffectiveRegistrationProfile — the cascade is field by field', () => {
+  it('inherits everything when the event states nothing', () => {
+    const event = { eventId: 'e' } as Event;
+    const effective: any = getEffectiveRegistrationProfile({ event, tournamentRecord });
+    expect(effective.entriesClose).toBe('2026-06-01');
+    expect(effective.entryUrl).toBe('https://example.test/enter');
+  });
+
+  it('an event overriding ONE field keeps the tournament values for the rest', () => {
+    // The whole point. Object-level fallback would drop entryUrl, entriesOpen and the fees.
+    const event = { eventId: 'e', registrationProfile: { entriesClose: '2026-05-20' } } as Event;
+    const effective: any = getEffectiveRegistrationProfile({ event, tournamentRecord });
+    expect(effective.entriesClose).toBe('2026-05-20');
+    expect(effective.entryUrl).toBe('https://example.test/enter');
+    expect(effective.entriesOpen).toBe('2026-05-01');
+    expect(effective.withdrawalDeadline).toBe('2026-06-05');
+    expect(effective.entryFees).toHaveLength(1);
+  });
+
+  it('does not surface tournament-wide fields that are not event-scoped concepts', () => {
+    const event = { eventId: 'e' } as Event;
+    const effective: any = getEffectiveRegistrationProfile({ event, tournamentRecord });
+    expect(effective.dressCode).toBeUndefined();
+    expect(effective.sponsors).toBeUndefined();
+  });
+
+  it('undefined does not override, but null does', () => {
+    // Absent means "not stated here"; null means "explicitly nothing".
+    const undef = { eventId: 'e', registrationProfile: { entryUrl: undefined } } as Event;
+    expect((getEffectiveRegistrationProfile({ event: undef, tournamentRecord }) as any).entryUrl).toBe(
+      'https://example.test/enter',
+    );
+
+    const explicit = { eventId: 'e', registrationProfile: { entryUrl: null } } as unknown as Event;
+    expect((getEffectiveRegistrationProfile({ event: explicit, tournamentRecord }) as any).entryUrl).toBeNull();
+  });
+
+  it('survives a missing event or tournament without throwing', () => {
+    expect(getEffectiveRegistrationProfile({})).toBeDefined();
+    expect(getEffectiveRegistrationProfile({ event: { eventId: 'e' } as Event })).toBeDefined();
+  });
+});
+
+describe('getEventEntryFees — selectors, most specific first', () => {
+  const record = {
+    tournamentId: 't',
+    registrationProfile: {
+      entryFees: [
+        { amount: 30, currencyCode: 'USD', unit: 'MAJOR' as const },
+        { amount: 75, currencyCode: 'USD', unit: 'MAJOR' as const, eventType: 'DOUBLES' },
+        { amount: 95, currencyCode: 'USD', unit: 'MAJOR' as const, eventId: 'open-doubles' },
+      ],
+    },
+  } as unknown as Tournament;
+
+  it('eventId beats eventType', () => {
+    const event = { eventId: 'open-doubles', eventType: 'DOUBLES' } as Event;
+    const fees: any = getEventEntryFees({ event, tournamentRecord: record });
+    expect(fees).toHaveLength(1);
+    expect(fees[0].amount).toBe(95);
+  });
+
+  it('eventType applies when no eventId-keyed fee exists', () => {
+    const event = { eventId: 'over35-doubles', eventType: 'DOUBLES' } as Event;
+    const fees: any = getEventEntryFees({ event, tournamentRecord: record });
+    expect(fees).toHaveLength(1);
+    expect(fees[0].amount).toBe(75);
+  });
+
+  it('an unselected fee is tournament-wide', () => {
+    const event = { eventId: 'singles', eventType: 'SINGLES' } as Event;
+    const fees: any = getEventEntryFees({ event, tournamentRecord: record });
+    expect(fees).toHaveLength(1);
+    expect(fees[0].amount).toBe(30);
+  });
+
+  it('does not return a fee keyed to a DIFFERENT event as a fallback', () => {
+    const onlyOther = {
+      tournamentId: 't',
+      registrationProfile: {
+        entryFees: [{ amount: 95, currencyCode: 'USD', unit: 'MAJOR' as const, eventId: 'other' }],
+      },
+    } as unknown as Tournament;
+    const event = { eventId: 'mine', eventType: 'SINGLES' } as Event;
+    expect(getEventEntryFees({ event, tournamentRecord: onlyOther })).toEqual([]);
+  });
+
+  it('reads a fee stated on the event itself', () => {
+    const event = {
+      eventId: 'e',
+      eventType: 'SINGLES',
+      registrationProfile: { entryFees: [{ amount: 60, currencyCode: 'USD', unit: 'MAJOR' as const }] },
+    } as Event;
+    const fees: any = getEventEntryFees({ event, tournamentRecord: record });
+    expect(fees).toHaveLength(1);
+    expect(fees[0].amount).toBe(60);
+  });
+});
+
+describe('EventEntryProfile round-trips', () => {
+  it('carries the selection process AND the scale it sorts on', () => {
+    // "top down by ranking" and "top down by WTN" are different products; the method alone is
+    // under-specified, which is why selectionScaleName exists.
+    const event = {
+      eventId: 'e',
+      entryProfile: {
+        entriesLimit: 64,
+        targetDrawSize: 64,
+        selectionProcess: 'TOP_DOWN_BY_RATING' as const,
+        selectionScaleName: 'WTN',
+        wildcardCount: 4,
+        waitlistEnabled: true,
+      },
+    } as Event;
+    expect(event.entryProfile?.selectionProcess).toBe('TOP_DOWN_BY_RATING');
+    expect(event.entryProfile?.selectionScaleName).toBe('WTN');
+    expect(event.entryProfile?.entriesLimit).toBe(64);
+  });
+});

--- a/src/types/enumExports.ts
+++ b/src/types/enumExports.ts
@@ -8,7 +8,7 @@
  *
  * Regenerate:   pnpm gen:enum-exports
  * Drift guard:  pnpm check:enum-exports
- * Covers 70 enums across 4 modules.
+ * Covers 71 enums across 4 modules.
  */
 
 export { SportEnum } from './competitionFormat';
@@ -66,6 +66,7 @@ export { SanctionDecisionEnum } from './tournamentTypes';
 export { SanctionEnforcementEnum } from './tournamentTypes';
 export { SanctionFeeKindEnum } from './tournamentTypes';
 export { SeedingProfileEnum } from './tournamentTypes';
+export { SelectionProcessEnum } from './tournamentTypes';
 export { SexEnum } from './tournamentTypes';
 export { ShotDetailEnum } from './tournamentTypes';
 export { ShotOutcomeEnum } from './tournamentTypes';

--- a/src/types/factoryEngineMethods.ts
+++ b/src/types/factoryEngineMethods.ts
@@ -270,6 +270,7 @@ export type FactoryEngineMethod =
   | 'getDrawParticipantRepresentativeIds'
   | 'getDrawStructures'
   | 'getDrawTypeCoercion'
+  | 'getEffectiveRegistrationProfile'
   | 'getEligibleEvents'
   | 'getEligibleVoluntaryConsolationParticipants'
   | 'getEntriesAndSeedsCount'
@@ -282,6 +283,7 @@ export type FactoryEngineMethod =
   | 'getEvent'
   | 'getEventCompleteness'
   | 'getEventData'
+  | 'getEventEntryFees'
   | 'getEventInconsistencies'
   | 'getEventMatchUpFormatTiming'
   | 'getEventProperties'
@@ -943,6 +945,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'getDrawParticipantRepresentativeIds',
   'getDrawStructures',
   'getDrawTypeCoercion',
+  'getEffectiveRegistrationProfile',
   'getEligibleEvents',
   'getEligibleVoluntaryConsolationParticipants',
   'getEntriesAndSeedsCount',
@@ -955,6 +958,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'getEvent',
   'getEventCompleteness',
   'getEventData',
+  'getEventEntryFees',
   'getEventInconsistencies',
   'getEventMatchUpFormatTiming',
   'getEventProperties',

--- a/src/types/methodSignatures.ts
+++ b/src/types/methodSignatures.ts
@@ -185,6 +185,10 @@ import type { generateCourts } from '../assemblies/generators/venues/generateCou
 import type { generateEventsFromTieFormat } from '@Generators/events/generateEventsFromTieFormat';
 import type { generateStatCrew } from '@Generators/tournamentRecords/generateStatCrew';
 import type { getCompetitionParticipants } from '@Query/participants/getCompetitionParticipants';
+import type {
+  getEffectiveRegistrationProfile,
+  getEventEntryFees,
+} from '@Query/entries/getEffectiveRegistrationProfile';
 import type { getMatchUpFormatVariance } from '@Query/drawDefinition/getMatchUpFormatVariance';
 import type { getMatchUpOfficialConflicts } from '@Query/officiating/getMatchUpOfficialConflicts';
 import type { getParticipantEventDetails } from '@Query/participants/getParticipantEventDetails';
@@ -840,6 +844,7 @@ export interface MethodSignatures {
   getDrawParticipantRepresentativeIds: EngineMethod<typeof getDrawParticipantRepresentativeIds>;
   getDrawStructures: EngineMethod<typeof getDrawStructures>;
   getDrawTypeCoercion: EngineMethod<typeof getDrawTypeCoercion>;
+  getEffectiveRegistrationProfile: EngineMethod<typeof getEffectiveRegistrationProfile>;
   getEligibleEvents: EngineMethod<typeof getEligibleEvents>;
   getEligibleVoluntaryConsolationParticipants: EngineMethod<typeof getEligibleVoluntaryConsolationParticipants>;
   getEntriesAndSeedsCount: EngineMethod<typeof getEntriesAndSeedsCount>;
@@ -852,6 +857,7 @@ export interface MethodSignatures {
   getEvent: EngineMethod<typeof getEvent>;
   getEventCompleteness: EngineMethod<typeof getEventCompleteness>;
   getEventData: EngineMethod<typeof getEventData>;
+  getEventEntryFees: EngineMethod<typeof getEventEntryFees>;
   getEventInconsistencies: EngineMethod<typeof getEventInconsistencies>;
   getEventMatchUpFormatTiming: EngineMethod<typeof getEventMatchUpFormatTiming>;
   getEventProperties: EngineMethod<typeof getEventProperties>;

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -170,6 +170,14 @@ export interface Event {
    */
   prizeMoneyAwards?: PrizeMoneyAward[];
   /**
+   * Registration windows, fees and entry URL for THIS event, where they differ from the
+   * tournament's. Resolve with `getEffectiveRegistrationProfile`, which merges field by field —
+   * an event that overrides only `entriesClose` still inherits the tournament's `entryUrl`.
+   */
+  registrationProfile?: EventRegistration;
+  /** how this event accepts entries, and how many — see {@link EventEntryProfile} */
+  entryProfile?: EventEntryProfile;
+  /**
    * Event-grain sanction. Grade is genuinely per-event in several federations — one tournament
    * routinely carries different categories for different age groups — mirroring `eventTier`.
    * Where absent, the tournament's `sanction` applies.
@@ -1890,6 +1898,73 @@ export interface RegistrationProfile {
   notes?: string;
   timeItems?: TimeItem[];
 }
+
+/**
+ * Registration facts that genuinely differ between events of the same tournament.
+ *
+ * Deliberately NOT the full {@link RegistrationProfile}. That type carries `accommodation`,
+ * `transportation`, `hospitality`, `sponsors`, `dressCode`, `socialEvents` and `codeOfConduct`,
+ * which are tournament-wide by nature — a tournament does not run one hotel block for the over-35s
+ * and another for the juniors. Putting the full profile on `Event` would ASSERT that all of them
+ * are overridable per event, and would make the field-level cascade unenforceable because most of
+ * its fields can never legitimately differ. Six fields, so the wrong data is inexpressible rather
+ * than merely discouraged.
+ *
+ * Resolve with `getEffectiveRegistrationProfile` — never by reading this directly. See that
+ * function for why the obvious fallback is wrong.
+ */
+export interface EventRegistration {
+  entriesOpen?: Date | string;
+  entriesClose?: Date | string;
+  withdrawalDeadline?: Date | string;
+  /** fees for THIS event; each entry still states its own `unit` — see {@link RegistrationEntryFee} */
+  entryFees?: RegistrationEntryFee[];
+  entryUrl?: string;
+  eligibilityNotes?: string;
+  extensions?: Extension[];
+}
+
+/**
+ * How an event accepts entries, and how many.
+ *
+ * Event-grain for a structural reason rather than a presentational one: events within a single
+ * `tournamentRecord` can carry DIFFERENT SANCTIONING BODIES (`Event.sanction`, and
+ * `eventOtherIds[].isOrigin` at the identity grain), so a limit set by body A must not be expressed
+ * at a grain body B shares.
+ *
+ * There is a second, different question this does NOT answer: what the whole competition can
+ * physically schedule and play, given courts, days and daily match limits. The sum of individually
+ * valid `entriesLimit` values can exceed that. It is an acceptance rule here; feasibility is the
+ * scheduler's to report, and is deliberately not stored — two statements of one fact drift.
+ */
+export interface EventEntryProfile {
+  /** how many entries the event will accept */
+  entriesLimit?: number;
+  /** intended draw size before a `drawDefinition` exists to carry one */
+  targetDrawSize?: number;
+  selectionProcess?: SelectionProcessUnion;
+  /**
+   * WHICH scale orders acceptance — 'WTN', 'NTRP', a federation ranking list.
+   *
+   * `TOP_DOWN_BY_RANKING` alone is under-specified: two events sorting by different scales accept
+   * different players. Organisers currently state this in the tournament TITLE, after an asterisk
+   * ("*top down by ranking", "*top down by WTN"), which is the evidence that it needs a field.
+   */
+  selectionScaleName?: string;
+  wildcardCount?: number;
+  waitlistEnabled?: boolean;
+  extensions?: Extension[];
+}
+
+/** How an event chooses which entries to accept when it is over-subscribed. */
+export enum SelectionProcessEnum {
+  FIRST_COME_FIRST_SERVED = 'FIRST_COME_FIRST_SERVED',
+  TOP_DOWN_BY_RANKING = 'TOP_DOWN_BY_RANKING',
+  TOP_DOWN_BY_RATING = 'TOP_DOWN_BY_RATING',
+  MANUAL = 'MANUAL',
+  LOTTERY = 'LOTTERY',
+}
+export type SelectionProcessUnion = `${SelectionProcessEnum}`;
 
 export interface LogisticsSection {
   notes?: string;


### PR DESCRIPTION
**A2 and A3** — the largest remaining discovery-surface gap. One tournament routinely has divisions closing on different days at different prices, and CODES could state neither.

## A2 — `Event.registrationProfile`, a narrow leaf

An earlier draft proposed reusing the full `RegistrationProfile`, on the grounds that *"a field nobody sets costs nothing"*. **That is false when the type implies a contract.** `RegistrationProfile` carries `accommodation`, `transportation`, `hospitality`, `sponsors`, `dressCode`, `socialEvents`, `codeOfConduct` — a tournament does not run one hotel block for the over-35s and another for the juniors. Putting it on `Event` would *assert* all of those are per-event overridable, and would make the cascade unenforceable because most fields can never legitimately differ.

Six fields: `entriesOpen`, `entriesClose`, `withdrawalDeadline`, `entryFees`, `entryUrl`, `eligibilityNotes`. The wrong data becomes **inexpressible** rather than merely discouraged.

### The cascade is field by field, not object by object

`getEffectiveRegistrationProfile` exists because the obvious implementation is wrong in a way that looks right:

```ts
event.registrationProfile ?? tournamentRecord.registrationProfile
```

An event overriding only `entriesClose` silently loses the tournament's `entryUrl`, `entryFees` and everything else — and it surfaces as a missing registration link on one division, not as an error.

**Verified non-vacuous.** Swapping the naive fallback in turns **three of eleven tests red**, including the one-field-override case. `undefined` does not override (absent = "not stated here"); `null` does (an explicit "nothing").

`getEventEntryFees` resolves which fees apply, most specific first — `eventId` > `category` > `eventType`, unselected = tournament-wide. It returns **only the tier that matched**, since returning all of them would leave the caller to re-derive precedence and get it wrong. A fee keyed to a *different* event is excluded rather than offered as a fallback.

## A3 — `Event.entryProfile`

`entriesLimit`, `targetDrawSize`, `selectionProcess`, `selectionScaleName`, `wildcardCount`, `waitlistEnabled`.

**Event-grain for a structural reason, not a presentational one:** events within one `tournamentRecord` can carry **different sanctioning bodies**, so a limit set by body A must not be expressed at a grain body B shares.

`selectionScaleName` is not decoration — `TOP_DOWN_BY_RANKING` alone is under-specified, since two events sorting by different scales accept different players. The evidence it needs a field is that organisers currently put it in the tournament **title**, after an asterisk:

```
… One Day Tournament Championships *top down by ranking
… NO SPEED LIMIT CLASSIC BG18      *top down by WTN
```

**Deliberately not included:** a tournament-grain aggregate cap. That is a *feasibility ceiling* on what the competition can physically schedule and play, not an *acceptance rule*, and the sum of valid `entriesLimit` values can breach it. The inputs already exist, so storing it would be a second, staler statement of what the schedule already knows. Recorded as concept-only in the spec.

## Schema is load-bearing here

`Event` is `additionalProperties: false`. Without `EventRegistration`, `EventEntryProfile` and `SelectionProcessEnum` being defined **and wired**, any record carrying the new fields would **fail validation**. No dangling `$ref`s.

(This is the narrow, correct case of the wider gap now raised in `TASKS.md` — `#4710`'s twelve sanction types are still absent from the schema, and `Tournament.sanction` is declared `{"type":"object"}`, so `{ decision: 'BANANA' }` validates. That sweep is separate.)

`SelectionProcessEnum` is registered enum-only in `enumConstConformance`. Its values already appear in captured federation records as `selectionProcessConstraints` — the authority's permitted **set**, a different object from the organiser's chosen **value**, and not to be fused with it.

## Verification

`pnpm verify` green — all 15 steps, including `surface` and `pack`. **11,547 tests pass.**