### PR TITLE
fix(participants): correct the getScaleValues return type and unify PAIR naming

### DIFF
--- a/documentation/docs/concepts/participant-context.md
+++ b/documentation/docs/concepts/participant-context.md
@@ -208,14 +208,30 @@ const { participants } = tournamentEngine.getParticipants({
 });
 
 participants.forEach((p) => {
-  if (p.rankings?.SINGLES) {
-    console.log(`${p.person.standardFamilyName}: Rank ${p.rankings.SINGLES.ranking}`);
+  // `rankings.SINGLES` and `ratings.SINGLES` are ARRAYS, with one entry per
+  // distinct scaleName — a participant may hold WTN and UTR and NTRP at once.
+  // Address entries by `scaleName`, never by position: the set of scales is
+  // open, so the array has no canonical order and index [0] is only the scale
+  // you want for as long as it is the only one present.
+  const ranking = p.rankings?.SINGLES?.find(({ scaleName }) => scaleName === 'U18');
+  if (ranking) {
+    console.log(`${p.person.standardFamilyName}: Rank ${ranking.scaleValue}`);
   }
-  if (p.ratings?.SINGLES) {
-    console.log(`  Rating: ${p.ratings.SINGLES.rating}`);
+
+  // Each entry is `{ scaleName, scaleDate, scaleValue }`. For a multi-property
+  // scale, `scaleValue` is an object — WTN carries `wtnRating` and `confidence`.
+  // `scaleDate` reflects the timeItem's `itemDate` and may be undefined.
+  const rating = p.ratings?.SINGLES?.find(({ scaleName }) => scaleName === 'WTN');
+  if (rating) {
+    console.log(`  Rating: ${rating.scaleValue.wtnRating}, confidence ${rating.scaleValue.confidence}`);
   }
 });
 ```
+
+:::note
+`scaleName` may carry a modifier suffix (`WTN.<modifier>`), so match with
+`startsWith` where modifiers are in play.
+:::
 
 **Converts timeItems like:**
 

--- a/documentation/docs/governors/participant-governor.md
+++ b/documentation/docs/governors/participant-governor.md
@@ -435,16 +435,38 @@ const {
 
 ## getScaleValues
 
-Returns all scale values (rankings/ratings) for participants.
+Resolves one participant's scale timeItems into ratings, rankings and seedings.
 
 ```js
-const { scaleValues } = engine.getScaleValues({
-  tournamentRecord, // required
-  scaleAttributes, // optional - filter to specific scale
+const { ratings, rankings, seedings } = engine.getScaleValues({
+  participant, // required
 });
 ```
 
-**Purpose:** Get all ratings/rankings across all participants.
+Each of `ratings` / `rankings` / `seedings` is keyed by event type
+(`SINGLES`, `DOUBLES`, `TEAM`), and **each event type holds an ARRAY** with one
+entry per distinct `scaleName` — a participant may hold WTN and UTR at once:
+
+```js
+// { scaleName, scaleDate, scaleValue }
+const wtn = ratings.SINGLES?.find(({ scaleName }) => scaleName === 'WTN');
+const rating = wtn?.scaleValue?.wtnRating;
+```
+
+Within a single `scaleName` the entry is the **latest** value, so "current" is
+resolved for you. Across scale names nothing is: the set of rating and ranking
+scales is open — any number of scales, from any number of bodies, including ones
+not yet invented — so the array has no canonical order and never will.
+
+:::warning
+**Address entries by `scaleName`, never by index.** `ratings.SINGLES[0]` is the
+scale you want only for as long as it is the only one present; the day a second
+appears, `[0]` returns a different rating system's number in the same shape and
+nothing throws.
+:::
+
+**Purpose:** Read a participant's current value for a given scale, with the date
+it was recorded.
 
 ---
 
@@ -491,7 +513,11 @@ A supplied `participantName` can be superseded by a derived one — from `person
 
 ```js
 const result = engine.modifyParticipant({
-  participant: { participantId, participantName: 'Ignored', person: { standardGivenName: 'Roger', standardFamilyName: 'Federer' } },
+  participant: {
+    participantId,
+    participantName: 'Ignored',
+    person: { standardGivenName: 'Roger', standardFamilyName: 'Federer' },
+  },
 });
 // result.success → true
 // result.info    → PARTICIPANT_NAME_DERIVED_FROM_PERSON

--- a/src/assemblies/generators/tournamentRecords/anonymizeTournamentRecord.ts
+++ b/src/assemblies/generators/tournamentRecords/anonymizeTournamentRecord.ts
@@ -1,3 +1,4 @@
+import { generatePairParticipantName } from '@Functions/participants/generatePairParticipantName';
 import { postalCodeMocks, stateMocks, cityMocks } from '../mocks/address';
 import { extractDate, formatDate } from '@Tools/dateTime';
 import { generatePersons } from '../mocks/generatePersons';
@@ -464,16 +465,4 @@ function anonymizeExtensionIds({ tournamentRecord, idMap }) {
       request.personId = idMap[request.personId];
     });
   }
-}
-
-function generatePairParticipantName({ individualParticipantIds, individualParticipants }) {
-  let participantName = individualParticipants
-    .filter(({ participantId }) => individualParticipantIds.includes(participantId))
-    .map((p) => p.person?.standardFamilyName || p.participantOtherName || p.participantName || '')
-    .filter(Boolean)
-    .sort()
-    .join('/');
-
-  if (individualParticipantIds.length === 1) participantName += '/Unknown';
-  return participantName;
 }

--- a/src/functions/participants/generatePairParticipantName.ts
+++ b/src/functions/participants/generatePairParticipantName.ts
@@ -1,0 +1,97 @@
+import { isFemale } from '@Validators/isFemale';
+import { isMale } from '@Validators/isMale';
+
+type PairNameMember = {
+  participantOtherName?: string;
+  participantName?: string;
+  participantId?: string;
+  person?: { standardFamilyName?: string; sex?: string } & Record<string, any>;
+} & Record<string, any>;
+
+type GeneratePairParticipantNameArgs = {
+  individualParticipantIds?: string[];
+  individualParticipants?: PairNameMember[];
+};
+
+// Pinned to 'en' rather than the runtime default. An unqualified
+// localeCompare resolves against the host locale, so the same pair would be
+// named differently on a server in Stockholm than in New York — and the
+// difference is invisible until a name reorders in production.
+const collator = new Intl.Collator('en');
+
+// Which surname a member contributes. `standardFamilyName` first because the
+// convention is a surname convention; the alternates exist for members that
+// carry no person record.
+function memberName(member: PairNameMember): string {
+  return member?.person?.standardFamilyName || member?.participantOtherName || member?.participantName || '';
+}
+
+/**
+ * Generate the display name for a PAIR participant.
+ *
+ * **The result is display text, not an identifier.** It is a rendering of the
+ * pair's members and nothing may parse it to recover them — members are
+ * addressed through `individualParticipantIds`. Two orderings of the same pair
+ * are both correct, which is precisely why the order must not be load-bearing.
+ *
+ * Ordering follows the convention the sport actually uses:
+ *
+ * - **Same-sex pairs are alphabetical by surname.** Verified across a full
+ *   Grand Slam seeding (32/32 men's and women's teams), and it is alphabetical
+ *   rather than ranking-based — an Olympic draw lists `Alcaraz / Nadal` and
+ *   `Evans / Murray` though every report led with Nadal and with Murray.
+ * - **Mixed pairs list the woman first**, which overrides alphabetical:
+ *   `Świątek / Ruud`, `Pegula / Draper`, `Rybakina / Fritz`.
+ *
+ * Neither rule is codified by any governing body — the 2026 WTA Rulebook uses
+ * "alphabetical" only for ranking tie-breaks — so it is encoded here
+ * deliberately rather than inherited from whatever a `.sort()` happened to do.
+ *
+ * "Mixed" is derived from the members' own `person.sex`, not from an event's
+ * gender: a PAIR is a tournament-level participant that may be entered in
+ * several events, so the pair itself is the only reliable source. Anything
+ * other than exactly one male and one female — a missing sex, `OTHER`, a
+ * single member — falls back to alphabetical.
+ */
+export function generatePairParticipantName({
+  individualParticipantIds,
+  individualParticipants,
+}: GeneratePairParticipantNameArgs): string {
+  const members = (individualParticipants ?? []).filter((member) => {
+    if (!Array.isArray(individualParticipantIds)) return true;
+    const participantId = member?.participantId;
+    return typeof participantId === 'string' && individualParticipantIds.includes(participantId);
+  });
+
+  const named = members.filter((member) => !!memberName(member));
+
+  const ordered = orderMembers(named);
+  let participantName = ordered.map(memberName).join('/');
+
+  // Fewer than two contributing names means the partner is not known. Guard on
+  // the names actually produced rather than on the id count: two ids where one
+  // resolves to nothing is the same situation as one id, and previously the
+  // two write paths disagreed about which of those they measured.
+  if (ordered.length === 1) participantName += '/Unknown';
+
+  return participantName;
+}
+
+function orderMembers(members: PairNameMember[]): PairNameMember[] {
+  if (members.length !== 2) return alphabetical(members);
+
+  const [a, b] = members;
+  const aFemale = isFemale(a?.person?.sex);
+  const bFemale = isFemale(b?.person?.sex);
+  const aMale = isMale(a?.person?.sex);
+  const bMale = isMale(b?.person?.sex);
+
+  if (aFemale && bMale) return [a, b];
+  if (bFemale && aMale) return [b, a];
+
+  return alphabetical(members);
+}
+
+function alphabetical(members: PairNameMember[]): PairNameMember[] {
+  return [...members].sort((a, b) => collator.compare(memberName(a), memberName(b)));
+}

--- a/src/functions/participants/generatePairParticipantName.ts
+++ b/src/functions/participants/generatePairParticipantName.ts
@@ -57,10 +57,14 @@ export function generatePairParticipantName({
   individualParticipantIds,
   individualParticipants,
 }: GeneratePairParticipantNameArgs): string {
+  // Set rather than Array#includes for the membership test, per the standards:
+  // built once here instead of re-scanned per member.
+  const memberIds = Array.isArray(individualParticipantIds) ? new Set(individualParticipantIds) : undefined;
+
   const members = (individualParticipants ?? []).filter((member) => {
-    if (!Array.isArray(individualParticipantIds)) return true;
+    if (!memberIds) return true;
     const participantId = member?.participantId;
-    return typeof participantId === 'string' && individualParticipantIds.includes(participantId);
+    return typeof participantId === 'string' && memberIds.has(participantId);
   });
 
   const named = members.filter((member) => !!memberName(member));

--- a/src/mutate/participants/addParticipant.ts
+++ b/src/mutate/participants/addParticipant.ts
@@ -1,3 +1,4 @@
+import { generatePairParticipantName } from '@Functions/participants/generatePairParticipantName';
 import { decorateResult } from '@Functions/global/decorateResult';
 import { definedAttributes } from '@Tools/definedAttributes';
 import { normalizeGender } from '@Helpers/coercedGender';
@@ -130,13 +131,7 @@ function validatePairParticipant({
       participant.individualParticipantIds?.includes(tp.participantId),
     );
 
-    let participantName = individualParticipants
-      .map((p) => p.person?.standardFamilyName || p.participantOtherName || p.participantName || '')
-      .filter(Boolean)
-      .join('/');
-    if (individualParticipants.length === 1) participantName += '/Unknown';
-
-    participant.participantName = participantName;
+    participant.participantName = generatePairParticipantName({ individualParticipants });
   }
 
   return undefined;

--- a/src/mutate/participants/modifyParticipant.ts
+++ b/src/mutate/participants/modifyParticipant.ts
@@ -1,3 +1,4 @@
+import { generatePairParticipantName } from '@Functions/participants/generatePairParticipantName';
 import { findTournamentParticipant } from '@Acquire/findTournamentParticipant';
 import { addIndividualParticipantIds } from './addIndividualParticipantIds';
 import { getParticipants } from '@Query/participants/getParticipants';
@@ -173,23 +174,10 @@ function updateIndividualParticipantIds({
 
   if (existingParticipant.participantType === participantTypes.PAIR && updateParticipantName) {
     newValues.participantName = generatePairParticipantName({
+      individualParticipantIds: newValues.individualParticipantIds,
       individualParticipants,
-      newValues,
     });
   }
-}
-
-function generatePairParticipantName({ individualParticipants, newValues }) {
-  const individualParticipantIds = newValues.individualParticipantIds;
-  let participantName = individualParticipants
-    .filter(({ participantId }) => individualParticipantIds.includes(participantId))
-    .map((p) => p.person?.standardFamilyName || p.participantOtherName || p.participantName || '')
-    .filter(Boolean)
-    .sort()
-    .join('/');
-
-  if (individualParticipantIds.length === 1) participantName += '/Unknown';
-  return participantName;
 }
 
 // An explicit empty string means "clear this field". `undefined` must keep meaning "leave

--- a/src/query/participant/getScaleValues.ts
+++ b/src/query/participant/getScaleValues.ts
@@ -8,15 +8,47 @@ import { PARTICIPANT } from '@Constants/attributeConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 import { ResultType } from '@Types/factoryTypes';
 
-type ScaleType = {
+export type ScaleType = {
   scaleName: string;
   scaleDate: string;
   scaleValue: any;
 };
-type ScalesType = {
-  [SINGLES_EVENT]?: ScaleType;
-  [DOUBLES_EVENT]?: ScaleType;
-  [TEAM_EVENT]?: ScaleType;
+
+/**
+ * Scale entries for one participant, grouped by event type.
+ *
+ * **Each event type holds an ARRAY with one entry per distinct `scaleName`** —
+ * a participant may carry WTN and UTR and NTRP simultaneously. Within a single
+ * `scaleName` the entry is the latest value (see `latestScaleItem` below), so
+ * "current" is resolved for you; across scale names nothing is.
+ *
+ * **The array has no canonical order, and never will.** The set of rating and
+ * ranking scales is open — any number of scales, from any number of bodies,
+ * including ones not yet invented — so there is no position to assign. Entries
+ * land in first-appearance order across the participant's `timeItems`, which is
+ * an artefact of iteration and not a contract.
+ *
+ * So **address entries by `scaleName`, never by position**:
+ *
+ * ```ts
+ * // WRONG — [0] is only WTN while WTN is the sole scale present
+ * const wtn = ratings.SINGLES[0].scaleValue.wtnRating;
+ *
+ * // RIGHT — see getDetailsWTN for this pattern in use
+ * const entry = ratings.SINGLES?.find(({ scaleName }) => scaleName === WTN);
+ * ```
+ *
+ * Note that `scaleName` may carry a modifier suffix (`WTN.<modifier>`), built
+ * below from the `itemType` segments — match accordingly where modifiers are in
+ * play.
+ *
+ * This type previously declared a single `ScaleType` per event type while the
+ * implementation built arrays, so anything typed against it read `undefined`.
+ */
+export type ScalesType = {
+  [SINGLES_EVENT]?: ScaleType[];
+  [DOUBLES_EVENT]?: ScaleType[];
+  [TEAM_EVENT]?: ScaleType[];
 };
 
 type ScaleTypes = {

--- a/src/tests/functions/generatePairParticipantName.test.ts
+++ b/src/tests/functions/generatePairParticipantName.test.ts
@@ -1,0 +1,168 @@
+import { generatePairParticipantName } from '@Functions/participants/generatePairParticipantName';
+import { describe, it, expect } from 'vitest';
+
+// constants
+import { FEMALE, MALE, OTHER } from '@Constants/genderConstants';
+
+const member = (participantId: string, standardFamilyName: string, sex?: string) => ({
+  person: { standardFamilyName, ...(sex ? { sex } : {}) },
+  participantId,
+});
+
+describe('same-sex pairs are alphabetical by surname', () => {
+  it('orders two surnames alphabetically regardless of the order supplied', () => {
+    const individualParticipants = [member('p1', 'Salisbury', MALE), member('p2', 'Cash', MALE)];
+
+    expect(generatePairParticipantName({ individualParticipants })).toEqual('Cash/Salisbury');
+
+    // reversing the input must not change the output — that is the whole point
+    expect(generatePairParticipantName({ individualParticipants: individualParticipants.toReversed() })).toEqual(
+      'Cash/Salisbury',
+    );
+  });
+
+  it('is alphabetical rather than ranking- or seniority-based', () => {
+    // The Olympic draw lists these alphabetically though every report led with
+    // Nadal and with Murray. Encoded here so the convention is not "fixed" later.
+    expect(
+      generatePairParticipantName({
+        individualParticipants: [member('p1', 'Nadal', MALE), member('p2', 'Alcaraz', MALE)],
+      }),
+    ).toEqual('Alcaraz/Nadal');
+
+    expect(
+      generatePairParticipantName({
+        individualParticipants: [member('p1', 'Murray', MALE), member('p2', 'Evans', MALE)],
+      }),
+    ).toEqual('Evans/Murray');
+  });
+});
+
+describe('collation is locale-aware, not code-unit order', () => {
+  // A bare `.sort()` compares UTF-16 code units, which files every diacritic
+  // after `z`. Both of these came back reversed before the shared generator.
+  it.each([
+    { a: 'Göransson', b: 'Granollers', expectation: 'Göransson/Granollers' },
+    { a: 'Öberg', b: 'Olsson', expectation: 'Öberg/Olsson' },
+  ])('orders $a and $b as $expectation', ({ a, b, expectation }) => {
+    expect(
+      generatePairParticipantName({ individualParticipants: [member('p1', a, MALE), member('p2', b, MALE)] }),
+    ).toEqual(expectation);
+
+    // and a bare sort would NOT produce it — pins why the collator is there
+    expect([a, b].sort().join('/')).not.toEqual(expectation);
+  });
+
+  it('does not disturb pairs a bare sort already ordered correctly', () => {
+    expect(
+      generatePairParticipantName({
+        individualParticipants: [member('p1', 'Mektić', MALE), member('p2', 'Melo', MALE)],
+      }),
+    ).toEqual('Mektić/Melo');
+  });
+});
+
+describe('mixed pairs list the woman first, overriding alphabetical', () => {
+  it.each([
+    { woman: 'Świątek', man: 'Ruud' },
+    { woman: 'Pegula', man: 'Draper' },
+    { woman: 'Rybakina', man: 'Fritz' },
+    { woman: 'Raducanu', man: 'Alcaraz' },
+  ])('lists $woman before $man though alphabetical would not', ({ woman, man }) => {
+    const individualParticipants = [member('p1', man, MALE), member('p2', woman, FEMALE)];
+
+    expect(generatePairParticipantName({ individualParticipants })).toEqual(`${woman}/${man}`);
+
+    // each of these is a real break of alphabetical, which is what makes it a test
+    expect([woman, man].sort((a, b) => a.localeCompare(b, 'en')).join('/')).not.toEqual(`${woman}/${man}`);
+  });
+
+  it('still lists the woman first when she is also alphabetically first', () => {
+    expect(
+      generatePairParticipantName({
+        individualParticipants: [member('p1', 'Errani', FEMALE), member('p2', 'Vavassori', MALE)],
+      }),
+    ).toEqual('Errani/Vavassori');
+  });
+
+  it('accepts the abbreviated sex values', () => {
+    expect(
+      generatePairParticipantName({
+        individualParticipants: [member('p1', 'Ruud', 'M'), member('p2', 'Świątek', 'F')],
+      }),
+    ).toEqual('Świątek/Ruud');
+  });
+});
+
+describe('falls back to alphabetical when a pair is not male/female', () => {
+  it.each([
+    { label: 'sex absent on both', a: undefined, b: undefined },
+    { label: 'sex absent on one', a: MALE, b: undefined },
+    { label: 'OTHER is present', a: OTHER, b: MALE },
+    { label: 'both female', a: FEMALE, b: FEMALE },
+    { label: 'both male', a: MALE, b: MALE },
+  ])('$label', ({ a, b }) => {
+    expect(
+      generatePairParticipantName({
+        individualParticipants: [member('p1', 'Zeballos', a), member('p2', 'Granollers', b)],
+      }),
+    ).toEqual('Granollers/Zeballos');
+  });
+});
+
+describe('member resolution', () => {
+  it('filters to individualParticipantIds when supplied', () => {
+    const individualParticipants = [
+      member('p1', 'Cash', MALE),
+      member('p2', 'Glasspool', MALE),
+      member('p3', 'Salisbury', MALE),
+    ];
+
+    expect(generatePairParticipantName({ individualParticipantIds: ['p1', 'p3'], individualParticipants })).toEqual(
+      'Cash/Salisbury',
+    );
+  });
+
+  it('ignores ids that resolve to no member', () => {
+    expect(
+      generatePairParticipantName({
+        individualParticipantIds: ['p1', 'missing'],
+        individualParticipants: [member('p1', 'Cash', MALE)],
+      }),
+    ).toEqual('Cash/Unknown');
+  });
+
+  it('appends /Unknown for a single member', () => {
+    expect(generatePairParticipantName({ individualParticipants: [member('p1', 'Cash', MALE)] })).toEqual(
+      'Cash/Unknown',
+    );
+  });
+
+  it('returns an empty string when no member contributes a name', () => {
+    expect(generatePairParticipantName({ individualParticipants: [] })).toEqual('');
+    expect(generatePairParticipantName({})).toEqual('');
+    expect(generatePairParticipantName({ individualParticipants: [{ participantId: 'p1' }] })).toEqual('');
+  });
+
+  it('falls back through participantOtherName then participantName', () => {
+    expect(
+      generatePairParticipantName({
+        individualParticipants: [
+          { participantId: 'p1', participantOtherName: 'Cash' },
+          { participantId: 'p2', participantName: 'Glasspool' },
+        ],
+      }),
+    ).toEqual('Cash/Glasspool');
+  });
+
+  it('prefers standardFamilyName over the alternates', () => {
+    expect(
+      generatePairParticipantName({
+        individualParticipants: [
+          { participantId: 'p1', participantOtherName: 'Zeballos', person: { standardFamilyName: 'Cash' } },
+          { participantId: 'p2', participantName: 'Glasspool' },
+        ],
+      }),
+    ).toEqual('Cash/Glasspool');
+  });
+});

--- a/src/tests/functions/generatePairParticipantName.test.ts
+++ b/src/tests/functions/generatePairParticipantName.test.ts
@@ -49,8 +49,14 @@ describe('collation is locale-aware, not code-unit order', () => {
       generatePairParticipantName({ individualParticipants: [member('p1', a, MALE), member('p2', b, MALE)] }),
     ).toEqual(expectation);
 
-    // and a bare sort would NOT produce it — pins why the collator is there
-    expect([a, b].sort().join('/')).not.toEqual(expectation);
+    // and UTF-16 code-unit order would NOT produce it — pins why the collator
+    // is there. Spelled as an explicit comparator rather than a bare `.sort()`,
+    // which the standards forbid even when demonstrating its behaviour.
+    const codeUnitOrder = (x: string, y: string) => {
+      if (x < y) return -1;
+      return x > y ? 1 : 0;
+    };
+    expect([a, b].sort(codeUnitOrder).join('/')).not.toEqual(expectation);
   });
 
   it('does not disturb pairs a bare sort already ordered correctly', () => {

--- a/src/tests/mutations/participants/pairNameStability.test.ts
+++ b/src/tests/mutations/participants/pairNameStability.test.ts
@@ -1,0 +1,87 @@
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { describe, it, expect } from 'vitest';
+
+// constants
+import { INDIVIDUAL, PAIR } from '@Constants/participantConstants';
+import { FEMALE, MALE } from '@Constants/genderConstants';
+import { COMPETITOR } from '@Constants/participantRoles';
+
+const individual = (participantId: string, standardFamilyName: string, sex: string) => ({
+  person: { standardFamilyName, standardGivenName: 'Test', sex },
+  participantRole: COMPETITOR,
+  participantType: INDIVIDUAL,
+  participantId,
+});
+
+function setup(members: any[]) {
+  const { tournamentRecord } = mocksEngine.generateTournamentRecord({ setState: true });
+  tournamentEngine.setState(tournamentRecord);
+
+  const result = tournamentEngine.addParticipants({ participants: members });
+  expect(result.success).toEqual(true);
+
+  return { tournamentId: tournamentRecord.tournamentId };
+}
+
+function pairNameFor(individualParticipantIds: string[]) {
+  const added = tournamentEngine.addParticipants({
+    participants: [{ participantType: PAIR, participantRole: COMPETITOR, individualParticipantIds }],
+  });
+  expect(added.success).toEqual(true);
+
+  const { participants } = tournamentEngine.getParticipants({
+    participantFilters: { participantTypes: [PAIR] },
+  });
+  const pair = participants.find((p: any) => p.individualParticipantIds?.length === 2);
+
+  return { pair, participantId: pair.participantId };
+}
+
+describe('a PAIR name does not reorder after an unrelated edit', () => {
+  it('creation and modification agree, even when array order is not alphabetical', () => {
+    // Added deliberately out of alphabetical order. Creation used to name the
+    // pair from the tournament participants ARRAY order while modification
+    // sorted, so these two paths disagreed and the name flipped on any edit.
+    setup([individual('p1', 'Zeballos', MALE), individual('p2', 'Granollers', MALE)]);
+
+    const { pair, participantId } = pairNameFor(['p1', 'p2']);
+    const nameAtCreation = pair.participantName;
+
+    expect(nameAtCreation).toEqual('Granollers/Zeballos');
+
+    // an edit that says nothing about the members
+    const modified = tournamentEngine.modifyParticipant({
+      participant: { participantId, participantType: PAIR, individualParticipantIds: ['p1', 'p2'] },
+    });
+    expect(modified.success).toEqual(true);
+
+    const { participants } = tournamentEngine.getParticipants({
+      participantFilters: { participantTypes: [PAIR] },
+    });
+    const after = participants.find((p: any) => p.participantId === participantId);
+
+    expect(after.participantName).toEqual(nameAtCreation);
+  });
+
+  it('holds for a mixed pair, where the convention is woman-first rather than alphabetical', () => {
+    setup([individual('p1', 'Ruud', MALE), individual('p2', 'Swiatek', FEMALE)]);
+
+    const { pair, participantId } = pairNameFor(['p1', 'p2']);
+
+    // alphabetical would be Ruud/Swiatek — the mixed convention inverts it
+    expect(pair.participantName).toEqual('Swiatek/Ruud');
+
+    const modified = tournamentEngine.modifyParticipant({
+      participant: { participantId, participantType: PAIR, individualParticipantIds: ['p1', 'p2'] },
+    });
+    expect(modified.success).toEqual(true);
+
+    const { participants } = tournamentEngine.getParticipants({
+      participantFilters: { participantTypes: [PAIR] },
+    });
+    const after = participants.find((p: any) => p.participantId === participantId);
+
+    expect(after.participantName).toEqual('Swiatek/Ruud');
+  });
+});


### PR DESCRIPTION
Two fixes found by an external consumer reading our published output — neither is visible from inside a single write path.

## 1. `getScaleValues` declared a return type its implementation never produced

`ScalesType` declared `{ SINGLES?: ScaleType }` — a single object per event type — while the implementation built `ScaleType[]`. The published `.d.ts` therefore described a shape the function never returns, so anything typed against it compiled clean and read `undefined`.

Now declares the arrays, exports the types, and documents why the array has no canonical order: the set of rating and ranking scales is **open** — any number of scales, from any number of bodies, including ones not yet invented — so there is no position to assign. Entries are addressed by `scaleName`, never by index.

Verified where it matters: `dist/tods-competition-factory.d.ts` now ships `[SINGLES_EVENT]?: ScaleType[]`.

**Not changed: the array shape itself.** An unordered array is the honest representation of an open set, and a `scaleName`-keyed map would be worse — `scaleName` is itself open and carries modifier suffixes. Indexing `[0]` is a consumer error, not a library one.

## 2. PAIR `participantName` was generated by three functions that disagreed

| site | ordered by | sorted? |
|---|---|---|
| `addParticipant` | the tournament participants **array** | no |
| `modifyParticipant` | `individualParticipantIds` | yes |
| `anonymizeTournamentRecord` | `individualParticipantIds` | yes |

So a pair's name could reorder itself after an edit that never touched the pair. All three now use `src/functions/participants/generatePairParticipantName.ts`, which follows the convention the sport actually uses:

- **Same-sex pairs: alphabetical by surname.** Via a collator pinned to `'en'`. The previous bare `.sort()` compared UTF-16 code units, filing every diacritic after `z` — `Göransson`/`Granollers` came back reversed, and tennis surnames carry diacritics constantly. An unqualified `localeCompare` would resolve against the *host* locale, naming the same pair differently in Stockholm than in New York.
- **Mixed pairs: the woman is listed first**, overriding alphabetical.

"Mixed" is derived from the members' own `person.sex` rather than an event's gender, because a PAIR is a tournament-level participant that may be entered in several events. Anything other than exactly one male and one female falls back to alphabetical.

Neither rule is codified by any governing body, so it is encoded deliberately rather than inherited from whatever a sort happened to do.

`participantName` remains **display text, not an identifier** — members are addressed through `individualParticipantIds`. Two orderings of a pair are both correct, which is exactly why the order must not be load-bearing.

## Verification

- `pnpm verify` green — all 15 stages, including publint, bundle-size, surface and pack.
- 11,570 tests pass (+24). Coverage 95.34 / 87.18 / 98.07 / 97.79; the new generator is 100% on all four metrics.
- **The regression tests were confirmed to fail against the old code.** Reverting `addParticipant.ts` alone yields `Zeballos/Granollers` (array order) and `Ruud/Swiatek` (blind alphabetical) — exactly the two wrong behaviours.
- Swept every consumer repo for `[0]` indexing into a scale array: none. TMX's `extractRating.ts` already documents `participant.ratings.SINGLES[]` as an array, so the corrected type matches what it assumed.

## Follow-on, deliberately not included

`src/functions/sorters/stringSort.ts` calls `localeCompare` with no locale, carrying the same host-locale non-determinism. Wide blast radius and many callers, so it wants its own pass.