### PR TITLE
fix(sorters): pin stringSort's collator so ordering does not depend on the host

### DIFF
--- a/src/functions/sorters/stringSort.ts
+++ b/src/functions/sorters/stringSort.ts
@@ -1,3 +1,21 @@
+// Pinned to 'en'. An unqualified `localeCompare` resolves against the HOST's
+// default locale, and locales genuinely disagree about where accented
+// characters belong: Swedish, Finnish and Danish collation sort ö/ä/å AFTER z,
+// while English sorts them with o/a. So the same data sorted on a server in
+// Stockholm came out in a different order than in New York, with nothing in the
+// code to point at.
+//
+// No behaviour change for the current callers, which sort ASCII identifiers and
+// enum constants — participantId and matchUpId pair keys, collectionIds, gender
+// constants — where every locale agrees. The pin closes a trap rather than
+// fixing a live defect: a helper named `stringSort` invites use on human names,
+// and tennis surnames carry diacritics constantly.
+//
+// That the ordering was undetermined is visible in this function's own tests,
+// which fed it 'café'/'cafe'/'cafè' and 'ñ'/'n'/'o' and could only assert that
+// the result had three elements. They assert the order now.
+const collator = new Intl.Collator('en');
+
 export function stringSort(a, b) {
-  return (a || '').localeCompare(b || '');
+  return collator.compare(a || '', b || '');
 }

--- a/src/tests/functions/sorters/stringSort.test.ts
+++ b/src/tests/functions/sorters/stringSort.test.ts
@@ -64,8 +64,9 @@ describe('stringSort', () => {
   it('handles unicode characters', () => {
     const arr = ['ñ', 'n', 'o'];
     arr.sort(stringSort);
-    // Depends on locale, but should not throw
-    expect(arr).toHaveLength(3);
+    // Order is now determined: the collator is pinned to 'en', which sorts ñ
+    // with n rather than after z the way a Scandinavian locale would.
+    expect(arr).toEqual(['n', 'ñ', 'o']);
   });
 
   it('handles emoji', () => {
@@ -119,13 +120,38 @@ describe('stringSort', () => {
   it('handles strings with accented characters', () => {
     const arr = ['café', 'cafe', 'cafè'];
     arr.sort(stringSort);
-    expect(arr).toHaveLength(3);
+    expect(arr).toEqual(['cafe', 'café', 'cafè']);
   });
 
   it('handles strings with diacritics', () => {
     const arr = ['naïve', 'naive'];
     arr.sort(stringSort);
-    expect(arr).toHaveLength(2);
+    expect(arr).toEqual(['naive', 'naïve']);
+  });
+
+  it('is deterministic across host locales', () => {
+    // The regression this pin exists for: Scandinavian collation files ö/ä/å
+    // after z, English sorts them with o/a. Before the pin, which of these two
+    // orderings you got depended on the machine.
+    const arr = ['Öberg', 'Olsson', 'Zeballos', 'Ärnold'];
+    arr.sort(stringSort);
+    expect(arr).toEqual(['Ärnold', 'Öberg', 'Olsson', 'Zeballos']);
+
+    // and the host-default comparator is NOT guaranteed to agree with it
+    const swedish = [...arr].sort((a, b) => a.localeCompare(b, 'sv'));
+    expect(swedish).toEqual(['Olsson', 'Zeballos', 'Ärnold', 'Öberg']);
+  });
+
+  it('is unchanged for the ASCII identifiers its callers actually sort', () => {
+    // All production callers sort participantId/matchUpId pair keys,
+    // collectionIds and gender constants — every locale agrees on these, which
+    // is why pinning is a no-op at runtime.
+    const ids = ['p9', 'p10', 'p1', 'MALE', 'FEMALE'];
+    const codeUnitOrder = (a: string, b: string) => {
+      if (a < b) return -1;
+      return a > b ? 1 : 0;
+    };
+    expect([...ids].sort(stringSort)).toEqual([...ids].sort(codeUnitOrder));
   });
 
   it('handles empty array', () => {


### PR DESCRIPTION
Follow-on from #4730, which flagged this and deliberately left it out.

## The defect

```ts
export function stringSort(a, b) {
  return (a || '').localeCompare(b || '');
}
```

`localeCompare` with no locale resolves against the **host's** default, and locales genuinely disagree about where accented characters belong — Swedish, Finnish and Danish collation sort `ö`/`ä`/`å` **after** `z`, while English sorts them with `o`/`a`. Measured on the same four names:

| locale | result |
|---|---|
| `en`, `de` | `Ärnold < Öberg < Olsson < Zeballos` |
| `sv`, `fi`, `da` | `Olsson < Zeballos < Ärnold < Öberg` |

Same data, a different answer per machine, and nothing in the code to point at.

## The evidence it was undetermined is in its own test file

Three existing tests fed it `'café'`/`'cafe'`/`'cafè'`, `'ñ'`/`'n'`/`'o'` and `'naïve'`/`'naive'` — and could only assert `toHaveLength(3)`, with a comment reading *"Depends on locale, but should not throw"*. The ordering, which is the entire point of a sort function, was not assertable.

**Those three now assert order**, plus two new tests: one pinning the en-vs-sv divergence as a regression, one pinning the ASCII no-op below.

## No runtime change for any current caller

All four production call sites sort ASCII identifiers or enum constants, where every locale agrees:

| site | sorts |
|---|---|
| `drawMatic/generateCandidate.ts:208` | `participantId` pair key |
| `getParticipantEntries.ts:878` | `matchUpId` pair key |
| `compareTieFormats.ts:129` | `collectionIds` |
| `addEventEntryPairs.ts:89` | gender constants |

A test now pins that equivalence, so it is checked rather than asserted.

## Why do it, then

This closes a trap rather than fixing a live defect. A helper named `stringSort` invites use on human names, and tennis surnames carry diacritics constantly — the next caller would have inherited silent per-host ordering. That is exactly the bug class #4730 fixed in PAIR naming.

**No performance argument either way.** I expected a cached collator to be faster and measured the opposite: bare `localeCompare` came out slightly ahead on ASCII. Both are far from any hot path here. Determinism is the whole reason for the change.

## Verification

`pnpm verify` green — all 15 stages. 11,548 tests pass.