### PR TITLE
fix(scales): keep the ratings governor attached through tree shaking

### DIFF
--- a/scripts/verify/runtime.mjs
+++ b/scripts/verify/runtime.mjs
@@ -9,12 +9,22 @@
  * The CJS path imports the dist via require('./tods-competition-factory.development.cjs.js').
  * The ESM path imports via import statements against dist/esm/index.mjs.
  *
+ * A third, BUNDLED pass then re-runs an ESM consumer through esbuild with tree
+ * shaking on. That is not redundant with the ESM pass: Node evaluates every
+ * module in the graph, so an engine whose methods are attached by a module
+ * side effect always looks complete there. A bundler is allowed to drop a
+ * module whose exports nobody uses — and with `"sideEffects": false` in
+ * package.json, it will — so the bundled pass is the only one that sees what
+ * a consumer's production build actually ships. See `bundledChecks` below.
+ *
  * No npm install required — we point Node directly at the dist files.
  */
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { execSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+import { build } from 'esbuild';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FACTORY_ROOT = resolve(__dirname, '../..');
@@ -110,4 +120,77 @@ try {
   fail('ESM smoke failed', err);
 }
 
-log('OK — CJS + ESM dists both load and behave as expected');
+// --- Bundled (tree-shaken) ESM smoke ---
+//
+// Every engine below is assembled by MUTATING a shared singleton — `importMethods`
+// bolts governor methods onto the one `syncEngine` object — so an engine's method
+// surface depends on its module having been EVALUATED, not merely resolved. Any
+// module that reaches a consumer as a bare `import './x.mjs'` is fair game for
+// elimination under `"sideEffects": false`, and the loss is silent: the engine still
+// arrives, still has `setState`, and only fails at the call site with
+// `<method> is not a function` — in production builds only, since dev servers do not
+// shake. That is exactly how `scaleEngine.generateDynamicRatings` reached production.
+//
+// Add a row here whenever a new engine is assembled by side effect.
+const bundledChecks = [
+  // The regression this exists for: `scaleEngine` is the shared `syncEngine` with the
+  // ranking + ratings governors attached, and a pure re-export let the bundler drop the
+  // module that attaches them.
+  {
+    engine: 'scaleEngine',
+    methods: ['setState', 'generateDynamicRatings', 'calculateNewRatings', 'generateRankingList'],
+  },
+  { engine: 'tournamentEngine', methods: ['setState', 'getTournament', 'addEvent'] },
+  { engine: 'competitionEngine', methods: ['setState', 'getCompetitionMatchUps'] },
+  { engine: 'tournamentEngineAsync', methods: ['setState', 'getTournament', 'addEvent'] },
+  { engine: 'askEngine', methods: ['setState', 'getTournament'] },
+  { engine: 'matchUpEngine', methods: ['setState', 'analyzeScore', 'isValidMatchUpFormat'] },
+  { engine: 'mocksEngine', methods: ['generateTournamentRecord'] },
+];
+
+log('BUNDLED: esbuild tree-shaken consumer smoke…');
+const bundleDir = mkdtempSync(join(tmpdir(), 'factory-runtime-bundled-'));
+try {
+  for (const { engine, methods } of bundledChecks) {
+    const entry = join(bundleDir, `${engine}.mjs`);
+    writeFileSync(
+      entry,
+      `import { ${engine} } from ${JSON.stringify(join(FACTORY_ROOT, 'dist/esm/index.mjs'))};\n` +
+        `const missing = ${JSON.stringify(methods)}.filter((m) => typeof ${engine}[m] !== 'function');\n` +
+        `if (missing.length) { console.error('${engine} is missing after tree-shaking: ' + missing.join(', ')); process.exit(1); }\n` +
+        `console.log('${engine} OK');\n`,
+    );
+
+    // minify:true so terser-style dead-code elimination gets its pass too, matching
+    // what a consumer's production build does.
+    const built = await build({
+      entryPoints: [entry],
+      bundle: true,
+      format: 'esm',
+      platform: 'node',
+      minify: true,
+      treeShaking: true,
+      write: false,
+      logLevel: 'silent',
+    });
+
+    const bundled = join(bundleDir, `${engine}.bundled.mjs`);
+    writeFileSync(bundled, built.outputFiles[0].text);
+
+    try {
+      execSync(`node ${JSON.stringify(bundled)}`, { encoding: 'utf8', cwd: FACTORY_ROOT });
+    } catch (err) {
+      fail(
+        `bundled smoke failed for \`${engine}\` — its methods did not survive tree shaking.\n` +
+          `        A pure re-export (\`export { x as engineName }\`) lets the bundler flatten the alias and drop\n` +
+          `        the module that attaches the methods. Declare the binding in the module that mutates the\n` +
+          `        engine, with the \`importMethods\` call inside the initializer.`,
+        err,
+      );
+    }
+  }
+} finally {
+  rmSync(bundleDir, { recursive: true, force: true });
+}
+
+log('OK — CJS + ESM dists load, and every side-effect-assembled engine survives tree shaking');

--- a/src/assemblies/engines/scale/index.ts
+++ b/src/assemblies/engines/scale/index.ts
@@ -8,7 +8,28 @@ const ratingsGovernor = {
   generateDynamicRatings,
 };
 
-syncEngine.importMethods({ ...rankingGovernor, ...ratingsGovernor });
+/**
+ * `scaleEngine` IS the shared `syncEngine` singleton, with the ranking and ratings
+ * governors attached to it. That attachment MUST stay inside this initializer.
+ *
+ * The obvious spelling — a top-level `syncEngine.importMethods(...)` followed by
+ * `export { syncEngine as scaleEngine }` — is a pure re-export alias, so Rollup
+ * flattens it: `dist/esm/index.mjs` then exports `scaleEngine` straight off the
+ * sync module and demotes this one to a bare `import './scale/index.mjs'`. With
+ * `"sideEffects": false` in package.json, a consumer bundler is entitled to drop
+ * that bare import — and Vite/esbuild do, in production builds only. The engine
+ * still arrives with `setState`, so the failure surfaces late, as
+ * `scaleEngine.generateDynamicRatings is not a function` at the call site.
+ *
+ * Declaring the binding here, with the side effect in its initializer, makes the
+ * module un-droppable for anyone who imports `scaleEngine`. `verify:runtime`
+ * bundles a tree-shaken consumer to hold this. Do not "simplify" it back to a
+ * re-export.
+ */
+const scaleEngine = (() => {
+  syncEngine.importMethods({ ...rankingGovernor, ...ratingsGovernor });
+  return syncEngine;
+})();
 
-export { syncEngine as scaleEngine };
-export default syncEngine;
+export { scaleEngine };
+export default scaleEngine;


### PR DESCRIPTION
## The bug

On a production client build, the Ratings view of a DrawMatic (AD_HOC) draw died with
`scaleEngine.generateDynamicRatings is not a function`.

`scaleEngine` is the shared `syncEngine` singleton with the ranking and ratings governors
bolted on by `importMethods`, re-exported as a plain alias:

```ts
syncEngine.importMethods({ ...rankingGovernor, ...ratingsGovernor });
export { syncEngine as scaleEngine };
```

Rollup flattens a pure re-export, so `dist/esm/index.mjs` emitted `scaleEngine` straight off the
sync module and demoted the attaching module to a bare side-effect import. With
`"sideEffects": false` in `package.json`, a consumer bundler is entitled to drop that bare import
— and Vite/esbuild do, in production builds only. The engine still arrived and still had
`setState`, having silently lost `generateDynamicRatings`, `calculateNewRatings` and every
`rankingGovernor` method.

Reproduced at the bundle level against the pre-fix `dist`:

```text
setState: function
generateDynamicRatings: undefined     ← tree-shaken bundle
generateDynamicRatings: function      ← same dist, unbundled
```

Only `scale` had this shape; the other engines bind their own objects.

## The fix

`scaleEngine` becomes a module-local `const` whose initializer performs the `importMethods`, so
the module cannot be flattened away by anyone importing the binding. The rebuilt entry now emits
`export { scaleEngine } from './assemblies/engines/scale/index.mjs'` and carries no bare
side-effect imports at all.

`"sideEffects": false` is deliberately left alone — it is accurate again for the emitted entry,
and narrowing it would cost the package its tree-shakeability.

## The guard

`verify:runtime` gains a third, **bundled** pass: it esbuild-bundles a tree-shaken, minified
consumer per engine and asserts the method surface survives.

This is not redundant with the existing passes. Both the CJS and ESM smokes import the dist
directly, so Node evaluates every module in the graph and a side-effect-assembled engine always
looks complete — **both stayed green on the broken build**. Falsified in both directions: on a
`dist` restored to the old emission the new pass fails with

```text
scaleEngine is missing after tree-shaking: generateDynamicRatings, calculateNewRatings, generateRankingList
```

and it passes on the fixed one.

## Verification

Full `pnpm verify` green — all 15 steps, on this branch rebased onto current master.

Client-side coverage lands separately as TMX journey 118, which reproduces the original failure
verbatim under `TEST_PROD=1` and passes against this branch.
