### PR TITLE
fix(avoidance): check the pair a swapped participant lands in, not the one it leaves

### DIFF
--- a/src/mutate/drawDefinitions/positionGovernor/randomUnseededSeparation.ts
+++ b/src/mutate/drawDefinitions/positionGovernor/randomUnseededSeparation.ts
@@ -240,7 +240,12 @@ export function randomUnseededSeparation({
     }
   }
 
-  return { ...SUCCESS };
+  // Report residual conflicts rather than swallowing them. The candidate applied above is the
+  // lowest-conflict one generated, but "lowest" can still be non-zero when the repair loop in
+  // generatePositioningCandidate runs out of options. Returning bare SUCCESS meant
+  // automatedPositioning's `if (result.conflicts)` never fired, so a same-group first-round
+  // pairing shipped as `{ success: true, conflicts: {} }` with no way for a caller to notice.
+  return candidate.conflicts ? { ...SUCCESS, conflicts: candidate.conflicts } : { ...SUCCESS };
 }
 
 function roundRobinParticipantGroups(params) {

--- a/src/query/drawDefinition/avoidance/getSwapOptions.ts
+++ b/src/query/drawDefinition/avoidance/getSwapOptions.ts
@@ -25,6 +25,9 @@ function hasNoConflict({
   isRoundRobin: boolean;
   getAvoidanceConflicts: (params: { isRoundRobin: boolean; groupedParticipants: any[][] }) => any[];
 }): boolean {
+  // A swap exchanges two participants: `moveableParticipant` goes from its current position to
+  // `possibleDrawPosition`, and whoever occupies `possibleDrawPosition` goes the other way. Both
+  // halves must be checked against the opponent each one FACES AFTER the swap.
   const potentialOpponentDrawPosition = getPotentialOpponentDrawPosition(drawPositionGroups, possibleDrawPosition);
   const potentialOpponent = findParticipantByDrawPosition(positionedParticipants, potentialOpponentDrawPosition);
   const possibleDrawPositionGroup = [moveableParticipant, potentialOpponent];
@@ -32,8 +35,19 @@ function hasNoConflict({
     isRoundRobin,
     groupedParticipants: [possibleDrawPositionGroup],
   });
+
+  // The swapped-out participant inherits the position `moveableParticipant` vacates, so it faces
+  // that position's opponent. Checking it against `potentialOpponent` instead would evaluate the
+  // pairing it is being moved OUT of — which is the pre-swap state of the target match. That test
+  // rejects every swap into an already-conflicted match, and when all first-round matches are
+  // conflicted it rejects every swap there is, leaving the conflicts unrepaired.
+  const vacatedOpponentDrawPosition = getPotentialOpponentDrawPosition(
+    drawPositionGroups,
+    moveableParticipant.drawPosition,
+  );
+  const vacatedOpponent = findParticipantByDrawPosition(positionedParticipants, vacatedOpponentDrawPosition);
   const swappedParticipant = findParticipantByDrawPosition(positionedParticipants, possibleDrawPosition);
-  const possibleExistingOpponentGroup = [swappedParticipant, potentialOpponent];
+  const possibleExistingOpponentGroup = [swappedParticipant, vacatedOpponent];
   const existingOpponentConflictPotential = getAvoidanceConflicts({
     isRoundRobin,
     groupedParticipants: [possibleExistingOpponentGroup],

--- a/src/tests/mutations/drawDefinitions/avoidance/playoffSwapTarget.test.ts
+++ b/src/tests/mutations/drawDefinitions/avoidance/playoffSwapTarget.test.ts
@@ -1,0 +1,93 @@
+import { getSwapOptions } from '@Query/drawDefinition/avoidance/getSwapOptions';
+import { describe, expect, it } from 'vitest';
+
+// Four first-round matches, every one of them holding a same-group pair — the state a playoff
+// draw fed by four round-robin groups lands in when the greedy placement pairs each group
+// against itself. A collision-free arrangement plainly exists (pair each group's qualifiers
+// against a different group), so the repair loop must be able to find a swap.
+const GROUP_OF = { 1: 'A', 2: 'A', 3: 'B', 4: 'B', 5: 'C', 6: 'C', 7: 'D', 8: 'D' };
+
+const positionedParticipants = Object.entries(GROUP_OF).map(([drawPosition, group]) => ({
+  participantId: `p${drawPosition}-${group}`,
+  drawPosition: Number(drawPosition),
+  values: [group],
+}));
+
+const drawPositionGroups: [number, number][] = [
+  [1, 2],
+  [3, 4],
+  [5, 6],
+  [7, 8],
+];
+
+const participantAt = (drawPosition: number) =>
+  positionedParticipants.find((participant) => participant.drawPosition === drawPosition);
+
+describe('playoff avoidance swap targets', () => {
+  it('offers a swap when every first-round pair is a same-group conflict', () => {
+    // Every pair conflicts, so the repair loop is choosing among conflicted targets exclusively.
+    // Evaluating the swapped-out participant against the pairing it is being moved OUT of would
+    // reject all four, leaving the draw with same-group opening matches.
+    const avoidanceConflicts = drawPositionGroups.map((pair) => pair.map(participantAt));
+
+    const result: any = getSwapOptions({
+      potentialDrawPositions: [1, 2, 3, 4, 5, 6, 7, 8],
+      positionedParticipants,
+      avoidanceConflicts,
+      drawPositionGroups,
+      isRoundRobin: false,
+    });
+
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('never offers a swap that would seat the swapped-out participant against its own group', () => {
+    // Four groups of three qualifiers into a 12-draw — the shape when playoff groups take
+    // finishing positions [1, 2, 3]. With three members per group the swapped-out participant CAN
+    // land against its own group, which is the case the second half of the guard exists to reject.
+    const groupOf = {
+      1: 'A',
+      2: 'A',
+      3: 'B',
+      4: 'C',
+      5: 'A',
+      6: 'B',
+      7: 'C',
+      8: 'D',
+      9: 'B',
+      10: 'D',
+      11: 'C',
+      12: 'D',
+    };
+    const participants = Object.entries(groupOf).map(([drawPosition, group]) => ({
+      participantId: `p${drawPosition}-${group}`,
+      drawPosition: Number(drawPosition),
+      values: [group],
+    }));
+    const positionGroups: [number, number][] = [
+      [1, 2],
+      [3, 4],
+      [5, 6],
+      [7, 8],
+      [9, 10],
+      [11, 12],
+    ];
+    const at = (drawPosition: number) => participants.find((p) => p.drawPosition === drawPosition);
+
+    // Only positions 1 and 2 conflict. Position 5 holds the third group-A qualifier: moving it
+    // into position 1 would seat it against the group-A participant at position 2.
+    const result: any = getSwapOptions({
+      potentialDrawPositions: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+      avoidanceConflicts: [[at(1), at(2)]],
+      positionedParticipants: participants,
+      drawPositionGroups: positionGroups,
+      isRoundRobin: false,
+    });
+
+    const offeredFromPosition1 = result.find((option) => option.drawPosition === 1);
+    expect(offeredFromPosition1).toBeDefined();
+    expect(offeredFromPosition1.possibleDrawPositions).not.toContain(5);
+    // and the guard has not simply rejected everything
+    expect(offeredFromPosition1.possibleDrawPositions.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Resolves the `roundRobinPlayoffsPriorityPlacement` intermittent
(`Mentat/TASKS.md` → *Known intermittent*, raised earlier today). It is a
**product defect**, not a flaky test. The spec has been correctly failing about
1 run in 10 for a long time.

## The guarantee that was being broken

`positionUnseededParticipants.ts:92-104` synthesises a `'Playoff Avoidance'`
policy for any `PLAY_OFF` stage, built from each entry's `groupingValue` — the
round-robin group the participant qualified from. This happens **unconditionally
and with no `policyDefinitions` supplied**. `getAvoidanceConflicts` then defines
a conflict as a first-round pair sharing a value, which for this policy means
sharing a round-robin group.

In other words: *no first-round playoff pair holds two participants from the same
group* is a guarantee the engine makes by default, and it is exactly what the
spec asserts. With 4 groups × 2 qualifiers into 4 first-round matches, a
collision-free arrangement always exists.

## The defect

A swap exchanges two participants: `moveableParticipant` goes from **M** to
**B**, and whoever sits at **B** goes back to **M**. Both halves must be checked
against the opponent each faces *after* the swap.

`getSwapOptions.ts` checked the first half correctly and the second half against
`opponent(B)` — the pairing the swapped-out participant is being moved **out of**.
Since `[swappedParticipant, opponent(B)]` is just B's current pair, the guard
collapsed into *"reject any swap into a match that already conflicts"*.

That fails in both directions:

- **Too strict.** When every first-round match conflicts — four groups landing as
  A1-A2, B1-B2, C1-C2, D1-D2 — every candidate swap is rejected. `getSwapOptions`
  returns `[]`, `generatePositioningCandidate` exhausts its attempts and applies
  the conflicted candidate. This is the intermittent failure.
- **Too lax.** Where a group contributes three qualifiers (playoff groups taking
  finishing positions [1,2,3]), the same wrong pairing *permits* a swap that
  seats the swapped-out participant against its own group — creating a conflict
  rather than failing to fix one.

The fix evaluates the swapped-out participant against
`opponent(moveableParticipant.drawPosition)`, the position it actually inherits.

## The second defect — why this hid for so long

`randomUnseededSeparation` selects the lowest-conflict candidate and applies it,
then returned bare `{ ...SUCCESS }`. `automatedPositioning`'s
`if (result.conflicts)` therefore never fired, and a draw with a same-group
opening match was reported as `{ success: true, conflicts: {} }`. No caller —
TMX, the server, anyone — had a way to detect it. The only symptom in existence
was a 1-in-10 test failure.

It now returns the residual conflicts.

## Verification

The regression test is deterministic — no randomness — and both assertions were
proven to detect the bug rather than merely pass:

| source under test | test 1 (stuck state offers a swap) | test 2 (never creates a conflict) |
|---|---|---|
| unfixed | **fails** — `expected 0 to be greater than 0` | **fails** — offers position 5 |
| guard made permissive (probe) | passes | **fails** — offers position 5 |
| fixed | passes | passes |

The middle row exists because test 2 passes on the unfixed code in an 8-draw with
two qualifiers per group — the check cannot bite there. It was rewritten to a
12-draw with three per group, where it can.

Also run:

- `pnpm verify:coverage` — 1119 files, 11,574 tests, thresholds met. This
  matters because `hasNoConflict` is shared with the round-robin branch;
  `countryAvoidance`, `pairAvoidance`, `qualifyingAvoidance` and
  `seededGroupAvoidanceEndToEnd` all still pass.
- `roundRobinPlayoffsPriorityPlacement` 60 consecutive runs — 60 pass. On its own
  this is weak evidence at a ~1-in-600 local base rate; the deterministic unit
  test is the real proof.
- `pnpm verify:types`, `pnpm verify:lint` — clean.

## Not related to

- The 2026-08-24 *seeded avoidance* workstream — that was `positionSeeds` on the
  **seeded** path. This is the unseeded path.
- #4731's `stringSort` collator fix. The nondeterminism here is `Math.random`
  inside placement, not locale-sensitive ordering. Note this also means adding
  `nonRandom: 1` to the fixture would **not** have made the spec deterministic —
  the tempting "just stabilise the test" fix would have silently kept shipping
  bad draws.

## Also affected

The second test in that same file (drawSize 20, five groups, byes) asserts the
identical invariant through the identical path.