### PR TITLE
fix(codes): make the schema say something about a sanction

### DIFF
--- a/src/global/schema/tournament.schema.json
+++ b/src/global/schema/tournament.schema.json
@@ -182,19 +182,19 @@
           }
         },
         "sanction": {
-          "type": "object"
+          "$ref": "#/definitions/TournamentSanction"
         },
         "sanctions": {
           "type": "array",
           "items": {
-            "type": "object"
+            "$ref": "#/definitions/TournamentSanction"
           }
         },
         "scheduling": {
           "type": "object"
         },
         "tournamentTier": {
-          "type": "object"
+          "$ref": "#/definitions/TierClassification"
         },
         "weekdays": {
           "type": "array",
@@ -291,6 +291,22 @@
       "required": ["name", "value"],
       "additionalProperties": true,
       "$comment": "OPEN, deliberately and permanently. Extensions are CODES' escape hatch: `value` is unconstrained by design, and callers attach their own keys. This is the one exception that is not a backlog item."
+    },
+    "TierClassification": {
+      "type": "object",
+      "properties": {
+        "system": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        },
+        "numericRank": {
+          "type": "number"
+        }
+      },
+      "required": ["system", "value"],
+      "additionalProperties": false
     },
     "TimeItem": {
       "type": "object",
@@ -491,7 +507,7 @@
           }
         },
         "sanction": {
-          "type": "object"
+          "$ref": "#/definitions/TournamentSanction"
         },
         "eventOtherIds": {
           "type": "array",
@@ -500,7 +516,7 @@
           }
         },
         "eventTier": {
-          "type": "object"
+          "$ref": "#/definitions/TierClassification"
         },
         "weekdays": {
           "type": "array",
@@ -3374,6 +3390,277 @@
       "required": ["name"],
       "additionalProperties": false
     },
+    "SanctionDecisionEnum": {
+      "type": "string",
+      "enum": [
+        "PENDING",
+        "APPROVED",
+        "CONDITIONAL",
+        "DENIED",
+        "WITHDRAWN",
+        "REVOKED",
+        "SUSPENDED",
+        "EXPIRED",
+        "DOWNGRADED"
+      ]
+    },
+    "RecognitionEnum": {
+      "type": "string",
+      "enum": ["SANCTIONED", "APPROVED", "OBSERVED", "RECOGNISED", "LICENSED", "UNSANCTIONED"]
+    },
+    "AuthorityRoleEnum": {
+      "type": "string",
+      "enum": [
+        "INTERNATIONAL",
+        "NATIONAL",
+        "ZONE",
+        "SECTION",
+        "REGION",
+        "PROVINCE",
+        "STATE",
+        "COUNTY",
+        "DISTRICT",
+        "LEAGUE",
+        "CONFERENCE",
+        "CLUB",
+        "PROVIDER"
+      ]
+    },
+    "SanctionEnforcementEnum": {
+      "type": "string",
+      "enum": ["ENFORCE", "AUDIT", "WARN"]
+    },
+    "SanctionFeeKindEnum": {
+      "type": "string",
+      "enum": ["SANCTION", "HEAD_TAX", "LATE", "ENTRY"]
+    },
+    "SanctioningAuthority": {
+      "type": "object",
+      "properties": {
+        "organisationAbbreviation": {
+          "type": "string"
+        },
+        "organisationName": {
+          "type": "string"
+        },
+        "organisationId": {
+          "type": "string"
+        },
+        "role": {
+          "$ref": "#/definitions/AuthorityRoleEnum"
+        },
+        "regionCode": {
+          "type": "string"
+        },
+        "extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Extension"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "SanctionFee": {
+      "type": "object",
+      "properties": {
+        "feeKind": {
+          "$ref": "#/definitions/SanctionFeeKindEnum"
+        },
+        "fee": {
+          "$ref": "#/definitions/MonetaryAmount"
+        },
+        "percentage": {
+          "type": "number"
+        },
+        "perParticipant": {
+          "type": "boolean"
+        },
+        "maximum": {
+          "$ref": "#/definitions/MonetaryAmount"
+        },
+        "appliesTo": {
+          "type": "string"
+        },
+        "note": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SanctionConferral": {
+      "type": "object",
+      "properties": {
+        "rankingEligible": {
+          "type": "boolean"
+        },
+        "rankingPointsProfile": {
+          "type": "string"
+        },
+        "recordEligible": {
+          "type": "boolean"
+        },
+        "officialResults": {
+          "type": "boolean"
+        },
+        "insured": {
+          "type": "boolean"
+        },
+        "extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Extension"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "SanctionRuleset": {
+      "type": "object",
+      "properties": {
+        "rulesetId": {
+          "type": "string"
+        },
+        "edition": {
+          "type": "string"
+        },
+        "enforcement": {
+          "$ref": "#/definitions/SanctionEnforcementEnum"
+        },
+        "appliedRules": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Extension"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "SanctionDecisionRecord": {
+      "type": "object",
+      "properties": {
+        "decidedAt": {
+          "type": "string"
+        },
+        "decidedByPersonId": {
+          "type": "string"
+        },
+        "decidedByName": {
+          "type": "string"
+        },
+        "appealable": {
+          "type": "boolean"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "note": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SanctionIdentifier": {
+      "type": "object",
+      "properties": {
+        "organisationId": {
+          "type": "string"
+        },
+        "identifier": {
+          "type": "string"
+        },
+        "identifierType": {
+          "type": "string"
+        }
+      },
+      "required": ["identifier"],
+      "additionalProperties": false
+    },
+    "SanctionSubmissionWindow": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "string"
+        },
+        "to": {
+          "type": "string"
+        },
+        "timeZone": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "TournamentSanction": {
+      "$comment": "What a governing body DECIDED about a competition — the instance model from #4710. Three orthogonal axes: decision (did the application succeed), recognition (what the body asserts), classification (what grade is conferred). Before this definition existed the property was declared {\"type\": \"object\"}, so a record carrying decision: 'BANANA' validated.",
+      "type": "object",
+      "properties": {
+        "decision": {
+          "$ref": "#/definitions/SanctionDecisionEnum"
+        },
+        "recognition": {
+          "$ref": "#/definitions/RecognitionEnum"
+        },
+        "classification": {
+          "$ref": "#/definitions/TierClassification"
+        },
+        "authority": {
+          "$ref": "#/definitions/SanctioningAuthority"
+        },
+        "approvalChain": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SanctioningAuthority"
+          }
+        },
+        "decisionRecord": {
+          "$ref": "#/definitions/SanctionDecisionRecord"
+        },
+        "confers": {
+          "$ref": "#/definitions/SanctionConferral"
+        },
+        "ruleset": {
+          "$ref": "#/definitions/SanctionRuleset"
+        },
+        "sanctioningId": {
+          "type": "string"
+        },
+        "identifiers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SanctionIdentifier"
+          }
+        },
+        "fees": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SanctionFee"
+          }
+        },
+        "submissionWindow": {
+          "$ref": "#/definitions/SanctionSubmissionWindow"
+        },
+        "timeItems": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TimeItem"
+          }
+        },
+        "extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Extension"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "SocialEvent": {
       "type": "object",
       "properties": {
@@ -3465,6 +3752,27 @@
           "items": {
             "$ref": "#/definitions/Extension"
           }
+        }
+      },
+      "required": ["amount", "currencyCode", "unit"],
+      "additionalProperties": false
+    },
+    "CurrencyUnitEnum": {
+      "type": "string",
+      "enum": ["MINOR", "MAJOR"]
+    },
+    "MonetaryAmount": {
+      "$comment": "All three fields are required together: an amount with no stated scale is readable at two scales 100x apart. NOTE this definition is $ref'd where a whole VALUE is a monetary amount (SanctionFee.fee, SanctionFee.maximum). It is deliberately NOT composed into PrizeMoney, PrizeMoneyAward or RegistrationEntryFee via allOf, even though those extend it in TypeScript: `allOf` + `additionalProperties: false` REJECTS the inherited fields, because additionalProperties only sees the properties declared alongside it. Those three inline the triple instead. Verified against ajv before choosing.",
+      "type": "object",
+      "properties": {
+        "amount": {
+          "type": "number"
+        },
+        "currencyCode": {
+          "type": "string"
+        },
+        "unit": {
+          "$ref": "#/definitions/CurrencyUnitEnum"
         }
       },
       "required": ["amount", "currencyCode", "unit"],

--- a/src/tests/global/sanctionSchemaValidation.test.ts
+++ b/src/tests/global/sanctionSchemaValidation.test.ts
@@ -1,0 +1,140 @@
+import addFormats from 'ajv-formats';
+import { describe, expect, it } from 'vitest';
+import fs from 'fs-extra';
+import Ajv from 'ajv';
+
+/**
+ * The sanction instance model, validated as a SCHEMA rather than only as a TypeScript type.
+ *
+ * `schemaValidation.test.ts` validates the 16 TODS files in `testHarness` — and **not one of them
+ * carries a `sanction`, `sanctions`, `tournamentTier` or `eventTier`.** So it would have reported
+ * green over this change having exercised none of it. That is why these fixtures exist: without
+ * them the schema definitions added here are asserted, not tested.
+ *
+ * Each negative case below is the SAME record as the positive one with a single field made wrong,
+ * so a failure localizes to that field rather than to "the fixture is malformed".
+ */
+
+const ajv = new Ajv({ allowUnionTypes: true, verbose: true, allErrors: true });
+ajv.addFormat('date-time', (dateTime: any) => {
+  if (typeof dateTime === 'object') dateTime = dateTime.toISOString();
+  return !Number.isNaN(Date.parse(dateTime));
+});
+addFormats(ajv);
+
+const schema = JSON.parse(fs.readFileSync('./src/global/schema/tournament.schema.json', { encoding: 'utf8' }));
+const validate = ajv.compile(schema);
+
+/** A record exercising every branch of the sanction model, shaped like real captured data. */
+const sanctioned = () => ({
+  tournamentId: 'schema-sanction-fixture',
+  tournamentName: 'Sanction Schema Fixture',
+  startDate: '2026-07-27',
+  endDate: '2026-08-03',
+  tournamentTier: { system: 'USTA', value: 'Level 2', numericRank: 2 },
+  sanction: {
+    decision: 'APPROVED',
+    recognition: 'UNSANCTIONED',
+    classification: { system: 'USTA', value: 'Unsanctioned' },
+    authority: {
+      organisationAbbreviation: 'USTA',
+      organisationName: 'United States Tennis Association',
+      organisationId: 'usta',
+      role: 'NATIONAL',
+      regionCode: 'N00',
+    },
+    approvalChain: [
+      { organisationName: 'National', role: 'NATIONAL', regionCode: 'N00' },
+      { organisationName: 'Southern', role: 'SECTION', regionCode: '070' },
+      { organisationName: 'Georgia', role: 'DISTRICT', regionCode: '034' },
+    ],
+    decisionRecord: { decidedAt: '2025-05-17T00:40:41.294Z', decidedByName: 'A District Official', appealable: true },
+    confers: { rankingEligible: false, insured: true },
+    ruleset: { edition: '2026', enforcement: 'ENFORCE', appliedRules: ['R1', 'R2'] },
+    identifiers: [{ organisationId: 'usta', identifier: '26-93384', identifierType: 'USTA_TOURNAMENT_NUMBER' }],
+    fees: [
+      { feeKind: 'SANCTION', fee: { amount: 4000, currencyCode: 'USD', unit: 'MINOR' } },
+      {
+        feeKind: 'HEAD_TAX',
+        fee: { amount: 500, currencyCode: 'USD', unit: 'MINOR' },
+        perParticipant: true,
+        maximum: { amount: 25000, currencyCode: 'USD', unit: 'MINOR' },
+      },
+    ],
+    submissionWindow: { from: '2025-01-01', to: '2025-06-01', timeZone: 'America/New_York' },
+  },
+});
+
+const errorText = () => ajv.errorsText(validate.errors, { dataVar: 'record' });
+
+describe('sanction instance model — the schema now says something', () => {
+  it('accepts a fully-populated sanction', () => {
+    const valid = validate(sanctioned());
+    if (!valid) throw new Error(errorText());
+    expect(valid).toBe(true);
+  });
+
+  it('accepts multiple sanctions — dual sanctioning is real', () => {
+    const record: any = sanctioned();
+    record.sanctions = [record.sanction, { decision: 'APPROVED', recognition: 'RECOGNISED' }];
+    expect(validate(record)).toBe(true);
+  });
+
+  it('REJECTS an unknown decision — this is what {"type":"object"} used to accept', () => {
+    const record: any = sanctioned();
+    record.sanction.decision = 'BANANA';
+    expect(validate(record)).toBe(false);
+    expect(errorText()).toContain('decision');
+  });
+
+  it('REJECTS a non-string recognition', () => {
+    const record: any = sanctioned();
+    record.sanction.recognition = 42;
+    expect(validate(record)).toBe(false);
+  });
+
+  it('REJECTS an unknown authority role', () => {
+    const record: any = sanctioned();
+    record.sanction.authority.role = 'SUPREME_LEADER';
+    expect(validate(record)).toBe(false);
+  });
+
+  it('REJECTS a fee amount with no unit — the money rule holds inside the sanction too', () => {
+    const record: any = sanctioned();
+    delete record.sanction.fees[0].fee.unit;
+    expect(validate(record)).toBe(false);
+  });
+
+  it('REJECTS a misspelled field rather than silently keeping it', () => {
+    const record: any = sanctioned();
+    record.sanction.recognitionn = 'SANCTIONED';
+    expect(validate(record)).toBe(false);
+  });
+
+  it('REJECTS an identifier with no identifier value', () => {
+    const record: any = sanctioned();
+    delete record.sanction.identifiers[0].identifier;
+    expect(validate(record)).toBe(false);
+  });
+
+  it('REJECTS a tier with no system', () => {
+    const record: any = sanctioned();
+    delete record.tournamentTier.system;
+    expect(validate(record)).toBe(false);
+  });
+
+  it('accepts an event-grain sanction and tier', () => {
+    const record: any = sanctioned();
+    record.events = [
+      {
+        eventId: 'e1',
+        eventName: 'Open Singles',
+        eventTier: { system: 'USTA', value: 'Level 2' },
+        sanction: { decision: 'APPROVED', recognition: 'SANCTIONED' },
+      },
+    ];
+    const valid = validate(record);
+    if (!valid) throw new Error(errorText());
+    expect(valid).toBe(true);
+  });
+});


### PR DESCRIPTION
`tournament.schema.json` is the third declaration of CODES, after the types and the docs site. #4718 revived its dead validator; #4719 documented and enforced its `additionalProperties` convention. This closes the largest remaining gap in what it actually *declares*.

## The defect

`#4710`'s sanction instance model — **twelve types** — had no definitions here at all. Not a dangling-`$ref` bug. **Worse, because nothing failed:**

```json
"sanction":       { "type": "object" },
"sanctions":      { "type": "array", "items": { "type": "object" } },
"tournamentTier": { "type": "object" }
```

So a record carrying `sanction: { decision: 'BANANA', recognition: 42 }` **validated**. The vocabulary was enforced at TypeScript compile time and nowhere else — a server validating inbound JSON, another language, or a federation checking a file against the published standard got **no contract at all**.

## What lands

**Fifteen definitions**, all closed per #4719's convention: `TournamentSanction` + `SanctioningAuthority`, `SanctionFee`, `SanctionConferral`, `SanctionRuleset`, `SanctionDecisionRecord`, `SanctionIdentifier`, `SanctionSubmissionWindow`; the five sanction enums plus `AuthorityRoleEnum`; `MonetaryAmount` + `CurrencyUnitEnum`; `TierClassification`.

`Tournament.sanction`, `.sanctions`, `.tournamentTier` and `Event.sanction`, `.eventTier` now `$ref` them.

## One finding that reverses a recorded recommendation

`MonetaryAmount` is defined and `$ref`'d where a whole **value** is a monetary amount (`SanctionFee.fee`, `.maximum`). It is **deliberately not** composed into `PrizeMoney`, `PrizeMoneyAward` or `RegistrationEntryFee` via `allOf`, even though those extend it in TypeScript.

**Measured with ajv before choosing:** `allOf` + `additionalProperties: false` **rejects the inherited fields**, because `additionalProperties` only sees the properties declared alongside it. Those three keep the triple inlined, and the reason is recorded on the definition so the next person doesn't "fix" it into an `allOf` and break validation.

This reverses the *repoint-the-inliners* half of the recommendation in Mentat `TASKS.md`.

## The existing detector was silent on this change

`schemaValidation.test.ts` validates the 16 TODS files in `testHarness` — and **not one carries a `sanction`, `sanctions`, `tournamentTier` or `eventTier`.** It would have gone green having exercised none of this.

So `sanctionSchemaValidation.test.ts` adds a fully-populated positive fixture plus **seven negatives**, each the same record with one field made wrong so a failure localizes to that field.

**Falsified, not assumed.** Reverting *only* the property wiring — leaving the definitions in place — turns all seven rejection tests red and the positives green. They fail against the pre-change schema and pass against this one.

## Deliberately out of scope

`Tournament.scheduling` stays `{"type": "object"}`. It is a group leaf whose TypeScript type is itself `{[key: string]: any}`, so declaring a shape here would **assert more than the types do**. `ScheduleScenario`, `ScheduleLock` and `PracticeRegistration` hang off it and are left with it. Typing that group is a separate task with a real design question in it.

## Verification

`pnpm verify` green — all 15 steps. Schema-only: no TypeScript types change, no behaviour changes.