### PR TITLE
feat(codes): say who may enter an event, and when a competition was cancelled

### DIFF
--- a/src/global/schema/tournament.schema.json
+++ b/src/global/schema/tournament.schema.json
@@ -145,6 +145,13 @@
         "tournamentStatus": {
           "$ref": "#/definitions/TournamentStatusEnum"
         },
+        "cancelledAt": {
+          "type": ["string", "object"],
+          "format": "date-time"
+        },
+        "cancellationReason": {
+          "type": "string"
+        },
         "tournamentName": {
           "type": "string"
         },
@@ -206,6 +213,39 @@
       "required": ["tournamentId"],
       "additionalProperties": true,
       "$comment": "OPEN, and this is a KNOWN GAP rather than a decision — closing it is blocked, not declined. Measured 2026-08-28 against the 16 TODS fixtures: 13 records carry `venueIds`, 6 carry `deleted`, and `dualMatchMetadata`, `associatedOrganisations`, `rootOrganisationId`, `tournamentExternalId` and a nested `tournamentRecord` each appear. Closing this definition today fails 14 of 16 fixtures. Each undeclared field must first be resolved as either a real CODES concept (declare it in `types/tournamentTypes.ts` AND here) or as legacy data (correct the fixtures), after which this should become `false` to match the other 51."
+    },
+    "EntryRestrictionEnum": {
+      "type": "string",
+      "enum": ["RESIDENCY", "MEMBERSHIP", "RANKING_FLOOR", "CLEARANCE", "INVITATION", "OTHER"]
+    },
+    "EntryRestriction": {
+      "$comment": "A condition on WHO may enter, beyond age/gender/rating. Advisory in v1: CODES holds no section roster or membership register, so `evaluable` defaults to undecidable and getParticipantEligibility reports indeterminate rather than guessing.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/EntryRestrictionEnum"
+        },
+        "organisationId": {
+          "type": "string"
+        },
+        "membershipCategory": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "evaluable": {
+          "type": "boolean"
+        },
+        "extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Extension"
+          }
+        }
+      },
+      "required": ["type"],
+      "additionalProperties": false
     },
     "EventRegistration": {
       "type": "object",
@@ -341,6 +381,19 @@
         },
         "entryProfile": {
           "$ref": "#/definitions/EventEntryProfile"
+        },
+        "entryRestrictions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EntryRestriction"
+          }
+        },
+        "cancelledAt": {
+          "type": ["string", "object"],
+          "format": "date-time"
+        },
+        "cancellationReason": {
+          "type": "string"
         },
         "flightProfile": {
           "type": "object"

--- a/src/query/entries/getParticipantEligibility.ts
+++ b/src/query/entries/getParticipantEligibility.ts
@@ -3,12 +3,19 @@ import { getEventDateRange, validateParticipantCategory } from '@Query/entries/c
 // constants and types
 import { MISSING_PARTICIPANT, MISSING_EVENT } from '@Constants/errorConditionConstants';
 import type { RejectionReason } from '@Query/entries/categoryValidation';
-import type { Event, Participant, Tournament } from '@Types/tournamentTypes';
+import type { EntryRestriction, Event, Participant, Tournament } from '@Types/tournamentTypes';
 import type { ResultType } from '@Types/factoryTypes';
 
 export interface ParticipantEligibility {
   /** the participant satisfies every category rule that could be evaluated */
   eligible: boolean;
+  /**
+   * Restrictions that could not be decided from the record — residency, membership, clearance.
+   *
+   * Surfaced rather than swallowed so a consumer can say "this event is closed to your section —
+   * check with the organiser" instead of either a flat no or a misleading yes.
+   */
+  undeterminedRestrictions?: EntryRestriction[];
   /**
    * At least one rule could NOT be evaluated because the data it needs is absent — an unknown
    * birthDate, an unrecorded rating. Distinct from `eligible: false`, which asserts a rule is
@@ -16,6 +23,18 @@ export interface ParticipantEligibility {
    */
   indeterminate: boolean;
   rejectionReasons: RejectionReason[];
+}
+
+/**
+ * Restrictions this record cannot settle.
+ *
+ * **Absence of `evaluable: true` means undecidable, not satisfied.** CODES holds no section roster
+ * and no membership register, so a RESIDENCY or MEMBERSHIP gate is normally undecidable here — and
+ * defaulting the other way would answer "yes, you may enter" on a rule nothing checked. A producer
+ * that HAS resolved a restriction sets `evaluable: true` explicitly and takes responsibility for it.
+ */
+function undeterminedRestrictions(restrictions?: EntryRestriction[]): EntryRestriction[] {
+  return (restrictions ?? []).filter((restriction) => restriction && restriction.evaluable !== true);
 }
 
 /**
@@ -47,8 +66,17 @@ export function getParticipantEligibility(params: {
   if (!participant?.participantId) return { error: MISSING_PARTICIPANT };
   if (!event?.eventId) return { error: MISSING_EVENT };
 
-  // An event with no category restricts nobody. Not a silent pass: there is genuinely no rule.
-  if (!event.category) return { eligible: true, indeterminate: false, rejectionReasons: [] };
+  // Entry restrictions are evaluated whether or not a category exists: an open-age event can still
+  // be closed to a section. Collected first so the no-category path below cannot skip them.
+  const undetermined = undeterminedRestrictions(event.entryRestrictions);
+
+  // An event with no category restricts nobody on age or rating. Not a silent pass — there is
+  // genuinely no such rule — but a restriction may still make the answer undecidable.
+  if (!event.category) {
+    return undetermined.length
+      ? { eligible: false, indeterminate: true, rejectionReasons: [], undeterminedRestrictions: undetermined }
+      : { eligible: true, indeterminate: false, rejectionReasons: [] };
+  }
 
   const dateRange = getEventDateRange(event, tournamentRecord);
   if ('error' in dateRange) return { error: dateRange.error };
@@ -62,7 +90,13 @@ export function getParticipantEligibility(params: {
     tournamentRecord,
   );
 
-  if (!rejection) return { eligible: true, indeterminate: false, rejectionReasons: [] };
+  if (!rejection) {
+    // Every category rule passed. An undecidable restriction still prevents a clean yes — saying
+    // "eligible" here would assert something the record cannot support.
+    return undetermined.length
+      ? { eligible: false, indeterminate: true, rejectionReasons: [], undeterminedRestrictions: undetermined }
+      : { eligible: true, indeterminate: false, rejectionReasons: [] };
+  }
 
   const rejectionReasons = rejection.rejectionReasons;
 
@@ -71,7 +105,12 @@ export function getParticipantEligibility(params: {
   // breach that was established on other grounds.
   const indeterminate = rejectionReasons.length > 0 && rejectionReasons.every((reason) => reason.indeterminate);
 
-  return { eligible: false, indeterminate, rejectionReasons };
+  return {
+    eligible: false,
+    indeterminate,
+    rejectionReasons,
+    ...(undetermined.length ? { undeterminedRestrictions: undetermined } : {}),
+  };
 }
 
 export interface EventEligibility extends ParticipantEligibility {

--- a/src/tests/constants/enumConstConformance.test.ts
+++ b/src/tests/constants/enumConstConformance.test.ts
@@ -228,6 +228,11 @@ const ENUM_ONLY = [
   // currency UNIT (minor vs whole) is a representation concern with no const-module twin — the
   // currencies themselves are ISO 4217 strings, not a factory vocabulary
   'CurrencyUnitEnum',
+  // kinds of entry restriction (residency, membership, clearance…). No const-module twin: this is
+  // an EVENT-CONFIGURATION vocabulary consumed as a typed field, and its members name gates that
+  // resolve against rosters and registers CODES does not hold — there is nothing for a constants
+  // module to carry beyond the strings themselves.
+  'EntryRestrictionEnum',
   // how an over-subscribed event chooses whom to accept. No const-module twin: the values are an
   // EVENT-CONFIGURATION vocabulary consumed as a typed field, and the same strings already appear in
   // captured federation records as `selectionProcessConstraints` — the authority's permitted SET,

--- a/src/tests/queries/entries/entryRestrictions.test.ts
+++ b/src/tests/queries/entries/entryRestrictions.test.ts
@@ -1,0 +1,164 @@
+import addFormats from 'ajv-formats';
+import { describe, expect, it } from 'vitest';
+import fs from 'fs-extra';
+import Ajv from 'ajv';
+
+import { getParticipantEligibility } from '@Query/entries/getParticipantEligibility';
+import type { Event, Participant, Tournament } from '@Types/tournamentTypes';
+
+/**
+ * A6 and A8.
+ *
+ * The point of A6 is not the type — it is that an unevaluable restriction reaches the eligibility
+ * answer as `indeterminate` instead of being silently ignored. A restriction nothing reads is
+ * inert, and inert is worse than absent because it looks like coverage.
+ */
+
+const tournamentRecord = {
+  tournamentId: 't',
+  startDate: '2026-06-01',
+  endDate: '2026-06-07',
+} as unknown as Tournament;
+
+const participant = {
+  participantId: 'p',
+  participantType: 'INDIVIDUAL',
+  person: { birthDate: '2010-03-04' },
+} as unknown as Participant;
+
+const u18 = { categoryName: 'U18', ageMax: 17 };
+
+describe('entry restrictions reach the eligibility answer', () => {
+  it('an event with no restrictions is unaffected', () => {
+    const event = { eventId: 'e', category: u18 } as unknown as Event;
+    const result: any = getParticipantEligibility({ participant, event, tournamentRecord });
+    expect(result.eligible).toBe(true);
+    expect(result.indeterminate).toBe(false);
+    expect(result.undeterminedRestrictions).toBeUndefined();
+  });
+
+  it('an undecidable RESIDENCY restriction makes the answer indeterminate, not a refusal', () => {
+    // The participant satisfies every category rule. The honest answer is "cannot tell", because
+    // CODES holds no section roster — not "no", and not "yes".
+    const event = {
+      eventId: 'e',
+      category: u18,
+      entryRestrictions: [{ type: 'RESIDENCY', organisationId: 'usta-southern' }],
+    } as unknown as Event;
+    const result: any = getParticipantEligibility({ participant, event, tournamentRecord });
+    expect(result.eligible).toBe(false);
+    expect(result.indeterminate).toBe(true);
+    expect(result.undeterminedRestrictions).toHaveLength(1);
+    expect(result.undeterminedRestrictions[0].type).toBe('RESIDENCY');
+  });
+
+  it('absence of evaluable means undecidable — it does NOT mean satisfied', () => {
+    // Defaulting the other way would answer "you may enter" on a rule nothing checked.
+    const event = {
+      eventId: 'e',
+      category: u18,
+      entryRestrictions: [{ type: 'MEMBERSHIP', organisationId: 'ita', membershipCategory: 'PLAYER' }],
+    } as unknown as Event;
+    const result: any = getParticipantEligibility({ participant, event, tournamentRecord });
+    expect(result.indeterminate).toBe(true);
+  });
+
+  it('a restriction a producer has resolved does not cloud the answer', () => {
+    const event = {
+      eventId: 'e',
+      category: u18,
+      entryRestrictions: [{ type: 'MEMBERSHIP', organisationId: 'ita', evaluable: true }],
+    } as unknown as Event;
+    const result: any = getParticipantEligibility({ participant, event, tournamentRecord });
+    expect(result.eligible).toBe(true);
+    expect(result.indeterminate).toBe(false);
+  });
+
+  it('restrictions apply to an event with NO category — an open-age event can still be closed', () => {
+    const event = {
+      eventId: 'e',
+      entryRestrictions: [{ type: 'RESIDENCY', organisationId: 'usta-southern' }],
+    } as unknown as Event;
+    const result: any = getParticipantEligibility({ participant, event, tournamentRecord });
+    expect(result.indeterminate).toBe(true);
+    expect(result.undeterminedRestrictions).toHaveLength(1);
+  });
+
+  it('a real category breach stays a refusal — an unevaluable restriction does not soften it', () => {
+    const tooOld = { ...participant, person: { birthDate: '2000-03-04' } } as unknown as Participant;
+    const event = {
+      eventId: 'e',
+      category: u18,
+      entryRestrictions: [{ type: 'RESIDENCY' }],
+    } as unknown as Event;
+    const result: any = getParticipantEligibility({ participant: tooOld, event, tournamentRecord });
+    expect(result.eligible).toBe(false);
+    expect(result.indeterminate).toBe(false); // the age breach is decided, so the answer is "no"
+    expect(result.rejectionReasons[0].type).toBe('age');
+  });
+});
+
+/**
+ * Schema cover. `schemaValidation.test.ts` validates the 16 harness TODS files and none carries an
+ * `entryRestrictions` or a `cancelledAt`, so it is silent on this change — the same gap that made
+ * the sanction sweep need its own fixtures.
+ */
+describe('A6 + A8 schema', () => {
+  const ajv = new Ajv({ allowUnionTypes: true, verbose: true, allErrors: true });
+  ajv.addFormat('date-time', (dateTime: any) => {
+    if (typeof dateTime === 'object') dateTime = dateTime.toISOString();
+    return !Number.isNaN(Date.parse(dateTime));
+  });
+  addFormats(ajv);
+  const schema = JSON.parse(fs.readFileSync('./src/global/schema/tournament.schema.json', { encoding: 'utf8' }));
+  const validate = ajv.compile(schema);
+
+  const record = () => ({
+    tournamentId: 'a6-a8-fixture',
+    tournamentName: 'Restrictions Fixture',
+    tournamentStatus: 'CANCELLED',
+    cancelledAt: '2026-05-01T12:00:00.000Z',
+    cancellationReason: 'Insufficient entries',
+    events: [
+      {
+        eventId: 'e1',
+        eventName: 'Level 4 Closed Singles',
+        cancelledAt: '2026-05-01T12:00:00.000Z',
+        cancellationReason: 'Merged into the open draw',
+        entryRestrictions: [
+          {
+            type: 'RESIDENCY',
+            organisationId: 'usta-southern',
+            description: 'Open to Southern Section residents',
+            evaluable: false,
+          },
+          { type: 'MEMBERSHIP', organisationId: 'ita', membershipCategory: 'PLAYER' },
+        ],
+      },
+    ],
+  });
+
+  it('accepts restrictions and cancellation provenance', () => {
+    const valid = validate(record());
+    if (!valid) throw new Error(ajv.errorsText(validate.errors, { dataVar: 'record' }));
+    expect(valid).toBe(true);
+  });
+
+  it('REJECTS an unknown restriction type', () => {
+    const r: any = record();
+    r.events[0].entryRestrictions[0].type = 'VIBES';
+    expect(validate(r)).toBe(false);
+  });
+
+  it('REJECTS a restriction with no type', () => {
+    const r: any = record();
+    delete r.events[0].entryRestrictions[0].type;
+    expect(validate(r)).toBe(false);
+  });
+
+  it('REJECTS a misspelled restriction field rather than keeping it', () => {
+    const r: any = record();
+    r.events[0].entryRestrictions[0].evaluible = true;
+    expect(validate(r)).toBe(false);
+  });
+});

--- a/src/types/enumExports.ts
+++ b/src/types/enumExports.ts
@@ -8,7 +8,7 @@
  *
  * Regenerate:   pnpm gen:enum-exports
  * Drift guard:  pnpm check:enum-exports
- * Covers 71 enums across 4 modules.
+ * Covers 72 enums across 4 modules.
  */
 
 export { SportEnum } from './competitionFormat';
@@ -42,6 +42,7 @@ export { CurrencyUnitEnum } from './tournamentTypes';
 export { DisciplineEnum } from './tournamentTypes';
 export { DrawStatusEnum } from './tournamentTypes';
 export { DrawTypeEnum } from './tournamentTypes';
+export { EntryRestrictionEnum } from './tournamentTypes';
 export { EntryStatusEnum } from './tournamentTypes';
 export { EventTypeEnum } from './tournamentTypes';
 export { FinishingPositionEnum } from './tournamentTypes';

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -75,6 +75,17 @@ export interface Tournament {
   tournamentOtherIds?: UnifiedTournamentID[];
   tournamentRank?: string;
   tournamentStatus?: TournamentStatusUnion;
+  /**
+   * When the competition was cancelled.
+   *
+   * `TournamentStatusEnum.CANCELLED` says THAT it was; this says when, and `cancellationReason`
+   * says why. A discovery surface has to strike a cancelled tournament through rather than drop it,
+   * because somebody entered it and needs to see what happened.
+   *
+   * Unrelated to `PracticeRegistration.cancelledAt`, which is a different object's own lifecycle.
+   */
+  cancelledAt?: Date | string;
+  cancellationReason?: string;
   tournamentTier?: TierClassification;
   updatedAt?: Date | string;
   venues?: Venue[];
@@ -177,6 +188,18 @@ export interface Event {
   registrationProfile?: EventRegistration;
   /** how this event accepts entries, and how many — see {@link EventEntryProfile} */
   entryProfile?: EventEntryProfile;
+  /**
+   * Conditions on WHO may enter this event, beyond what `category` and `gender` express.
+   *
+   * Where a governing body's level name encodes one — "Level 4 Closed" meaning closed to the
+   * section — the grade belongs in `sanction.classification` and the rule belongs here. Welding
+   * them into one string makes the grade unsortable and the rule unreadable.
+   */
+  entryRestrictions?: EntryRestriction[];
+  /** when this event was cancelled — the *when* behind a CANCELLED status */
+  cancelledAt?: Date | string;
+  /** why this event was cancelled, for a consumer that must explain it to an entrant */
+  cancellationReason?: string;
   /**
    * Event-grain sanction. Grade is genuinely per-event in several federations — one tournament
    * routinely carries different categories for different age groups — mirroring `eventTier`.
@@ -1955,6 +1978,74 @@ export interface EventEntryProfile {
   waitlistEnabled?: boolean;
   extensions?: Extension[];
 }
+
+/**
+ * A condition on WHO may enter, beyond the age / gender / rating that {@link Category} already
+ * carries.
+ *
+ * Evidenced by two federations independently. One gates on residency — a level whose name ends
+ * "Closed" is open only to competitors of the sanctioning section, which is why its grade and its
+ * eligibility rule are currently welded into one facet string. The other gates on membership:
+ * "required to compete in all Summer Series tournaments", where the membership is bought from the
+ * organisation running the event.
+ *
+ * **Advisory in v1, and that is deliberate.** CODES does not hold the section rosters or membership
+ * registers these resolve against, so most restrictions cannot be evaluated here — see `evaluable`.
+ * A restriction that ANNOUNCES itself is strictly more useful than one that stays silent, because
+ * silence is indistinguishable from "no restriction". That is the same reasoning `#4711` applied to
+ * a validator that cannot evaluate a rule.
+ */
+export interface EntryRestriction {
+  type: EntryRestrictionUnion;
+  /**
+   * Whose territory, roster or register the restriction resolves against.
+   *
+   * Required in practice for MEMBERSHIP and RESIDENCY and meaningless without it: "members only" is
+   * not a rule until it says whose members. A membership of the organisation running the event and
+   * a membership of its national body are different gates.
+   */
+  organisationId?: string;
+  /**
+   * WHICH membership, where an organisation sells more than one that confers different rights.
+   *
+   * One federation's player membership gates entry while its team membership does not, so naming
+   * the organisation alone is not enough to decide whether a given competitor satisfies this.
+   */
+  membershipCategory?: string;
+  /** free text for what a consumer should tell a competitor — not parsed */
+  description?: string;
+  /**
+   * Whether this can be decided from the record alone.
+   *
+   * Defaults to FALSE in effect: a restriction with no explicit `evaluable: true` is treated as
+   * undecidable by {@link getParticipantEligibility}, which reports `indeterminate` rather than
+   * guessing. Optimism here would be a confident wrong answer about whether someone may play.
+   */
+  evaluable?: boolean;
+  extensions?: Extension[];
+}
+
+/**
+ * Kinds of entry restriction.
+ *
+ * Open in spirit — governing bodies invent gates — but enumerated so a consumer can branch on the
+ * common ones rather than parse `description`.
+ */
+export enum EntryRestrictionEnum {
+  /** competitor must be of the stated organisation's territory */
+  RESIDENCY = 'RESIDENCY',
+  /** competitor must hold a membership of the stated organisation */
+  MEMBERSHIP = 'MEMBERSHIP',
+  /** competitor must hold a ranking or rating at or above a threshold */
+  RANKING_FLOOR = 'RANKING_FLOOR',
+  /** competitor must hold a current safeguarding / background clearance */
+  CLEARANCE = 'CLEARANCE',
+  /** entry is by invitation of the organiser */
+  INVITATION = 'INVITATION',
+  /** stated by the organiser and not one of the above */
+  OTHER = 'OTHER',
+}
+export type EntryRestrictionUnion = `${EntryRestrictionEnum}`;
 
 /** How an event chooses which entries to accept when it is over-subscribed. */
 export enum SelectionProcessEnum {


### PR DESCRIPTION
**A6 and A8.** With these, A1–A8 are landed; only A9 remains.

## A6 — `Event.entryRestrictions`

`Category` carries age, gender and rating. Nothing carried the conditions that sit beside them. **Two federations gate independently on this** — one on **residency** (a level whose name ends "Closed" is open only to competitors of the sanctioning section), one on **membership** (*"required to compete in all Summer Series tournaments"*).

It also **unwelds a grade from a rule**. "Level 4 Closed" currently puts both in one facet string, which makes the grade unsortable — *Unsanctioned* and *WTN Tournament* have no rank among Levels — and the rule unreadable. Grade → `sanction.classification`; restriction → here. That closes **D-9**.

### Advisory in v1, and the wiring is the point

CODES holds no section rosters and no membership registers, so most restrictions cannot be settled from the record. **A restriction nothing reads is inert, and inert is worse than absent because it looks like coverage.** So `getParticipantEligibility` reports them: `undeterminedRestrictions` surfaces on the result and the answer becomes `indeterminate` rather than a false yes.

**Absence of `evaluable: true` means undecidable, not satisfied.** Defaulting the other way would answer *"you may enter"* on a rule nothing checked.

`membershipCategory` exists because naming the organisation isn't enough: one federation's PLAYER membership gates entry while its TEAM membership does not. *"Members only"* is not a rule until it says whose members, and which.

**A decided breach still wins.** An over-age participant is `eligible: false, indeterminate: false` — an unevaluable restriction cannot soften a refusal established on other grounds. Restrictions are also evaluated when an event has **no category**, since an open-age event can still be closed to a section.

## A8 — cancellation provenance

`cancelledAt` + `cancellationReason` on `Tournament` and `Event`. `TournamentStatusEnum.CANCELLED` says *that*; these say *when* and *why*. A discovery surface has to strike a cancelled tournament through rather than drop it, because somebody entered it.

Unrelated to `PracticeRegistration.cancelledAt` — noted on the field so the name collision isn't mistaken for a duplicate.

## Schema is load-bearing

`Event` is `additionalProperties: false`, so without `EntryRestriction` and `EntryRestrictionEnum` defined **and wired**, any record carrying the new fields would **fail validation**. Both closed per #4719's convention. `Tournament` is permissive, but the fields are declared there too — #4719's point is that silence is the problem.

## Both halves falsified independently

They fail **different** tests, which is what makes them separate evidence rather than one standing in for the other:

| probe | result |
|---|---|
| restriction filter returns `[]` | **3 behaviour tests red** |
| schema loosened to `{"type":"object"}` | **3 schema tests red** |

The harness could not have caught either: `schemaValidation.test.ts` validates 16 TODS files and none carries an `entryRestrictions` or a `cancelledAt` — the same gap that made the sanction sweep need its own fixtures.

## Verification

`pnpm verify` green — all 15 steps.