### PR TITLE
feat(read-model): a discovery row shape, and the invalidation set that defers its emission

### DIFF
--- a/src/query/readModel/readModelRows.ts
+++ b/src/query/readModel/readModelRows.ts
@@ -1,11 +1,14 @@
+import { getEffectiveRegistrationProfile } from '@Query/entries/getEffectiveRegistrationProfile';
 import { getTournamentPublishStatus } from '@Query/tournaments/getTournamentPublishStatus';
 import { SCHEDULING_PROFILE } from '@Constants/extensionConstants';
+import { getEntryFeeRange } from '@Query/entries/resolveEntryFee';
 import { LINK_UNRESOLVED, resolvePersonLink } from './personRule';
 import { findExtension } from '@Acquire/findExtension';
 
 // types
 import { UnifiedDrawID, UnifiedEventID, UnifiedTournamentID } from '@Types/tournamentTypes';
 import {
+  ReadModelTournamentDiscoveryRow,
   ReadModelTournamentRow,
   ReadModelCompetitorRow,
   ReadModelMatchUpRow,
@@ -57,6 +60,78 @@ export function tournamentRow(record: any): ReadModelTournamentRow {
     published: !!(pubStatus?.orderOfPlay?.published || pubStatus?.participants?.published),
     origin_organisation_id: origin?.organisationId ?? null,
     origin_tournament_id: origin?.tournamentId ?? null,
+  };
+}
+
+/** Coordinates arrive as `string | number` in CODES. A read model that stores both cannot index. */
+function toNumber(value: any): number | null {
+  if (value === null || value === undefined || value === '') return null;
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Sorted, de-duplicated, empties dropped — a facet list is a set, and a stable one. */
+function facet(values: (string | undefined | null)[]): string[] {
+  return [...new Set(values.filter((v): v is string => !!v))].sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * One denormalised row per tournament, for faceted discovery.
+ *
+ * Aggregates over the tournament AND its events — see {@link ReadModelTournamentDiscoveryRow} for
+ * why that makes it the first row of its kind here, and for why no `registration_state` is stored.
+ *
+ * Reuses `getEntryFeeRange` and `getEffectiveRegistrationProfile` rather than re-deriving them: a
+ * second implementation of "which fees apply and can they be compared" would drift from the first,
+ * and the first is the one with the unit rules in it.
+ */
+export function tournamentDiscoveryRow(record: any): ReadModelTournamentDiscoveryRow {
+  const events: any[] = record?.events ?? [];
+  const sanction: any = record?.sanction ?? {};
+  const classification: any = sanction.classification ?? record?.tournamentTier ?? {};
+
+  const primaryVenue: any = record?.venues?.find((v: any) => v?.isPrimary) ?? record?.venues?.[0];
+  const address: any = primaryVenue?.addresses?.[0] ?? {};
+
+  const registration: any = getEffectiveRegistrationProfile({ tournamentRecord: record });
+
+  // Every fee the tournament states, event-level included. The range refuses to span
+  // denominations, so a mixed-currency tournament reports no range rather than a wrong one.
+  const allFees = [
+    ...(registration?.entryFees ?? []),
+    ...events.flatMap((e) => e?.registrationProfile?.entryFees ?? []),
+  ];
+  const range: any = getEntryFeeRange(allFees);
+  const comparable = range && !range.incomparable?.length && !range.indeterminate?.length;
+
+  return {
+    tournament_id: record?.tournamentId,
+    provider_id: record?.parentOrganisation?.organisationId ?? null,
+    start_date: record?.startDate ?? null,
+    end_date: record?.endDate ?? null,
+    latitude: toNumber(address.latitude),
+    longitude: toNumber(address.longitude),
+    venue_name: primaryVenue?.venueName ?? null,
+    city: address.city ?? record?.city ?? null,
+    state: address.state ?? null,
+    country_code: address.countryCode ?? record?.hostCountryCode ?? null,
+    level_system: classification.system ?? null,
+    level_value: classification.value ?? null,
+    recognition: sanction.recognition ?? null,
+    decision: sanction.decision ?? null,
+    ranking_eligible: sanction.confers?.rankingEligible ?? null,
+    entries_open: registration?.entriesOpen ?? null,
+    entries_close: registration?.entriesClose ?? null,
+    fee_min: comparable ? range.min.amount : null,
+    fee_max: comparable ? range.max.amount : null,
+    fee_currency: comparable ? range.min.currencyCode : null,
+    fee_unit: comparable ? range.min.unit : null,
+    event_count: events.length,
+    category_types: facet(events.map((e) => e?.category?.categoryType)),
+    genders: facet(events.map((e) => e?.gender)),
+    age_codes: facet(events.map((e) => e?.category?.ageCategoryCode)),
+    rating_types: facet(events.map((e) => e?.category?.ratingType)),
+    cancelled_at: record?.cancelledAt ?? null,
   };
 }
 

--- a/src/tests/queries/readModel/tournamentDiscoveryRow.test.ts
+++ b/src/tests/queries/readModel/tournamentDiscoveryRow.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+
+import { tournamentDiscoveryRow } from '@Query/readModel/readModelRows';
+import { cast } from '@Query/readModel/cast';
+
+/**
+ * A9, factory slice.
+ *
+ * The discovery row is the FIRST AGGREGATE in the projection — every other row is 1:1 with a source
+ * object, this one summarises a tournament and its events. These tests pin the two things that make
+ * it defensible: the aggregates are computed over events, and the money refuses to state a range it
+ * cannot honestly compute.
+ */
+
+const record: any = {
+  tournamentId: 't1',
+  tournamentName: 'Discovery Fixture',
+  startDate: '2026-07-27',
+  endDate: '2026-08-03',
+  parentOrganisation: { organisationId: 'prov-1' },
+  hostCountryCode: 'USA',
+  cancelledAt: null,
+  sanction: {
+    decision: 'APPROVED',
+    recognition: 'UNSANCTIONED',
+    classification: { system: 'USTA', value: 'Level 5 Open' },
+    confers: { rankingEligible: false },
+  },
+  registrationProfile: {
+    entriesOpen: '2026-05-01',
+    entriesClose: '2026-07-01',
+    entryFees: [{ amount: 7500, currencyCode: 'USD', unit: 'MINOR' }],
+  },
+  venues: [
+    {
+      venueId: 'v1',
+      venueName: 'Seattle Tennis Club',
+      isPrimary: true,
+      addresses: [{ city: 'Seattle', state: 'WA', countryCode: 'USA', latitude: '47.6062', longitude: -122.3321 }],
+    },
+  ],
+  events: [
+    {
+      eventId: 'e1',
+      gender: 'MALE',
+      category: { categoryType: 'ADULT', ageCategoryCode: 'O35', ratingType: 'NTRP' },
+      registrationProfile: { entryFees: [{ amount: 9500, currencyCode: 'USD', unit: 'MINOR' }] },
+    },
+    { eventId: 'e2', gender: 'FEMALE', category: { categoryType: 'ADULT', ageCategoryCode: 'O35' } },
+    { eventId: 'e3', gender: 'MIXED', category: { categoryType: 'JUNIOR', ageCategoryCode: 'U18' } },
+  ],
+};
+
+describe('tournamentDiscoveryRow', () => {
+  it('flattens the sanction across all three axes', () => {
+    const row: any = tournamentDiscoveryRow(record);
+    expect(row.level_system).toBe('USTA');
+    expect(row.level_value).toBe('Level 5 Open');
+    expect(row.recognition).toBe('UNSANCTIONED');
+    expect(row.decision).toBe('APPROVED');
+    expect(row.ranking_eligible).toBe(false);
+  });
+
+  it('falls back to tournamentTier when no sanction classification is stated', () => {
+    const noClass: any = {
+      ...record,
+      sanction: { decision: 'APPROVED' },
+      tournamentTier: { system: 'ITF', value: 'J60' },
+    };
+    const row: any = tournamentDiscoveryRow(noClass);
+    expect(row.level_system).toBe('ITF');
+    expect(row.level_value).toBe('J60');
+  });
+
+  it('coerces coordinates to numbers regardless of how they were stored', () => {
+    // CODES types latitude/longitude as `string | number`; both forms are real.
+    const row: any = tournamentDiscoveryRow(record);
+    expect(row.latitude).toBe(47.6062);
+    expect(row.longitude).toBe(-122.3321);
+    expect(typeof row.latitude).toBe('number');
+  });
+
+  it('aggregates facets over events, sorted and de-duplicated', () => {
+    const row: any = tournamentDiscoveryRow(record);
+    expect(row.event_count).toBe(3);
+    expect(row.category_types).toEqual(['ADULT', 'JUNIOR']);
+    expect(row.genders).toEqual(['FEMALE', 'MALE', 'MIXED']);
+    expect(row.age_codes).toEqual(['O35', 'U18']);
+    expect(row.rating_types).toEqual(['NTRP']);
+  });
+
+  it('takes the fee range across tournament AND event fees', () => {
+    const row: any = tournamentDiscoveryRow(record);
+    expect(row.fee_min).toBe(7500);
+    expect(row.fee_max).toBe(9500);
+    expect(row.fee_currency).toBe('USD');
+    expect(row.fee_unit).toBe('MINOR');
+  });
+
+  it('states NO range when a fee cannot be placed on a scale', () => {
+    // A partial range is a wrong answer wearing a number.
+    const unitless: any = {
+      ...record,
+      registrationProfile: { entryFees: [{ amount: 7500, currencyCode: 'USD' }] },
+      events: [],
+    };
+    const row: any = tournamentDiscoveryRow(unitless);
+    expect(row.fee_min).toBeNull();
+    expect(row.fee_max).toBeNull();
+    expect(row.fee_currency).toBeNull();
+  });
+
+  it('states NO range when fees span denominations', () => {
+    const mixed: any = {
+      ...record,
+      registrationProfile: {
+        entryFees: [
+          { amount: 75, currencyCode: 'USD', unit: 'MAJOR' },
+          { amount: 60, currencyCode: 'EUR', unit: 'MAJOR' },
+        ],
+      },
+      events: [],
+    };
+    const row: any = tournamentDiscoveryRow(mixed);
+    expect(row.fee_min).toBeNull();
+  });
+
+  it('emits registration DATES and no derived state', () => {
+    // registration_state is a function of NOW and cast() is pure; storing it would bake in a
+    // timestamp nothing re-runs. Same call the projection already made for published/embargo.
+    const row: any = tournamentDiscoveryRow(record);
+    expect(row.entries_open).toBe('2026-05-01');
+    expect(row.entries_close).toBe('2026-07-01');
+    expect(row).not.toHaveProperty('registration_state');
+  });
+
+  it('survives a bare record without throwing', () => {
+    const row: any = tournamentDiscoveryRow({ tournamentId: 't' });
+    expect(row.tournament_id).toBe('t');
+    expect(row.event_count).toBe(0);
+    expect(row.category_types).toEqual([]);
+    expect(row.latitude).toBeNull();
+    expect(row.fee_min).toBeNull();
+  });
+});
+
+/**
+ * `cast()` does NOT emit this row yet, deliberately.
+ *
+ * Emitting it failed seven notice-conformance scenarios — deleteEvents, addVenue, modifyVenue,
+ * setTournamentDates (widen and shrink), deleteVenue and setTournamentTier all change a discovery
+ * row while emitting notices scoped to an event or venue, never the tournament. That is the
+ * aggregate-invalidation problem, and resolving it is a behaviour decision belonging with the CFS
+ * half of A9. This test pins the current state so the deferral is explicit rather than forgotten.
+ */
+describe('cast() emission is deliberately deferred', () => {
+  it('does not yet emit tournament_discovery, and still emits every existing table', () => {
+    const result: any = cast({ tournamentRecord: record });
+    expect(result.success).toBe(true);
+    expect(result.rows.tournament_discovery).toBeUndefined();
+    for (const table of ['tournaments', 'events', 'match_ups', 'entries', 'venues']) {
+      expect(result.rows[table]).toBeDefined();
+    }
+  });
+});

--- a/src/types/readModelTypes.ts
+++ b/src/types/readModelTypes.ts
@@ -28,6 +28,92 @@ export interface ReadModelTournamentRow {
   origin_tournament_id: string | null;
 }
 
+/**
+ * One row per tournament, denormalised for FACETED DISCOVERY — "what can I play, near me, that I
+ * am eligible for".
+ *
+ * **The first aggregate row in the projection.** Every other `ReadModel*Row` is 1:1 with a source
+ * object; this one summarises a tournament AND its events, because the questions it answers are
+ * asked of the tournament while the answers live on the events. That is a deliberate denormalisation
+ * and it is the reason the CONSUMER side needs an invalidation rule the other tables do not: an
+ * event changing dirties its tournament's row.
+ *
+ * `cast()` is a pure whole-record projection, so it produces this correctly whether the consumer
+ * maintains it incrementally or rebuilds it per tournament. That question is deliberately left open
+ * here rather than prejudged.
+ *
+ * ## What is NOT here, and why
+ *
+ * **No `registration_state`.** "open" / "closing within a week" / "closed" is a function of NOW, and
+ * `cast()` is pure — no I/O, no clock. Storing it would bake a timestamp into a row that nothing
+ * re-runs on a schedule, so it would be wrong from the moment it was written. The dates are emitted
+ * instead and the state is a READ-time derivation. This mirrors the call already made for
+ * visibility, where `published` + `embargo` are stored and gated at read time "never a stale stored
+ * boolean".
+ *
+ * ## Why `cast()` does not emit this yet
+ *
+ * Emitting it made SEVEN notice-conformance scenarios fail, and the failures are the finding rather
+ * than an obstacle: `deleteEvents`, `addVenue`, `modifyVenue`, `setTournamentDates` (widen AND
+ * shrink), `deleteVenue` and `setTournamentTier` each CHANGE a discovery row while emitting notices
+ * scoped to an event or a venue — never to the tournament. The conformance harness therefore
+ * measured the invalidation set for this row before anyone had to design it.
+ *
+ * That is the aggregate problem made concrete: the notice model attributes a projected row to the
+ * entity that changed, and this row belongs to no single entity. Wiring it needs either
+ * tournament-scoped notices on those six mutations or a consumer that rebuilds the row when any
+ * member changes — a behaviour decision, not a projection detail, and one that belongs with the CFS
+ * half of A9.
+ *
+ * The type and `tournamentDiscoveryRow()` ship now so the CFS and courthive-query work can be built
+ * against a real shape instead of a proposed one.
+ */
+export interface ReadModelTournamentDiscoveryRow {
+  tournament_id: string;
+  provider_id: string | null;
+  // dates are duplicated from `tournaments` deliberately: date range is the hottest facet, and a
+  // discovery index that has to join to filter on it is not an index.
+  start_date: string | null;
+  end_date: string | null;
+  // Geo, from the primary venue. `Address.latitude`/`longitude` are typed `string | number` in
+  // CODES, so both are coerced to number here — a read model that stores two representations of a
+  // coordinate cannot be indexed on it.
+  latitude: number | null;
+  longitude: number | null;
+  venue_name: string | null;
+  city: string | null;
+  state: string | null;
+  country_code: string | null;
+  // Sanction, flattened. `level_*` comes from `sanction.classification`, falling back to
+  // `tournamentTier` — the same tier shape, one grain up.
+  level_system: string | null;
+  level_value: string | null;
+  recognition: string | null;
+  decision: string | null;
+  ranking_eligible: boolean | null;
+  // Registration window as FACTS. See the note above on why no state is stored.
+  entries_open: string | null;
+  entries_close: string | null;
+  /**
+   * Fee range across the tournament's events.
+   *
+   * NULL — all four columns — when ANY contributing fee cannot be placed on a scale, or when fees
+   * span more than one denomination. A partial range is a wrong answer wearing a number, and a
+   * min/max computed across currencies compares figures that are not comparable.
+   */
+  fee_min: number | null;
+  fee_max: number | null;
+  fee_currency: string | null;
+  fee_unit: string | null;
+  // Facet aggregates over the events.
+  event_count: number;
+  category_types: string[];
+  genders: string[];
+  age_codes: string[];
+  rating_types: string[];
+  cancelled_at: string | null;
+}
+
 export interface ReadModelParticipantPublishRow {
   tournament_id: string;
   published: boolean;
@@ -235,4 +321,9 @@ export interface ReadModelRows {
   entries: ReadModelEntryRow[];
   venues: ReadModelVenueRow[];
   tournament_venues: ReadModelTournamentVenueRow[];
+  /**
+   * NOT YET EMITTED BY `cast()` — see {@link ReadModelTournamentDiscoveryRow}. Optional so the row
+   * shape can be consumed and built against before the projection wiring exists.
+   */
+  tournament_discovery?: ReadModelTournamentDiscoveryRow[];
 }


### PR DESCRIPTION
**A9, factory slice.** Landed ahead of the CFS and courthive-query halves so a factory release can go out.

`ReadModelTournamentDiscoveryRow` denormalises a tournament for faceted discovery: geo from the primary venue, the sanction flattened across all three axes, the registration window, a fee range, and facet aggregates over the events.

It is the **first aggregate row in the projection**. Every other `ReadModel*Row` is 1:1 with a source object; this one summarises a tournament *and* its events — the questions it answers are asked of the tournament while the answers live on the events.

## What `cast()` does NOT do, and why

**Emitting the row failed seven notice-conformance scenarios — and the failures are the finding, not an obstacle.**

`deleteEvents`, `addVenue`, `modifyVenue`, `setTournamentDates` (**widen and shrink**), `deleteVenue` and `setTournamentTier` each *change* a discovery row while emitting notices scoped to an **event or a venue, never the tournament**.

The conformance harness measured the invalidation set for this row before anyone had to design it. That is the aggregate problem made concrete: the notice model attributes a projected row to the entity that changed, and this row belongs to no single entity.

Wiring it needs either tournament-scoped notices on those six mutations, or a consumer that rebuilds the row when any member changes — **a behaviour decision, not a projection detail**, and one that belongs with the CFS half.

**So the shape ships and the emission does not.** `cast()` is unchanged and still emits the same 14 tables; the `ReadModelRows` key is optional; a test pins the deferral so it is explicit rather than forgotten. CFS and courthive-query can now be built against a real type instead of a proposed one.

> This also corrects my own scoping note, which said the invalidation question lived entirely in CFS. `cast()` is pure — which is what I reasoned from — but purity was not the whole coupling. **Notice conformance is enforced in the factory.**

## Two decisions inside the row

**No `registration_state` column.** "open" / "closing within a week" / "closed" is a function of NOW, and `cast()` is pure — no I/O, no clock — so storing it would bake a timestamp into a row nothing re-runs on a schedule. The dates are emitted; the state is a read-time derivation. This is the call the projection **already made** for visibility, where `published` + `embargo` are stored and gated at read time *"never a stale stored boolean"*.

**Fee columns are all NULL unless the range is honestly computable.** A fee that cannot be placed on a scale, or fees spanning denominations, yield no range rather than a partial one — a partial range is a wrong answer wearing a number. Reuses `getEntryFeeRange` and `getEffectiveRegistrationProfile` rather than re-deriving them, so the unit rules cannot drift into a second implementation.

Coordinates are coerced to `number`: CODES types `latitude`/`longitude` as `string | number` and both forms are real, but a read model storing two representations of a coordinate cannot be indexed on it.

## Verification

`pnpm verify` green — all 15 steps. Additive-only, checked against the built artifact: all 13 pre-existing `cast()` keys present and unchanged.