### PR TITLE
fix(read-model): export the discovery row builder so a consumer can reach it

### DIFF
--- a/src/query/readModel/index.ts
+++ b/src/query/readModel/index.ts
@@ -12,6 +12,7 @@ export type { MatchUpPublishState } from './readModelPublish';
 export { isFactoryUuid, resolvePersonLink, LINK_PROVIDER_ID, LINK_UNRESOLVED } from './personRule';
 export type { PersonLink } from './personRule';
 export {
+  tournamentDiscoveryRow,
   tournamentRow,
   tournamentOrigin,
   eventRow,
@@ -39,6 +40,7 @@ export type {
   CourtRowContext,
 } from './readModelRows';
 export type {
+  ReadModelTournamentDiscoveryRow,
   ReadModelEventRow,
   ReadModelSeedRow,
   ReadModelDrawRow,


### PR DESCRIPTION
#4741 shipped `ReadModelTournamentDiscoveryRow` and `tournamentDiscoveryRow()` but **did not export the builder from the `readModel` namespace** — which is the door CFS comes through (`import { readModel } from 'tods-competition-factory'`).

The shape was reachable; the builder was not. So the slice did not actually unblock the consumer it was landed to unblock.

**Caught by asking the built artifact rather than the source:**

```
readModel.tournamentDiscoveryRow → undefined
```

This matters more than a missing line. CFS has **no local copy** of these builders by design — `query/readModel/index.ts` calls this toolkit *"the single source for TODS → read-model rows, shared by `cast()` (full rebuild) and the CFS incremental producer (per-draw), so both paths emit byte-identical rows."*

A builder the incremental producer cannot import is precisely the one way that guarantee breaks: CFS would have had to hand-roll the row, and the two paths would drift.

The row **type** is exported alongside it for the same reason.

Verified after the change, against the built dist rather than the source:

```
tournamentDiscoveryRow reachable: function
produces a row: t | event_count: 1 | genders: ["MALE"]
```

`pnpm verify` green — all 15 steps.