### PR TITLE
feat(read-model): cast() emits the discovery row, via an aggregate attribution kind

### DIFF
--- a/src/query/readModel/cast.ts
+++ b/src/query/readModel/cast.ts
@@ -10,6 +10,7 @@ import {
   resolveSchedulingProfile,
   seedRow,
   structureRow,
+  tournamentDiscoveryRow,
   tournamentRow,
   venueRow,
   MatchUpRowContext,
@@ -135,6 +136,7 @@ export function cast(params?: CastArgs): { error?: ErrorType; success?: boolean;
     ...SUCCESS,
     rows: {
       tournaments: [tournamentRow(tournamentRecord)],
+      tournament_discovery: [tournamentDiscoveryRow(tournamentRecord)],
       events,
       draws,
       structures,

--- a/src/tests/mutations/notifications/noticeConformance/aggregateCoverage.test.ts
+++ b/src/tests/mutations/notifications/noticeConformance/aggregateCoverage.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { DELETE_EVENT, MODIFY_TOURNAMENT_DETAIL } from '@Constants/topicConstants';
+import { fidelityViolations } from './harness';
+
+/**
+ * The `tournamentAggregate` coverage rule, falsified.
+ *
+ * Registering `tournament_discovery` under a kind whose coverage is "the mutation announced
+ * something" is a LOOSENING of the oracle, and a loosening has to prove it still catches the thing
+ * it exists to catch. The failure that matters is a mutation which moves an aggregate row and
+ * announces NOTHING — that is a silent read-model divergence, and it must still be a violation.
+ *
+ * Without these, the aggregate kind would be indistinguishable from deleting the check.
+ *
+ * The topics below are the REAL constants. An earlier draft of this file used the string
+ * 'deleteEvents', which `noticedEntityKeys` does not recognise, so the notice registered as nothing
+ * and the test failed — a fabricated topic looks identical to no notice at all.
+ */
+
+const base = (overrides: any = {}) => ({
+  tournamentId: 't1',
+  tournamentName: 'Aggregate Coverage',
+  startDate: '2026-07-01',
+  endDate: '2026-07-07',
+  events: [{ eventId: 'e1', eventName: 'Singles', gender: 'MALE', category: { categoryType: 'ADULT' } }],
+  venues: [],
+  participants: [],
+  ...overrides,
+});
+
+describe('tournamentAggregate coverage still catches a silent change', () => {
+  it('VIOLATES when the discovery row moves and no notice fired at all', () => {
+    const before = base();
+    const after = base({ tournamentTier: { system: 'USTA', value: 'Level 4' } });
+    const violations = fidelityViolations(before, after, []);
+    const aggregate = violations.filter((v: any) => v.table === 'tournament_discovery');
+    expect(aggregate.length).toBeGreaterThan(0);
+    expect(aggregate[0].kind).toBe('tournamentAggregate');
+  });
+
+  it('does NOT violate when the mutation announced something', () => {
+    const before = base();
+    const after = base({ tournamentTier: { system: 'USTA', value: 'Level 4' } });
+    const violations = fidelityViolations(before, after, [
+      { topic: MODIFY_TOURNAMENT_DETAIL, payload: { tournamentId: 't1' } },
+    ]);
+    expect(violations.filter((v: any) => v.table === 'tournament_discovery')).toEqual([]);
+  });
+
+  it('an event-scoped notice covers it — that is the whole point', () => {
+    // The six mutations that move this row announce the event or venue, never the tournament.
+    const before = base();
+    const after = base({ events: [] });
+    const violations = fidelityViolations(before, after, [
+      { topic: DELETE_EVENT, payload: { eventIds: ['e1'], tournamentId: 't1' } },
+    ]);
+    expect(violations.filter((v: any) => v.table === 'tournament_discovery')).toEqual([]);
+  });
+});

--- a/src/tests/mutations/notifications/noticeConformance/harness.ts
+++ b/src/tests/mutations/notifications/noticeConformance/harness.ts
@@ -49,7 +49,29 @@ import {
 } from '@Constants/topicConstants';
 
 export type EntityKind =
-  'tournament' | 'participant' | 'event' | 'drawDefinition' | 'structure' | 'matchUp' | 'entries' | 'venue';
+  | 'tournament'
+  | 'participant'
+  | 'event'
+  | 'drawDefinition'
+  | 'structure'
+  | 'matchUp'
+  | 'entries'
+  | 'venue'
+  /**
+   * A row that summarises a tournament AND its contents, belonging to no single entity.
+   *
+   * Every other kind names the object a projected row is 1:1 with, and coverage asks "did a notice
+   * fire for THAT object". An aggregate has no such object: `tournament_discovery` changes when an
+   * event, a venue, a date or a tier changes, and those mutations correctly announce the event or
+   * the venue — never the tournament. Attributing the row to `tournament` therefore reported seven
+   * false violations, which is the oracle applying a 1:1 assumption to a row that is not 1:1.
+   *
+   * Coverage for this kind is "the mutation announced SOMETHING", because that is exactly what the
+   * consumer keys off: CFS rebuilds the row for every tournament its intent batch touched, and
+   * intents are derived from notices. A mutation that changes an aggregate row and emits NO notice
+   * is still a violation — that is the failure this kind must keep catching, and it is falsified.
+   */
+  | 'tournamentAggregate';
 export type ChangeType = 'added' | 'modified' | 'removed';
 export type CapturedNotice = { topic: string; payload: any };
 export type EntityChange = { kind: EntityKind; id: string; change: ChangeType };
@@ -68,6 +90,9 @@ const INCIDENTAL_KEYS = new Set(['updatedAt', 'createdAt', 'timeStamp', 'process
  */
 export const entityTopicSpec: Record<EntityKind, Partial<Record<ChangeType, string[]>>> = {
   tournament: { modified: [MODIFY_TOURNAMENT_DETAIL] },
+  // No topic list: an aggregate is not covered by naming ONE topic, because the mutations that move
+  // it announce whichever event or venue changed. Coverage is decided in isEntityCovered instead.
+  tournamentAggregate: {},
   participant: { added: [ADD_PARTICIPANTS], modified: [MODIFY_PARTICIPANTS], removed: [DELETE_PARTICIPANTS] },
   matchUp: {
     added: [ADD_MATCHUPS],
@@ -180,6 +205,10 @@ function structureCovered(change: EntityChange, noticed: Set<string>, parentage:
  * under any draw notice, and — for removals — an ancestor delete notice.
  */
 function isEntityCovered(change: EntityChange, noticed: Set<string>, parentage: Parentage): boolean {
+  // An aggregate row is covered when the mutation announced anything at all. See EntityKind.
+  // Deliberately NOT `noticed.has('tournament:<id>')`: the mutations that move this row announce
+  // the event or venue that changed, which is the correct signal and the one the consumer uses.
+  if (change.kind === 'tournamentAggregate') return noticed.size > 0;
   if (change.kind === 'entries') return entriesCovered(change, noticed);
   if (noticed.has(`${change.kind}:${change.id}`)) return true;
   if (change.kind === 'structure') return structureCovered(change, noticed, parentage);
@@ -243,6 +272,10 @@ function collectMatchUps(structure: any, out: Map<string, any>): void {
 export function collectEntities(record: any): EntityMaps {
   const maps: EntityMaps = {
     tournament: new Map(),
+    // Never populated by structural collection: an aggregate has no source object to collect. It
+    // is diffed as a cast() ROW, not as a record entity, so the map exists only to satisfy the
+    // exhaustive EntityKind record.
+    tournamentAggregate: new Map(),
     participant: new Map(),
     event: new Map(),
     drawDefinition: new Map(),
@@ -434,6 +467,9 @@ const CAST_TABLE_OWNER: Record<string, { kind: EntityKind; idOf: (row: Row) => s
   order_of_play: { kind: 'tournament', idOf: (r) => r.tournament_id },
   participant_publish: { kind: 'tournament', idOf: (r) => r.tournament_id },
   scheduling_profile: { kind: 'tournament', idOf: (r) => r.tournament_id },
+  // The only aggregate. Summarises the tournament AND its events, so it is attributed to a kind
+  // whose coverage rule matches how it actually changes — see EntityKind.tournamentAggregate.
+  tournament_discovery: { kind: 'tournamentAggregate', idOf: (r) => r.tournament_id },
 };
 
 /** The cast() tables the fidelity oracle knows how to attribute — for the drift guard. */

--- a/src/tests/queries/readModel/tournamentDiscoveryRow.test.ts
+++ b/src/tests/queries/readModel/tournamentDiscoveryRow.test.ts
@@ -145,21 +145,27 @@ describe('tournamentDiscoveryRow', () => {
 });
 
 /**
- * `cast()` does NOT emit this row yet, deliberately.
+ * `cast()` now emits the row. The deferral in #4741 is lifted.
  *
- * Emitting it failed seven notice-conformance scenarios — deleteEvents, addVenue, modifyVenue,
- * setTournamentDates (widen and shrink), deleteVenue and setTournamentTier all change a discovery
- * row while emitting notices scoped to an event or venue, never the tournament. That is the
- * aggregate-invalidation problem, and resolving it is a behaviour decision belonging with the CFS
- * half of A9. This test pins the current state so the deferral is explicit rather than forgotten.
+ * What unblocked it was not wiring but a modelling correction: the conformance oracle attributed
+ * every projected row to ONE source object, and an aggregate has none. `tournament_discovery` is
+ * registered under the `tournamentAggregate` kind, whose coverage rule matches how the row actually
+ * changes — the mutations that move it announce the event or the venue that changed, never the
+ * tournament.
  */
-describe('cast() emission is deliberately deferred', () => {
-  it('does not yet emit tournament_discovery, and still emits every existing table', () => {
+describe('cast() emits the discovery row', () => {
+  it('produces exactly one row per tournament, alongside every existing table', () => {
     const result: any = cast({ tournamentRecord: record });
     expect(result.success).toBe(true);
-    expect(result.rows.tournament_discovery).toBeUndefined();
+    expect(result.rows.tournament_discovery).toHaveLength(1);
+    expect(result.rows.tournament_discovery[0].tournament_id).toBe('t1');
     for (const table of ['tournaments', 'events', 'match_ups', 'entries', 'venues']) {
       expect(result.rows[table]).toBeDefined();
     }
+  });
+
+  it('the emitted row equals the builder — cast() adds no second derivation', () => {
+    const result: any = cast({ tournamentRecord: record });
+    expect(result.rows.tournament_discovery[0]).toEqual(tournamentDiscoveryRow(record));
   });
 });


### PR DESCRIPTION
Lifts the deferral from #4741. **The blocker was never wiring** — it was that the conformance oracle attributes every projected row to **one** source object, and an aggregate has none.

`tournament_discovery` changes when an event, a venue, a date or a tier changes, and those mutations correctly announce **the event or the venue, never the tournament**. Attributing the row to `tournament` therefore produced seven *false* violations: `deleteEvents`, `addVenue`, `modifyVenue`, `setTournamentDates` (widen and shrink), `deleteVenue`, `setTournamentTier`. The oracle was applying a 1:1 assumption to a row that is not 1:1.

## The change

New `EntityKind` — `tournamentAggregate` — whose coverage rule is *"the mutation announced something"*. That is exactly what the consumer keys off: CFS rebuilds the row for every tournament its intent batch touched, and intents are derived from notices.

**Existing kinds are untouched.** This is a new branch at the top of `isEntityCovered` plus one `CAST_TABLE_OWNER` entry — not a modification of the rules every other row depends on.

## It is a loosening, so it is falsified

This relaxes a guard over the whole projection, so it isn't trusted on a green run. `aggregateCoverage.test.ts` pins the failure that matters:

| case | expected |
|---|---|
| discovery row moves, **no notice at all** | **still violates** ✓ |
| tournament-scoped notice | covered ✓ |
| event-scoped notice | covered ✓ — *the whole point* |

Without the first, the new kind would be indistinguishable from deleting the check.

## Two things caught while writing those tests

**TypeScript's exhaustive `Record<EntityKind, …>`** flagged two maps the new kind had to appear in — `entityTopicSpec` and `collectEntities`. Both now carry it with a comment saying why one is empty and the other never populated: an aggregate has no single topic and no source object to collect.

**A fixture of mine used the literal `'deleteEvents'`**, which is not in the notice vocabulary — the constant is `DELETE_EVENT` (`'deleteEvent'`) carrying a plural `eventIds` array, **one notice for many events**. `noticedEntityKeys` ignored the fabricated topic, so it registered as *nothing* — indistinguishable from "no notice fired". Had the assertion been written the other way round, it would have **passed for the wrong reason**. The tests now import the real constants, and the file says why.

## Also

The deferral test from #4741 is **inverted rather than deleted**, and a second assertion pins that `cast()`'s emitted row equals the builder's output — so `cast()` cannot grow a second derivation of the same row.

`pnpm verify` green — all 15 steps. 163 tests pass.