### PR TITLE
fix(tools): report matchUps that could not be placed, instead of dropping them

### DIFF
--- a/src/tests/tools/buildFromSources/repairAndMatchUpPath.test.ts
+++ b/src/tests/tools/buildFromSources/repairAndMatchUpPath.test.ts
@@ -177,16 +177,15 @@ describe('buildFromSources — malformed and partial input', () => {
   });
 
   /**
-   * ⚠️ DOCUMENTS A DATA-LOSS BEHAVIOUR, it does not endorse one.
+   * INVERTED 2026-08-30. This test previously asserted the DROP and named it pre-existing: a matchUp
+   * whose `structureId` matched no structure vanished, because `augmentDrawWithMatchUps` computed
+   * `insertMatchUpIntoStructure`'s result and discarded it. It is kept rather than deleted because
+   * it is the record of what changed — the behaviour is now REPORTED.
    *
-   * `augmentDrawWithMatchUps` inserts a matchUp only into an EXISTING structure whose structureId
-   * matches. When none does, `insertMatchUpIntoStructure` returns false and the matchUp is dropped —
-   * `placed` is computed and discarded, so nothing is reported. Ported verbatim and asserted as-is
-   * rather than changed, because a port whose behaviour shifts cannot be verified by the suite it
-   * came with. Raised as a follow-up: it is the same silent-drop family as the link loss that
-   * prompted this move.
+   * Note what it still does NOT do: no structure is invented to hold the orphan. Trading a silent
+   * drop for a silent fabrication would be no better and harder to unpick.
    */
-  it('DROPS a matchUp whose structureId matches no structure in the draw (pre-existing)', () => {
+  it('REPORTS a matchUp whose structureId matches no structure, rather than dropping it silently', () => {
     const result: any = buildFromSources([
       {
         tournamentPublicEventData: {
@@ -214,17 +213,48 @@ describe('buildFromSources — malformed and partial input', () => {
     ]);
 
     const draw = result.record.events[0].drawDefinitions.find((d: any) => d.drawId === 'd1');
-    const ids: string[] = [];
+    const placed: string[] = [];
     const walk = (structures: any[] = []) => {
       for (const s of structures) {
-        for (const m of s.matchUps ?? []) ids.push(m.matchUpId);
+        for (const m of s.matchUps ?? []) placed.push(m.matchUpId);
         walk(s.structures);
       }
     };
     walk(draw.structures);
-    expect(ids).toContain('m1');
-    // m2 is gone, and nothing in the result says so. That is the finding.
-    expect(ids).not.toContain('m2');
+
+    expect(placed).toContain('m1');
+    expect(placed).not.toContain('m2');
+
+    // The change: m2 is still not in the draw, but it is no longer invisible.
+    expect(result.unplacedMatchUps).toHaveLength(1);
+    expect(result.unplacedMatchUps[0]).toMatchObject({
+      matchUpId: 'm2',
+      eventId: 'e1',
+      drawId: 'd1',
+      structureId: 'no-such-structure',
+    });
+  });
+
+  it('reports an empty unplaced list when every matchUp finds a home', () => {
+    // The negative half: a report that is never empty is as useless as one that is never populated.
+    const result: any = buildFromSources([
+      {
+        tournamentPublicEventData: {
+          eventData: {
+            eventInfo: { eventId: 'e1', eventName: 'E', eventType: 'SINGLES' },
+            drawsData: [{ drawId: 'd1', drawName: 'Main', structures: [{ structureId: 's1', matchUps: [] }] }],
+          },
+        },
+      },
+      {
+        tournamentMatchUps: {
+          dateMatchUps: [
+            { matchUpId: 'm1', eventId: 'e1', drawId: 'd1', structureId: 's1', roundNumber: 1, sides: [] },
+          ],
+        },
+      },
+    ]);
+    expect(result.unplacedMatchUps).toEqual([]);
   });
 
   it('ignores a matchUp with no eventId rather than inventing one', () => {

--- a/src/tools/buildFromSources/buildFromSources.ts
+++ b/src/tools/buildFromSources/buildFromSources.ts
@@ -54,6 +54,21 @@ export interface BuildTournamentRecordArgs {
   eventDataDocs?: any[];
   matchUpDocs?: any[];
   participantDocs?: any[];
+  /**
+   * Optional collector for matchUps that could not be placed. Passed in rather than returned so this
+   * function's shape stays exactly what it was — callers assembling a record by hand are not broken
+   * by a new wrapper, and one that wants the report opts in by handing over an array.
+   */
+  unplaced?: UnplacedMatchUp[];
+}
+
+/** A matchUp the assembler could not place, and enough identity to find it in the source. */
+export interface UnplacedMatchUp {
+  matchUpId?: string;
+  eventId?: string;
+  drawId?: string;
+  /** the structureId it named — which no structure in that draw carries */
+  structureId?: string;
 }
 
 export interface BuildFromSourcesResult {
@@ -69,6 +84,11 @@ export interface BuildFromSourcesResult {
    * can inspect this and decide.
    */
   inferredLinks: { drawId?: string; inferred: any[]; issues: string[] }[];
+  /**
+   * matchUps that named a structure the draw does not contain. Empty in the ordinary case. Reported
+   * rather than dropped: a shorter draw with no complaint is the hardest loss to notice.
+   */
+  unplacedMatchUps: UnplacedMatchUp[];
 }
 
 // ----------------------------------------------------------------- wrappers
@@ -571,14 +591,30 @@ function buildDrawDefinitionFromMatchUps(drawId, matchUps) {
   return { ...drawShell, structures: groupStructures };
 }
 
-function augmentDrawWithMatchUps(drawDef, matchUps) {
+/**
+ * Returns the matchUps it could NOT place.
+ *
+ * `insertMatchUpIntoStructure` reports whether it found a home; this used to compute that result and
+ * discard it, so a matchUp whose `structureId` names no structure in the draw vanished with nothing
+ * said. That is the hardest kind of loss to notice — no error, no empty structure, and a matchUp
+ * count that still looks plausible. The draw is simply smaller than it should be.
+ *
+ * Deliberately does NOT invent a structure to hold them: that would trade a silent drop for a silent
+ * fabrication, which is no better and harder to unpick later. The module's convention is to report
+ * what it could not handle (`unknownCount`, `inferredLinks`); this now follows it.
+ */
+function augmentDrawWithMatchUps(drawDef, matchUps): any[] {
   const seen = collectSeenMatchUpIds(drawDef);
+  const unplaced: any[] = [];
   for (const m of matchUps) {
     if (seen.has(m.matchUpId)) continue;
     if (insertMatchUpIntoStructure(drawDef, m)) {
       seen.add(m.matchUpId);
+    } else {
+      unplaced.push(m);
     }
   }
+  return unplaced;
 }
 
 function collectSeenMatchUpIds(drawDef) {
@@ -602,11 +638,26 @@ function insertMatchUpIntoStructure(drawDef, m) {
 }
 
 // ----------------------------------------------------------- event building
-function buildEvents({ eventDataDocs, matchUps }) {
+function buildEvents({
+  eventDataDocs,
+  matchUps,
+  unplaced,
+}: {
+  eventDataDocs: any[];
+  matchUps: any[];
+  unplaced?: UnplacedMatchUp[];
+}) {
   const events = new Map();
   seedEventsFromTournamentInfo(events, eventDataDocs);
   ingestDrawsDataIntoEvents(events, eventDataDocs);
-  if (matchUps.length > 0) ingestMatchUpsIntoEvents(events, matchUps);
+  if (matchUps.length > 0) {
+    // NOT `unplaced?.push(...ingest(...))` — optional chaining short-circuits the WHOLE expression,
+    // so with no collector the ingest itself never runs and every matchUp silently disappears. The
+    // ported contract suite caught it immediately, which is the argument for porting the tests with
+    // the code.
+    const unplacedHere = ingestMatchUpsIntoEvents(events, matchUps);
+    if (unplaced) unplaced.push(...unplacedHere);
+  }
   for (const event of events.values()) {
     for (const drawDef of event.drawDefinitions) {
       deriveDrawEntries(drawDef);
@@ -642,19 +693,23 @@ function ingestDrawsDataIntoEvents(events, eventDataDocs) {
   }
 }
 
-function ingestMatchUpsIntoEvents(events, matchUps) {
+function ingestMatchUpsIntoEvents(events, matchUps): UnplacedMatchUp[] {
+  const unplaced: UnplacedMatchUp[] = [];
   const grouped = groupMatchUpsByEventAndDraw(matchUps);
   for (const [eventId, drawMap] of grouped) {
     const event = ensureEvent(events, eventId, drawMap);
     for (const [drawId, mList] of drawMap) {
       const existing = event.drawDefinitions.find((d) => d.drawId === drawId);
       if (existing) {
-        augmentDrawWithMatchUps(existing, mList);
+        for (const m of augmentDrawWithMatchUps(existing, mList)) {
+          unplaced.push({ matchUpId: m?.matchUpId, eventId, drawId, structureId: m?.structureId });
+        }
       } else {
         event.drawDefinitions.push(buildDrawDefinitionFromMatchUps(drawId, mList));
       }
     }
   }
+  return unplaced;
 }
 
 function groupMatchUpsByEventAndDraw(matchUps) {
@@ -794,12 +849,15 @@ export function buildTournamentRecord({
   eventDataDocs = [],
   matchUpDocs = [],
   participantDocs = [],
+  unplaced,
 }: BuildTournamentRecordArgs = {}) {
   const record: Record<string, any> = buildTournamentMetadata(eventDataDocs, matchUpDocs);
   const participants = mergeParticipants({ participantDocs, eventDataDocs, matchUps: matchUpDocs });
   const venues = buildVenues(eventDataDocs);
   const events =
-    eventDataDocs.length > 0 || matchUpDocs.length > 0 ? buildEvents({ eventDataDocs, matchUps: matchUpDocs }) : [];
+    eventDataDocs.length > 0 || matchUpDocs.length > 0
+      ? buildEvents({ eventDataDocs, matchUps: matchUpDocs, unplaced })
+      : [];
 
   if (participants.length > 0) record.participants = participants;
   if (venues.length > 0) record.venues = venues;
@@ -832,9 +890,10 @@ export function buildFromSources(sources?: any[]): BuildFromSourcesResult {
     else unknownCount += 1;
   }
 
-  const record = buildTournamentRecord({ eventDataDocs, matchUpDocs, participantDocs });
+  const unplacedMatchUps: UnplacedMatchUp[] = [];
+  const record = buildTournamentRecord({ eventDataDocs, matchUpDocs, participantDocs, unplaced: unplacedMatchUps });
   // Repair before returning: a reconstructed draw that cannot be read is not a usable result, and
   // the caller should not have to know to ask.
   const inferredLinks = repairDrawLinks(record);
-  return { record, classification, unknownCount, inferredLinks };
+  return { record, classification, unknownCount, inferredLinks, unplacedMatchUps };
 }


### PR DESCRIPTION
`insertMatchUpIntoStructure` reports whether it found a home for a matchUp; `augmentDrawWithMatchUps` computed that result and **discarded it**. A matchUp whose `structureId` names no structure in the draw vanished with nothing said.

### Why this one is worth the change

Third defect of the same shape in a week, and the hardest to notice:

| defect | how it announced itself |
|---|---|
| `Venue missing venueId` | the server refused the record |
| `ERR_MISSING_STRUCTURE_LINKS` | the draw could not be read |
| **this** | **it doesn't** — the draw is simply smaller, with a plausible count |

### What changed

`buildFromSources` now returns `unplacedMatchUps` alongside `unknownCount` and `inferredLinks` — the convention the module already followed everywhere except here.

**It still does not invent a structure** to hold the orphan. Trading a silent drop for a silent fabrication would be no better and harder to unpick later. The caller is told, and decides.

`buildTournamentRecord` takes an optional collector rather than gaining a wrapper, so its shape is unchanged for callers assembling a record by hand.

### On the tests

The pinning test is **inverted, not deleted** — it asserted the drop and named it pre-existing, and it is the record of what changed. A negative case is added too: a report that is never empty is as useless as one that is never populated.

**A regression the ported suite caught.** The first version wrote `unplaced?.push(...ingestMatchUpsIntoEvents(...))` — optional chaining short-circuits the *whole* expression, so with no collector the ingest never ran and every matchUp silently disappeared. One of the 39 contract tests failed immediately. That is the argument for porting tests with code.

Falsified: reverting the reporting (types 0, lint 0 in that state) turns exactly the inverted test red.

### Gate

Full `verify` green. Tests **11,637 → 11,668**. Coverage *improved* — statements headroom 145 → **157**, branches 804 → **833**.