### PR TITLE
feat(query): project tournamentLevel, so it reaches the calendar entry

### DIFF
--- a/src/query/tournaments/getTournamentInfo.ts
+++ b/src/query/tournaments/getTournamentInfo.ts
@@ -106,6 +106,7 @@ export function getTournamentInfo(params?: {
 
   const extractTournamentInfo = ({
     tournamentId,
+    tournamentLevel,
     tournamentRank,
     tournamentStatus,
     tournamentTier,
@@ -130,6 +131,7 @@ export function getTournamentInfo(params?: {
     updatedAt,
   }: Tournament) => ({
     tournamentId,
+    tournamentLevel,
     tournamentRank,
     tournamentStatus,
     tournamentTier,

--- a/src/tests/queries/tournaments/getTournamentCalendarEntry.test.ts
+++ b/src/tests/queries/tournaments/getTournamentCalendarEntry.test.ts
@@ -26,6 +26,27 @@ describe('getTournamentCalendarEntry', () => {
     expect(result.tournament.endDate).toBe('2026-05-12');
   });
 
+  test('carries tournamentLevel through to the calendar entry, alongside the other classifiers', () => {
+    // The producer landed before the projection did, so the value survived the save and then stopped
+    // at `extractTournamentInfo` — populated on the record, absent from every calendar built from it.
+    // Asserting on the ENTRY rather than on the projection is the point: the calendar is the consumer.
+    const record = build();
+    record.tournamentLevel = 'INTERNATIONAL';
+    record.tournamentTier = 'ELITE';
+
+    let result: any = getTournamentCalendarEntry({ tournamentRecord: record });
+    expect(result.tournament.tournamentLevel).toBe('INTERNATIONAL');
+    // Its neighbours already made this trip; the new field must not arrive at their expense.
+    expect(result.tournament.tournamentTier).toBe('ELITE');
+  });
+
+  test('omits tournamentLevel when the record does not state one', () => {
+    // An unstated level must not become a default. `undefined` here is the honest answer, and it is
+    // what distinguishes "this tournament declares no level" from any particular level.
+    let result: any = getTournamentCalendarEntry({ tournamentRecord: build() });
+    expect(result.tournament.tournamentLevel).toBeUndefined();
+  });
+
   test('flattens a URL tournamentImage into tournamentImageURL', () => {
     const record = build([
       { name: 'tournamentImage', resourceType: 'URL', resourceSubType: 'IMAGE', identifier: 'https://cdn/x.png' },


### PR DESCRIPTION
## The gap

`extractTournamentInfo` in `getTournamentInfo.ts` projects `tournamentRank`, `tournamentStatus` and `tournamentTier` — and **not** `tournamentLevel`. `getTournamentCalendarEntry` builds its entry as `{ ...tournamentInfo, … }`, so the field was written to the record, survived the save, and then stopped one destructure short of every calendar built from it.

Populated at rest, absent everywhere it is read. `tournamentLevel` gained its first producer recently; this is the consumer half, and it is the line that makes the producer observable.

## The change

`tournamentLevel` joins its three classifier neighbours in both the destructure and the projection. Two lines.

## Tests

Two, asserted on the calendar **entry** rather than on the projection — the entry is the thing that was broken, and testing the projection would pass while the consumer stayed empty.

The second test pins the absence case: a record that states no level yields `undefined`, not a default. That distinction is the one this field can most easily lose.

## Falsification

Done first, and the first attempt was not good enough. Removing the field from the returned object alone left `tournamentLevel` destructured-but-unread, so the probe failed to compile (TS6133) — a probe that does not compile proves nothing. Redone by removing both lines, which is the true prior state: it compiles clean, and exactly the one new test fails.

## Verification

Full `verify` green, with the exit code read directly rather than through a pipe (a `| tail` had earlier reported `tail`'s status as the gate's).

- 11,673 tests pass
- statements headroom **157**, unchanged — floor 95%, budget 25 items per change