### PR TITLE
feat(read-model): carry organisational scope on the discovery row, distinct from grade

### DIFF
--- a/src/query/readModel/readModelRows.ts
+++ b/src/query/readModel/readModelRows.ts
@@ -115,6 +115,9 @@ export function tournamentDiscoveryRow(record: any): ReadModelTournamentDiscover
     city: address.city ?? record?.city ?? null,
     state: address.state ?? null,
     country_code: address.countryCode ?? record?.hostCountryCode ?? null,
+    // Scope, not grade — see the row type. Never defaulted: an unstated level is unknown, and a
+    // discovery facet that invented one would silently narrow every search that used it.
+    tournament_level: record?.tournamentLevel ?? null,
     level_system: classification.system ?? null,
     level_value: classification.value ?? null,
     recognition: sanction.recognition ?? null,

--- a/src/tests/queries/readModel/tournamentDiscoveryRow.test.ts
+++ b/src/tests/queries/readModel/tournamentDiscoveryRow.test.ts
@@ -19,6 +19,7 @@ const record: any = {
   endDate: '2026-08-03',
   parentOrganisation: { organisationId: 'prov-1' },
   hostCountryCode: 'USA',
+  tournamentLevel: 'NATIONAL',
   cancelledAt: null,
   sanction: {
     decision: 'APPROVED',
@@ -59,6 +60,19 @@ describe('tournamentDiscoveryRow', () => {
     expect(row.recognition).toBe('UNSANCTIONED');
     expect(row.decision).toBe('APPROVED');
     expect(row.ranking_eligible).toBe(false);
+  });
+
+  it('carries the organisational SCOPE separately from the competitive grade', () => {
+    // Two different facets: "show me national events" vs "show me Level 5 events".
+    const row: any = tournamentDiscoveryRow(record);
+    expect(row.tournament_level).toBe('NATIONAL');
+    expect(row.level_value).toBe('Level 5 Open');
+  });
+
+  it('does not invent a level when the record states none', () => {
+    // A discovery facet that acquired a default would silently narrow every search using it.
+    const { tournamentLevel, ...noLevel }: any = record;
+    expect(tournamentDiscoveryRow(noLevel).tournament_level).toBeNull();
   });
 
   it('falls back to tournamentTier when no sanction classification is stated', () => {

--- a/src/types/readModelTypes.ts
+++ b/src/types/readModelTypes.ts
@@ -84,6 +84,18 @@ export interface ReadModelTournamentDiscoveryRow {
   city: string | null;
   state: string | null;
   country_code: string | null;
+  /**
+   * ORGANISATIONAL SCOPE — how far the competition reaches: CLUB, DISTRICT, REGIONAL, NATIONAL,
+   * INTERNATIONAL.
+   *
+   * A DIFFERENT question from `level_system`/`level_value` below, which carry the competitive GRADE
+   * (`{system: 'USTA', value: 'Level 5 Open'}`). "Show me national events" and "show me Level 5
+   * events" are separate facets, and a row that flattened both into one could answer neither
+   * reliably. `#4710` makes the same distinction in the other direction, noting `AuthorityRoleEnum`
+   * is "deliberately broader than TournamentLevelEnum (which is the ORGANISATIONAL SCOPE of a
+   * competition)".
+   */
+  tournament_level: string | null;
   // Sanction, flattened. `level_*` comes from `sanction.classification`, falling back to
   // `tournamentTier` — the same tier shape, one grain up.
   level_system: string | null;


### PR DESCRIPTION
The row could answer *"show me Level 5 events"* and not *"show me national events"*. Those are different facets, and it now carries both.

| column | source | question it answers |
|---|---|---|
| `tournament_level` | `Tournament.tournamentLevel` | **organisational scope** — CLUB / DISTRICT / REGIONAL / NATIONAL / INTERNATIONAL |
| `level_system` / `level_value` | `sanction.classification` → `tournamentTier` | **competitive grade** — `{system: 'USTA', value: 'Level 5 Open'}` |

Two fields, two questions. A row flattening both into one could answer neither reliably. #4710 draws the same line from the other side, noting `AuthorityRoleEnum` is *"deliberately broader than `TournamentLevelEnum` (which is the ORGANISATIONAL SCOPE of a competition)."*

## Why this isn't a duplicate of #4746

#4746 projected the same field onto the **calendar entry** — `getTournamentInfo` → `getTournamentCalendarEntry`, the provider-calendar surface. This is `cast()` → `ReadModelRows`, the read model. **Neither reads the other's output**, so there is no duplicate derivation and no drift risk.

I checked that before adding, rather than assuming the adjacency was a conflict — it was the reason I paused on this in the first place.

## Never defaulted

An unstated level stays `null`. A discovery facet that invented one would **silently narrow every search that used it** — the same property #4746 pinned in its own second test.

## Falsified, and the probes are distinguishing

| probe | result |
|---|---|
| builder hardcodes a default | **only** the no-default test reddens |
| field omitted entirely | **both** tests redden |

Two tests that fail together on every probe are really one test. These don't.

`pnpm verify` green — all 15 steps.