### PR TITLE
feat(query): getParticipation — what a record says about who took part

### DIFF
--- a/src/assemblies/governors/participantGovernor/query.ts
+++ b/src/assemblies/governors/participantGovernor/query.ts
@@ -8,6 +8,7 @@ export { getPairedParticipant } from '@Query/participant/getPairedParticipant';
 export { getParticipantPaymentStatus } from '@Query/participant/paymentStatus';
 export { getParticipantSignInStatus } from '@Query/participant/signInStatus';
 export { filterParticipants } from '@Query/participants/filterParticipants';
+export { getParticipation } from '@Query/participants/getParticipation';
 export { getParticipants } from '@Query/participants/getParticipants';
 export { getScaleValues } from '@Query/participant/getScaleValues';
 export { validateLineUp } from '@Validators/validateTeamLineUp';

--- a/src/query/participants/getParticipation.ts
+++ b/src/query/participants/getParticipation.ts
@@ -1,0 +1,99 @@
+import { INDIVIDUAL, TEAM } from '@Constants/participantConstants';
+
+// types
+import { Tournament } from '@Types/tournamentTypes';
+
+export type ParticipationSubjectType = 'TEAM' | 'PERSON';
+
+export type ParticipationEntry = {
+  /** the grain the subject is identified at */
+  subjectType: ParticipationSubjectType;
+  /** the id an organisation ISSUED for this subject — stable across tournamentRecords */
+  subjectId: string;
+  /** the organisation that issued `subjectId`; two bodies may both number the same competitor */
+  organisationId?: string;
+  /** this record's own id for the competitor — tournament-local, never a subject key */
+  participantId: string;
+  tournamentId: string;
+  tournamentName?: string;
+  startDate?: string;
+  endDate?: string;
+  eventCount: number;
+  providerId?: string;
+};
+
+/**
+ * Derive what a tournamentRecord asserts about WHO TOOK PART — the rows a participation index is
+ * built from, without loading anything but this record.
+ *
+ * The counterpart to {@link getTournamentCalendarEntry}, and the reason both live here. A calendar
+ * entry answers *what does this provider own*; participation answers *what did this competitor take
+ * part in*. They are different relations and a calendar cannot express the second: a record lives in
+ * exactly ONE provider's calendar, while a team fixture belongs to the seasons of BOTH sides, so
+ * ownership can only ever name one of them.
+ *
+ * That is also why participation reads both sides of every fixture and needs no notion of a host —
+ * useful, because a source that states who hosted is the exception rather than the rule.
+ *
+ * ## Subject identity comes from the issued id, never from `participantId`
+ *
+ * A `participantId` is tournament-local: the same competitor carries a different one in every record
+ * it appears in. Keyed on that, a competitor's history would be exactly one entry long per record —
+ * plausible-looking, and wrong in a way nothing errors on. So the subject is read from
+ * `participantOtherIds` (TEAM) and `person.personOtherIds` (PERSON), which carry the issuing
+ * organisation's own id and are stable by construction.
+ *
+ * **A competitor stating no issued id contributes no entry.** That is a recorded gap — this record
+ * does not say who the competitor is in any durable sense — and manufacturing one from the local id
+ * would produce precisely the wrong answer described above. Callers wanting to detect the gap can
+ * compare the entry count against the competitors they expected.
+ *
+ * A competitor issued ids by two organisations yields one entry per organisation, which is correct:
+ * each is a distinct claim about identity, and a consumer indexes whichever body it speaks for.
+ *
+ * Pure: reads only the record. Storage keys, timestamps and server-specific projections are the
+ * caller's concern, not the factory's.
+ */
+export function getParticipation({ tournamentRecord }: { tournamentRecord: Tournament }): ParticipationEntry[] {
+  const tournamentId = tournamentRecord?.tournamentId;
+  if (!tournamentId) return [];
+
+  const shared = {
+    tournamentId,
+    tournamentName: tournamentRecord.tournamentName,
+    startDate: tournamentRecord.startDate,
+    endDate: tournamentRecord.endDate,
+    eventCount: tournamentRecord.events?.length ?? 0,
+    providerId: tournamentRecord.parentOrganisation?.organisationId,
+  };
+
+  const entries: ParticipationEntry[] = [];
+  // One entry per (subjectType, subjectId, participantId). A competitor entered twice under one
+  // issued id is one participation, and a consumer's natural key would reject the duplicate anyway.
+  const seen = new Set<string>();
+
+  const add = (subjectType: ParticipationSubjectType, issued: any, participantId?: string) => {
+    const subjectId = subjectType === TEAM ? issued?.participantId : issued?.personId;
+    if (!subjectId || !participantId) return;
+    const key = `${subjectType}|${subjectId}|${participantId}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    entries.push({
+      subjectType,
+      subjectId,
+      organisationId: issued?.organisationId,
+      participantId,
+      ...shared,
+    });
+  };
+
+  for (const participant of tournamentRecord.participants ?? []) {
+    if (participant?.participantType === TEAM) {
+      for (const issued of participant.participantOtherIds ?? []) add('TEAM', issued, participant.participantId);
+    } else if (participant?.participantType === INDIVIDUAL) {
+      for (const issued of participant.person?.personOtherIds ?? []) add('PERSON', issued, participant.participantId);
+    }
+  }
+
+  return entries;
+}

--- a/src/tests/queries/participants/getParticipation.test.ts
+++ b/src/tests/queries/participants/getParticipation.test.ts
@@ -1,0 +1,160 @@
+import { getParticipation } from '@Query/participants/getParticipation';
+import { mocksEngine } from '@Assemblies/engines/mock';
+import { expect, it, describe } from 'vitest';
+
+import { INDIVIDUAL, TEAM } from '@Constants/participantConstants';
+
+const ORG = 'org-1';
+const OTHER_ORG = 'org-2';
+
+const issuedTeam = (participantId: string, issuedId: string, organisationId = ORG) => ({
+  participantId,
+  participantType: TEAM,
+  participantName: `Team ${issuedId}`,
+  participantOtherIds: [{ organisationId, participantId: issuedId }],
+});
+
+const issuedPerson = (participantId: string, issuedId: string) => ({
+  participantId,
+  participantType: INDIVIDUAL,
+  participantName: `Person ${issuedId}`,
+  person: { personId: `p-${participantId}`, personOtherIds: [{ organisationId: ORG, personId: issuedId }] },
+});
+
+const record = (participants: any[]): any => ({
+  tournamentId: 't-1',
+  tournamentName: 'A vs B',
+  startDate: '2026-03-28',
+  endDate: '2026-03-28',
+  parentOrganisation: { organisationId: 'prov-1' },
+  events: [{ eventId: 'e-1' }],
+  participants,
+});
+
+describe('getParticipation', () => {
+  it('reports BOTH sides of a fixture — the relation a calendar cannot express', () => {
+    // A record lives in exactly one provider's calendar, so ownership can name only one side.
+    // If this returned one entry, a visiting competitor's away fixtures would simply be absent.
+    const result: any = getParticipation({
+      tournamentRecord: record([issuedTeam('local-a', 'A'), issuedTeam('local-b', 'B')]),
+    });
+    expect(result.map((entry) => entry.subjectId).sort((a, b) => a.localeCompare(b, 'en'))).toEqual(['A', 'B']);
+    expect(result.every((entry) => entry.subjectType === 'TEAM')).toEqual(true);
+  });
+
+  it('keys the subject on the ISSUED id and keeps the local id separately', () => {
+    const result: any = getParticipation({ tournamentRecord: record([issuedTeam('local-a', 'A')]) });
+    expect(result[0].subjectId).toEqual('A');
+    expect(result[0].participantId).toEqual('local-a');
+    expect(result[0].organisationId).toEqual(ORG);
+  });
+
+  it('derives PERSON subjects from person.personOtherIds', () => {
+    const result: any = getParticipation({ tournamentRecord: record([issuedPerson('local-p', 'P1')]) });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ subjectType: 'PERSON', subjectId: 'P1', participantId: 'local-p' });
+  });
+
+  it('reports TEAM and PERSON from one record, each at its own grain', () => {
+    const result: any = getParticipation({
+      tournamentRecord: record([issuedTeam('local-a', 'A'), issuedPerson('local-p', 'P1')]),
+    });
+    expect(result.filter((entry) => entry.subjectType === 'TEAM')).toHaveLength(1);
+    expect(result.filter((entry) => entry.subjectType === 'PERSON')).toHaveLength(1);
+  });
+
+  it('yields one entry PER ISSUING ORGANISATION, because each is a distinct identity claim', () => {
+    const twiceIssued: any = issuedTeam('local-a', 'A');
+    twiceIssued.participantOtherIds.push({ organisationId: OTHER_ORG, participantId: 'A-alt' });
+    const result: any = getParticipation({ tournamentRecord: record([twiceIssued]) });
+    expect(result).toHaveLength(2);
+    expect(result.map((entry) => entry.organisationId).sort((a, b) => a.localeCompare(b, 'en'))).toEqual([
+      ORG,
+      OTHER_ORG,
+    ]);
+  });
+
+  it('contributes NO entry for a competitor stating no issued id', () => {
+    // A recorded gap. Falling back to the tournament-local participantId would manufacture a subject
+    // that joins to nothing and looks exactly like a real one.
+    const result: any = getParticipation({
+      tournamentRecord: record([
+        { participantId: 'local-x', participantType: TEAM, participantName: 'X' },
+        issuedTeam('local-b', 'B'),
+      ]),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].subjectId).toEqual('B');
+  });
+
+  it('contributes no entry for a MALFORMED issued id, and does not fall back to the local one', () => {
+    // Distinct from "no participantOtherIds at all": here the record CLAIMS an issued identity and
+    // fails to state it. A `?? participantId` fallback would look reasonable and would silently mint
+    // a tournament-local subject — the precise failure this function is shaped to avoid.
+    const malformed: any = {
+      participantId: 'local-a',
+      participantType: TEAM,
+      participantOtherIds: [{ organisationId: ORG }],
+    };
+    expect(getParticipation({ tournamentRecord: record([malformed]) })).toEqual([]);
+
+    const malformedPerson: any = {
+      participantId: 'local-p',
+      participantType: INDIVIDUAL,
+      person: { personId: 'p-1', personOtherIds: [{ organisationId: ORG }] },
+    };
+    expect(getParticipation({ tournamentRecord: record([malformedPerson]) })).toEqual([]);
+  });
+
+  it('carries what a history renders from, so reading one needs no record load', () => {
+    const result: any = getParticipation({ tournamentRecord: record([issuedTeam('local-a', 'A')]) });
+    expect(result[0]).toMatchObject({
+      tournamentId: 't-1',
+      tournamentName: 'A vs B',
+      startDate: '2026-03-28',
+      endDate: '2026-03-28',
+      eventCount: 1,
+      providerId: 'prov-1',
+    });
+  });
+
+  it('does not duplicate a competitor entered twice under one issued id', () => {
+    const duplicated: any = issuedTeam('local-a', 'A');
+    duplicated.participantOtherIds.push({ organisationId: ORG, participantId: 'A' });
+    expect(getParticipation({ tournamentRecord: record([duplicated]) })).toHaveLength(1);
+  });
+
+  it('ignores participant types that carry no issued identity of their own', () => {
+    const withPair: any = record([issuedTeam('local-a', 'A')]);
+    withPair.participants.push({ participantId: 'pair-1', participantType: 'PAIR' });
+    expect(getParticipation({ tournamentRecord: withPair })).toHaveLength(1);
+  });
+
+  it('returns nothing rather than throwing on partial or absent input', () => {
+    expect(getParticipation({ tournamentRecord: { participants: [] } as any })).toEqual([]);
+    expect(getParticipation({ tournamentRecord: { tournamentId: 't' } as any })).toEqual([]);
+    expect(getParticipation({ tournamentRecord: undefined as any })).toEqual([]);
+    expect(getParticipation({ tournamentRecord: record([]) })).toEqual([]);
+  });
+
+  it('counts events and omits a provider the record does not name', () => {
+    const noProvider: any = record([issuedTeam('local-a', 'A')]);
+    delete noProvider.parentOrganisation;
+    noProvider.events = [{ eventId: 'e-1' }, { eventId: 'e-2' }];
+    const result: any = getParticipation({ tournamentRecord: noProvider });
+    expect(result[0].eventCount).toEqual(2);
+    expect(result[0].providerId).toBeUndefined();
+  });
+
+  it('reads a GENERATED record without inventing subjects for it', () => {
+    // The factory's own participants carry no issued ids, so an honest derivation finds none here.
+    // This is the guard against a future fallback to participantId: the moment one is added, this
+    // record starts producing subjects that cannot join to anything and this test fails.
+    const { tournamentRecord }: any = mocksEngine.generateTournamentRecord({
+      participantsProfile: { participantsCount: 8 },
+      drawProfiles: [{ drawSize: 8 }],
+    });
+    expect(tournamentRecord.participants.length).toBeGreaterThan(0);
+    expect(getParticipation({ tournamentRecord })).toEqual([]);
+  });
+});

--- a/src/types/factoryEngineMethods.ts
+++ b/src/types/factoryEngineMethods.ts
@@ -334,6 +334,7 @@ export type FactoryEngineMethod =
   | 'getParticipantSignInStatus'
   | 'getParticipantStats'
   | 'getParticipantTimeItem'
+  | 'getParticipation'
   | 'getPersonRequests'
   | 'getPolicyDefinitions'
   | 'getPositionAssignments'
@@ -1009,6 +1010,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'getParticipantSignInStatus',
   'getParticipantStats',
   'getParticipantTimeItem',
+  'getParticipation',
   'getPersonRequests',
   'getPolicyDefinitions',
   'getPositionAssignments',

--- a/src/types/methodSignatures.ts
+++ b/src/types/methodSignatures.ts
@@ -409,6 +409,7 @@ import type { getAppliedPolicies, getPolicyDefinitions } from '@Query/extensions
 import type { getEventInconsistencies } from '@Query/event/getEventInconsistencies';
 import type { getMatchUpFormat } from '@Query/hierarchical/getMatchUpFormat';
 import type { getMatchUpRatingDelta } from '@Query/matchUp/getMatchUpRatingDelta';
+import type { getParticipation } from '@Query/participants/getParticipation';
 import type { getRounds } from '@Query/matchUps/scheduling/getRounds';
 import type { getTournamentInfo } from '@Query/tournaments/getTournamentInfo';
 import type { hydrateTournamentRecord } from '@Mutate/base/hydrateTournamentRecord';
@@ -907,6 +908,7 @@ export interface MethodSignatures {
   getParticipantSignInStatus: EngineMethod<typeof getParticipantSignInStatus>;
   getParticipantStats: EngineMethod<typeof getParticipantStats>;
   getParticipantTimeItem: EngineMethod<typeof getParticipantTimeItem>;
+  getParticipation: EngineMethod<typeof getParticipation>;
   getPersonRequests: EngineMethod<typeof getPersonRequests>;
   getPolicyDefinitions: EngineMethod<typeof getPolicyDefinitions>;
   getPositionAssignments: EngineMethod<typeof getPositionAssignments>;


### PR DESCRIPTION
The counterpart to `getTournamentCalendarEntry`, and it belongs beside it.

## Why here

A calendar entry answers *what does this provider own*. Participation answers *what did this competitor take part in*. Those are different relations, and a calendar **cannot** express the second: a record lives in exactly ONE provider's calendar, while a team fixture belongs to the seasons of BOTH sides, so ownership can only ever name one of them.

That is also why participation reads both sides of a fixture and needs no notion of a host — useful, because a source that states who hosted is the exception rather than the rule.

The derivation shipped in a consumer first. Moving it here follows the same reasoning `getTournamentCalendarEntry`'s own JSDoc gives for living in the factory — *"Keeping one deriver here is what prevents the two sides drifting"* — and holds the same boundary: pure, reads only the record, storage keys and server-specific projections stay with the caller.

It also unblocks a check that currently has no home. The contract is with records produced by adapters elsewhere; with the derivation published, a producer's own repo can assert its output against the real reader instead of against a fixture that only agrees with itself.

## Subject identity comes from the issued id, never `participantId`

A `participantId` is tournament-local: the same competitor carries a different one in every record it appears in. Keyed on that, a competitor's history would be exactly one entry long per record — plausible-looking, and wrong in a way nothing errors on.

Subjects come from `participantOtherIds` (TEAM) and `person.personOtherIds` (PERSON) — `Unified*ID` shapes carrying the issuing organisation's own id, stable by construction. A competitor stating no issued id contributes **no entry**: a recorded gap, not an identity invented from a local id. A competitor issued ids by two organisations yields one entry each, since each is a distinct identity claim.

Both grains ship together: they are one function with a different accessor, and the PERSON grain has a named consumer already. Splitting them would only guarantee a second copy.

## Falsification found a gap instead of confirming the code

The first probe — a `?? participantId` fallback — **passed all twelve tests**. None of them exercised a `participantOtherIds` entry that exists and omits its id, so the fallback was unreachable in every case tested. That is a coverage hole the tests would have kept quiet about.

Added that case, then re-falsified both ways:

| injected defect | tests failing | compiles |
|---|---|---|
| `?? participantId` fallback | 1 | ✅ |
| key subjects on `participantId` wholesale | 6 | ✅ |

## Verification

Full `verify` green, exit code read directly rather than through a pipe.

| | |
|---|---|
| tests | **11,689** |
| statements headroom | 157 → **156** (one item of a 25-item budget) |
| branches headroom | 833 → **836** |
| bundle-size | within +10% on all 7 tracked files |
| surface | `getParticipation` added; nothing removed |

Bundle impact was measured before writing: a leaf import bundles to 132 bytes while `tournamentEngine` bundles to 1.53 MB, so engine consumers already pull everything and this adds ~0.07% — three orders of magnitude under the budget. Governor placement was chosen over `tools` deliberately for that reason.

## Follow-up, not in this PR

The consumer cannot drop its local copy until a version ships. That is a second PR, after a release.