### PR TITLE
feat(read-model): carry a TEAM entry's issued identity on the entries fact

### DIFF
--- a/src/query/readModel/readModelRows.ts
+++ b/src/query/readModel/readModelRows.ts
@@ -664,21 +664,59 @@ function buildPersonIndex(participants: any[]): Map<string, string | undefined> 
   return index;
 }
 
+/**
+ * participantId → the id an organisation ISSUED for that TEAM, plus the issuing body.
+ *
+ * Read from `participantOtherIds`, which CODES documents for exactly this ("entry per organisation
+ * … this works for PAIR and TEAM"), and NEVER from `participantId`. A participantId is
+ * tournament-local: the same programme carries a different one in every record it appears in, so a
+ * season keyed on it would be exactly one fixture long — plausible-looking, and wrong with nothing
+ * to signal it. A TEAM stating no issued id contributes no team identity; that is a recorded gap,
+ * and inventing one from the local id produces precisely the wrong answer just described.
+ *
+ * Where a team is issued ids by two bodies, the FIRST is taken and its `organisation_id` recorded
+ * alongside, so a consumer can tell which body's id space a row belongs to. One row per entry means
+ * there is nowhere to put a second; a consumer needing every issuing body should read
+ * `getParticipation`, which emits one entry per (body, team).
+ */
+function buildTeamIssuedIndex(participants: any[]): Map<string, { teamId: string; organisationId: string | null }> {
+  const index = new Map<string, { teamId: string; organisationId: string | null }>();
+  for (const participant of participants) {
+    if (participant?.participantType !== TEAM) continue;
+    const participantId = participant?.participantId;
+    if (!participantId) continue;
+    for (const issued of participant.participantOtherIds ?? []) {
+      if (!issued?.participantId) continue;
+      index.set(participantId, { teamId: issued.participantId, organisationId: issued.organisationId ?? null });
+      break;
+    }
+  }
+  return index;
+}
+
 /** Project the entries fact for one tournament: every event entry (accepted,
  *  alternate, withdrawn, un-drawn) → an `entries` row, person resolved per the
- *  person rule. */
+ *  person rule.
+ *
+ *  TEAM entries additionally carry the team's ISSUED id, which is what makes "this programme's
+ *  season" answerable from entries alone. That matters because a fixture reaches the entries fact
+ *  the moment it is entered, whereas the competitor fact requires projected matchUps — so a dual
+ *  with no matchUps yet, or none published, is invisible to a competitor-derived read. */
 export function entryRows(record: any): ReadModelEntryRow[] {
   const tournamentId = record?.tournamentId;
   const providerId = record?.parentOrganisation?.organisationId ?? null;
   if (!tournamentId) return [];
 
-  const personByParticipantId = buildPersonIndex(record?.participants ?? []);
+  const participants = record?.participants ?? [];
+  const personByParticipantId = buildPersonIndex(participants);
+  const teamIssuedByParticipantId = buildTeamIssuedIndex(participants);
   const rows: ReadModelEntryRow[] = [];
   for (const event of record?.events ?? []) {
     for (const entry of event?.entries ?? []) {
       const participantId = entry?.participantId;
       if (!participantId) continue;
       const link = resolvePersonLink(participantId, personByParticipantId.get(participantId));
+      const issued = teamIssuedByParticipantId.get(participantId);
       rows.push({
         tournament_id: tournamentId,
         event_id: event?.eventId ?? null,
@@ -686,6 +724,8 @@ export function entryRows(record: any): ReadModelEntryRow[] {
         person_id: link.personId,
         provider_id: providerId,
         entry_status: entry?.entryStatus ?? null,
+        team_id: issued?.teamId ?? null,
+        organisation_id: issued?.organisationId ?? null,
       });
     }
   }

--- a/src/tests/queries/readModel/readModelRows.test.ts
+++ b/src/tests/queries/readModel/readModelRows.test.ts
@@ -691,4 +691,72 @@ describe('entryRows', () => {
     expect(p2.entry_status).toBeNull();
     expect(p2.person_id).toBeNull();
   });
+
+  // A TEAM entry has to reach the read side carrying an identity that survives the record it is in.
+  // These four cases are the whole contract, and the second is the one that matters: a fallback to
+  // `participantId` would satisfy every other assertion here while giving each programme a season
+  // exactly one fixture long.
+  it("carries a TEAM entry's ISSUED id and the body that issued it", () => {
+    const rows = entryRows({
+      tournamentId: 't1',
+      parentOrganisation: { organisationId: 'PROV' },
+      participants: [
+        {
+          participantId: 'local-a',
+          participantType: 'TEAM',
+          participantOtherIds: [{ organisationId: 'ITA', participantId: 'ITA-TEAM-1' }],
+        },
+      ],
+      events: [{ eventId: 'dual', entries: [{ participantId: 'local-a', entryStatus: 'ACCEPTED' }] }],
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].team_id).toEqual('ITA-TEAM-1');
+    expect(rows[0].organisation_id).toEqual('ITA');
+    // The local id is still carried, and is still NOT the identity.
+    expect(rows[0].participant_id).toEqual('local-a');
+  });
+
+  it('leaves team_id NULL for a TEAM stating no issued id — never the tournament-local id', () => {
+    const rows = entryRows({
+      tournamentId: 't1',
+      participants: [{ participantId: 'local-a', participantType: 'TEAM' }],
+      events: [{ eventId: 'dual', entries: [{ participantId: 'local-a' }] }],
+    });
+    expect(rows[0].team_id).toBeNull();
+    expect(rows[0].organisation_id).toBeNull();
+  });
+
+  it('leaves team_id NULL for a non-TEAM entry even when it states otherIds', () => {
+    const rows = entryRows({
+      tournamentId: 't1',
+      participants: [
+        {
+          participantId: 'p1',
+          participantType: 'INDIVIDUAL',
+          participantOtherIds: [{ organisationId: 'ITA', participantId: 'SHOULD-NOT-APPEAR' }],
+        },
+      ],
+      events: [{ eventId: 'e1', entries: [{ participantId: 'p1' }] }],
+    });
+    expect(rows[0].team_id).toBeNull();
+  });
+
+  it('takes the first issuing body and records which one it was', () => {
+    const rows = entryRows({
+      tournamentId: 't1',
+      participants: [
+        {
+          participantId: 'local-a',
+          participantType: 'TEAM',
+          participantOtherIds: [
+            { organisationId: 'ITA', participantId: 'ITA-1' },
+            { organisationId: 'NCAA', participantId: 'NCAA-9' },
+          ],
+        },
+      ],
+      events: [{ eventId: 'dual', entries: [{ participantId: 'local-a' }] }],
+    });
+    expect(rows[0].team_id).toEqual('ITA-1');
+    expect(rows[0].organisation_id).toEqual('ITA');
+  });
 });

--- a/src/types/readModelTypes.ts
+++ b/src/types/readModelTypes.ts
@@ -181,6 +181,16 @@ export interface ReadModelCompetitorRow {
   individual_participant_id: string | null;
   person_id: string | null; // canonical; NULL when synthetic/unresolved
   link_source: string; // providerId | unresolved
+  /**
+   * ⚠️ A DIFFERENT RULE FROM {@link ReadModelEntryRow.team_id}, and the two must not be assumed
+   * interchangeable. This one is `participant.teamId ?? participantId`, so it falls back to a
+   * TOURNAMENT-LOCAL id when a record states no durable team identity; the entry row's is the
+   * ISSUED id from `participantOtherIds` and is `null` rather than local when none is stated.
+   *
+   * They coincide wherever a producer happens to set `participantId` to the issued id — which the
+   * college-dual corpus does — and diverge everywhere else. Reconciling them is deliberately not
+   * part of the entries work; treat this field as the pre-existing id space until it is.
+   */
   team_id: string | null;
   provider_id: string | null;
   participant_name: string | null;
@@ -193,6 +203,22 @@ export interface ReadModelEntryRow {
   person_id: string | null;
   provider_id: string | null;
   entry_status: string | null;
+  /**
+   * For a TEAM entry, the id an organisation ISSUED for that team — the durable identity, taken
+   * from `participantOtherIds`. `null` for every other participantType, and for a TEAM stating no
+   * issued id.
+   *
+   * NOT `participant_id`, which is tournament-local: keyed on that, a programme would look like a
+   * different competitor in every record and its season would be exactly one fixture long. Also NOT
+   * the rule `ReadModelCompetitorRow.team_id` uses (`participant.teamId ?? participantId`), which
+   * falls back to that local id — see the note on {@link ReadModelCompetitorRow}.
+   */
+  team_id: string | null;
+  /**
+   * The organisation that issued `team_id`. A subjectId is unique only WITHIN its issuing body, so
+   * a consumer indexing one body's ids must be able to say which body it means.
+   */
+  organisation_id: string | null;
 }
 
 export interface ReadModelEventRow {


### PR DESCRIPTION
Step 1 of the read-model migration (Mentat TASKS § *Team participation belongs in courthive-query*, punch-list **M8**). Pairs with courthive-query [#42](https://github.com/CourtHive/courthive-query/pull/42), which adds the migration and the allow-list entry that let this field survive projection.

## What changes

`readModel.entryRows()` now emits `team_id` and `organisation_id` on TEAM entries, taken from `participantOtherIds`.

## Why

A team's season is read from `match_up_competitors.team_id`, so a fixture becomes visible only once its matchUps are **projected**. A dual that has been entered but not yet played is invisible to that read. Entries are the earlier and more complete fact — a competitor is entered before it plays, and the row exists whether or not a matchUp ever does. That is already why this fact carries `person_id`: "my participation" is entries UNION matchUps.

What entries lacked was a durable identity. `participant_id` is **tournament-local**, so a season keyed on it is exactly one fixture long for every team — plausible, and wrong with nothing to signal it. `team_id` is the id an organisation **issued**, stable across records by construction; `organisation_id` records which body issued it, because an issued id is unique only within its issuer. A TEAM stating no issued id gets `null`, never the local id.

## Not the same rule as `ReadModelCompetitorRow.team_id`

That one is `participant.teamId ?? participantId` and falls back to the tournament-local id. The two coincide wherever a producer sets `participantId` to the issued id — the college-dual corpus does — and diverge everywhere else. **Both types now carry a note saying so**, because two same-named fields with different identity rules is exactly the kind of thing that gets assumed interchangeable. Reconciling the id spaces is its own piece of work.

## Evidence

Four cases cover the contract, and the second is the one that matters:

- carries the issued id and its issuing body
- **`null` for a TEAM stating no issued id — never the local id**
- `null` for a non-TEAM entry even when it states otherIds
- takes the first issuing body and records which one

Falsified: reintroducing the `?? participantId` fallback fails exactly the two `null` guards and **leaves the happy-path test green** — which is why that pair exists rather than a single assertion.

`pnpm verify` green — all 15 steps, including `verify:generated`, `verify:attr-audit`, `verify:coverage`, `verify:surface` and `verify:pack`. Full suite 11,693 passed / 1 skipped.

## Downstream

Inert until consumers pin it. courthive-query drops the field unless #42 lands too; CFS carries the row through untouched and needs only a version bump to start emitting it.