### PR TITLE
fix(scales): one RankingListEntry, and emit the bucketTotals it promises

### DIFF
--- a/attr-audit.allow.json
+++ b/attr-audit.allow.json
@@ -2,6 +2,7 @@
   "actions",
   "addParticipant",
   "ballTypes",
+  "bucketTotals",
   "cast",
   "change",
   "completed",

--- a/src/constants/rankingConstants.ts
+++ b/src/constants/rankingConstants.ts
@@ -1,5 +1,13 @@
+import type { PointComponent } from '@Types/rankingTypes';
+
 // Scale name for ranking points stored on participants
 export const RANKING_POINTS = 'RANKING_POINTS';
+
+// What a counting bucket sums when the policy names no `pointComponents`.
+// A quality-win bonus arrives as its own award carrying `qualityWinPoints`
+// and no `points`, so this pair addresses disjoint awards rather than
+// counting either one twice.
+export const DEFAULT_POINT_COMPONENTS: PointComponent[] = ['points', 'qualityWinPoints'];
 
 // Bonus type identifiers
 export const QUALITY_WIN = 'QUALITY_WIN';
@@ -38,6 +46,7 @@ export const PROFILE_SCOPE_FIELDS = [
 ] as const;
 
 export const rankingConstants = {
+  DEFAULT_POINT_COMPONENTS,
   RANKING_POINTS,
   QUALITY_WIN,
   FULL_TO_EACH,

--- a/src/query/scales/applyDerivedRankings.ts
+++ b/src/query/scales/applyDerivedRankings.ts
@@ -1,5 +1,4 @@
-import type { RankingListEntry } from './generateRankingList';
-import type { DerivedFilter } from '@Types/rankingTypes';
+import type { RankingListEntry, DerivedFilter } from '@Types/rankingTypes';
 
 /**
  * Per-participant context the filter needs from the consumer.

--- a/src/query/scales/generateRankingList.ts
+++ b/src/query/scales/generateRankingList.ts
@@ -1,38 +1,22 @@
 import { processBucketResults, type ScoredAward } from './processBucketResults';
+import { DEFAULT_POINT_COMPONENTS } from '@Constants/rankingConstants';
 import type {
+  RankingListBucketBreakdown,
   CategoryAggregationRule,
-  CategoryScope,
-  DoublesAttribution,
-  MandatoryRule,
-  PointComponent,
-  PointPoolModel,
-  SourceFilter,
   TiebreakCriterion,
+  AggregationRules,
+  RankingListAward,
+  RankingListEntry,
+  PointComponent,
+  CountingBucket,
+  PointPoolModel,
+  CategoryScope,
+  SourceFilter,
 } from '@Types/rankingTypes';
 
-type PointAward = Record<string, any>;
-
-type CountingBucket = {
-  bucketName: string;
-  eventTypes?: string[];
-  pointComponents: string[];
-  bestOfCount: number;
-  maxResultsPerLevel?: Record<number, number>;
-  mandatoryRules?: MandatoryRule[];
-};
-
-type AggregationRules = {
-  rollingPeriodDays?: number;
-  separateByGender?: boolean;
-  perCategory?: boolean;
-  countingBuckets?: CountingBucket[];
-  tiebreakCriteria?: TiebreakCriterion[];
-  minCountableResults?: number;
-  maxResultsPerLevel?: Record<number, number>;
-  bestOfCount?: number;
-  doublesAttribution?: DoublesAttribution;
-  categoryAggregation?: CategoryAggregationRule[];
-};
+// Re-exported so deep importers of this module keep resolving the type; it is
+// the same declaration `@Types/rankingTypes` exports, not a second one.
+export type { RankingListEntry, RankingListAward };
 
 type CategoryFilter = {
   ageCategoryCodes?: string[];
@@ -40,23 +24,8 @@ type CategoryFilter = {
   eventTypes?: string[];
 };
 
-export type RankingListEntry = {
-  personId: string;
-  totalPoints: number;
-  rank: number;
-  meetsMinimum: boolean;
-  countingResults: PointAward[];
-  droppedResults: PointAward[];
-  bucketBreakdown?: {
-    bucketName: string;
-    countingResults: PointAward[];
-    droppedResults: PointAward[];
-    bucketTotal: number;
-  }[];
-};
-
 type GenerateRankingListArgs = {
-  pointAwards: PointAward[];
+  pointAwards: RankingListAward[];
   aggregationRules?: AggregationRules;
   categoryFilter?: CategoryFilter;
   asOfDate?: string;
@@ -92,7 +61,7 @@ export function generateRankingList({
 
   // Carried contributions from categoryAggregation rules whose target matches
   // the categoryFilter. Skipped entirely under shared-pool model.
-  const carriedByPerson: Record<string, PointAward[]> =
+  const carriedByPerson: Record<string, RankingListAward[]> =
     pointPoolModel === 'shared'
       ? {}
       : expandCarriedContributions({
@@ -133,11 +102,11 @@ export function generateRankingList({
 }
 
 function filterAwards(
-  pointAwards: PointAward[],
+  pointAwards: RankingListAward[],
   categoryFilter: CategoryFilter | undefined,
   rollingPeriodDays: number | undefined,
   asOfDate: string | undefined,
-): PointAward[] {
+): RankingListAward[] {
   let filtered = pointAwards;
 
   if (categoryFilter) {
@@ -167,8 +136,8 @@ function filterAwards(
   return filtered;
 }
 
-function groupByPerson(filtered: PointAward[]): Record<string, PointAward[]> {
-  const byPerson: Record<string, PointAward[]> = {};
+function groupByPerson(filtered: RankingListAward[]): Record<string, RankingListAward[]> {
+  const byPerson: Record<string, RankingListAward[]> = {};
   for (const award of filtered) {
     const key = award.personId;
     if (!key) continue;
@@ -187,13 +156,13 @@ function expandCarriedContributions({
   rollingPeriodDays,
   asOfDate,
 }: {
-  pointAwards: PointAward[];
+  pointAwards: RankingListAward[];
   rules: CategoryAggregationRule[];
   categoryFilter: CategoryFilter | undefined;
   rollingPeriodDays: number | undefined;
   asOfDate: string | undefined;
-}): Record<string, PointAward[]> {
-  const carriedByPerson: Record<string, PointAward[]> = {};
+}): Record<string, RankingListAward[]> {
+  const carriedByPerson: Record<string, RankingListAward[]> = {};
   if (!rules.length) return carriedByPerson;
 
   for (const rule of rules) {
@@ -208,7 +177,7 @@ function expandCarriedContributions({
     const inWindow = applyRollingWindow(sourceAwards, rollingPeriodDays, asOfDate);
 
     // Group, multiply, cap per (personId, rule).
-    const perPersonForRule: Record<string, PointAward[]> = {};
+    const perPersonForRule: Record<string, RankingListAward[]> = {};
     for (const award of inWindow) {
       const personId = award.personId;
       if (!personId) continue;
@@ -243,7 +212,7 @@ function ruleTargetMatchesFilter(target: CategoryScope, categoryFilter: Category
   return genderOverlap;
 }
 
-function awardMatchesScope(award: PointAward, source: CategoryScope): boolean {
+function awardMatchesScope(award: RankingListAward, source: CategoryScope): boolean {
   if (source.ageCategoryCodes?.length) {
     const code = award.category?.ageCategoryCode;
     if (!code || !source.ageCategoryCodes.includes(code)) return false;
@@ -263,7 +232,7 @@ function awardMatchesScope(award: PointAward, source: CategoryScope): boolean {
   return true;
 }
 
-function sourceFilterDisqualifies(award: PointAward, filters: SourceFilter[] | undefined): boolean {
+function sourceFilterDisqualifies(award: RankingListAward, filters: SourceFilter[] | undefined): boolean {
   if (!filters?.length) return false;
   return filters.some((f) => {
     if (f.levels?.length && award.level !== undefined && f.levels.includes(award.level)) return true;
@@ -276,10 +245,10 @@ function sourceFilterDisqualifies(award: PointAward, filters: SourceFilter[] | u
 }
 
 function applyRollingWindow(
-  awards: PointAward[],
+  awards: RankingListAward[],
   rollingPeriodDays: number | undefined,
   asOfDate: string | undefined,
-): PointAward[] {
+): RankingListAward[] {
   if (!rollingPeriodDays || !asOfDate) return awards;
   const cutoff = new Date(asOfDate);
   cutoff.setDate(cutoff.getDate() - rollingPeriodDays);
@@ -287,7 +256,7 @@ function applyRollingWindow(
   return awards.filter((a) => !a.endDate || new Date(a.endDate).getTime() >= cutoffTime);
 }
 
-function buildCarriedAward(source: PointAward, rule: CategoryAggregationRule): PointAward {
+function buildCarriedAward(source: RankingListAward, rule: CategoryAggregationRule): RankingListAward {
   // rerateTo is deferred — needs AwardProfile lookup. Multiplier path only here.
   const multiplier = rule.multiplier ?? 1;
   const components: PointComponent[] = rule.carryComponents ?? [
@@ -297,7 +266,7 @@ function buildCarriedAward(source: PointAward, rule: CategoryAggregationRule): P
     'bonusPoints',
   ];
 
-  const carried: PointAward = {
+  const carried: RankingListAward = {
     ...source,
     carriedFromRule: rule.ruleName,
     subjectToBucketLimits: rule.subjectToBucketLimits ?? true,
@@ -331,8 +300,8 @@ function applyParticipationGating({
   rules,
   categoryFilter,
 }: {
-  nativeByPerson: Record<string, PointAward[]>;
-  carriedByPerson: Record<string, PointAward[]>;
+  nativeByPerson: Record<string, RankingListAward[]>;
+  carriedByPerson: Record<string, RankingListAward[]>;
   rules: CategoryAggregationRule[];
   categoryFilter: CategoryFilter | undefined;
 }): string[] {
@@ -372,25 +341,27 @@ function computePersonEntry({
   maxResultsPerLevel: Record<number, number> | undefined;
   bestOfCount: number | undefined;
   personId: string;
-  awards: PointAward[];
+  awards: RankingListAward[];
 }): RankingListEntry {
   let totalPoints = 0;
-  let allCountingResults: PointAward[] = [];
-  let allDroppedResults: PointAward[] = [];
-  let bucketBreakdown: RankingListEntry['bucketBreakdown'];
+  let allCountingResults: RankingListAward[] = [];
+  let allDroppedResults: RankingListAward[] = [];
+  let bucketBreakdown: RankingListBucketBreakdown[] | undefined;
+  let bucketTotals: Record<string, number> | undefined;
 
   if (countingBuckets?.length) {
     bucketBreakdown = [];
+    bucketTotals = {};
 
-    for (const bucket of countingBuckets) {
-      const {
-        bucketName,
-        eventTypes,
-        pointComponents,
-        bestOfCount: bucketBestOf,
-        maxResultsPerLevel: bucketMaxPerLevel,
-        mandatoryRules,
-      } = bucket;
+    for (const [bucketIndex, bucket] of countingBuckets.entries()) {
+      const { eventTypes, maxResultsPerLevel: bucketMaxPerLevel, mandatoryRules } = bucket;
+
+      // `bucketName` is optional on the policy. Fall back to a positional label
+      // so `bucketTotals` never carries an `undefined` key and both views of
+      // the bucket agree on what to call it.
+      const bucketName = bucket.bucketName ?? `bucket-${bucketIndex}`;
+      const pointComponents = bucket.pointComponents ?? DEFAULT_POINT_COMPONENTS;
+      const bucketBestOf = bucket.bestOfCount ?? 0;
 
       let bucketAwards = awards;
       if (eventTypes?.length) {
@@ -421,8 +392,7 @@ function computePersonEntry({
 
       const subTotal = limitedTotal + additiveTotal;
       totalPoints += subTotal;
-      allCountingResults.push(...counting.map((sa) => sa.award));
-      allCountingResults.push(...additiveScored.map((sa) => sa.award));
+      allCountingResults.push(...counting.map((sa) => sa.award), ...additiveScored.map((sa) => sa.award));
       allDroppedResults.push(...dropped.map((sa) => sa.award));
 
       bucketBreakdown.push({
@@ -431,6 +401,11 @@ function computePersonEntry({
         droppedResults: dropped.map((sa) => sa.award),
         bucketTotal: subTotal,
       });
+
+      // Accumulate rather than assign: two buckets sharing a name is a policy
+      // error, but summing keeps the reported total truthful instead of
+      // silently discarding one of them.
+      bucketTotals[bucketName] = (bucketTotals[bucketName] ?? 0) + subTotal;
     }
   } else {
     const bucketLimited = awards.filter((a) => a.subjectToBucketLimits !== false);
@@ -438,14 +413,14 @@ function computePersonEntry({
 
     const { counting, dropped, bucketTotal } = processBucketResults({
       awards: bucketLimited,
-      pointComponents: ['points', 'qualityWinPoints'],
+      pointComponents: DEFAULT_POINT_COMPONENTS,
       bestOfCount: bestOfCount || 0,
       maxResultsPerLevel,
     });
 
     const additiveScored: ScoredAward[] = additive.map((a) => ({
       award: a,
-      value: sumComponents(a, ['points', 'qualityWinPoints']),
+      value: sumComponents(a, DEFAULT_POINT_COMPONENTS),
     }));
     const additiveTotal = additiveScored.reduce((s, sa) => s + sa.value, 0);
 
@@ -464,10 +439,11 @@ function computePersonEntry({
   };
 
   if (bucketBreakdown) entry.bucketBreakdown = bucketBreakdown;
+  if (bucketTotals) entry.bucketTotals = bucketTotals;
   return entry;
 }
 
-function sumComponents(award: PointAward, components: string[] | undefined): number {
+function sumComponents(award: RankingListAward, components: string[] | undefined): number {
   const list = components ?? ['points'];
   let value = 0;
   for (const c of list) {

--- a/src/query/scales/getParticipantPoints.ts
+++ b/src/query/scales/getParticipantPoints.ts
@@ -1,42 +1,15 @@
+import { DEFAULT_POINT_COMPONENTS } from '@Constants/rankingConstants';
 import { processBucketResults } from './processBucketResults';
-import type { MandatoryRule } from '@Types/rankingTypes';
-
-type PointAward = Record<string, any>;
-
-type CountingBucket = {
-  bucketName: string;
-  eventTypes?: string[];
-  pointComponents: string[];
-  bestOfCount: number;
-  maxResultsPerLevel?: Record<number, number>;
-  mandatoryRules?: MandatoryRule[];
-};
-
-type AggregationRules = {
-  countingBuckets?: CountingBucket[];
-  maxResultsPerLevel?: Record<number, number>;
-  bestOfCount?: number;
-};
-
-type BucketBreakdown = {
-  bucketName: string;
-  countingResults: PointAward[];
-  droppedResults: PointAward[];
-  bucketTotal: number;
-};
+import type { RankingListBucketBreakdown, RankingListAward, AggregationRules } from '@Types/rankingTypes';
 
 type GetParticipantPointsArgs = {
-  pointAwards: PointAward[];
+  pointAwards: RankingListAward[];
   personId: string;
   aggregationRules?: AggregationRules;
 };
 
-export function getParticipantPoints({
-  pointAwards,
-  personId,
-  aggregationRules = {},
-}: GetParticipantPointsArgs): {
-  buckets: BucketBreakdown[];
+export function getParticipantPoints({ pointAwards, personId, aggregationRules = {} }: GetParticipantPointsArgs): {
+  buckets: RankingListBucketBreakdown[];
   totalPoints: number;
 } {
   const { countingBuckets, maxResultsPerLevel, bestOfCount } = aggregationRules;
@@ -45,11 +18,17 @@ export function getParticipantPoints({
   const awards = pointAwards.filter((a) => a.personId === personId);
 
   if (countingBuckets?.length) {
-    const buckets: BucketBreakdown[] = [];
+    const buckets: RankingListBucketBreakdown[] = [];
     let totalPoints = 0;
 
-    for (const bucket of countingBuckets) {
-      const { bucketName, eventTypes, pointComponents, bestOfCount: bucketBestOf, maxResultsPerLevel: bucketMaxPerLevel, mandatoryRules } = bucket;
+    for (const [bucketIndex, bucket] of countingBuckets.entries()) {
+      const { eventTypes, maxResultsPerLevel: bucketMaxPerLevel, mandatoryRules } = bucket;
+
+      // Same positional fallback generateRankingList uses, so a bucket is
+      // labelled identically whichever of the two reports on it.
+      const bucketName = bucket.bucketName ?? `bucket-${bucketIndex}`;
+      const pointComponents = bucket.pointComponents ?? DEFAULT_POINT_COMPONENTS;
+      const bucketBestOf = bucket.bestOfCount ?? 0;
 
       let bucketAwards = awards;
       if (eventTypes?.length) {
@@ -80,7 +59,7 @@ export function getParticipantPoints({
   // No buckets — single "All" bucket
   const { counting, dropped, bucketTotal } = processBucketResults({
     awards,
-    pointComponents: ['points', 'qualityWinPoints'],
+    pointComponents: DEFAULT_POINT_COMPONENTS,
     bestOfCount: bestOfCount || 0,
     maxResultsPerLevel,
   });

--- a/src/query/scales/processBucketResults.ts
+++ b/src/query/scales/processBucketResults.ts
@@ -1,14 +1,12 @@
-import type { MandatoryRule } from '@Types/rankingTypes';
-
-type PointAward = Record<string, any>;
+import type { RankingListAward, MandatoryRule } from '@Types/rankingTypes';
 
 export type ScoredAward = {
-  award: PointAward;
+  award: RankingListAward;
   value: number;
 };
 
 type ProcessBucketResultsArgs = {
-  awards: PointAward[];
+  awards: RankingListAward[];
   pointComponents: string[];
   bestOfCount: number;
   maxResultsPerLevel?: Record<number, number>;

--- a/src/tests/queries/scales/rankingListEntryShape.test.ts
+++ b/src/tests/queries/scales/rankingListEntryShape.test.ts
@@ -1,0 +1,181 @@
+import { getParticipantPoints } from '@Query/scales/getParticipantPoints';
+import { generateRankingList } from '@Query/scales/generateRankingList';
+import { describe, expect, it } from 'vitest';
+
+import { SINGLES, DOUBLES } from '@Constants/eventConstants';
+
+// Regression cover for the RankingListEntry reconciliation: `@Types/rankingTypes`
+// declared a shape (`participantId`, numeric `countingResults`, `tournamentResults`,
+// `tiebreakValues`) that generateRankingList never emitted, and promised a
+// `bucketTotals` the implementation had no code to produce. A consumer persisting
+// `entry.bucketTotals` therefore stored null for every bucketed policy.
+
+function makeAward(overrides: Record<string, any> = {}) {
+  return {
+    personId: 'person-1',
+    eventType: SINGLES,
+    positionPoints: 0,
+    perWinPoints: 0,
+    bonusPoints: 0,
+    points: 0,
+    level: 3,
+    endDate: '2025-06-01',
+    ...overrides,
+  };
+}
+
+describe('RankingListEntry shape', () => {
+  it('emits bucketTotals whenever it emits bucketBreakdown, and the two agree', () => {
+    const awards = [
+      makeAward({ personId: 'p1', eventType: SINGLES, positionPoints: 500 }),
+      makeAward({ personId: 'p1', eventType: SINGLES, positionPoints: 300 }),
+      makeAward({ personId: 'p1', eventType: DOUBLES, positionPoints: 120 }),
+    ];
+
+    const result: any = generateRankingList({
+      pointAwards: awards,
+      aggregationRules: {
+        countingBuckets: [
+          { bucketName: 'Singles', eventTypes: [SINGLES], pointComponents: ['positionPoints'], bestOfCount: 2 },
+          { bucketName: 'Doubles', eventTypes: [DOUBLES], pointComponents: ['positionPoints'], bestOfCount: 2 },
+        ],
+      },
+    });
+
+    const p1 = result.find((e: any) => e.personId === 'p1');
+
+    // Control: the fixture is non-degenerate — two buckets actually scored.
+    expect(p1.bucketBreakdown).toHaveLength(2);
+    expect(p1.totalPoints).toEqual(920);
+
+    expect(p1.bucketTotals).toEqual({ Singles: 800, Doubles: 120 });
+
+    // The summary view must not drift from the detailed one.
+    const fromBreakdown = Object.fromEntries(p1.bucketBreakdown.map((b: any) => [b.bucketName, b.bucketTotal]));
+    expect(p1.bucketTotals).toEqual(fromBreakdown);
+    expect(Object.values(p1.bucketTotals).reduce((a: any, b: any) => a + b, 0)).toEqual(p1.totalPoints);
+  });
+
+  it('labels an unnamed bucket by position in both views rather than keying on undefined', () => {
+    const result: any = generateRankingList({
+      pointAwards: [makeAward({ personId: 'p1', positionPoints: 250 })],
+      aggregationRules: {
+        countingBuckets: [{ pointComponents: ['positionPoints'], bestOfCount: 0 }],
+      },
+    });
+
+    const p1 = result.find((e: any) => e.personId === 'p1');
+    expect(p1.bucketTotals).toEqual({ 'bucket-0': 250 });
+    expect(p1.bucketBreakdown[0].bucketName).toEqual('bucket-0');
+    expect(Object.keys(p1.bucketTotals)).not.toContain('undefined');
+  });
+
+  it('omits bucketTotals when the policy defines no countingBuckets', () => {
+    const result: any = generateRankingList({
+      pointAwards: [makeAward({ personId: 'p1', points: 400 })],
+    });
+
+    const p1 = result.find((e: any) => e.personId === 'p1');
+    expect(p1.totalPoints).toEqual(400);
+    expect(p1.bucketBreakdown).toBeUndefined();
+    expect(p1.bucketTotals).toBeUndefined();
+  });
+
+  it('returns the fields the declared type promises, and none it does not', () => {
+    const result: any = generateRankingList({
+      pointAwards: [makeAward({ personId: 'p1', points: 400 })],
+    });
+
+    const p1 = result.find((e: any) => e.personId === 'p1');
+    expect(Object.keys(p1).toSorted((a, b) => a.localeCompare(b, 'en'))).toEqual([
+      'countingResults',
+      'droppedResults',
+      'meetsMinimum',
+      'personId',
+      'rank',
+      'totalPoints',
+    ]);
+
+    // countingResults is the contributing awards, not a count — the declared
+    // type said `number`, which is what drove a consumer to coerce defensively.
+    expect(Array.isArray(p1.countingResults)).toEqual(true);
+  });
+
+  it('defaults an unnamed bucket to the same components getParticipantPoints does', () => {
+    const awards = [makeAward({ personId: 'p1', points: 300, qualityWinPoints: 50 })];
+
+    const list: any = generateRankingList({
+      pointAwards: awards,
+      aggregationRules: { countingBuckets: [{ bucketName: 'All' }] },
+    });
+    const breakdown: any = getParticipantPoints({
+      pointAwards: awards,
+      personId: 'p1',
+      aggregationRules: { countingBuckets: [{ bucketName: 'All' }] },
+    });
+
+    // points + qualityWinPoints, from disjoint award populations in the real
+    // pipeline; here one award carries both, which is still a single sum.
+    expect(list.find((e: any) => e.personId === 'p1').bucketTotals).toEqual({ All: 350 });
+    expect(breakdown.totalPoints).toEqual(350);
+    expect(breakdown.buckets[0].bucketName).toEqual('All');
+  });
+
+  it('sums buckets that share a name rather than letting the last one win', () => {
+    const awards = [
+      makeAward({ personId: 'p1', eventType: SINGLES, positionPoints: 400 }),
+      makeAward({ personId: 'p1', eventType: DOUBLES, positionPoints: 100 }),
+    ];
+
+    const result: any = generateRankingList({
+      pointAwards: awards,
+      aggregationRules: {
+        countingBuckets: [
+          { bucketName: 'Combined', eventTypes: [SINGLES], pointComponents: ['positionPoints'] },
+          { bucketName: 'Combined', eventTypes: [DOUBLES], pointComponents: ['positionPoints'] },
+        ],
+      },
+    });
+
+    const p1 = result.find((e: any) => e.personId === 'p1');
+
+    // Two breakdown rows, one merged total — the points of the second bucket
+    // must not vanish because it reused the first one's label.
+    expect(p1.bucketBreakdown).toHaveLength(2);
+    expect(p1.bucketTotals).toEqual({ Combined: 500 });
+    expect(p1.totalPoints).toEqual(500);
+  });
+
+  it('getParticipantPoints labels an unnamed bucket by position too', () => {
+    const breakdown: any = getParticipantPoints({
+      pointAwards: [makeAward({ personId: 'p1', positionPoints: 250 })],
+      personId: 'p1',
+      aggregationRules: { countingBuckets: [{ pointComponents: ['positionPoints'] }] },
+    });
+
+    expect(breakdown.buckets[0].bucketName).toEqual('bucket-0');
+    expect(breakdown.totalPoints).toEqual(250);
+  });
+
+  it('sums awards marked subjectToBucketLimits=false on top of the best-of cap', () => {
+    const awards = [
+      makeAward({ personId: 'p1', points: 500 }),
+      makeAward({ personId: 'p1', points: 400 }),
+      // Exempt from the cap: contributes on top rather than competing for a slot.
+      makeAward({ personId: 'p1', points: 50, subjectToBucketLimits: false }),
+    ];
+
+    const result: any = generateRankingList({
+      pointAwards: awards,
+      aggregationRules: { bestOfCount: 1 },
+    });
+
+    const p1 = result.find((e: any) => e.personId === 'p1');
+
+    // best-of-1 keeps 500 and drops 400; the exempt 50 is added regardless.
+    expect(p1.totalPoints).toEqual(550);
+    expect(p1.countingResults).toHaveLength(2);
+    expect(p1.droppedResults).toHaveLength(1);
+    expect(p1.droppedResults[0].points).toEqual(400);
+  });
+});

--- a/src/types/rankingTypes.ts
+++ b/src/types/rankingTypes.ts
@@ -537,9 +537,10 @@ export interface CountingBucket {
   eventTypes?: EventTypeUnion[];
 
   /**
-   * Which components of PointAward to sum for this bucket.
-   * Valid values: 'positionPoints', 'perWinPoints', 'bonusPoints', 'qualityWinPoints'
-   * If omitted, sums the total `points` field (all components).
+   * Which components of an award to sum for this bucket.
+   * See {@link PointComponent} for the vocabulary and for why `'points'`
+   * must not be mixed with the granular components.
+   * If omitted, defaults to `['points', 'qualityWinPoints']`.
    */
   pointComponents?: PointComponent[];
 
@@ -580,7 +581,20 @@ export interface MandatoryRule {
   bestOfCount?: number;
 }
 
-export type PointComponent = 'positionPoints' | 'perWinPoints' | 'bonusPoints' | 'qualityWinPoints';
+/**
+ * A summable component of an award.
+ *
+ * `'points'` is the award's own pre-summed total rather than a fifth granular
+ * component, and it is a legitimate bucket component: `generateRankingList`
+ * and `getParticipantPoints` both default to `['points', 'qualityWinPoints']`
+ * when a policy declares none. That pairing does not double-count — a
+ * quality-win bonus is emitted as its OWN award carrying `qualityWinPoints`
+ * and no `points`, so the two names address disjoint award populations.
+ *
+ * Do not, however, mix `'points'` with the granular components in one bucket:
+ * there it would count the same award's total twice.
+ */
+export type PointComponent = 'points' | 'positionPoints' | 'perWinPoints' | 'bonusPoints' | 'qualityWinPoints';
 
 export type DoublesAttribution = 'fullToEach' | 'splitEven' | 'teamOnly';
 
@@ -649,24 +663,74 @@ export interface PointAward {
 
 // ─── Ranking List Output ─────────────────────────────────────────────
 
+/**
+ * An award as it flows THROUGH list aggregation — deliberately permissive,
+ * and named so that the looseness is explicit rather than accidental.
+ *
+ * Three different producers feed the same array, and only the first of them
+ * mints a nominal {@link PointAward}:
+ *
+ * - `getTournamentPointAwards` — mints strict `PointAward`s.
+ * - A consumer's own storage — a ranking service that persists awards and
+ *   later projects the rows back into award shape is matching structurally,
+ *   not nominally.
+ * - `generateRankingList` itself — `categoryAggregation` carry rules
+ *   synthesise awards annotated with `carriedFromRule` and
+ *   `subjectToBucketLimits`, which are aggregation-time markers rather than
+ *   properties of the underlying result.
+ *
+ * Components are also indexed by name off `pointComponents` in policy config,
+ * so the type has to stay index-accessible.
+ *
+ * Prefer {@link PointAward} anywhere an award is being *produced*.
+ */
+export type RankingListAward = Record<string, any>;
+
+/** Per-bucket detail for one participant, when the policy defines countingBuckets. */
+export interface RankingListBucketBreakdown {
+  /** The bucket's `bucketName`, or `bucket-<index>` when the policy left it unnamed. */
+  bucketName: string;
+  bucketTotal: number;
+  countingResults: RankingListAward[];
+  droppedResults: RankingListAward[];
+}
+
+/**
+ * One participant's row in a generated ranking list.
+ *
+ * This interface is the single declaration of the shape `generateRankingList`
+ * returns; the implementation imports it rather than restating it. It
+ * previously disagreed with what the function actually emitted (`participantId`
+ * / a numeric `countingResults` / `tournamentResults` / `tiebreakValues`, none
+ * of which were ever produced), and because both declarations reached the
+ * published `.d.ts` a consumer resolved one or the other by import path.
+ */
 export interface RankingListEntry {
   rank: number;
-  participantId: string;
-  personId?: string;
+
+  /** Ranking lists are person-keyed: awards aggregate across a person's participantIds. */
+  personId: string;
 
   totalPoints: number;
-  countingResults: number;
 
-  /** Per-bucket breakdown (when countingBuckets defined) */
+  /** Whether the entry clears `AggregationRules.minCountableResults`. */
+  meetsMinimum: boolean;
+
+  /** The awards that contributed to `totalPoints`. */
+  countingResults: RankingListAward[];
+
+  /** Awards excluded by a best-of-N or per-level cap. Retained for auditing. */
+  droppedResults: RankingListAward[];
+
+  /**
+   * Per-bucket totals keyed by bucket name — the summary form of
+   * `bucketBreakdown`, for consumers that persist or display totals without
+   * the underlying awards. Present whenever `bucketBreakdown` is.
+   */
   bucketTotals?: Record<string, number>;
 
-  tournamentResults: PointAward[];
-
-  // Tiebreaker metadata (for deterministic ordering)
-  tiebreakValues?: Record<TiebreakCriterion, number>;
-
-  // Whether this entry meets minimum requirements
-  meetsMinimum: boolean;
+  /** Full per-bucket detail. Present when the policy defines countingBuckets. */
+  bucketBreakdown?: RankingListBucketBreakdown[];
 }
 
 // ─── Supporting Types ────────────────────────────────────────────────


### PR DESCRIPTION
## The problem

`RankingListEntry` was declared **twice, incompatibly**:

| `types/rankingTypes.ts` (declared) | `query/scales/generateRankingList.ts` (actually emitted) |
|---|---|
| `participantId: string` | `personId: string` |
| `countingResults: number` | `countingResults: RankingListAward[]` |
| `tournamentResults` / `tiebreakValues` | *(never emitted)* |
| `bucketTotals` | *(no code produced it)* |
| — | `droppedResults`, `bucketBreakdown` |

`rankingGovernor/query.ts` re-exports the function, so consumers received the second shape while `@Types` advertised the first. Both reached the published surface: `dist/tods-competition-factory.d.ts` carried `RankingListEntry` **and** `RankingListEntry$1`, so which one a consumer resolved depended on import path.

The declared `bucketTotals` had no implementation behind it at all. Any consumer persisting it stored nothing, for every policy defining counting buckets. (courthive-rankings did exactly this — its `ranking_entries.bucket_totals` column was NULL on every bucketed row. Fixed separately in courthive-rankings.)

## The change

- **One `RankingListEntry`**, matching what the function emits; the implementation imports it. `bucketTotals` is now emitted alongside `bucketBreakdown` as its summary view.
- **Three `type PointAward = Record<string, any>` shadows removed** (`generateRankingList`, `processBucketResults`, `getParticipantPoints`) in favour of an exported, documented `RankingListAward`. That shadowing is *why* the declarations could drift: inside those files `PointAward` named something entirely different from the strict `PointAward` in `rankingTypes.ts`.
- `getParticipantPoints` also carried duplicate `CountingBucket`, `AggregationRules` and a `BucketBreakdown` structurally identical to the canonical one — all folded in.
- **`'points'` added to `PointComponent`.** It was already a supported runtime component — `['points', 'qualityWinPoints']` is the default both aggregators use — that the union omitted. It does not double-count: a quality-win bonus is emitted as its **own** award carrying `qualityWinPoints` and no `points`, so the pair addresses disjoint award populations.
- Unnamed buckets get a positional `bucket-<index>` label instead of keying `bucketTotals` on `undefined`; buckets sharing a name accumulate rather than overwrite.

## Type-surface note

This **alters the published type surface**. The removed fields were never populated, so no working runtime behaviour changes, but a consumer type-checking against the old declaration would need updating. An ecosystem sweep across 20 repos found no such consumer outside courthive-rankings, which types the boundary as `any`. Flagging it in case you'd rather this ride a major.

## Verification

- Full suite **11701 passed / 1 skipped**; coverage gate green (95.35 stmts / 87.2 branch / 98.08 funcs / 97.79 lines against 95/85/95/95).
- All 14 `verify:*` steps green — including `verify:attr-audit`, which fired on `bucketTotals ~ bucketTotal`. Both names are real and both predate this change (`bucketTotal` is the per-bucket numeric, `bucketTotals` the keyed summary), so per the standards this is an `attr-audit.allow.json` entry rather than a rename. Falsified: removing the entry re-fails the gate.
- Confirmed on the built artifact that `dist/tods-competition-factory.d.ts` now carries **one** `RankingListEntry` where it previously carried two.
- Both behavioural fixes falsified — reverting each turns exactly the intended assertions red.

## Known gaps, not addressed here

- `generateRankingList`'s `categoryAggregation` paths remain at ~81% branch coverage — pre-existing, untouched by this change.
- `getParticipantPoints` does not honour `subjectToBucketLimits` while `generateRankingList` does, so additive carry contributions are counted differently by the two. Real inconsistency, but semantic and out of scope for a type reconciliation.
