### PR TITLE
fix(scales): getParticipantPoints was ignoring subjectToBucketLimits

### DIFF
--- a/src/query/scales/generateRankingList.ts
+++ b/src/query/scales/generateRankingList.ts
@@ -1,4 +1,4 @@
-import { processBucketResults, type ScoredAward } from './processBucketResults';
+import { processBucketResults } from './processBucketResults';
 import { DEFAULT_POINT_COMPONENTS } from '@Constants/rankingConstants';
 import type {
   RankingListBucketBreakdown,
@@ -368,36 +368,26 @@ function computePersonEntry({
         bucketAwards = bucketAwards.filter((a) => a.eventType && eventTypes.includes(a.eventType));
       }
 
-      // Split bucket-limited (default) vs additive (subjectToBucketLimits=false).
-      const bucketLimited = bucketAwards.filter((a) => a.subjectToBucketLimits !== false);
-      const additive = bucketAwards.filter((a) => a.subjectToBucketLimits === false);
-
+      // processBucketResults owns the bucket-limited vs additive split.
       const {
         counting,
         dropped,
-        bucketTotal: limitedTotal,
+        bucketTotal: subTotal,
       } = processBucketResults({
-        awards: bucketLimited,
+        awards: bucketAwards,
         pointComponents,
         bestOfCount: bucketBestOf,
         maxResultsPerLevel: bucketMaxPerLevel,
         mandatoryRules,
       });
 
-      const additiveScored: ScoredAward[] = additive.map((a) => ({
-        award: a,
-        value: sumComponents(a, pointComponents),
-      }));
-      const additiveTotal = additiveScored.reduce((s, sa) => s + sa.value, 0);
-
-      const subTotal = limitedTotal + additiveTotal;
       totalPoints += subTotal;
-      allCountingResults.push(...counting.map((sa) => sa.award), ...additiveScored.map((sa) => sa.award));
+      allCountingResults.push(...counting.map((sa) => sa.award));
       allDroppedResults.push(...dropped.map((sa) => sa.award));
 
       bucketBreakdown.push({
         bucketName,
-        countingResults: [...counting.map((sa) => sa.award), ...additiveScored.map((sa) => sa.award)],
+        countingResults: counting.map((sa) => sa.award),
         droppedResults: dropped.map((sa) => sa.award),
         bucketTotal: subTotal,
       });
@@ -408,24 +398,15 @@ function computePersonEntry({
       bucketTotals[bucketName] = (bucketTotals[bucketName] ?? 0) + subTotal;
     }
   } else {
-    const bucketLimited = awards.filter((a) => a.subjectToBucketLimits !== false);
-    const additive = awards.filter((a) => a.subjectToBucketLimits === false);
-
     const { counting, dropped, bucketTotal } = processBucketResults({
-      awards: bucketLimited,
+      awards,
       pointComponents: DEFAULT_POINT_COMPONENTS,
       bestOfCount: bestOfCount || 0,
       maxResultsPerLevel,
     });
 
-    const additiveScored: ScoredAward[] = additive.map((a) => ({
-      award: a,
-      value: sumComponents(a, DEFAULT_POINT_COMPONENTS),
-    }));
-    const additiveTotal = additiveScored.reduce((s, sa) => s + sa.value, 0);
-
-    totalPoints = bucketTotal + additiveTotal;
-    allCountingResults = [...counting.map((sa) => sa.award), ...additiveScored.map((sa) => sa.award)];
+    totalPoints = bucketTotal;
+    allCountingResults = counting.map((sa) => sa.award);
     allDroppedResults = dropped.map((sa) => sa.award);
   }
 
@@ -441,15 +422,6 @@ function computePersonEntry({
   if (bucketBreakdown) entry.bucketBreakdown = bucketBreakdown;
   if (bucketTotals) entry.bucketTotals = bucketTotals;
   return entry;
-}
-
-function sumComponents(award: RankingListAward, components: string[] | undefined): number {
-  const list = components ?? ['points'];
-  let value = 0;
-  for (const c of list) {
-    if (typeof award[c] === 'number') value += award[c];
-  }
-  return value;
 }
 
 function sortAndRankEntries(entries: RankingListEntry[], tiebreakCriteria: TiebreakCriterion[] | string[]) {

--- a/src/query/scales/processBucketResults.ts
+++ b/src/query/scales/processBucketResults.ts
@@ -24,14 +24,24 @@ export function processBucketResults({
   dropped: ScoredAward[];
   bucketTotal: number;
 } {
-  // 1. Score each award by summing pointComponents
-  const scoredAwards: ScoredAward[] = awards.map((a) => {
+  // 1. Score each award by summing pointComponents, and split off the awards
+  //    that are exempt from this bucket's limits.
+  //
+  //    A categoryAggregation rule with `subjectToBucketLimits: false` says its
+  //    carried contribution sums ON TOP of the cap rather than competing for a
+  //    slot. That split belongs here, in the helper all three callers share:
+  //    `generateRankingList` used to do it inline (twice) and
+  //    `getParticipantPoints` did not do it at all, so the two reported
+  //    different totals for the same awards.
+  const scoredAwards: ScoredAward[] = [];
+  const additive: ScoredAward[] = [];
+  for (const award of awards) {
     let value = 0;
     for (const component of pointComponents) {
-      value += typeof a[component] === 'number' ? a[component] : 0;
+      value += typeof award[component] === 'number' ? award[component] : 0;
     }
-    return { award: a, value };
-  });
+    (award.subjectToBucketLimits === false ? additive : scoredAwards).push({ award, value });
+  }
 
   // 2. Sort descending by score
   scoredAwards.sort((a, b) => b.value - a.value);
@@ -59,7 +69,7 @@ export function processBucketResults({
 
   // 4. Mandatory selection + optional fill
   if (mandatoryRules?.length) {
-    return processMandatory(capped, levelDropped, bestOfCount, mandatoryRules);
+    return withAdditive(processMandatory(capped, levelDropped, bestOfCount, mandatoryRules), additive);
   }
 
   // No mandatory rules — standard bestOfCount
@@ -67,7 +77,25 @@ export function processBucketResults({
   const dropped = [...(bestOfCount > 0 ? capped.slice(bestOfCount) : []), ...levelDropped];
   const bucketTotal = counting.reduce((sum, sa) => sum + sa.value, 0);
 
-  return { counting, dropped, bucketTotal };
+  return withAdditive({ counting, dropped, bucketTotal }, additive);
+}
+
+/**
+ * Fold the bucket-limit-exempt awards back in: they always count, are never
+ * dropped, and their value is added to the total. Appended after the selected
+ * awards so the order callers already observed is unchanged.
+ */
+function withAdditive(
+  result: { counting: ScoredAward[]; dropped: ScoredAward[]; bucketTotal: number },
+  additive: ScoredAward[],
+): { counting: ScoredAward[]; dropped: ScoredAward[]; bucketTotal: number } {
+  if (!additive.length) return result;
+
+  return {
+    counting: [...result.counting, ...additive],
+    dropped: result.dropped,
+    bucketTotal: result.bucketTotal + additive.reduce((sum, sa) => sum + sa.value, 0),
+  };
 }
 
 function processMandatory(

--- a/src/tests/queries/scales/rankingListEntryShape.test.ts
+++ b/src/tests/queries/scales/rankingListEntryShape.test.ts
@@ -179,3 +179,82 @@ describe('RankingListEntry shape', () => {
     expect(p1.droppedResults[0].points).toEqual(400);
   });
 });
+
+// The two functions are the list view and the per-participant view of the SAME
+// computation, so they must agree. They did not: `generateRankingList` split
+// bucket-limit-exempt awards out and summed them on top, and
+// `getParticipantPoints` ignored the flag, reporting 500 where the list said 550.
+// The split now lives in processBucketResults, which both call.
+describe('generateRankingList / getParticipantPoints parity', () => {
+  const additiveAwards = [
+    makeAward({ personId: 'p1', points: 500 }),
+    makeAward({ personId: 'p1', points: 400 }),
+    makeAward({ personId: 'p1', points: 50, subjectToBucketLimits: false }),
+  ];
+
+  function bothTotals(aggregationRules: any) {
+    const list: any = generateRankingList({ pointAwards: additiveAwards, aggregationRules });
+    const single: any = getParticipantPoints({ pointAwards: additiveAwards, personId: 'p1', aggregationRules });
+    return { list: list.find((e: any) => e.personId === 'p1').totalPoints, single: single.totalPoints };
+  }
+
+  it('agrees on an additive award with no counting buckets', () => {
+    const { list, single } = bothTotals({ bestOfCount: 1 });
+    expect(list).toEqual(550);
+    expect(single).toEqual(list);
+  });
+
+  it('agrees on an additive award inside a counting bucket', () => {
+    const { list, single } = bothTotals({
+      countingBuckets: [{ bucketName: 'All', pointComponents: ['points'], bestOfCount: 1 }],
+    });
+    expect(list).toEqual(550);
+    expect(single).toEqual(list);
+  });
+
+  it('agrees when mandatory rules select the counted awards', () => {
+    const awards = [
+      makeAward({ personId: 'p1', points: 500, level: 1 }),
+      makeAward({ personId: 'p1', points: 400, level: 3 }),
+      makeAward({ personId: 'p1', points: 50, level: 3, subjectToBucketLimits: false }),
+    ];
+    const aggregationRules: any = {
+      countingBuckets: [
+        {
+          bucketName: 'All',
+          pointComponents: ['points'],
+          bestOfCount: 1,
+          mandatoryRules: [{ ruleName: 'Slams', levels: [1] }],
+        },
+      ],
+    };
+    const list: any = generateRankingList({ pointAwards: awards, aggregationRules });
+    const single: any = getParticipantPoints({ pointAwards: awards, personId: 'p1', aggregationRules });
+
+    expect(list.find((e: any) => e.personId === 'p1').totalPoints).toEqual(550);
+    expect(single.totalPoints).toEqual(550);
+  });
+
+  it('never drops a bucket-limit-exempt award, in either view', () => {
+    const aggregationRules = { bestOfCount: 1 };
+    const list: any = generateRankingList({ pointAwards: additiveAwards, aggregationRules });
+    const single: any = getParticipantPoints({ pointAwards: additiveAwards, personId: 'p1', aggregationRules });
+    const p1 = list.find((e: any) => e.personId === 'p1');
+
+    const exempt = (a: any) => a.subjectToBucketLimits === false;
+    expect(p1.countingResults.filter(exempt)).toHaveLength(1);
+    expect(p1.droppedResults.filter(exempt)).toHaveLength(0);
+    expect(single.buckets[0].countingResults.filter(exempt)).toHaveLength(1);
+    expect(single.buckets[0].droppedResults.filter(exempt)).toHaveLength(0);
+  });
+
+  it('control — with no exempt award the two already agreed, and still do', () => {
+    const plain = [makeAward({ personId: 'p1', points: 500 }), makeAward({ personId: 'p1', points: 400 })];
+    const aggregationRules = { bestOfCount: 1 };
+    const list: any = generateRankingList({ pointAwards: plain, aggregationRules });
+    const single: any = getParticipantPoints({ pointAwards: plain, personId: 'p1', aggregationRules });
+
+    expect(list.find((e: any) => e.personId === 'p1').totalPoints).toEqual(500);
+    expect(single.totalPoints).toEqual(500);
+  });
+});


### PR DESCRIPTION
## The problem

`generateRankingList` and `getParticipantPoints` are the list view and the per-participant view of the **same** computation. They disagreed.

A `categoryAggregation` rule carrying `subjectToBucketLimits: false` means its contribution sums **on top of** the best-of cap rather than competing for a slot. `generateRankingList` implemented that inline, in both its bucketed and non-bucketed branches. `getParticipantPoints` did not implement it at all.

Same awards, same `aggregationRules`, different answers:

| input | `generateRankingList` | `getParticipantPoints` |
|---|---|---|
| 500 + 400 + 50(exempt), `bestOfCount: 1` | **550** | **500** |
| same, wrapped in a `countingBucket` | **550** | **500** |
| control — no exempt award | 500 | 500 ✓ |

A consumer showing a player's ranking total and then drilling into the per-participant breakdown got two different numbers, with nothing to indicate which was right.

## Why it happened

`git log -S "subjectToBucketLimits === false"` dates it precisely: `8fcf3e34b` ("feat(ranking): interpret categoryAggregation in generateRankingList") added the split **and its tests, and touched nothing else**. `getParticipantPoints` predates the feature and was never brought along. An oversight, not a design decision.

## The change

Rather than add a **third** copy of the split, it moves into `processBucketResults` — the helper all three call sites already share.

- `generateRankingList`'s two manual splits collapse; its now-dead `sumComponents` helper is removed (−28 net lines there, +28 in the helper).
- **`getParticipantPoints.ts` is not in this diff at all.** It is fixed purely by the helper gaining the behaviour, which is the point of putting it there — the logic can no longer diverge a fourth time.

## Verification

- Full suite **11706 passed / 1 skipped**, coverage green (95.34 / 87.2 / 98.08 / 97.79 against 95 / 85 / 95 / 95). `verify:generated`, `verify:attr-audit`, `verify:server` all exit 0.
- **Behaviour-preserving for `generateRankingList`**: the pre-existing cross-category spec `subjectToBucketLimits: false — carried adds on top of bestOfCount instead of competing` passes untouched.
- **Falsified**: neutering the split so every award is bucket-limited again compiles cleanly (so the failure is behavioural, not a broken build) and turns **6** tests red — the five new parity specs *and* that pre-existing cross-category spec, which is the evidence the behaviour under test is the real one.
- New parity specs assert the two functions agree on totals with no buckets, inside a bucket, and under mandatory rules; that an exempt award is never dropped in either view; plus a control proving they already agreed when no exempt award is present.
