### PR TITLE
fix(scales): type getAwardProfile, and stop two .d.ts declarations drifting

### DIFF
--- a/src/constants/entryStatusConstants.ts
+++ b/src/constants/entryStatusConstants.ts
@@ -67,13 +67,39 @@ export const VALID_ENTRY_STATUSES: EntryStatusUnion[] = [
   WITHDRAWN,
 ];
 
+/**
+ * Explicitly named so the emitted `.d.ts` references `EntryStatusUnion[]` by
+ * alias instead of inlining the expanded literal union.
+ *
+ * `EntryStatusUnion` is `` `${EntryStatusEnum}` `` — a template-literal type,
+ * which TypeScript resolves to a union whose member ORDER is not stable across
+ * builds. Inlined into the `as const` aggregate below, that made
+ * `dist/tods-competition-factory.d.ts` differ from build to build for exactly
+ * these five groupings: ten lines of churn in every release diff, and enough to
+ * defeat any byte-comparison of the published types. A plain-union alias
+ * (`PointComponent`) already printed by name in the same position, which is
+ * what identified the fix.
+ */
+type EntryStatusGroups = {
+  readonly DIRECT_ENTRY_STATUSES: EntryStatusUnion[];
+  readonly DRAW_SPECIFIC_STATUSES: EntryStatusUnion[];
+  readonly EQUIVALENT_ACCEPTANCE_STATUSES: EntryStatusUnion[];
+  readonly STRUCTURE_SELECTED_STATUSES: EntryStatusUnion[];
+  readonly VALID_ENTRY_STATUSES: EntryStatusUnion[];
+};
+
+const entryStatusGroups: EntryStatusGroups = {
+  DIRECT_ENTRY_STATUSES,
+  DRAW_SPECIFIC_STATUSES,
+  EQUIVALENT_ACCEPTANCE_STATUSES,
+  STRUCTURE_SELECTED_STATUSES,
+  VALID_ENTRY_STATUSES,
+};
+
 export const entryStatusConstants = {
   ALTERNATE,
   CONFIRMED,
   DIRECT_ACCEPTANCE,
-  DIRECT_ENTRY_STATUSES,
-  DRAW_SPECIFIC_STATUSES,
-  EQUIVALENT_ACCEPTANCE_STATUSES,
   FEED_IN,
   JUNIOR_EXEMPT,
   LUCKY_LOSER,
@@ -81,10 +107,9 @@ export const entryStatusConstants = {
   QUALIFIER,
   REGISTERED,
   SPECIAL_EXEMPT,
-  STRUCTURE_SELECTED_STATUSES,
   UNGROUPED,
   UNPAIRED,
-  VALID_ENTRY_STATUSES,
   WILDCARD,
   WITHDRAWN,
+  ...entryStatusGroups,
 } as const;

--- a/src/query/scales/getAwardProfile.ts
+++ b/src/query/scales/getAwardProfile.ts
@@ -1,68 +1,103 @@
 import { CATEGORY_SCOPE_FIELDS, PROFILE_SCOPE_FIELDS } from '@Constants/rankingConstants';
 
-import type { CategoryScope } from '@Types/rankingTypes';
+import type { AwardProfile, CategoryScope, DateRange } from '@Types/rankingTypes';
+import type { Category, EventTypeUnion } from '@Types/tournamentTypes';
 
-export function getAwardProfile(params) {
-  const {
-    participation = {},
-    awardProfiles,
-    wheelchairClass,
-    startDate,
-    eventType,
-    drawSize,
-    drawType,
-    category,
-    endDate,
-    gender,
-    level,
-  } = params;
+/** The slice of a participant's draw participation that scopes profile selection. */
+type AwardProfileParticipation = {
+  participationOrder?: number;
+  flightNumber?: number;
+  rankingStage?: string;
+};
+
+type GetAwardProfileArgs = {
+  awardProfiles: AwardProfile[];
+  participation?: AwardProfileParticipation;
+  wheelchairClass?: string;
+  eventType?: EventTypeUnion;
+  startDate?: string;
+  endDate?: string;
+  drawSize?: number;
+  drawType?: string;
+  category?: Category;
+  gender?: string;
+  level?: number;
+};
+
+/**
+ * `values.includes(value)` where the value may be absent.
+ *
+ * An absent value never matches, which is the long-standing behaviour: a profile
+ * that declares a filter does not match an event that lacks the field at all.
+ * Written as a helper rather than inline so the undefined case stays explicit —
+ * the obvious type-safe rewrite (`value !== undefined && !values.includes(value)`
+ * folded into the caller's negation) silently inverts it.
+ */
+function includesValue<T>(values: readonly T[], value: T | undefined): boolean {
+  return value !== undefined && values.includes(value);
+}
+
+export function getAwardProfile({
+  participation = {},
+  awardProfiles,
+  wheelchairClass,
+  startDate,
+  eventType,
+  drawSize,
+  drawType,
+  category,
+  endDate,
+  gender,
+  level,
+}: GetAwardProfileArgs): { awardProfile: AwardProfile | undefined } {
   const { participationOrder, flightNumber, rankingStage } = participation;
 
-  const isValidDateRange = (profile) => {
+  const isValidDateRange = (profile: AwardProfile): boolean => {
     if ((!startDate && !endDate) || !profile.dateRanges) return true;
-    return profile.dateRanges.some((dateRange) => {
+    return profile.dateRanges.some((dateRange: DateRange) => {
       const validStartDate = !startDate || !dateRange.startDate || new Date(startDate) > new Date(dateRange.startDate);
       const validEndDate = !endDate || !dateRange.endDate || new Date(endDate) <= new Date(dateRange.endDate);
       return validStartDate && validEndDate;
     });
   };
 
-  const matchesCategory = (profileCategory: CategoryScope | undefined) => {
+  const matchesCategory = (profileCategory: CategoryScope | undefined): boolean => {
     if (!profileCategory) return true;
-    const c = category ?? {};
+    const c: Category = category ?? {};
 
     // Each populated CategoryScope field must match (AND logic)
     // Within each array, any value suffices (OR logic)
-    if (profileCategory.ageCategoryCodes?.length && !profileCategory.ageCategoryCodes.includes(c.ageCategoryCode))
+    if (profileCategory.ageCategoryCodes?.length && !includesValue(profileCategory.ageCategoryCodes, c.ageCategoryCode))
       return false;
-    if (profileCategory.genders?.length && !profileCategory.genders.includes(gender)) return false;
-    if (profileCategory.categoryNames?.length && !profileCategory.categoryNames.includes(c.categoryName)) return false;
-    if (profileCategory.categoryTypes?.length && !profileCategory.categoryTypes.includes(c.type)) return false;
-    if (profileCategory.ratingTypes?.length && !profileCategory.ratingTypes.includes(c.ratingType)) return false;
-    if (profileCategory.ballTypes?.length && !profileCategory.ballTypes.includes(c.ballType)) return false;
-    if (profileCategory.wheelchairClasses?.length && !profileCategory.wheelchairClasses.includes(wheelchairClass))
+    if (profileCategory.genders?.length && !includesValue(profileCategory.genders, gender)) return false;
+    if (profileCategory.categoryNames?.length && !includesValue(profileCategory.categoryNames, c.categoryName))
       return false;
-    if (profileCategory.subTypes?.length && !profileCategory.subTypes.includes(c.subType)) return false;
+    if (profileCategory.categoryTypes?.length && !includesValue(profileCategory.categoryTypes, c.type)) return false;
+    if (profileCategory.ratingTypes?.length && !includesValue(profileCategory.ratingTypes, c.ratingType)) return false;
+    if (profileCategory.ballTypes?.length && !includesValue(profileCategory.ballTypes, c.ballType)) return false;
+    if (profileCategory.wheelchairClasses?.length && !includesValue(profileCategory.wheelchairClasses, wheelchairClass))
+      return false;
+    if (profileCategory.subTypes?.length && !includesValue(profileCategory.subTypes, c.subType)) return false;
 
     return true;
   };
 
-  const matchesProfile = (profile) =>
+  const matchesProfile = (profile: AwardProfile): boolean =>
     isValidDateRange(profile) &&
-    (!profile.maxFlightNumber || flightNumber <= profile.maxFlightNumber) &&
-    (!profile.drawTypes?.length || profile.drawTypes?.includes(drawType)) &&
-    (!profile.drawSizes?.length || profile.drawSizes.includes(drawSize)) &&
-    (!profile.stages?.length || profile.stages.includes(rankingStage)) &&
-    (!profile.levels?.length || profile.levels.includes(level)) &&
-    (!profile.maxDrawSize || drawSize <= profile.maxDrawSize) &&
+    (!profile.maxFlightNumber || (flightNumber !== undefined && flightNumber <= profile.maxFlightNumber)) &&
+    (!profile.drawTypes?.length || includesValue(profile.drawTypes, drawType)) &&
+    (!profile.drawSizes?.length || includesValue(profile.drawSizes, drawSize)) &&
+    (!profile.stages?.length || includesValue(profile.stages, rankingStage)) &&
+    (!profile.levels?.length || includesValue(profile.levels, level)) &&
+    (!profile.maxDrawSize || (drawSize !== undefined && drawSize <= profile.maxDrawSize)) &&
     (!profile.drawSize || profile.drawSize === drawSize) &&
-    (!profile.maxLevel || level <= profile.maxLevel) &&
+    (!profile.maxLevel || (level !== undefined && level <= profile.maxLevel)) &&
     (!flightNumber ||
       !profile.flights?.flightNumbers?.length ||
       profile.flights.flightNumbers.includes(flightNumber)) &&
     (!profile.participationOrder || profile.participationOrder === participationOrder) &&
     matchesCategory(profile.category) &&
-    (!profile.eventTypes?.length || profile.eventTypes?.includes(eventType));
+    (!profile.eventTypes?.length || includesValue(profile.eventTypes, eventType));
 
   // Collect all matching profiles
   const matchingProfiles = awardProfiles.filter(matchesProfile);
@@ -71,7 +106,9 @@ export function getAwardProfile(params) {
   if (matchingProfiles.length === 1) return { awardProfile: matchingProfiles[0] };
 
   // If any matching profile has an explicit priority, the highest priority wins
-  const withPriority = matchingProfiles.filter((p) => p.priority !== undefined);
+  const withPriority = matchingProfiles.filter(
+    (p): p is AwardProfile & { priority: number } => p.priority !== undefined,
+  );
   if (withPriority.length) {
     const maxPriority = Math.max(...withPriority.map((p) => p.priority));
     const awardProfile = withPriority.find((p) => p.priority === maxPriority);
@@ -96,7 +133,7 @@ export function getAwardProfile(params) {
  * Each populated scope field adds 1 point.
  * Each populated CategoryScope sub-field adds 1 additional point.
  */
-function getSpecificityScore(profile): number {
+function getSpecificityScore(profile: AwardProfile): number {
   let score = 0;
 
   // Score profile-level scope fields

--- a/src/query/scales/getEventRankingPoints.ts
+++ b/src/query/scales/getEventRankingPoints.ts
@@ -6,12 +6,13 @@ import { policyRegistry } from '@Global/policyRegistry';
 import { POLICY_TYPE_RANKING_POINTS } from '@Constants/policyConstants';
 import { PolicyDefinitions } from '@Types/factoryTypes';
 import { SUCCESS } from '@Constants/resultConstants';
-import { Tournament } from '@Types/tournamentTypes';
+import { EventTypeUnion, Tournament } from '@Types/tournamentTypes';
 import { DOUBLES } from '@Constants/eventConstants';
 import {
   MISSING_EVENT,
   MISSING_POLICY_DEFINITION,
   MISSING_TOURNAMENT_RECORD,
+  type ErrorType,
 } from '@Constants/errorConditionConstants';
 
 type GetEventRankingPointsArgs = {
@@ -21,6 +22,34 @@ type GetEventRankingPointsArgs = {
   eventId: string;
   level?: number;
 };
+
+/**
+ * Declared rather than inferred, because the inferred union was not stable.
+ *
+ * When TypeScript builds a union from these two object literals it may or may
+ * not add `error?: undefined` to the success branch, and which it does varied
+ * between builds of identical source — one line of churn in every published
+ * `.d.ts`. Stating the type pins it.
+ *
+ * `error?: undefined` is retained deliberately: it is what lets a caller
+ * destructure `error` off the result without first narrowing the union, which
+ * is how every consumer of this shape is written.
+ *
+ * The error branch is `ErrorType`, not any one constant: this function returns
+ * MISSING_TOURNAMENT_RECORD, MISSING_EVENT and MISSING_POLICY_DEFINITION, and
+ * naming a single one of them would compile (they share a shape) while telling
+ * the reader something untrue.
+ */
+type GetEventRankingPointsResult =
+  | { error: ErrorType }
+  | {
+      success: boolean;
+      eventAwards: any[];
+      eventName: string | undefined;
+      eventType: EventTypeUnion | undefined;
+      isDoubles: boolean;
+      error?: undefined;
+    };
 
 /**
  * Generates ranking points scoped to a single event.
@@ -37,7 +66,7 @@ export function getEventRankingPoints({
   policyName,
   eventId,
   level,
-}: GetEventRankingPointsArgs) {
+}: GetEventRankingPointsArgs): GetEventRankingPointsResult {
   if (!tournamentRecord) return { error: MISSING_TOURNAMENT_RECORD };
   if (!eventId) return { error: MISSING_EVENT };
 

--- a/src/tests/queries/scales/awardProfileSelection.test.ts
+++ b/src/tests/queries/scales/awardProfileSelection.test.ts
@@ -336,3 +336,43 @@ describe('profileName in output', () => {
     expect(withProfileName.length).toEqual(0);
   });
 });
+
+// `AwardProfileScope.drawSize` (singular, exact match) was read by matchesProfile
+// but undeclared on the type, so a policy could set it and have it honoured while
+// the type said it did not exist. Now declared — these pin the behaviour that
+// justified declaring it rather than deleting the clause.
+describe('AwardProfileScope drawSize', () => {
+  const exact = { profileName: 'Exactly 32', drawSize: 32, finishingPositionRanges: { 1: 999 } };
+  const catchAll = { profileName: 'Any', finishingPositionRanges: { 1: 10 } };
+
+  it('matches a profile whose exact drawSize equals the draw', () => {
+    const { awardProfile }: any = getAwardProfile({ awardProfiles: [exact, catchAll], drawSize: 32 });
+    expect(awardProfile.profileName).toEqual('Exactly 32');
+  });
+
+  it('excludes the profile when the draw size differs', () => {
+    const { awardProfile }: any = getAwardProfile({ awardProfiles: [exact, catchAll], drawSize: 64 });
+    expect(awardProfile.profileName).toEqual('Any');
+  });
+
+  it('excludes the profile when the draw size is absent', () => {
+    const { awardProfile }: any = getAwardProfile({ awardProfiles: [exact, catchAll] });
+    expect(awardProfile.profileName).toEqual('Any');
+  });
+
+  it('does NOT contribute to specificity, so a catch-all declared first beats it', () => {
+    // Both match a 32 draw. `drawSize` is absent from PROFILE_SCOPE_FIELDS, so the
+    // narrower profile scores 0 exactly like the catch-all, and the array-order
+    // tie-break awards it to whichever came first. Pinned deliberately: this is
+    // current behaviour, and it is a wart — `drawSizes: [32]` DOES score, so the
+    // two spellings of the same constraint rank differently.
+    const { awardProfile }: any = getAwardProfile({ awardProfiles: [catchAll, exact], drawSize: 32 });
+    expect(awardProfile.profileName).toEqual('Any');
+  });
+
+  it('drawSizes, by contrast, does score and wins against a catch-all declared first', () => {
+    const viaList = { profileName: 'viaList', drawSizes: [32], finishingPositionRanges: { 1: 2 } };
+    const { awardProfile }: any = getAwardProfile({ awardProfiles: [catchAll, viaList], drawSize: 32 });
+    expect(awardProfile.profileName).toEqual('viaList');
+  });
+});

--- a/src/types/rankingTypes.ts
+++ b/src/types/rankingTypes.ts
@@ -129,6 +129,18 @@ export interface AwardProfileScope {
   eventTypes?: EventTypeUnion[];
   drawTypes?: string[];
   drawSizes?: number[];
+
+  /**
+   * Exact draw-size match. Honoured by `getAwardProfile` alongside `drawSizes`
+   * and `maxDrawSize`, and declared here because it was already being read —
+   * a policy could set it and have it matched while the type denied it existed.
+   *
+   * `drawSizes: [64]` expresses the same thing and is the preferred form. Note
+   * that this field is NOT in `PROFILE_SCOPE_FIELDS`, so unlike `drawSizes` it
+   * contributes nothing to specificity scoring when two profiles tie.
+   */
+  drawSize?: number;
+
   maxDrawSize?: number;
   stages?: string[];
   stageSequences?: number[];


### PR DESCRIPTION
Two leftovers from the ranking-schema work, both raised earlier and neither previously done.

## `getAwardProfile` took an implicit `any`

It published as `getAwardProfile(params: any): { awardProfile: any }` — the profile-selection heart of ranking-points resolution, with no contract at all. Now `GetAwardProfileArgs` → `{ awardProfile: AwardProfile | undefined }`.

**Typing it surfaced a declaration gap.** `matchesProfile` reads `profile.drawSize` (singular), which `AwardProfileScope` never declared. Nothing in-repo sets it — every `drawSize:` in the fixtures is inside a `PositionValue` array or a seeding policy — but ranking policies are **runtime data** loaded from a policy service, so an external policy could set it and have it honoured while the type denied it existed. Declared rather than deleting the clause.

**Checked and NOT a bug:** `matchesProfile` reads `c.type` for `categoryTypes`, and `Category` carries **both** `categoryType` and `type`. Verified before assuming.

**The undefined-matching semantics are load-bearing.** A profile that declares a filter must not match an event lacking that field. `includesValue` is a named helper precisely because the obvious type-safe rewrite inverts it — falsified by flipping it, which turns **6 specs across 4 files** red, including "produces no awards without a level".

### A behaviour wart this pins, and does not change

Writing the `drawSize` tests failed my own expectation, informatively: `drawSize` is absent from `PROFILE_SCOPE_FIELDS`, so it scores **0** for specificity, ties with a catch-all, and loses on array order. `drawSizes: [32]` *does* score. Two spellings of the same constraint rank differently.

Pinned as tests documenting current behaviour rather than silently changing selection on external policy data. Adding it to `PROFILE_SCOPE_FIELDS` is a live option, deliberately not taken here.

## Two `.d.ts` non-reproducibility sources

Builds of byte-identical source emitted different type declarations.

- **Five `EntryStatusUnion[]` groups** in the `as const` aggregate inlined an expanded literal union whose member **order** is unstable. Diagnosed by noticing `PointComponent` — a *plain* union — prints by alias in the same position, while `EntryStatusUnion`, a template-literal over an enum, does not. Now annotated; prints `EntryStatusUnion[]`.
- **`getEventRankingPoints`** had an inferred return union to which TypeScript sometimes added `error?: undefined`. Now declared. That property is kept deliberately — it is what lets callers destructure `error` without narrowing. The error branch is `ErrorType`, not any single constant: this function returns three, and naming one would have compiled (they share a shape) while telling the reader something untrue.

Each fix falsified by reverting it **alone**: the entry-status revert reproduced 10 lines of churn across 3 builds; the return-type revert reproduced variance at ~1 in 4 builds.

## This does NOT fully solve reproducibility

A third mechanism remains, in the mutate layer: `deleteFlightAndFlightDraw`'s inferred multi-branch union varies by **branch** order, and `refreshEventDrawOrder` feeding it has the same shape. So it is a class — any inferred multi-branch return union can emit nondeterministically — not a bug list.

Measured: **8 builds now yield 2 outputs differing by 4 lines**, down from 3 builds yielding 3 outputs. Annotating those would risk dropping nuances such as `refreshEventDrawOrder`'s `& { valid?: boolean }`, so they are left alone. The bounded general alternative, if release-diff noise ever justifies it, is canonicalising the `.d.ts` in `postbuild.mjs`.

## Verification

Full suite **11711 passed / 1 skipped**; coverage exit 0 (95.34 / 87.22 / 98.08 / 97.78 against 95 / 85 / 95 / 95). `verify:types`, `verify:lint`, `verify:format`, `verify:generated`, `verify:attr-audit` green; `verify:surface` reports no exports removed.
