### PR TITLE
docs(scales): cover bucketTotals, the 'points' component, and exempt awards

### DIFF
--- a/documentation/docs/policies/rankingPolicy.md
+++ b/documentation/docs/policies/rankingPolicy.md
@@ -108,29 +108,19 @@ const POLICY_RANKING_POINTS_TE_HYBRID = {
       {
         profileName: 'TE Circuit (16U/18U)',
         // matches TE-circuit events; no authority override → TENNIS_EUROPE
-        finishingPositionRanges: {
-          /* TE point values */
-        },
+        finishingPositionRanges: {/* TE point values */},
       },
       {
         profileName: 'ITF Junior crossover',
         pointsAuthority: ITF_JUNIOR, // override for ITF events
-        levels: [
-          /* ITF Jr levels */
-        ],
-        finishingPositionRanges: {
-          /* ITF point values */
-        },
+        levels: [/* ITF Jr levels */],
+        finishingPositionRanges: {/* ITF point values */},
       },
       {
         profileName: 'ATP crossover',
         pointsAuthority: ATP, // override for ATP events
-        levels: [
-          /* ATP levels */
-        ],
-        finishingPositionRanges: {
-          /* ATP point values */
-        },
+        levels: [/* ATP levels */],
+        finishingPositionRanges: {/* ATP point values */},
       },
     ],
   },
@@ -204,7 +194,8 @@ awardProfiles: [
   // Scope — determines when this profile applies
   eventTypes: ['SINGLES'],              // SINGLES, DOUBLES, TEAM
   drawTypes: ['SINGLE_ELIMINATION', 'FEED_IN_CHAMPIONSHIP'],
-  drawSizes: [32, 64],                 // exact draw sizes
+  drawSizes: [32, 64],                 // exact draw sizes (preferred)
+  drawSize: 32,                        // single exact draw size; see note below
   maxDrawSize: 128,                    // or a maximum
   levels: [1, 2, 3],                   // tournament levels
   maxLevel: 5,                         // or a maximum
@@ -262,6 +253,13 @@ awardProfiles: [
   requireWinFirstRound: true,
 }
 ```
+
+> **`drawSize` vs `drawSizes`.** Both are honoured, and `drawSizes: [32]` says the same
+> thing as `drawSize: 32`. Prefer the plural: only `drawSizes` participates in
+> [specificity scoring](/docs/scale-engine/ranking-points-pipeline#profile-selection).
+> A profile narrowed by the singular `drawSize` scores zero for it, so it ties with a
+> catch-all profile and the tie is broken by declaration order — which is rarely what
+> a policy author intends.
 
 ## Position Value Resolution
 

--- a/documentation/docs/scale-engine/aggregation.md
+++ b/documentation/docs/scale-engine/aggregation.md
@@ -67,6 +67,14 @@ const rankingList = generateRankingList({
 
 Counting buckets define how awards are grouped and counted. Each bucket filters awards by `eventTypes` and extracts point values from `pointComponents`:
 
+Valid `pointComponents` are `positionPoints`, `perWinPoints`, `bonusPoints`,
+`qualityWinPoints`, and `points`. The last is the award's own pre-summed total rather
+than a fifth granular component — it is what a bucket sums when the policy names no
+`pointComponents` at all (the default is `['points', 'qualityWinPoints']`). That pair
+does not double-count, because a quality-win bonus is emitted as its **own** award
+carrying `qualityWinPoints` and no `points`. Do not mix `'points'` with the granular
+components in one bucket, though: there it would count the same award's total twice.
+
 ```js
 aggregationRules: {
   countingBuckets: [
@@ -247,6 +255,7 @@ Tied entries that remain unresolved after all criteria share the same rank.
   meetsMinimum: boolean;           // false if below minCountableResults
   countingResults: PointAward[];   // results that count toward total
   droppedResults: PointAward[];    // results excluded by bestOfCount or level cap
+  bucketTotals?: Record<string, number>;  // per-bucket totals keyed by bucketName
   bucketBreakdown?: [{             // present when countingBuckets are used
     bucketName: string;
     countingResults: PointAward[];
@@ -256,9 +265,32 @@ Tied entries that remain unresolved after all criteria share the same rank.
 }
 ```
 
+`bucketTotals` is the summary view of `bucketBreakdown` — the same numbers keyed by
+bucket name, for consumers that persist or display totals without the underlying
+awards. It is present whenever `bucketBreakdown` is. A bucket the policy left unnamed
+is keyed by position (`bucket-0`, `bucket-1`, …) in both views, and two buckets sharing
+a name are summed rather than one overwriting the other.
+
+## Awards Exempt From Bucket Limits
+
+A `categoryAggregation` rule carrying `subjectToBucketLimits: false` contributes **on top
+of** the bucket's `bestOfCount` cap rather than competing for a slot. Such an award always
+counts, is never dropped, and its value is added to the bucket total:
+
+```js
+// 500 + 400 + 50(exempt), bestOfCount: 1  ->  totalPoints 550
+//   the 500 wins the single slot, the 400 is dropped, the exempt 50 is added on top
+```
+
+`generateRankingList` and `getParticipantPoints` both honour this. They did not always
+agree — `getParticipantPoints` ignored the flag and under-reported, which is fixed as of
+6.37.1 by moving the split into the helper both call.
+
 ## Per-Participant Breakdown
 
-Use `getParticipantPoints` to inspect a single participant's counting/dropped breakdown:
+Use `getParticipantPoints` to inspect a single participant's counting/dropped breakdown.
+It is the per-participant view of exactly the computation `generateRankingList` performs,
+so the two agree on totals for the same awards and rules:
 
 ```js
 import { getParticipantPoints } from 'tods-competition-factory';


### PR DESCRIPTION
Brings the scale-engine docs level with 6.37.1 (#4756, #4758, #4761).

- `RankingListEntry` gains `bucketTotals`, with the positional bucket-name fallback and the same-name accumulation rule stated.
- `pointComponents` documents its full vocabulary **including `'points'`**, why the default `['points','qualityWinPoints']` does not double-count (a quality-win bonus is its own award, carrying no `points`), and why it must not be mixed with the granular components.
- New section on `subjectToBucketLimits`: exempt awards sum on top of `bestOfCount` rather than competing for a slot, and both `generateRankingList` and `getParticipantPoints` now honour it — they disagreed before 6.37.1.
- `rankingPolicy` documents `AwardProfileScope.drawSize` alongside `drawSizes`, with the caveat that only the plural participates in specificity scoring.

Worth noting: the `RankingListEntry` block already described the shape the implementation actually emits. It was the **type** that was wrong, which #4756 corrected — so this is an addition, not a correction.

Docusaurus builds clean; `markdownlint-cli2` reports 0 issues across all 156 doc files.

## Not covered by this PR

The last docs deploy was **2026-08-25** (gh-pages `8a17350bf`). Since then **28** feat/fix commits touched `src/`, and **23 of them shipped no docs**. Spot-checking the major new public surface, these are exported from factory and appear nowhere in `documentation/docs/`:

`getParticipation` · `buildFromSources` · `tournamentDiscoveryRow` / `ReadModelTournamentDiscoveryRow` · `SanctionConferral` · `getEligibleEvents`

That backlog predates this PR and is tracked separately — documenting other people's features properly needs their intent, not a guess.