### PR TITLE
docs: cover the 23 commits that shipped since the 2026-08-25 deploy

### DIFF
--- a/documentation/docs/codes/sanctioning.mdx
+++ b/documentation/docs/codes/sanctioning.mdx
@@ -172,6 +172,20 @@ uses "Approved" as the name of a delivery-model subtype rather than a status. CO
 _sanction_ consistently for approval; when surfacing these values to a federation's own users,
 translate to that federation's vocabulary rather than assuming the word travels.
 
+## Schema coverage
+
+`tournament.schema.json` — the [third declaration of CODES](../data-standards.md#the-json-schema) —
+now expresses the sanction shape rather than leaving it unstated. `TournamentSanction` and its parts
+are defined there: `decision`, `recognition`, `classification`, `authority`, `approvalChain`,
+`decisionRecord`, `confers`, `ruleset`, `sanctioningId`, `identifiers`, `fees` and
+`submissionWindow` — plus the `AuthorityRoleEnum` and `SanctionFeeKindEnum` vocabularies, and
+`SanctionRuleset` (`rulesetId`, `edition`, `enforcement`, `appliedRules`). Fees are built on the
+shared `MonetaryAmount`, so a levy states its `currencyCode` and `unit` like every other money value
+in CODES.
+
+A schema that says nothing about a field validates nothing about it. Until this was declared, a
+record could carry a malformed `sanction` and pass.
+
 ## Policy and constraints
 
 What a governing body _permits_ — allowed formats, fee bounds, submission windows, and which

--- a/documentation/docs/concepts/events/entry-eligibility.md
+++ b/documentation/docs/concepts/events/entry-eligibility.md
@@ -1,0 +1,183 @@
+---
+title: Entry Eligibility
+---
+
+Whether a participant **may** enter an event — asked, rather than attempted.
+
+The predicate is not new. `validateParticipantCategory` has evaluated age at both ends of an event,
+handled exact-DOB and calendar-year (`birthYear`) conventions, and expanded `ageCategoryCode` since
+it was written. It was reachable only through `addEventEntries`, so the only way to learn whether
+someone could enter was to try to enter them — which a discovery surface evaluating one person
+against thousands of events cannot do.
+
+```js
+import { eventGovernor } from 'tods-competition-factory';
+```
+
+## getParticipantEligibility
+
+```ts
+function getParticipantEligibility(params: {
+  participant: Participant;
+  event: Event;
+  tournamentRecord?: Tournament;
+}): ResultType & Partial<ParticipantEligibility>;
+
+interface ParticipantEligibility {
+  eligible: boolean;
+  indeterminate: boolean;
+  rejectionReasons: RejectionReason[];
+  undeterminedRestrictions?: EntryRestriction[];
+}
+```
+
+```js
+const { eligible, indeterminate, rejectionReasons, undeterminedRestrictions } = engine.getParticipantEligibility({
+  participant,
+  event,
+});
+```
+
+Read-only: it emits no notices and mutates nothing.
+
+### `indeterminate` is not `eligible: false`
+
+The two answer different questions, and collapsing them produces a confident wrong answer about
+whether someone may play:
+
+- **`eligible: false`** with `indeterminate: false` — a rule was **breached**. The participant is
+  over the age limit.
+- **`indeterminate: true`** — at least one rule could **not be evaluated**, because the data it needs
+  is absent: an unknown `birthDate`, an unrecorded rating. `eligible` is `false` alongside it, and
+  the honest reading is "cannot be determined".
+
+Indeterminate applies only when **nothing** was actually breached. A participant who is both over
+the age limit and missing a rating is ineligible, full stop — the missing rating cannot soften a
+breach established on other grounds.
+
+:::note
+
+`addEventEntries` keeps its own behaviour exactly: a participant whose `birthDate` is unknown is
+still filtered out of the entry list there, while here the same participant reports `indeterminate`.
+
+That divergence is deliberate. Both call sites share the predicate and apply different policy to its
+output, because "we cannot tell" is correctly a **refusal** when writing an entry and correctly
+**not** a refusal when answering a question.
+
+:::
+
+An event with no `category` restricts nobody on age or rating, and returns `eligible: true` — not a
+silent pass, but the absence of any such rule. An `entryRestriction` may still make the answer
+undecidable, so restrictions are collected before that path is taken.
+
+## getEligibleEvents
+
+The same question across many events — "which of these can I enter". The bulk form exists because
+asking per event means re-resolving the participant and the tournament for each one.
+
+```ts
+function getEligibleEvents(params: {
+  participant: Participant;
+  events: Event[];
+  tournamentRecord?: Tournament;
+}): ResultType & { eventEligibility?: EventEligibility[] };
+
+interface EventEligibility extends ParticipantEligibility {
+  eventId: string;
+}
+```
+
+```js
+const { eventEligibility } = engine.getEligibleEvents({ participant, events: tournamentRecord.events });
+
+const canEnter = eventEligibility.filter(({ eligible }) => eligible);
+const askOrganiser = eventEligibility.filter(({ indeterminate }) => indeterminate);
+```
+
+Events that cannot be evaluated at all — no resolvable date range, for instance — are returned as
+`indeterminate`, **never dropped**. A silently shortened list is indistinguishable from one where
+those events were checked and found ineligible.
+
+## entryRestrictions
+
+A condition on **who** may enter, beyond the age, gender and rating that `category` already carries.
+
+Two federations evidence the need independently. One gates on residency — a level whose name ends
+"Closed" is open only to competitors of the sanctioning section, which is why its grade and its
+eligibility rule are currently welded into one facet string. The other gates on membership, bought
+from the organisation running the event.
+
+Where a governing body's level name encodes a restriction, the **grade** belongs in
+`sanction.classification` and the **rule** belongs here. Welding them into one string makes the grade
+unsortable and the rule unreadable.
+
+```ts
+interface EntryRestriction {
+  type: EntryRestrictionUnion;
+  organisationId?: string; // whose territory, roster or register this resolves against
+  membershipCategory?: string; // which membership, where a body sells more than one
+  description?: string; // free text for a consumer to show — not parsed
+  evaluable?: boolean;
+  extensions?: Extension[];
+}
+```
+
+`EntryRestrictionEnum` is open in spirit — governing bodies invent gates — but enumerated so a
+consumer can branch on the common ones rather than parse `description`:
+
+| type | meaning |
+| --- | --- |
+| `RESIDENCY` | competitor must be of the stated organisation's territory |
+| `MEMBERSHIP` | competitor must hold a membership of the stated organisation |
+| `RANKING_FLOOR` | competitor must hold a ranking or rating at or above a threshold |
+| `CLEARANCE` | competitor must hold a current safeguarding / background clearance |
+| `INVITATION` | entry is by invitation of the organiser |
+| `OTHER` | stated by the organiser and not one of the above |
+
+`organisationId` is required in practice for `MEMBERSHIP` and `RESIDENCY` and meaningless without it:
+"members only" is not a rule until it says whose members. A membership of the organisation running
+the event and a membership of its national body are different gates.
+
+### `evaluable` — absence means undecidable, not satisfied
+
+CODES holds no section rosters and no membership registers, so most restrictions **cannot** be
+resolved from a record. A restriction with no explicit `evaluable: true` is therefore treated as
+undecidable and surfaced in `undeterminedRestrictions` rather than swallowed:
+
+```js
+const { eligible, undeterminedRestrictions } = engine.getParticipantEligibility({ participant, event });
+
+// eligible: false, indeterminate: true
+// undeterminedRestrictions: [{ type: 'RESIDENCY', organisationId: 'USTA-SOUTHERN' }]
+```
+
+That lets a consumer say _"this event is closed to your section — check with the organiser"_ instead
+of either a flat no or a misleading yes. Defaulting the other way would answer "yes, you may enter"
+on a rule nothing checked.
+
+A producer that **has** resolved a restriction sets `evaluable: true` explicitly and takes
+responsibility for it.
+
+**Advisory in v1, and deliberately so.** A restriction that announces itself is strictly more useful
+than one that stays silent, because silence is indistinguishable from "no restriction".
+
+## Cancellation
+
+`TournamentStatusEnum.CANCELLED` says **that** a competition was cancelled. Two event-grain fields say
+when and why, for a consumer that must explain it to an entrant:
+
+```ts
+interface Event {
+  cancelledAt?: Date | string;
+  cancellationReason?: string;
+}
+```
+
+The same pair exists at tournament grain. `Event.cancelledAt` is unrelated to
+`PracticeRegistration.cancelledAt`, which is a different object's own lifecycle.
+
+## Related
+
+- [Entries](./entries.mdx) — adding and modifying entries
+- [Categories](./categories.mdx) — the age / rating rules this evaluates
+- [Registration Profile](../registration-profile.md) — entry windows, fees and entry profile

--- a/documentation/docs/concepts/registration-profile.md
+++ b/documentation/docs/concepts/registration-profile.md
@@ -79,11 +79,19 @@ interface LogisticsOption {
 ## Supporting Types
 
 ```typescript
-interface RegistrationEntryFee {
+interface MonetaryAmount {
   amount: number; // required
   currencyCode: string; // required, e.g. "USD"
-  eventType?: EventTypeUnion; // SINGLES | DOUBLES | TEAM | HYBRID
+  unit: CurrencyUnitUnion; // required — MINOR | MAJOR
+}
+
+interface RegistrationEntryFee extends MonetaryAmount {
+  eventId?: string; // the specific event this fee buys entry to — the most specific selector
   category?: string;
+  eventType?: EventTypeUnion; // SINGLES | DOUBLES | TEAM | HYBRID
+  appliesFrom?: string; // early-bird / late-entry pricing window
+  appliesTo?: string;
+  extensions?: Extension[];
 }
 
 interface SocialEvent {
@@ -158,8 +166,92 @@ if (registrationProfile?.accommodation?.options?.length) {
 }
 ```
 
+## Event grain overrides
+
+An event may state its own registration facts where they differ from the tournament's:
+
+```typescript
+interface EventRegistration {
+  entriesOpen?: Date | string;
+  entriesClose?: Date | string;
+  withdrawalDeadline?: Date | string;
+  entryFees?: RegistrationEntryFee[];
+  entryUrl?: string;
+  eligibilityNotes?: string;
+  extensions?: Extension[];
+}
+```
+
+Those six fields are the only overridable ones — the tournament's logistics, sponsors and dress code are not event-scoped concepts.
+
+**Resolve them with `getEffectiveRegistrationProfile`, never by reaching for the fallback directly.** The cascade is **field by field**, and that distinction is the whole reason the function exists:
+
+```javascript
+// WRONG — an event overriding only entriesClose silently loses the tournament's
+// entryUrl, entryFees and every other field
+const profile = event.registrationProfile ?? tournamentRecord.registrationProfile;
+
+// RIGHT
+const profile = engine.getEffectiveRegistrationProfile({ event, tournamentRecord });
+```
+
+The wrong form fails invisibly at the call site and shows up as a missing registration link on one division.
+
+An `undefined` value on the event does **not** override — absent means "not stated here", never "explicitly nothing". A `null` **is** preserved, so a producer can still say "this event has no entry URL" when it means it.
+
+## Entry fees
+
+`RegistrationEntryFee` extends `MonetaryAmount`, so **`unit` is required by construction**. An optional unit would reintroduce exactly the ambiguity the type exists to remove, since the omitted case is indistinguishable from the unconsidered one: `{ amount: 4000, currencyCode: 'USD' }` is readable as either $40.00 or $4,000 with nothing to choose between them.
+
+Reads are tolerant where writes are strict — records written before `unit` existed still arrive over the wire without one. [`resolveEntryFee`](../governors/entries-governor.md#resolveentryfee) returns an explicit `{ indeterminate: true, reason }` rather than guessing, because the unit **cannot** be inferred from magnitude: "6000 is obviously minor units" is wrong on a real ¥6000 entry and on a genuine $6,000 pro-am, and both exist.
+
+### Selectors
+
+A tournament-grain fee list can carry entries for several events, so "the fees on this record" is not the question "the fees for this event". [`getEventEntryFees`](../governors/entries-governor.md#getevententryfees) matches selectors **most-specific first**:
+
+| selector | scope |
+| --- | --- |
+| `eventId` | this exact event |
+| `category` | events of that category name or `ageCategoryCode` |
+| `eventType` | SINGLES / DOUBLES / TEAM / HYBRID |
+| _(none)_ | every event — how a single tournament-wide price is stated |
+
+Only the most specific tier that matched is returned. A fee keyed to this exact `eventId` supersedes a blanket "all doubles" price, and returning both would leave the caller to re-derive precedence and get it wrong.
+
+`appliesFrom` / `appliesTo` bound the window in which a price is the one charged. Without them, an early rate and a late rate are two records with no stated relationship, and a consumer computing "what does this cost" has no way to exclude the one that has expired. Both ends are optional — an early-bird rate with no `appliesFrom` has simply always been available.
+
+## Entry profile
+
+How an event accepts entries, and how many. Separate from `registrationProfile` because it is an **acceptance rule**, not a published fact:
+
+```typescript
+interface EventEntryProfile {
+  entriesLimit?: number; // how many entries the event will accept
+  targetDrawSize?: number; // intended draw size before a drawDefinition exists to carry one
+  selectionProcess?: SelectionProcessUnion;
+  selectionScaleName?: string;
+  wildcardCount?: number;
+  waitlistEnabled?: boolean;
+  extensions?: Extension[];
+}
+```
+
+It is **event grain for a structural reason** rather than a presentational one: events within a single `tournamentRecord` can carry different sanctioning bodies (`Event.sanction`, and `eventOtherIds[].isOrigin` at the identity grain), so a limit set by body A must not be expressed at a grain body B shares.
+
+`SelectionProcessEnum` is `FIRST_COME_FIRST_SERVED` | `TOP_DOWN_BY_RANKING` | `TOP_DOWN_BY_RATING` | `MANUAL` | `LOTTERY`.
+
+`selectionScaleName` names **which** scale orders acceptance — 'WTN', 'NTRP', a federation ranking list. `TOP_DOWN_BY_RANKING` alone is under-specified: two events sorting by different scales accept different players. Organisers currently state this in the tournament title after an asterisk ("\*top down by ranking", "\*top down by WTN"), which is the evidence that it needs a field.
+
+:::note
+
+`entriesLimit` does **not** answer what the whole competition can physically schedule and play, given courts, days and daily match limits — the sum of individually valid limits can exceed that. Feasibility is the scheduler's to report and is deliberately not stored, because two statements of one fact drift.
+
+:::
+
 ## Related Concepts
 
+- **[Entry Eligibility](./events/entry-eligibility.md)** — who may enter, beyond age and rating: `entryRestrictions`, and asking rather than attempting.
+- **[Tournament Discovery](./tournament-discovery.md)** — the read-model row that flattens these registration windows and fee ranges into discovery facets.
 - **[Tournament Tier](./tournament-tier.md)** — the competitive prestige classification (`tournamentTier`). While the registration profile captures operational tournament metadata (deadlines, fees, logistics), the tier defines the competitive classification that determines ranking points, draw size requirements, and prize money bands. Both live on the tournament record and together provide a complete picture of what participants need to know.
 
 ## Design Principles

--- a/documentation/docs/concepts/tournament-discovery.md
+++ b/documentation/docs/concepts/tournament-discovery.md
@@ -1,0 +1,152 @@
+---
+title: Tournament Discovery
+---
+
+One read-model row per tournament, denormalised for **faceted discovery** — _"what can I play, near
+me, that I am eligible for"_.
+
+```js
+import { readModel } from 'tods-competition-factory';
+
+const row = readModel.tournamentDiscoveryRow(tournamentRecord);
+```
+
+It is also emitted by [`cast()`](../governors/query-governor.md#cast) as the `tournament_discovery`
+table, so a consumer rebuilding a whole tournament gets it without a second call.
+
+## The first aggregate row
+
+Every other `ReadModel*Row` is 1:1 with a source object. This one summarises a tournament **and its
+events**, because the questions it answers are asked of the tournament while the answers live on the
+events — genders, age codes, category types, fee range.
+
+That is a deliberate denormalisation, and it is the reason the consumer side needs an invalidation
+rule the other tables do not: **an event changing dirties its tournament's row.**
+
+`cast()` is a pure whole-record projection, so it produces the row correctly whether the consumer
+maintains it incrementally or rebuilds it per tournament.
+
+### `tournamentAggregate` — how a row with no owner is attributed
+
+The notice-conformance oracle attributes every projected row to **one** source object. An aggregate
+has none, and applying the 1:1 assumption to this row produced seven false violations:
+`deleteEvent`, `addVenue`, `modifyVenue`, `setTournamentDates` (widening **and** shrinking),
+`deleteVenue` and `setTournamentTier` each change a discovery row while emitting notices scoped to an
+event or a venue — never to the tournament, which is correct for what they changed.
+
+So the row is registered in the conformance harness under a distinct entity kind,
+`tournamentAggregate`, whose coverage rule is simply **"the mutation announced something"**. That is
+exactly what a consumer keys off: it rebuilds the row for every tournament its intent batch touched,
+and intents are derived from notices.
+
+The kind is the **oracle's** vocabulary, not a runtime API — nothing a consumer calls returns it. What
+it buys a consumer is the guarantee it protects: that a discovery row never moves without some notice
+firing.
+
+This loosens a guard over the whole projection, so it is pinned rather than trusted — a discovery
+row that moves while **no** notice fires at all is still a violation. The existing entity kinds are
+untouched.
+
+## Row shape
+
+```ts
+interface ReadModelTournamentDiscoveryRow {
+  tournament_id: string;
+  provider_id: string | null;
+
+  // date range — duplicated from `tournaments` deliberately
+  start_date: string | null;
+  end_date: string | null;
+
+  // geo, from the primary venue
+  latitude: number | null;
+  longitude: number | null;
+  venue_name: string | null;
+  city: string | null;
+  state: string | null;
+  country_code: string | null;
+
+  tournament_level: string | null; // organisational SCOPE
+  level_system: string | null; // competitive GRADE
+  level_value: string | null;
+  recognition: string | null;
+  decision: string | null;
+  ranking_eligible: boolean | null;
+
+  entries_open: string | null;
+  entries_close: string | null;
+
+  fee_min: number | null;
+  fee_max: number | null;
+  fee_currency: string | null;
+  fee_unit: string | null;
+
+  event_count: number;
+  category_types: string[];
+  genders: string[];
+  age_codes: string[];
+  rating_types: string[];
+  cancelled_at: string | null;
+}
+```
+
+Dates are duplicated from the `tournaments` row on purpose: date range is the hottest facet, and a
+discovery index that has to join in order to filter on it is not an index.
+
+`Address.latitude` / `longitude` are typed `string | number` in CODES; both are coerced to `number`
+here, because a read model storing two representations of a coordinate cannot be indexed on it.
+
+## `tournament_level` is scope, not grade
+
+`tournament_level` — CLUB, DISTRICT, REGIONAL, NATIONAL, INTERNATIONAL — is **how far the competition
+reaches**.
+
+`level_system` / `level_value` carry the competitive **grade** (`{ system: 'USTA', value: 'Level 5
+Open' }`), read from `sanction.classification` and falling back to `tournamentTier` — the same tier
+shape, one grain up.
+
+_"Show me national events"_ and _"show me Level 5 events"_ are separate facets. A row that flattened
+both into one could answer neither reliably.
+
+`tournament_level` is **never defaulted**: an unstated level is unknown, and a discovery facet that
+invented one would silently narrow every search that used it.
+
+## What is not here, and why
+
+### No `registration_state`
+
+"Open" / "closing within a week" / "closed" is a function of **now**, and `cast()` is pure — no I/O,
+no clock. Storing it would bake a timestamp into a row that nothing re-runs on a schedule, so it
+would be wrong from the moment it was written.
+
+The dates are emitted instead and the state is a **read-time** derivation. This mirrors the call
+already made for visibility, where `published` + `embargo` are stored and gated at read time rather
+than as a stale stored boolean.
+
+`entries_open` / `entries_close` come through
+[`getEffectiveRegistrationProfile`](./registration-profile.md#event-grain-overrides), so an event
+overriding only one of them does not lose the tournament's other registration facts.
+
+### A fee range that cannot be trusted is not emitted
+
+All four fee columns are `NULL` together when **any** contributing fee cannot be placed on a scale,
+or when the fees span more than one denomination.
+
+A partial range is a wrong answer wearing a number, and a min/max computed across currencies compares
+figures that are not comparable — 40 EUR "beats" 45 USD on arithmetic that means nothing.
+
+The range is computed over every fee the tournament states, event-level fees included. See
+[`getEntryFeeRange`](./registration-profile.md#entry-fees) for the resolution rules.
+
+## Facets
+
+`category_types`, `genders`, `age_codes` and `rating_types` are the distinct values across the
+tournament's events, and `event_count` is their number. `cancelled_at` carries the tournament's own
+cancellation timestamp.
+
+## Related
+
+- [Query Governor — `cast`](../governors/query-governor.md#cast) — the full projection
+- [Query Governor — `readModel` toolkit](../governors/query-governor.md#readmodel-toolkit) — the row builders
+- [Registration Profile](./registration-profile.md) — the registration and fee facts this flattens
+- [Sanctioning](../codes/sanctioning.mdx) — `recognition`, `decision` and `classification`

--- a/documentation/docs/data-standards.md
+++ b/documentation/docs/data-standards.md
@@ -135,6 +135,25 @@ The **Competition Factory** provides:
 
 All factory operations preserve CODES compliance, ensuring that tournament records remain portable, accessible, and standards-compliant throughout their lifecycle.
 
+### The JSON Schema
+
+`src/global/schema/tournament.schema.json` is the **third declaration of CODES**, after the TypeScript types and these docs. It is held in the repository and exercised by the test suite; it is not part of the published package, whose surface is `dist`.
+
+Because it is a third declaration it can drift from the other two, and drift here is consequential in both directions: a closed definition turns a CODES field added to the types but not mirrored in the schema into a loud validation failure, while an open one hides it.
+
+**Strictness is a stated convention, not an accident.** Of the 68 object definitions, **64 declare `additionalProperties: false`**. Four are deliberately open:
+
+| definition | why it is open |
+| --- | --- |
+| `Extension` | extensions carry caller-defined payloads by design |
+| `Tournament` | permissive pending the undeclared fields real records still carry |
+| `Venue` | as above |
+| `Organisation` | as above |
+
+Closing the three record-shaped definitions is **blocked rather than declined**: measured against the TODS fixtures, making them strict fails most of them and exposes undeclared fields carried by real records — `venueIds`, `deleted`, `Venue.parentOrganisation`, `Organisation.createdAt` / `updatedAt`, and others. Each needs a decision about whether it belongs in CODES before the definition can be closed around it.
+
+A producer writing CODES records should treat `additionalProperties: false` as the expected case and not rely on the four open definitions staying open.
+
 ## Related Documentation
 
 - **[Introduction](./)** - Overview of Competition Factory architecture

--- a/documentation/docs/governors/entries-governor.md
+++ b/documentation/docs/governors/entries-governor.md
@@ -206,6 +206,25 @@ engine.destroyPairEntry({
 
 ---
 
+## getEffectiveRegistrationProfile
+
+The registration facts that actually apply to an event, merging the event's `registrationProfile` over the tournament's **field by field**.
+
+```js
+const { entriesOpen, entriesClose, withdrawalDeadline, entryFees, entryUrl, eligibilityNotes } =
+  engine.getEffectiveRegistrationProfile({ event, tournamentRecord });
+```
+
+**The field-by-field cascade is the whole reason this function exists.** The obvious implementation — `event.registrationProfile ?? tournamentRecord.registrationProfile` — is wrong in a way that looks right: an event overriding only `entriesClose` would silently lose the tournament's `entryUrl`, `entryFees` and every other field, because the whole object was replaced rather than merged. The failure is invisible at the call site and shows up as a missing registration link on one division.
+
+Every reader of a registration window should come through here rather than reaching for the fallback itself.
+
+Only the six overridable fields are returned; the tournament's logistics, sponsors and dress code are not event-scoped concepts and are read from `tournamentRecord.registrationProfile` directly. An `undefined` value on the event does **not** override — absent means "not stated here", never "explicitly nothing" — while a `null` is preserved, so a producer can still say "this event has no entry URL" when it means it.
+
+See [Registration Profile](../concepts/registration-profile.md#event-grain-overrides).
+
+---
+
 ## getEntriesAndSeedsCount
 
 Calculates the number of seeds allowed for a draw based on entries count and seeding policy.
@@ -256,6 +275,40 @@ console.log(`${stageEntries.length} entries, ${seedsCount} seeds allowed`);
 - Respects seeding policy limits
 - Returns stage-specific entries (MAIN vs QUALIFYING)
 - Used internally by `generateDrawDefinition`
+
+---
+
+## getEntryFeeRange
+
+The lowest and highest of a set of fees — or nothing, when they cannot honestly be compared.
+
+```js
+const range = engine.getEntryFeeRange(fees);
+// { min: { amount, currencyCode, unit }, max: { ... }, indeterminate: [], incomparable: [] }
+```
+
+A displayed price range ("$30–$155") is only meaningful if every contributing fee is denominated identically. Comparing across currencies picks the smaller **number** rather than the smaller **value**: 40 EUR "beats" 45 USD on arithmetic that means nothing.
+
+So the range is computed only over the single most common `currencyCode`/`unit` pair — the largest group, so one stray currency does not suppress an otherwise usable range — and everything else is **reported rather than folded in or dropped**:
+
+- `indeterminate` — fees that could not be resolved at all, present so a caller can disclose rather than hide them.
+- `incomparable` — the distinct `currencyCode`/`unit` pairs found beyond the one the range is denominated in.
+
+Returns `undefined` when no fee can be resolved at all, so the caller renders nothing rather than a zero.
+
+---
+
+## getEventEntryFees
+
+The entry fees that apply to an event, narrowed by each fee's own selectors.
+
+```js
+const fees = engine.getEventEntryFees({ event, tournamentRecord });
+```
+
+A tournament-grain fee list can carry entries for several events, so "the fees on this record" is not the same question as "the fees for this event". Selectors are matched **most-specific first**: `eventId` > `category` > `eventType`. A fee with **no** selector applies to every event — that is how a single tournament-wide price is stated.
+
+Only the most specific tier that matched is returned, rather than everything that matched: a fee keyed to this exact `eventId` supersedes a blanket "all doubles" price, and returning both would leave the caller to re-derive precedence and get it wrong. Fees selecting a _different_ event are excluded rather than returned as a fallback.
 
 ---
 
@@ -409,6 +462,26 @@ const result = engine.removeEventEntries({
 ```
 
 **Purpose:** Removes entries from event and optionally from draws.
+
+---
+
+## resolveEntryFee
+
+Read a stored entry fee, refusing to guess its scale.
+
+```js
+const resolved = engine.resolveEntryFee(fee);
+// { amount, currencyCode, unit }
+// or { indeterminate: true, reason: 'no unit — scale unknown' }
+
+if (engine.isIndeterminateFee(resolved)) renderFeeOnRequest(resolved.reason);
+```
+
+`unit` is required on `RegistrationEntryFee` by construction, but records written before it existed still arrive over the wire without one, and a stored record is not a compile-time object. This is the read-side counterpart to that requirement: **writes are strict, reads are tolerant, and the tolerance takes the shape of an explicit "cannot tell" rather than an assumption.**
+
+**The unit is never inferred from magnitude.** "6000 is obviously minor units" is wrong on a real ¥6000 entry and on a genuine $6,000 pro-am, and both exist. A consumer receiving `indeterminate` should render "fee on request" or similar — anything but a figure that might be out by 100×. An absent `currencyCode` is likewise unknown, not the reader's own; defaulting it invents data.
+
+`isIndeterminateFee` is the type guard that narrows the union.
 
 ---
 

--- a/documentation/docs/governors/event-governor.md
+++ b/documentation/docs/governors/event-governor.md
@@ -293,6 +293,25 @@ const { events } = engine.generateEventsFromTieFormat({
 
 ---
 
+## getEligibleEvents
+
+Which of a set of events a participant may enter. The bulk form of `getParticipantEligibility` — asking per event means re-resolving the participant and the tournament for each one.
+
+```js
+const { eventEligibility } = engine.getEligibleEvents({
+  participant,
+  events, // Event[]
+  tournamentRecord, // optional
+});
+// eventEligibility: [{ eventId, eligible, indeterminate, rejectionReasons }]
+```
+
+Events that cannot be evaluated at all — no resolvable date range, for instance — are returned as `indeterminate`, **never dropped**. A silently shortened list is indistinguishable from one where those events were checked and found ineligible.
+
+See [Entry Eligibility](../concepts/events/entry-eligibility.md).
+
+---
+
 ## getEvent
 
 Returns a single event object with optional context and drawDefinition.
@@ -362,6 +381,34 @@ const { flightProfile } = engine.getFlightProfile({ eventId });
 ```
 
 **Purpose:** Access flight configuration for events split into multiple draws.
+
+---
+
+## getParticipantEligibility
+
+Whether a participant may enter an event — **asked, rather than attempted**.
+
+```js
+const { eligible, indeterminate, rejectionReasons, undeterminedRestrictions } = engine.getParticipantEligibility({
+  participant,
+  event,
+  tournamentRecord, // optional
+});
+```
+
+The predicate itself is not new — `validateParticipantCategory` has evaluated age at both event ends, handled exact-DOB and calendar-year conventions, and expanded `ageCategoryCode` since it was written. It was reachable only through `addEventEntries`, so the one way to learn whether someone could enter was to try to enter them. A discovery surface evaluating one person against thousands of events cannot use a mutation.
+
+Read-only: emits no notices and mutates nothing.
+
+**`indeterminate` is not `eligible: false`.** The first says a rule could not be evaluated (an unknown `birthDate`, an unrecorded rating); the second says a rule was **breached**. Indeterminate applies only when nothing was actually breached — a participant both over the age limit and missing a rating is ineligible, full stop.
+
+:::note
+
+This does **not** change who gets entered. `addEventEntries` keeps its behaviour exactly: a participant whose `birthDate` is unknown is still filtered out of the entry list there, while here the same participant reports `indeterminate`. "We cannot tell" is correctly a refusal when writing an entry and correctly not a refusal when answering a question.
+
+:::
+
+`undeterminedRestrictions` carries `entryRestrictions` the record cannot settle — residency, membership, clearance — so a consumer can say "this event is closed to your section, check with the organiser" instead of a flat no or a misleading yes. See [Entry Eligibility](../concepts/events/entry-eligibility.md).
 
 ---
 

--- a/documentation/docs/governors/participant-governor.md
+++ b/documentation/docs/governors/participant-governor.md
@@ -433,6 +433,47 @@ const {
 
 ---
 
+## getParticipation
+
+Derive what a `tournamentRecord` asserts about **who took part** — the rows a participation index is built from, without loading anything but this record.
+
+```js
+const entries = engine.getParticipation({ tournamentRecord });
+```
+
+```ts
+interface ParticipationEntry {
+  subjectType: 'TEAM' | 'PERSON'; // the grain the subject is identified at
+  subjectId: string; // the id an organisation ISSUED — stable across tournamentRecords
+  organisationId?: string; // the body that issued it; two may both number the same competitor
+  participantId: string; // this record's own id — tournament-local, never a subject key
+  tournamentId: string;
+  tournamentName?: string;
+  startDate?: string;
+  endDate?: string;
+  eventCount: number;
+  providerId?: string;
+}
+```
+
+The counterpart to [`getTournamentCalendarEntry`](./query-governor.md#gettournamentcalendarentry). A calendar entry answers _what does this provider own_; participation answers _what did this competitor take part in_. They are different relations and a calendar cannot express the second: a record lives in exactly **one** provider's calendar, while a team fixture belongs to the seasons of **both** sides, so ownership can only ever name one of them.
+
+That is also why participation reads both sides of every fixture and needs no notion of a host — useful, because a source stating who hosted is the exception rather than the rule.
+
+### Subject identity comes from the issued id, never from `participantId`
+
+A `participantId` is tournament-local: the same competitor carries a different one in every record it appears in. Keyed on that, a competitor's history would be exactly **one entry long per record** — plausible-looking, and wrong in a way nothing errors on.
+
+The subject is therefore read from `participantOtherIds` (TEAM) and `person.personOtherIds` (PERSON), which carry the issuing organisation's own id and are stable by construction.
+
+**A competitor stating no issued id contributes no entry.** That is a recorded gap — this record does not say who the competitor is in any durable sense — and manufacturing one from the local id would produce precisely the wrong answer above. Callers wanting to detect the gap can compare the entry count against the competitors they expected.
+
+A competitor issued ids by two organisations yields **one entry per organisation**, which is correct: each is a distinct claim about identity, and a consumer indexes whichever body it speaks for.
+
+Pure: reads only the record. Storage keys, timestamps and server-specific projections are the caller's concern.
+
+---
+
 ## getScaleValues
 
 Resolves one participant's scale timeItems into ratings, rankings and seedings.

--- a/documentation/docs/governors/query-governor.md
+++ b/documentation/docs/governors/query-governor.md
@@ -105,6 +105,7 @@ These are the only faithful representation of a non-standard topology: the stand
 const { rows } = engine.cast();
 // rows: {
 //   tournaments,            // one row: id, name, provider_id, dates, city, published (OoP-or-participants)
+//   tournament_discovery,   // one row: the faceted-discovery aggregate (geo, level, fees, facets)
 //   events,                 // one row/event: name, type, gender, category, matchUpFormat, dates, published
 //   draws,                  // one row/draw: name, type, matchUpFormat
 //   structures,             // one row/top-level structure: name, stage, stageSequence, type, matchUpFormat
@@ -123,6 +124,16 @@ const { rows } = engine.cast();
 
 **`events.published` resolves through the same cascade as the matchUps** — it is not a truthiness test on the event's `PUBLISH.STATUS.PUBLIC` envelope. `unPublishEvent` leaves that envelope in place with undefined-valued keys, so a truthiness (or even a non-empty) test reports an unpublished event as published while its matchUps correctly report `false`. `readModel.isEventPublished` resolves it at **draw** granularity — an event whose draw publishes only selected structures is still a published event — and treats **seeding as an independent publish surface**: `publishEventSeeding` writes `seeding: { published: true }` with no draw detail at all, and an event with published seeding is published even when no draw is.
 
+**`tournament_discovery` is the one aggregate row in the projection.** Every other table is 1:1 with a source object; this one summarises a tournament _and_ its events, so an event changing dirties its tournament's row. It is attributed through a distinct `tournamentAggregate` entity kind whose coverage rule is "the mutation announced something", because a row that belongs to no single entity cannot be attributed to one. See [Tournament Discovery](../concepts/tournament-discovery.md).
+
+**`entries` carries a TEAM entry's issued identity**, in `team_id` + `organisation_id`. `team_id` is the id an organisation **issued** for that team, taken from `participantOtherIds` — `null` for every other `participantType`, and for a TEAM stating no issued id. It is deliberately **not** `participant_id`, which is tournament-local: keyed on that, a programme would look like a different competitor in every record and its season would be exactly one fixture long. `organisation_id` names the body that issued it, because a subjectId is unique only _within_ its issuing body.
+
+:::warning
+
+`entries.team_id` and `match_up_competitors.team_id` follow **different rules and must not be assumed interchangeable.** The competitors column is `participant.teamId ?? participantId`, so it falls back to a tournament-local id when a record states no durable identity; the entries column is the issued id and is `null` rather than local when none is stated. They coincide wherever a producer happens to set `participantId` to the issued id — which the college-dual corpus does — and diverge everywhere else.
+
+:::
+
 `match_up_competitors.person_id` is populated only for a **real canonical person** — a `personId` that is not equal to the `participantId` and is not a factory `UUID()` (i.e. a provider/federation id such as a UTR id, `link_source: 'providerId'`); synthetic/local participants are left `NULL` (`link_source: 'unresolved'`). `venue.facilityId` is a canonical first-class attribute that **defaults to `venueId`**.
 
 Callable on the engine (injects the loaded `tournamentRecord`) or via `queryGovernor.cast({ tournamentRecord })` (the server / rebuild-pipeline call pattern).
@@ -140,7 +151,9 @@ import { readModel } from 'tods-competition-factory';
 | Export                                     | Purpose                                                                                                                                                                                                                             |
 | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `cast`                                     | Full-tournament projection (the same function documented above).                                                                                                                                                                    |
-| `tournamentRow` / `venueRow` / `entryRows` | Row builders for the `tournaments`, `venues`/`tournament_venues`, and `entries` tables.                                                                                                                                             |
+| `tournamentRow` / `venueRow` / `entryRows` | Row builders for the `tournaments`, `venues`/`tournament_venues`, and `entries` tables. `entryRows` carries a TEAM entry's issued `team_id` + `organisation_id` — see the warning above.                                                |
+| `tournamentDiscoveryRow`                   | Row builder for the `tournament_discovery` table — the faceted-discovery aggregate over a tournament and its events. The only builder that is not 1:1 with a source object; see [Tournament Discovery](../concepts/tournament-discovery.md). |
+| `applyProgressionEdges`                    | Stamps `winnerMatchUpId` / `loserMatchUpId` onto already-flattened in-context matchUps, **deriving** them from the draw's links and topology (`addGoesTo`) for records that never stored them — older records and non-factory TODS files. Without it such a draw projects `NULL` and cannot distinguish "no loser feed" from "never recorded". Pure with respect to the record; costs 1.16×–1.43× a plain flatten, so call it only where projected edges are needed. |
 | `eventRow` / `seedRow`                     | Row builders for the `events` table (one row/event) and the `seeds` table (one row per participant-holding seed assignment; caller supplies the structure context via `SeedRowContext`).                                            |
 | `drawRow` / `structureRow`                 | Row builders for the `draws` table (one row/draw) and the `structures` table (one row per top-level structure; context via `StructureRowContext`). Nested round-robin group sub-structures are not projected.                       |
 | `courtRow`                                 | Row builder for the `courts` table (one row per court of a placed venue; context via `CourtRowContext`).                                                                                                                            |
@@ -2292,6 +2305,8 @@ const { searchText, tournamentId, providerId, tournament } = engine.getTournamen
 // tournament: { ...getTournamentInfo projection, startDate, endDate, tournamentName, tournamentImageURL }
 ```
 
+Because the entry spreads the `getTournamentInfo` projection, a field must be projected there to reach a calendar at all — `tournamentLevel` was populated at rest and absent from every calendar built from it until the projection carried it. An unstated level stays `undefined` and must not acquire a default.
+
 ---
 
 ## getTournamentInfo
@@ -2304,6 +2319,7 @@ Returns tournament attributes. Used to attach details to publishing payload by `
 const { tournamentInfo } = getTournamentInfo({ tournamentRecord });
 const {
   tournamentId,
+  tournamentLevel, // organisational SCOPE (CLUB … INTERNATIONAL); undefined when unstated — never defaulted
   tournamentRank,
 
   formalName,

--- a/documentation/docs/governors/schedule-governor.md
+++ b/documentation/docs/governors/schedule-governor.md
@@ -1624,6 +1624,40 @@ occupancy specifically.
 
 ---
 
+## setMatchUpCalledAt
+
+Sets or clears `matchUp.schedule.calledAt` — the ISO instant captured when a tournament director deliberately places a matchUp on the TMX active strip, signalling that it is imminent.
+
+```js
+engine.setMatchUpCalledAt({
+  matchUpId, // required
+  drawId, // required
+  calledAt, // ISO timestamp; `null` or `undefined` CLEARS the previous value
+  disableNotice, // optional boolean
+});
+```
+
+Called directly, `undefined` reads as **clear**. That differs deliberately from [`addMatchUpScheduleItems`](#calledat), where an omitted key must not wipe a call to court.
+
+### A `calledAt` before the tournament starts is refused
+
+Calling a match to court is a physical act at the venue, so it cannot happen before the venue opens. `addMatchUpScheduledDate` already refuses a `scheduledDate` outside the tournament's range; a `calledAt` predating `startDate` is the same class of impossibility and was previously accepted without complaint.
+
+**The check needs a time zone to be correct.** `startDate` is a bare venue-local calendar day while `calledAt` is a UTC instant, and comparing them without a zone compares two different things. In Sydney (UTC+10) a 09:00 call on opening day is 23:00 UTC on the **previous** day, so a naive UTC-day comparison would reject a perfectly legitimate call — the opposite of the failure being fixed, and worse, because it blocks the running desk.
+
+So the venue's zone resolves the instant to its real local day, via the same `localTimeZone` the rest of the venue time frame already depends on.
+
+**Without a resolvable zone the guard weakens rather than guesses.** Many tournaments carry neither a `localTimeZone` nor a venue address, and there is then no exact answer to "which local day was that?" — only a bound. The furthest-ahead zone in use is UTC+14 (Kiritimati), so local midnight opening the tournament can be no earlier than `startDate 00:00 UTC − 14h`:
+
+- an instant before that bound is before the start in **every** zone that exists, and is refused;
+- an instant after it is opening day **somewhere**, and is admitted.
+
+That is the most the check can soundly say without a zone. It is deliberately weaker than the zoned form — an evening-before call in New York is caught only when the tournament names its zone — because refusing a real call stops play, which is by far the worse of the two failures.
+
+`endDate` is **not** guarded. A match called near midnight on the final day legitimately runs past it, and the last day's play routinely spills over; there is no equivalent impossibility on that side.
+
+---
+
 ## Auto-captured `scoredTime`
 
 `matchUp.schedule.scoredTime` is a first-class ISO-8601 timestamp that the engine

--- a/documentation/docs/policies/avoidance.md
+++ b/documentation/docs/policies/avoidance.md
@@ -427,6 +427,28 @@ tournamentEngine.generateDrawDefinition({
 });
 ```
 
+## Playoff avoidance is synthesised, not configured
+
+Playoff draws fed by round-robin groups get an avoidance policy **automatically**. `positionUnseededParticipants` builds it from each entry's `groupingValue` whenever the stage is `PLAY_OFF`, with no `policyDefinitions` required.
+
+So _"no first-round pair holds two participants from the same group"_ is a guarantee the engine makes, not a coincidence of the draw.
+
+## Residual conflicts are reported
+
+Automated positioning tries candidate arrangements and swaps participants to resolve conflicts. It cannot always succeed — four groups landing as A1-A2, B1-B2, C1-C2, D1-D2 leave no conflict-free first round to reach.
+
+The candidate applied is the lowest-conflict one generated, but "lowest" can still be non-zero when the repair loop runs out of options. When that happens `automatedPositioning` reports what is left under `conflicts.unseededConflicts` rather than returning a bare success:
+
+```js
+const { conflicts } = engine.automatedPositioning({ drawId, structureId });
+
+if (conflicts?.unseededConflicts) {
+  // the draw was positioned, but the avoidance guarantee could not be met in full
+}
+```
+
+An absent `conflicts.unseededConflicts` means the arrangement satisfied the policy. A same-group opening match previously shipped as `{ success: true, conflicts: {} }` with no way for a caller to notice, which left an intermittent test failure as the only available symptom.
+
 ## Related Documentation
 
 - **[Accessors](/docs/concepts/accessors)** - Complete accessor syntax and usage

--- a/documentation/docs/scale-engine/ranking-points-pipeline.md
+++ b/documentation/docs/scale-engine/ranking-points-pipeline.md
@@ -57,6 +57,14 @@ Profiles are scored by counting their populated scope fields. A profile that spe
 
 **Priority override:** If any matching profile has an explicit `priority` number, the highest priority wins regardless of specificity score.
 
+**An absent value never matches.** A profile that declares a filter does **not** match an event lacking that field at all — a profile scoped to `ratingTypes: ['WTN']` does not match an event with no `ratingType`, rather than matching it vacuously. This applies to every array-valued scope field above, and is long-standing behaviour rather than a new rule.
+
+:::note
+
+`matchesProfile` reads a singular `profile.drawSize` as well as `drawSizes`. Nothing in the factory's own fixtures sets it, but ranking policies are runtime data loaded from a policy service, so an external policy can set it and have it honoured — it is declared on `AwardProfileScope` for that reason. See [`drawSize` vs `drawSizes`](/docs/policies/rankingPolicy#full-profile) for why the plural is preferred.
+
+:::
+
 ### CategoryScope Matching
 
 The `category` field on an `awardProfile` uses `CategoryScope` to match against the event's competitive context:

--- a/documentation/docs/tools/build-from-sources.md
+++ b/documentation/docs/tools/build-from-sources.md
@@ -1,0 +1,181 @@
+---
+title: buildFromSources
+---
+
+```js
+import { tools } from 'tods-competition-factory';
+```
+
+Assemble a `tournamentRecord` from partial, heterogeneous or third-party sources — a set of API
+responses, a network-tab paste, an adapter's output — without knowing in advance what each one is.
+
+It exists because the factory cannot control how other systems present their data, and because the
+alternative is every ingest tool re-deriving the same assembly logic in a place that has no access
+to the generators which already know the answer.
+
+## buildFromSources
+
+Pass an array of raw objects in any combination and any order. Each is classified by shape, routed
+to the extractor for its kind, and merged into one record. Draw links are then repaired so the
+result is readable — see [Link repair](#link-repair) below.
+
+```ts
+function buildFromSources(sources?: any[]): BuildFromSourcesResult;
+
+interface BuildFromSourcesResult {
+  record: Record<string, any>;
+  classification: { index: number; kind: SourceKind }[];
+  unknownCount: number;
+  inferredLinks: { drawId?: string; inferred: InferredLink[]; issues: string[] }[];
+  unplacedMatchUps: UnplacedMatchUp[];
+}
+
+type SourceKind = 'event-data' | 'matchups' | 'participants' | 'unknown';
+```
+
+```js
+const { record, classification, unknownCount, inferredLinks, unplacedMatchUps } = tools.buildFromSources([
+  eventDataResponse, // { data: { tournamentPublicEventData: { ... } } }
+  scheduleResponse, // { tournamentMatchUps: [ ... ] }
+  participantsResponse, // { tournamentParticipants: [ ... ] }
+]);
+
+// classification: [{ index: 0, kind: 'event-data' }, { index: 1, kind: 'matchups' }, ...]
+```
+
+**Nothing is dropped silently.** Three of the five returned keys exist only so the caller can see
+what the assembler could not do:
+
+| key | reports |
+| --- | --- |
+| `classification` | what each input was taken to be, by index — so a caller can show its work |
+| `unknownCount` | inputs matching no known shape. Reported rather than discarded |
+| `inferredLinks` | links added to make reconstructed draws readable, with confidence |
+| `unplacedMatchUps` | matchUps naming a structure their draw does not contain |
+
+A caller that would rather refuse than accept a repaired or lossy record inspects these and decides.
+
+### Classification
+
+Sources are sniffed rather than labelled. A single-key `{ data: { ... } }` envelope is peeled
+recursively first — network-tab copies sometimes carry it and sometimes not — then:
+
+- a wrapper key (`tournamentPublicEventData`, `tournamentMatchUps`, `tournamentParticipants`) names
+  the kind outright;
+- an array is classified from its first object member (`matchUpId` → matchups, `participantId`
+  without `eventInfo` → participants);
+- an object is classified from its distinguishing keys (`dateMatchUps` → matchups, `eventData` →
+  event data).
+
+Anything else is `'unknown'` and increments `unknownCount`.
+
+`classifySource`, `extractEventData`, `extractMatchUps` and `extractParticipants` are exported
+separately for a caller that already knows what it holds.
+
+### unplacedMatchUps
+
+`augmentDrawWithMatchUps` inserts a matchUp only into an existing structure whose `structureId`
+matches. When no structure matches, the matchUp cannot be placed.
+
+It is reported rather than dropped, because a shorter draw with no complaint is the hardest kind of
+loss to notice:
+
+```js
+const { unplacedMatchUps } = tools.buildFromSources(sources);
+
+// [{ matchUpId, eventId, drawId, structureId }]
+// structureId is the one the matchUp NAMED — which no structure in that draw carries
+```
+
+Each entry carries enough identity to find the matchUp in the source. An empty array is the
+ordinary case.
+
+## buildTournamentRecord
+
+The lower-level assembler, for a caller that has already separated its sources.
+
+```ts
+function buildTournamentRecord(args?: {
+  eventDataDocs?: any[];
+  matchUpDocs?: any[];
+  participantDocs?: any[];
+  unplaced?: UnplacedMatchUp[];
+}): Record<string, any>;
+```
+
+```js
+const record = tools.buildTournamentRecord({ eventDataDocs, matchUpDocs, participantDocs });
+```
+
+**It does not repair links**, deliberately: a caller assembling a record by hand keeps exactly its
+previous behaviour and opts in via `repairDrawLinks`. Unplaced matchUps are collected only if the
+caller hands over an array to collect them into, so the function's shape is unchanged for callers
+that do not want the report.
+
+## Link repair
+
+A `drawDefinition` whose structures are not all joined into one group is **refused** by
+`getDrawData` — not degraded, refused (`ERR_MISSING_STRUCTURE_LINKS`). The record still saves and
+still lists in a calendar, so the failure is invisible until something asks for the draw.
+
+Links are a property of the draw while matchUps are a projection of it, so reconstruction from
+matchUps can never preserve them. Inference is the only route back.
+
+### inferDrawLinks
+
+```ts
+function inferDrawLinks(params: { drawDefinition: DrawDefinition }): InferDrawLinksResult;
+
+interface InferDrawLinksResult {
+  links: DrawLink[]; // the links to ADD — existing links are never modified or removed
+  inferred: InferredLink[];
+  alreadyLinked: boolean; // the draw already formed a single group; nothing was needed
+  issues: string[];
+}
+
+interface InferredLink {
+  linkType: string;
+  sourceStructureId: string;
+  targetStructureId: string;
+  basis: string; // why this pairing was chosen, in the stages' own vocabulary
+  confidence: 'exact' | 'shape';
+}
+```
+
+**This repairs; it does not reconstruct, and it says which.** Link count and `feedProfile` follow the
+`drawType`, not the structure shape:
+
+| drawType | structures | links |
+| --- | --- | --- |
+| `FIRST_MATCH_LOSER_CONSOLATION` | MAIN, CONSOLATION | 2, LOSER round 1 + 2 TOP_DOWN |
+| `FEED_IN_CHAMPIONSHIP` | MAIN, CONSOLATION | 4, alternating TOP_DOWN / BOTTOM_UP |
+| `ROUND_ROBIN_WITH_PLAYOFF` | MAIN, PLAY_OFF | 1, POSITION with feedProfile DRAW |
+| `COMPASS` | 8 | 7 |
+
+Two draws with identical structures therefore have different correct links, and nothing can recover
+that from the structures alone. So `inferDrawLinks` emits the **minimum** set of links that joins
+every structure into one group, and reports how confident it is:
+
+- **`'exact'`** — a two-structure draw whose stages name an unambiguous relationship.
+- **`'shape'`** — more than two structures, or stages that do not name one. The draw becomes
+  readable; the feed pattern is a guess and is flagged as one.
+
+The rule is read from the data rather than assumed: a `CONTAINER` source (round robin) feeds by
+`POSITION` with `feedProfile: DRAW`; an `ITEM` source feeds by `LOSER` `TOP_DOWN`; and `QUALIFYING`
+feeds `MAIN` by position — matching `generateQualifyingLink`.
+
+A caller that knows the `drawType` and wants the true feed pattern should **generate** the draw
+properly rather than repair it here.
+
+### repairDrawLinks
+
+Applies `inferDrawLinks` across every `drawDefinition` in a record, mutating it in place and
+returning the report.
+
+```js
+const inferredLinks = tools.repairDrawLinks(record);
+// [{ drawId, inferred: [{ linkType, basis, confidence, ... }], issues: [] }]
+```
+
+Empty when nothing needed repair. `buildFromSources` calls this before returning; `buildTournamentRecord`
+does not.

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -34,7 +34,7 @@ module.exports = {
         {
           type: 'category',
           label: 'Tournament Setup',
-          items: ['concepts/registration-profile', 'concepts/tournament-tier'],
+          items: ['concepts/registration-profile', 'concepts/tournament-tier', 'concepts/tournament-discovery'],
         },
         {
           type: 'category',
@@ -60,6 +60,7 @@ module.exports = {
             'concepts/events/entries',
             'concepts/events/flights',
             'concepts/events/event-origin',
+            'concepts/events/entry-eligibility',
           ],
         },
         {
@@ -397,6 +398,7 @@ module.exports = {
         'tools/make-deep-copy',
         'tools/structure-sort',
         'tools/json-to-csv',
+        'tools/build-from-sources',
         'tools/tools-api',
       ],
     },


### PR DESCRIPTION
Documentation for the backlog accumulated since the docs site was last deployed
(**2026-08-25**, gh-pages `8a17350bf`). Builds on #4762, which is merged.

## How the backlog was derived

```bash
LAST=$(git log -1 --format=%cI origin/gh-pages)          # 2026-08-25T09:55:26-04:00
git log --oneline -E --grep='^(feat|fix)' --since="$LAST" origin/master -- src/
```

**Controls, printed before trusting the result** — 52 commits on `origin/master` since the deploy,
31 touching `src/`, 12 touching `documentation/`, **28** matching `feat`/`fix` **and** touching
`src/`. Of those 28, five shipped documentation, so **23 examined** here.

Two detector corrections worth recording:

- `git --grep` is **line-based over the whole commit message**, not the subject. It admitted one
  `docs(codes):` commit (#4719) whose body matched. A subject-only cross-check gives 27; the
  audit set is the same 23 either way, because that commit shipped no site docs and is audited
  below regardless.
- Falsified in both directions before use: the filter correctly **excludes** the `test`/`chore`/`docs`
  commits touching `src/`, and returns 0 for a nonsense pattern.

## Per-commit audit

Every one of the 23 has a verdict. A "nothing needed" below is a decision, not an omission.

| # | commit | verdict | where |
| --- | --- | --- | --- |
| 4761 | `fix(scales)` type getAwardProfile | **edit** | `scale-engine/ranking-points-pipeline.md` — undefined-never-matches semantics; singular `drawSize` is a declared `AwardProfileScope` filter |
| 4758 | `fix(scales)` subjectToBucketLimits | **nothing** | covered by #4762 (`scale-engine/aggregation.md`) |
| 4756 | `fix(scales)` one RankingListEntry + bucketTotals | **nothing** | covered by #4762 (`aggregation.md`, `policies/rankingPolicy.md`) |
| 4751 | `feat(read-model)` TEAM entry issued identity | **edit** | `governors/query-governor.md` — `entries.team_id` / `organisation_id`, and the warning that it is a *different rule* from `match_up_competitors.team_id` |
| 4750 | `feat(query)` getParticipation | **edit** | `governors/participant-governor.md` — new method section |
| 4747 | `feat(read-model)` organisational scope on discovery row | **new** | `concepts/tournament-discovery.md` — scope vs grade |
| 4746 | `feat(query)` project tournamentLevel | **edit** | `governors/query-governor.md` — `getTournamentInfo` projection + why it gates the calendar entry |
| 4744 | `fix(tools)` report unplaced matchUps | **new** | `tools/build-from-sources.md` |
| 4743 | `feat(read-model)` cast() emits discovery row | **new + edit** | `concepts/tournament-discovery.md` (`tournamentAggregate` attribution) + `tournament_discovery` in the `cast()` row list |
| 4742 | `fix(read-model)` export discovery row builder | **edit** | `governors/query-governor.md` — `tournamentDiscoveryRow` in the `readModel` toolkit table |
| 4741 | `feat(read-model)` discovery row shape | **new** | `concepts/tournament-discovery.md` |
| 4740 | `feat(codes)` who may enter, and cancellation | **new** | `concepts/events/entry-eligibility.md` — `entryRestrictions`, `cancelledAt` |
| 4739 | `feat(tools)` buildFromSources + link repair | **new** | `tools/build-from-sources.md` |
| 4738 | `fix(codes)` schema says something about a sanction | **edit** | `codes/sanctioning.mdx` — schema coverage |
| 4736 | `fix(avoidance)` swap target | **edit** | `policies/avoidance.md` — synthesised playoff avoidance, and `conflicts.unseededConflicts` now reported |
| 4735 | `fix(scales)` ratings governor tree shaking | **nothing** | packaging fix; restores an already-documented surface, no behaviour or API change |
| 4731 | `fix(sorters)` pin stringSort's collator | **nothing** | `stringSort` is not exported from `tools` and appears in no doc; internal determinism fix with no public surface |
| 4727 | `feat(codes)` registration window + entry profile | **edit** | `concepts/registration-profile.md` + `governors/entries-governor.md` |
| 4724 | `fix(codes)` entry fee unit and event | **edit** | `concepts/registration-profile.md` (fee shape, selectors) + `governors/entries-governor.md` (`resolveEntryFee`, `getEntryFeeRange`) |
| 4723 | `fix(scheduling)` calledAt before startDate | **edit** | `governors/schedule-governor.md` — new `setMatchUpCalledAt` section |
| 4722 | `fix(entries)` make eligibility askable | **new** | `concepts/events/entry-eligibility.md` + `governors/event-governor.md` |
| 4719 | `docs(codes)` additionalProperties convention | **edit** | `data-standards.md` — the schema as third declaration |
| 4718 | `fix(codes)` revive the schema validator | **edit** | `data-standards.md` |

## Pages

**New** (all three registered in `sidebars.js`):

- `tools/build-from-sources.md`
- `concepts/events/entry-eligibility.md`
- `concepts/tournament-discovery.md`

**Edited:** `governors/query-governor.md`, `governors/entries-governor.md`,
`governors/event-governor.md`, `governors/participant-governor.md`,
`governors/schedule-governor.md`, `concepts/registration-profile.md`, `policies/avoidance.md`,
`scale-engine/ranking-points-pipeline.md`, `codes/sanctioning.mdx`, `data-standards.md`.

## Two things verified against source rather than taken from the commits

**`entryCapacity` does not exist.** #4727's subject promises "entry capacity", but the string
`capacity` appears nowhere in that commit's diff except the subject line itself, and nowhere in
`src/` today outside unrelated practice-court booking and format-wizard code. The shipped concept is
**`EventEntryProfile.entriesLimit`** on `event.entryProfile`, and that is what is documented.

**The `additionalProperties` counts in #4719 are stale.** That commit records 55 object definitions
(51 closed, 3 open, 1 with the keyword absent). Measured against the schema as it stands today:
**68 object definitions, 64 closed, 4 open (`Tournament`, `Extension`, `Organisation`, `Venue`), none
absent** — `Organisation` has since been given the keyword explicitly. The page states the measured
figures.

## Gaps flagged rather than filled

- **`documentation/docusaurus.config.js` sets `onBrokenLinks: 'warn'`, not `'throw'`.** A green
  `pnpm build` is therefore **not** a link check, contrary to the assumption in the session brief.
  Internal links here were checked by reading the build log for warnings. Changing that setting is a
  separate decision and is not made in this PR.
- **CORRECTION (post-merge).** The bullet below was **wrong** and is struck through rather than
  deleted. `augmentDrawWithMatchUps` is **not** an open follow-up: it is tracked as **DONE
  2026-08-30** (#4744, `10e94612f`), and *reporting* the unplaced matchUps was the specified fix —
  the tracker entry explicitly rules out inventing structures, "that would trade a silent drop for
  silent invention". The claim came from reading #4739's commit message ("DOCUMENTED, NOT FIXED ...
  Worth a follow-up") without checking whether the follow-up had landed. It had, six days earlier.
  The page's content is unaffected — it documents the reporting, which is correct.
- ~~**#4739 documents a known silent drop it did not fix:** `augmentDrawWithMatchUps` discards a
  matchUp whose named `structureId` matches no structure. #4744 made it *reported*
  (`unplacedMatchUps`) rather than *fixed*. The new page documents the reporting, and says the
  matchUp is not placed — it does not claim the drop is resolved.~~

## Verification

- `npx markdownlint-cli2 "documentation/docs/**/*.md"` — **0 issues, 159 files**, exit 0
  (156 at baseline; the three new pages account for the difference).
- `cd documentation && pnpm build` — **SUCCESS, exit 0, zero warnings.**
- All three new pages verified present in `documentation/build/` and reachable from the sidebar; a
  control path that should not exist is absent.
- **The link check was falsified rather than assumed.** A deliberately broken link was planted and
  rebuilt: docusaurus reported it (`[WARNING] Markdown link with URL ... couldn't be resolved`,
  `Docusaurus found broken links!`) **and still exited 0**. So the clean build's silence is
  meaningful, but a green build alone would not have been.

