### PR TITLE
fix(scales): populate PointAward.category.gender from the event

### DIFF
--- a/src/query/scales/getTournamentPoints.ts
+++ b/src/query/scales/getTournamentPoints.ts
@@ -38,6 +38,39 @@ function calculateBonusPoints(primaryAwardProfile, bestFinishingPosition, level)
   return bonusPoints;
 }
 
+/**
+ * The category snapshot an award carries — what the event WAS when the points
+ * were earned.
+ *
+ * `gender` is part of that snapshot and lives on the EVENT, not inside
+ * `event.category`. Assigning `event.category` verbatim therefore dropped it:
+ * `PointAward.category.gender` was declared in `rankingTypes.ts` and never
+ * populated by anything, so a consumer reading the documented field correctly
+ * got `undefined`. Measured downstream on 2026-09-06 —
+ * `courthive-rankings.point_awards.gender` was NULL on all 3,552 production
+ * rows, and every gendered ranking list it generated came out empty because
+ * `WHERE gender = 'MALE'` never matches a NULL.
+ *
+ * Most events have no `category` object at all (123 of 129 in that corpus), so
+ * the snapshot has to be CREATED when gender is the only thing known about the
+ * category, not merged into an object that is assumed to exist.
+ *
+ * An explicit `category.gender` wins over the event's own: it is the more
+ * specific statement, and an event that says both should be taken at its
+ * narrower word.
+ *
+ * The value is recorded as the event declares it, including `ANY`. Whether an
+ * `ANY` event counts toward a gendered ranking list is an aggregation policy
+ * question and is deliberately NOT decided here — the engine's job is to record
+ * what the event was. Recording it faithfully is what makes the choice
+ * expressible downstream without re-deriving every award.
+ */
+function resolveAwardCategory(category, gender) {
+  if (!gender) return category;
+  if (category?.gender) return category;
+  return { ...(category ?? {}), gender };
+}
+
 function resolveLineValue(levelValue, collectionPosition) {
   if (typeof levelValue === 'object' && levelValue.line) {
     if (levelValue.limit && collectionPosition > levelValue.limit) return undefined;
@@ -55,6 +88,8 @@ function awardLinePointsToWinningSide({
   personPoints,
   pointsAuthority,
   eventType,
+  category,
+  gender,
   drawId,
 }) {
   const { collectionPosition } = tieMatchUp;
@@ -72,11 +107,16 @@ function awardLinePointsToWinningSide({
       if (!personId) continue;
 
       if (!personPoints[personId]) personPoints[personId] = [];
+      // Carries the same category snapshot as every other award. A team line
+      // award that omitted it would reach a gendered ranking list with a NULL
+      // gender and be filtered out of it — the identical defect, just confined
+      // to team events.
       personPoints[personId].push({
         linePoints: lineValue,
         collectionPosition,
         pointsAuthority,
         eventType,
+        category: resolveAwardCategory(category, gender),
         drawId,
       });
     }
@@ -96,6 +136,8 @@ function calculateTeamLinePoints({
   personPoints,
   pointsAuthority,
   eventType,
+  category,
+  gender,
   drawId,
 }) {
   if (participantType !== TEAM_PARTICIPANT || !awardProfile || !levelValue) return;
@@ -123,6 +165,8 @@ function calculateTeamLinePoints({
         personPoints,
         pointsAuthority,
         eventType,
+        category,
+        gender,
         drawId,
       });
     }
@@ -515,6 +559,7 @@ function calculateDrawPoints({
         eventType,
         drawId,
         category,
+        gender,
         drawType,
         startDate,
         endDate,
@@ -634,6 +679,8 @@ function processAllParticipations({
         personPoints,
         pointsAuthority: awardProfile.pointsAuthority ?? pointsAuthority,
         eventType,
+        category,
+        gender,
         drawId,
       });
     }
@@ -647,6 +694,7 @@ function buildAndDistributeAward({
   eventType,
   drawId,
   category,
+  gender,
   drawType,
   startDate,
   endDate,
@@ -677,7 +725,7 @@ function buildAndDistributeAward({
     eventType,
     drawId,
     points,
-    category,
+    category: resolveAwardCategory(category, gender),
     drawType,
     startDate,
     endDate,

--- a/src/tests/queries/scales/awardCategoryGender.test.ts
+++ b/src/tests/queries/scales/awardCategoryGender.test.ts
@@ -1,0 +1,141 @@
+// Regression cover: `PointAward.category.gender` must be populated.
+//
+// THE DEFECT THIS REPLACES. The award's category snapshot was assigned
+// `category: event?.category` verbatim. Gender lives on the EVENT, beside
+// `category` rather than inside it — `resolveScope` in
+// getApplicableAwardProfileLevels reads `event?.gender` for award-profile
+// selection — so it never reached the award. `PointAward.category.gender` was
+// declared in `rankingTypes.ts` and populated by nothing.
+//
+// It was invisible from inside this repository. The consumer read exactly the
+// documented field and correctly got `undefined`; nothing here was red. It
+// surfaced only downstream, in production: `courthive-rankings.point_awards`
+// held 3,552 rows with `gender` NULL, and every gendered ranking list generated
+// from them came out with `entry_count = 0`, because `WHERE gender = 'MALE'`
+// never matches a NULL. `ranking_entries` held zero rows.
+//
+// The case that matters most is an event with a GENDER AND NO CATEGORY OBJECT —
+// 123 of the 129 events in that corpus. Merging into a category that does not
+// exist is the version of this fix that still produces `undefined`.
+
+import scaleEngine from '@Engines/scaleEngine';
+import { mocksEngine } from '../../..';
+import { describe, expect, it } from 'vitest';
+
+import { POLICY_TYPE_RANKING_POINTS } from '@Constants/policyConstants';
+import { SINGLE_ELIMINATION } from '@Constants/drawDefinitionConstants';
+import { ANY, FEMALE, MALE } from '@Constants/genderConstants';
+import { SINGLES } from '@Constants/eventConstants';
+
+const simplePolicy = {
+  [POLICY_TYPE_RANKING_POINTS]: {
+    awardProfiles: [
+      {
+        profileName: 'Standard SE',
+        drawTypes: [SINGLE_ELIMINATION],
+        finishingPositionRanges: {
+          1: { level: { 1: 1000 } },
+          2: { level: { 1: 700 } },
+          4: { level: { 1: 400 } },
+          8: { level: { 1: 200 } },
+        },
+      },
+    ],
+  },
+};
+
+function awardsForEvent(overrides: Record<string, any>) {
+  const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ drawType: SINGLE_ELIMINATION, drawSize: 8, eventType: SINGLES, ...overrides }],
+    completeAllMatchUps: true,
+    setState: true,
+  });
+
+  const result = scaleEngine.getTournamentPointAwards({
+    policyDefinitions: simplePolicy,
+    level: 1,
+  });
+
+  expect(result.success).toEqual(true);
+  expect(tournamentRecord).toBeDefined();
+  return result.pointAwards;
+}
+
+describe('PointAward.category.gender', () => {
+  it('carries the event gender when the event has NO category object', () => {
+    // The production shape: gender declared on the event, no category at all.
+    // This is the assertion that fails without the fix — `category` was
+    // `undefined`, so `category?.gender` was too.
+    const awards = awardsForEvent({ gender: MALE });
+
+    expect(awards.length).toBeGreaterThan(0);
+    for (const award of awards) {
+      expect(award.category?.gender).toEqual(MALE);
+    }
+  });
+
+  it('carries FEMALE the same way', () => {
+    const awards = awardsForEvent({ gender: FEMALE });
+
+    expect(awards.length).toBeGreaterThan(0);
+    for (const award of awards) {
+      expect(award.category?.gender).toEqual(FEMALE);
+    }
+  });
+
+  it('records ANY as the event declares it, rather than deciding a list for it', () => {
+    // 10 events in the production corpus are ANY. Whether an ANY event counts
+    // toward a gendered ranking list is an AGGREGATION POLICY question and is
+    // deliberately not answered by the engine. Recording the value faithfully
+    // is what makes that choice expressible downstream without re-deriving
+    // every award — and a gendered list that filters `= 'MALE'` still excludes
+    // it, which is the conservative default.
+    const awards = awardsForEvent({ gender: ANY });
+
+    expect(awards.length).toBeGreaterThan(0);
+    for (const award of awards) {
+      expect(award.category?.gender).toEqual(ANY);
+    }
+  });
+
+  it('preserves an explicit category.gender over the event gender', () => {
+    // An event that states both is taken at its narrower word: the category is
+    // the more specific statement.
+    const awards = awardsForEvent({
+      gender: ANY,
+      category: { categoryName: 'U18', ageCategoryCode: 'U18', gender: FEMALE },
+    });
+
+    expect(awards.length).toBeGreaterThan(0);
+    for (const award of awards) {
+      expect(award.category?.gender).toEqual(FEMALE);
+      // and the rest of the snapshot survives untouched
+      expect(award.category?.ageCategoryCode).toEqual('U18');
+    }
+  });
+
+  it('merges gender into an existing category without dropping its other fields', () => {
+    const awards = awardsForEvent({
+      gender: MALE,
+      category: { categoryName: 'U16', ageCategoryCode: 'U16' },
+    });
+
+    expect(awards.length).toBeGreaterThan(0);
+    for (const award of awards) {
+      expect(award.category?.gender).toEqual(MALE);
+      expect(award.category?.ageCategoryCode).toEqual('U16');
+      expect(award.category?.categoryName).toEqual('U16');
+    }
+  });
+
+  it('leaves category undefined when the event declares neither', () => {
+    // Not every event has a gender. Inventing a category object for an event
+    // that says nothing about one would assert a fact that does not exist.
+    const awards = awardsForEvent({});
+
+    expect(awards.length).toBeGreaterThan(0);
+    for (const award of awards) {
+      expect(award.category?.gender).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
`PointAward.category.gender` is declared in `rankingTypes.ts` and was populated by **nothing**.

Gender lives on the **event**, beside `category` rather than inside it — `resolveScope` in `getApplicableAwardProfileLevels` already reads `event?.gender` for award-profile selection — but the award's category snapshot was assigned `event.category` verbatim, so the value never reached the award.

## Why no test here caught it

Nothing in this repository was red. The consumer read exactly the documented field and correctly got `undefined`. It surfaced only downstream, in production, and only once something finally read the artifact:

| | |
|---|---|
| `courthive-rankings.point_awards` rows | **3,552** |
| …with `gender` NULL | **3,552** |
| `ranking_entries` rows in production | **0** |
| live bundle over the same corpus | 655 men, 358 women |

Every gendered ranking list came out with `entry_count = 0`, because `WHERE gender = 'MALE'` never matches a NULL. The bundle escaped it by splitting on `persons_observed.sex` — a different, populated field — so the visible surface was always right while the stored artifact was always empty. Full chain, measured at every link: `Mentat/planning/RANKING_LIST_AND_PERSON_HISTORY_STORAGE.md` §6.

## The fix

`resolveAwardCategory(category, gender)` — one helper, two call sites.

**The case that matters is an event with a gender and NO `category` object** — 123 of the 129 events in that corpus. Merging into a category that does not exist is the version of this fix that still produces `undefined`, so the helper *creates* the snapshot rather than assuming one.

- An explicit `category.gender` **wins** over the event's own: an event that states both is taken at its narrower word.
- `ANY` is recorded as the event declares it. Whether an `ANY` event counts toward a gendered ranking list is an **aggregation policy** question and is deliberately not answered here — the engine's job is to record what the event *was*. Recording it faithfully makes the choice expressible downstream without re-deriving every award, and a list filtering `= 'MALE'` still excludes it, which is the conservative default.
- An event that declares neither still yields no category. Inventing one would assert a fact that does not exist.

**Team line-point awards get the same snapshot.** They carried no `category` at all, so they would have reached a gendered list with a NULL gender — the identical defect, confined to team events.

## Verification

- `pnpm verify` **green end to end** — generated, types, lint, format, attr-audit, coverage, coverage-headroom, server, audit, build, publint, runtime, shakeable, bundle-size, surface, pack.
- `pnpm test` — **11,717 passed / 1 skipped** across 1,130 files. No downstream test moved.
- The regression spec was **falsified before being trusted**: reverting the fix fails **4 of its 6** cases. (The first falsification attempt was itself wrong — it replaced only the first of the two call sites, which is the team line-points path, so the singles cases kept passing and the run looked green. Worth knowing if you re-run it.)

## Downstream note

This does not repair data already written. Awards are durable and are the sole input to list generation, so the 3,552 existing rows need reprocessing (`POST /tournaments/:tournamentId/reprocess` in courthive-rankings) after this ships.