### PR TITLE
chore(deps): vitest 5, and the per-file coverage floor it makes real

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,9 @@ package-lock.json
 
 # Builds
 *.tsbuildinfo
-/html
+# vitest 5 writes every artifact (html reporter, blob, attachments) under .vitest;
+# it used to write the html reporter to /html
+.vitest
 dist
 
 # IDEs and editors and OS files

--- a/package.json
+++ b/package.json
@@ -177,8 +177,8 @@
     "@types/supertest": "7.2.1",
     "@typescript-eslint/eslint-plugin": "8.68.0",
     "@typescript-eslint/parser": "8.68.0",
-    "@vitest/coverage-v8": "4.1.11",
-    "@vitest/ui": "4.1.11",
+    "@vitest/coverage-v8": "5.0.0",
+    "@vitest/ui": "5.0.0",
     "agadoo": "^3.0.0",
     "ajv": "8.20.0",
     "ajv-formats": "3.0.1",
@@ -207,7 +207,7 @@
     "unplugin-swc": "^1.5.11",
     "variable-diff": "2.0.2",
     "vite": "8.2.2",
-    "vitest": "4.1.11"
+    "vitest": "5.0.0"
   },
   "lint-staged": {
     "*.{js,ts}": "eslint --cache --fix",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,11 +97,11 @@ importers:
         specifier: 8.68.0
         version: 8.68.0(eslint@10.9.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       '@vitest/coverage-v8':
-        specifier: 4.1.11
-        version: 4.1.11(vitest@4.1.11)
+        specifier: 5.0.0
+        version: 5.0.0(vitest@5.0.0)
       '@vitest/ui':
-        specifier: 4.1.11
-        version: 4.1.11(vitest@4.1.11)
+        specifier: 5.0.0
+        version: 5.0.0(vitest@5.0.0)
       agadoo:
         specifier: ^3.0.0
         version: 3.0.0
@@ -187,8 +187,8 @@ importers:
         specifier: 8.2.2
         version: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.6.1)(terser@5.50.0)(yaml@2.9.0)
       vitest:
-        specifier: 4.1.11
-        version: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.6.1)(terser@5.50.0)(yaml@2.9.0))
+        specifier: 5.0.0
+        version: 5.0.0(@types/node@24.13.3)(@vitest/coverage-v8@5.0.0)(@vitest/ui@5.0.0)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.6.1)(terser@5.50.0)(yaml@2.9.0))
 
 packages:
 
@@ -1341,20 +1341,25 @@ packages:
     resolution: {integrity: sha512-YR65gGdGvTUAWLldC3xLOvOzamdGzB4A5/N8rehEaHs3Zvoe39BhgY+u0SPch1OvrVTfLcc55wsSgK2NcnTS/A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@vitest/coverage-v8@4.1.11':
-    resolution: {integrity: sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==}
+  '@vitest/coverage-v8@5.0.0':
+    resolution: {integrity: sha512-toMg6PZGCIa/lQNCDoASrfb1ly4hsUKXFtFYC9kD4t78o5Y6LyNJU7AENt8eHPr3quYdxaxK7hj2mnbFfUk9NA==}
     peerDependencies:
-      '@vitest/browser': 4.1.11
-      vitest: 4.1.11
+      '@vitest/browser': 5.0.0
+      vitest: 5.0.0
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.11':
-    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
+  '@vitest/istanbul-lib-coverage@1.0.1':
+    resolution: {integrity: sha512-k3DJZ8LhMBK9NS4SclF1ASD3OgXEWDorbIcPTRDK0/Zae6fRvu+fJRxtFdLfHsa9Y24beCdPnoNZ4LviTNstfA==}
+    engines: {node: '>=22'}
 
-  '@vitest/mocker@4.1.11':
-    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
+  '@vitest/istanbul-lib-report@1.0.1':
+    resolution: {integrity: sha512-1EOLRfsTMnyAr3+kEAsP4o9dhaDlGPpD7H5iLBBeq//YpNB1VIahkPhB+eRp9N2Dkfw8oySROjE3yf9XDeaIkQ==}
+    engines: {node: '>=22'}
+
+  '@vitest/mocker@5.0.0':
+    resolution: {integrity: sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1364,25 +1369,19 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.11':
-    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
+  '@vitest/pretty-format@5.0.0':
+    resolution: {integrity: sha512-PVRNuB3wpReb4SQEs4zTKM4KWFhQ5pw3spE8naoDJNB5T5aWRzGKHwXcLUllr0WeOTXpB6bSr3CJLo5+7XQSSQ==}
 
-  '@vitest/runner@4.1.11':
-    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
+  '@vitest/spy@5.0.0':
+    resolution: {integrity: sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==}
 
-  '@vitest/snapshot@4.1.11':
-    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
-
-  '@vitest/spy@4.1.11':
-    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
-
-  '@vitest/ui@4.1.11':
-    resolution: {integrity: sha512-r/rwyKoev21mWdRGSEkZOqkQ2BYy68mwjihg9M90nNRbf4NGrgzZ4cj6JNCEwlOGJkbKeMgsjlykvwKUbRr7gw==}
+  '@vitest/ui@5.0.0':
+    resolution: {integrity: sha512-h2FIFwggCY2GxUd2UdQoYNVQkOIqEQLPhNREcl3FUiRsdzQep7NWwYbSmhGEA9nFLPDq5pXzRMcBZQU8Py83sg==}
     peerDependencies:
-      vitest: 4.1.11
+      vitest: 5.0.0
 
-  '@vitest/utils@4.1.11':
-    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
+  '@vitest/utils@5.0.0':
+    resolution: {integrity: sha512-dO++xL3vDfvhTAVimfkuQUA3k+JClIF1i1vAkPqpcGAthRmeWnXmHB7YPViPvgCwviX8u7Y5W1u2N//AaQr3fw==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -1997,9 +1996,6 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  html-escaper@2.0.2:
-    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
-
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -2108,18 +2104,6 @@ packages:
   istanbul-badges-readme@1.9.0:
     resolution: {integrity: sha512-sD9lTsFajcfK07euJReQ0C9dy0VmXViMDJk67EZseGRC+jv+esxt5I3Viqoi1b43m5in5ek5b+0rpxJi41bJVw==}
     hasBin: true
-
-  istanbul-lib-coverage@3.2.2:
-    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
-    engines: {node: '>=8'}
-
-  istanbul-lib-report@3.0.1:
-    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
-    engines: {node: '>=10'}
-
-  istanbul-reports@3.2.0:
-    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
-    engines: {node: '>=8'}
 
   iterare@1.2.1:
     resolution: {integrity: sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==}
@@ -2341,12 +2325,11 @@ packages:
   magic-string@1.0.0:
     resolution: {integrity: sha512-CGvjzMN08iv6w1mm4/x3Gh1hLb4VnyRUA15FFpl6CsCIGGoe36k7kY5KNz9QDbSBN5I/fWHM6ZlIkUTa5xdUEA==}
 
+  magic-string@1.2.3:
+    resolution: {integrity: sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==}
+
   magicast@0.5.4:
     resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
-
-  make-dir@4.0.0:
-    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
-    engines: {node: '>=10'}
 
   markdown-it@14.3.0:
     resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
@@ -2920,8 +2903,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  tinybench@2.9.0:
-    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+  tinybench@6.1.4:
+    resolution: {integrity: sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==}
+    engines: {node: '>=20.0.0'}
 
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
@@ -3110,23 +3094,23 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.11:
-    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
-    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+  vitest@5.0.0:
+    resolution: {integrity: sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==}
+    engines: {node: ^22.12.0 || ^24.0.0 || >=26.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
-      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.11
-      '@vitest/browser-preview': 4.1.11
-      '@vitest/browser-webdriverio': 4.1.11
-      '@vitest/coverage-istanbul': 4.1.11
-      '@vitest/coverage-v8': 4.1.11
-      '@vitest/ui': 4.1.11
+      '@types/node': ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 5.0.0
+      '@vitest/browser-preview': 5.0.0
+      '@vitest/browser-webdriverio': ^5.0.0-beta.5 || >=5.0.0
+      '@vitest/coverage-istanbul': 5.0.0
+      '@vitest/coverage-v8': 5.0.0
+      '@vitest/ui': 5.0.0
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: ^6.4.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -4206,69 +4190,52 @@ snapshots:
       '@typescript-eslint/types': 8.68.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitest/coverage-v8@4.1.11(vitest@4.1.11)':
+  '@vitest/coverage-v8@5.0.0(vitest@5.0.0)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.11
+      '@vitest/istanbul-lib-coverage': 1.0.1
+      '@vitest/istanbul-lib-report': 1.0.1
       ast-v8-to-istanbul: 1.0.5
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-reports: 3.2.0
       magicast: 0.5.4
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.6.1)(terser@5.50.0)(yaml@2.9.0))
+      vitest: 5.0.0(@types/node@24.13.3)(@vitest/coverage-v8@5.0.0)(@vitest/ui@5.0.0)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.6.1)(terser@5.50.0)(yaml@2.9.0))
 
-  '@vitest/expect@4.1.11':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.11
-      '@vitest/utils': 4.1.11
-      chai: 6.2.2
-      tinyrainbow: 3.1.1
+  '@vitest/istanbul-lib-coverage@1.0.1': {}
 
-  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.6.1)(terser@5.50.0)(yaml@2.9.0))':
+  '@vitest/istanbul-lib-report@1.0.1':
     dependencies:
-      '@vitest/spy': 4.1.11
+      '@vitest/istanbul-lib-coverage': 1.0.1
+
+  '@vitest/mocker@5.0.0(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.6.1)(terser@5.50.0)(yaml@2.9.0))':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@vitest/spy': 5.0.0
       estree-walker: 3.0.3
-      magic-string: 0.30.21
+      magic-string: 1.2.3
     optionalDependencies:
       vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.6.1)(terser@5.50.0)(yaml@2.9.0)
 
-  '@vitest/pretty-format@4.1.11':
+  '@vitest/pretty-format@5.0.0':
     dependencies:
       tinyrainbow: 3.1.1
 
-  '@vitest/runner@4.1.11':
-    dependencies:
-      '@vitest/utils': 4.1.11
-      pathe: 2.0.3
+  '@vitest/spy@5.0.0': {}
 
-  '@vitest/snapshot@4.1.11':
+  '@vitest/ui@5.0.0(vitest@5.0.0)':
     dependencies:
-      '@vitest/pretty-format': 4.1.11
-      '@vitest/utils': 4.1.11
-      magic-string: 0.30.21
-      pathe: 2.0.3
-
-  '@vitest/spy@4.1.11': {}
-
-  '@vitest/ui@4.1.11(vitest@4.1.11)':
-    dependencies:
-      '@vitest/utils': 4.1.11
+      '@vitest/utils': 5.0.0
       fflate: 0.8.3
       flatted: 3.4.4
       pathe: 2.0.3
       sirv: 3.0.2
-      tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.6.1)(terser@5.50.0)(yaml@2.9.0))
+      vitest: 5.0.0(@types/node@24.13.3)(@vitest/coverage-v8@5.0.0)(@vitest/ui@5.0.0)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.6.1)(terser@5.50.0)(yaml@2.9.0))
 
-  '@vitest/utils@4.1.11':
+  '@vitest/utils@5.0.0':
     dependencies:
-      '@vitest/pretty-format': 4.1.11
+      '@vitest/pretty-format': 5.0.0
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
 
@@ -4923,8 +4890,6 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  html-escaper@2.0.2: {}
-
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -5004,19 +4969,6 @@ snapshots:
   isexe@2.0.0: {}
 
   istanbul-badges-readme@1.9.0: {}
-
-  istanbul-lib-coverage@3.2.2: {}
-
-  istanbul-lib-report@3.0.1:
-    dependencies:
-      istanbul-lib-coverage: 3.2.2
-      make-dir: 4.0.0
-      supports-color: 7.2.0
-
-  istanbul-reports@3.2.0:
-    dependencies:
-      html-escaper: 2.0.2
-      istanbul-lib-report: 3.0.1
 
   iterare@1.2.1: {}
 
@@ -5201,15 +5153,15 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magic-string@1.2.3:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   magicast@0.5.4:
     dependencies:
       '@babel/parser': 7.29.8
       '@babel/types': 7.29.8
       source-map-js: 1.2.1
-
-  make-dir@4.0.0:
-    dependencies:
-      semver: 7.8.5
 
   markdown-it@14.3.0:
     dependencies:
@@ -5933,7 +5885,7 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
-  tinybench@2.9.0: {}
+  tinybench@6.1.4: {}
 
   tinyexec@1.3.0: {}
 
@@ -6062,32 +6014,26 @@ snapshots:
       terser: 5.50.0
       yaml: 2.9.0
 
-  vitest@4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.6.1)(terser@5.50.0)(yaml@2.9.0)):
+  vitest@5.0.0(@types/node@24.13.3)(@vitest/coverage-v8@5.0.0)(@vitest/ui@5.0.0)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.6.1)(terser@5.50.0)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.1.11
-      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.6.1)(terser@5.50.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.11
-      '@vitest/runner': 4.1.11
-      '@vitest/snapshot': 4.1.11
-      '@vitest/spy': 4.1.11
-      '@vitest/utils': 4.1.11
+      '@types/chai': 5.2.3
+      '@vitest/mocker': 5.0.0(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.6.1)(terser@5.50.0)(yaml@2.9.0))
+      chai: 6.2.2
       es-module-lexer: 2.3.2
       expect-type: 1.4.0
-      magic-string: 0.30.21
+      magic-string: 1.2.3
       obug: 2.1.4
-      pathe: 2.0.3
       picomatch: 4.0.7
       std-env: 4.2.0
-      tinybench: 2.9.0
+      tinybench: 6.1.4
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
-      tinyrainbow: 3.1.1
       vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.6.1)(terser@5.50.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.3
-      '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
-      '@vitest/ui': 4.1.11(vitest@4.1.11)
+      '@vitest/coverage-v8': 5.0.0(vitest@5.0.0)
+      '@vitest/ui': 5.0.0(vitest@5.0.0)
     transitivePeerDependencies:
       - msw
 

--- a/scripts/verify/coverage-headroom.mjs
+++ b/scripts/verify/coverage-headroom.mjs
@@ -64,15 +64,17 @@ function fail(msg) {
  * failure mode this script exists to make visible — `scripts/verify/README.md`
  * said the branch floor was 83 for the three months after it became 85.
  *
- * The per-file block (`'src/**': { perFile: true, … }`) is skipped: only the
- * first, unkeyed `thresholds` entries are global.
+ * The per-file block (`perFile: { statements: 50, … }`) is skipped: only the
+ * entries before it are global. Everything from the first `perFile` onwards is
+ * dropped, which covers both the vitest 5 object form and the `'src/**': {
+ * perFile: true, … }` glob group it replaced.
  */
 function readThresholds() {
   if (!existsSync(CONFIG)) fail(`missing ${CONFIG}`);
   const src = readFileSync(CONFIG, 'utf8');
   const block = src.slice(src.indexOf('thresholds: {'));
   const perFileAt = block.indexOf('perFile');
-  const globalBlock = perFileAt === -1 ? block : block.slice(0, block.lastIndexOf('{', perFileAt));
+  const globalBlock = perFileAt === -1 ? block : block.slice(0, perFileAt);
 
   const thresholds = {};
   for (const metric of METRICS) {

--- a/src/tests/generators/drawDefinitions/getDrawFormat.test.ts
+++ b/src/tests/generators/drawDefinitions/getDrawFormat.test.ts
@@ -1,0 +1,98 @@
+/**
+ * `getDrawFormat` resolves the TEAM tieFormat precedence chain.
+ *
+ * The chain (highest precedence first) is:
+ *   params.tieFormat > event.tieFormats[tieFormatId] > existing MAIN structure
+ *     > event.tieFormats[tieFormatName] > inline event.tieFormat matching tieFormatName
+ *     > tieFormatDefaults(tieFormatName) > event tieFormat > tieFormatDefaults()
+ *
+ * The two lookups in the middle of that chain — the MAIN-structure `find` and the
+ * `tieFormatId` `find` — were never invoked by any spec, so both callbacks sat
+ * uncovered while the file's happy path (a draw generated with no existing
+ * definition and no tieFormat reference) was well exercised. They are the arms an
+ * operator hits when REGENERATING a draw in an event that already carries formats,
+ * which is exactly where a silent precedence change would do damage.
+ */
+import { getDrawFormat } from '@Generators/drawDefinitions/getDrawFormat';
+import tieFormatDefaults from '@Generators/templates/tieFormatDefaults';
+import { describe, expect, it } from 'vitest';
+
+// constants
+import { MAIN } from '@Constants/drawDefinitionConstants';
+import { TEAM } from '@Constants/eventConstants';
+
+describe('getDrawFormat — TEAM tieFormat resolution', () => {
+  it('uses the existing MAIN structure tieFormat when params carry none', () => {
+    const tieFormat = tieFormatDefaults({});
+    const existingDrawDefinition: any = {
+      structures: [
+        { stage: 'QUALIFYING', structureId: 'q' },
+        { stage: MAIN, structureId: 'm', tieFormat },
+      ],
+    };
+
+    const result: any = getDrawFormat({ matchUpType: TEAM, eventType: TEAM, existingDrawDefinition });
+
+    expect(result.error).toBeUndefined();
+    expect(result.tieFormat).toEqual(tieFormat);
+    // a drawDefinition cannot carry both a tieFormat and a matchUpFormat
+    expect(result.matchUpFormat).toBeUndefined();
+  });
+
+  it('params.tieFormat outranks the existing MAIN structure tieFormat', () => {
+    const existingTieFormat = tieFormatDefaults({});
+    const paramsTieFormat = { ...tieFormatDefaults({}), tieFormatName: 'FROM_PARAMS' };
+    const existingDrawDefinition: any = { structures: [{ stage: MAIN, tieFormat: existingTieFormat }] };
+
+    const result: any = getDrawFormat({
+      tieFormat: paramsTieFormat,
+      existingDrawDefinition,
+      matchUpType: TEAM,
+      eventType: TEAM,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.tieFormat.tieFormatName).toEqual('FROM_PARAMS');
+  });
+
+  it('resolves tieFormatId against event.tieFormats, outranking the MAIN structure', () => {
+    const referenced = { ...tieFormatDefaults({}), tieFormatId: 'tf-referenced', tieFormatName: 'REFERENCED' };
+    const event: any = { tieFormats: [{ ...tieFormatDefaults({}), tieFormatId: 'tf-other' }, referenced] };
+    const existingDrawDefinition: any = { structures: [{ stage: MAIN, tieFormat: tieFormatDefaults({}) }] };
+
+    const result: any = getDrawFormat({
+      tieFormatId: 'tf-referenced',
+      existingDrawDefinition,
+      matchUpType: TEAM,
+      eventType: TEAM,
+      event,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.tieFormat.tieFormatId).toEqual('tf-referenced');
+    expect(result.tieFormat.tieFormatName).toEqual('REFERENCED');
+  });
+
+  it('falls through to the inline event tieFormat when its name matches tieFormatName', () => {
+    const event: any = { tieFormat: { ...tieFormatDefaults({}), tieFormatName: 'INLINE_NAMED' } };
+
+    const result: any = getDrawFormat({
+      tieFormatName: 'INLINE_NAMED',
+      matchUpType: TEAM,
+      eventType: TEAM,
+      event,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.tieFormat.tieFormatName).toEqual('INLINE_NAMED');
+  });
+
+  it('returns the validation error envelope when the resolved tieFormat is invalid', () => {
+    const existingDrawDefinition: any = { structures: [{ stage: MAIN, tieFormat: { collectionDefinitions: [] } }] };
+
+    const result: any = getDrawFormat({ matchUpType: TEAM, eventType: TEAM, existingDrawDefinition });
+
+    expect(result.error).toBeDefined();
+    expect(result.tieFormat).toBeUndefined();
+  });
+});

--- a/src/tests/mutations/engine/devContextLogging.test.ts
+++ b/src/tests/mutations/engine/devContextLogging.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, it, expect, vi } from 'vitest';
+import { afterAll, beforeEach, describe, it, expect, vi } from 'vitest';
 import tournamentEngine from '@Engines/syncEngine';
 import mocksEngine from '@Assemblies/engines/mock';
 
@@ -9,6 +9,13 @@ import { ELO } from '@Constants/ratingConstants';
 
 describe('should mock console.log', () => {
   const consoleMock = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+  // Call counts below are per-test, not cumulative. Vitest 5 clears mock history before
+  // every test (`clearMocks` defaults to true); this makes the expectations independent
+  // of that default, so they hold on both 4.x and 5.x.
+  beforeEach(() => {
+    consoleMock.mockClear();
+  });
 
   afterAll(() => {
     consoleMock.mockReset();
@@ -27,7 +34,7 @@ describe('should mock console.log', () => {
     tournamentEngine.setState(tournamentRecord);
     tournamentEngine.devContext({ errors: true });
     tournamentEngine.getEvent();
-    expect(consoleMock).toHaveBeenCalledTimes(2);
+    expect(consoleMock).toHaveBeenCalledTimes(1);
     expect(consoleMock).toHaveBeenLastCalledWith(
       'sync',
       expect.objectContaining({
@@ -42,19 +49,19 @@ describe('should mock console.log', () => {
     );
     tournamentEngine.devContext({ errors: false });
     tournamentEngine.getEvent();
-    expect(consoleMock).toHaveBeenCalledTimes(2);
+    expect(consoleMock).toHaveBeenCalledTimes(1);
 
     tournamentEngine.devContext({ errors: ['getEvent'] });
     tournamentEngine.getEvent();
-    expect(consoleMock).toHaveBeenCalledTimes(3);
+    expect(consoleMock).toHaveBeenCalledTimes(2);
 
     tournamentEngine.devContext({ result: ['getEvent'] });
     tournamentEngine.getEvent();
-    expect(consoleMock).toHaveBeenCalledTimes(4);
+    expect(consoleMock).toHaveBeenCalledTimes(3);
 
     tournamentEngine.devContext({ result: ['participantScaleItem'] });
     tournamentEngine.getEvent();
-    expect(consoleMock).toHaveBeenCalledTimes(4);
+    expect(consoleMock).toHaveBeenCalledTimes(3);
 
     consoleMock.mockReset();
     expect(consoleMock).toHaveBeenCalledTimes(0);

--- a/src/tests/queries/reports/wrappers/matchResultsSparseRows.test.ts
+++ b/src/tests/queries/reports/wrappers/matchResultsSparseRows.test.ts
@@ -1,0 +1,142 @@
+/**
+ * `wrapMatchResultsReport` row shaping for matchUps that are COMPLETED but sparse.
+ *
+ * The wrapper builds every cell with a fallback — `?? ''`, `?? 0`, `R${roundNumber}`
+ * — and the populated-tournament spec in `wrappers.test.ts` never reaches any of
+ * them, because mocked tournaments hydrate participants, scores and round names for
+ * every matchUp. The fallbacks exist for records that arrive from conversion or from
+ * a draw whose positions were never assigned, so they are the arm that runs on the
+ * least trustworthy data and the arm no spec was exercising.
+ *
+ * Two shapes matter and are covered here:
+ *   - sides carrying a bare `participantId` (no hydrated `participant`)
+ *   - sides carrying a nested `participant` object
+ * The report resolves an id from either, which is what lets a consumer open the
+ * participant behind a name.
+ */
+import { wrapMatchResultsReport } from '@Query/reports/wrappers/wrapMatchResultsReport';
+import { describe, expect, it } from 'vitest';
+
+// constants
+import { MATCH_RESULTS_REPORT } from '@Constants/reportConstants';
+import { COMPLETED } from '@Constants/matchUpStatusConstants';
+import { SINGLES_EVENT } from '@Constants/eventConstants';
+import { MAIN } from '@Constants/drawDefinitionConstants';
+
+const sparseTournament: any = {
+  tournamentId: 'sparse-match-results',
+  events: [
+    {
+      eventId: 'e1',
+      eventName: 'Sparse',
+      eventType: SINGLES_EVENT,
+      drawDefinitions: [
+        {
+          drawId: 'd1',
+          drawName: 'Sparse Draw',
+          structures: [
+            {
+              structureId: 's1',
+              stageSequence: 1,
+              stage: MAIN,
+              matchUps: [
+                {
+                  // ids only — no hydrated participant, no score, no roundName
+                  matchUpId: 'ids-only',
+                  matchUpStatus: COMPLETED,
+                  roundNumber: 1,
+                  roundPosition: 1,
+                  winningSide: 1,
+                  sides: [
+                    { sideNumber: 1, participantId: 'p1' },
+                    { sideNumber: 2, participantId: 'p2' },
+                  ],
+                },
+                {
+                  // nested participants, a score and an explicit roundName
+                  matchUpId: 'nested-participants',
+                  matchUpStatus: COMPLETED,
+                  roundName: 'Named Round',
+                  roundNumber: 1,
+                  roundPosition: 2,
+                  winningSide: 2,
+                  score: { scoreStringSide1: '6-1 6-2' },
+                  sides: [
+                    { sideNumber: 1, participant: { participantId: 'p3', participantName: 'Player Three' } },
+                    { sideNumber: 2, participant: { participantId: 'p4', participantName: 'Player Four' } },
+                  ],
+                },
+                {
+                  // no round ordering at all — exercises the sort fallbacks
+                  matchUpId: 'unordered',
+                  matchUpStatus: COMPLETED,
+                  sides: [{ sideNumber: 1 }, { sideNumber: 2 }],
+                },
+                {
+                  // not completed — must not appear in the report
+                  matchUpId: 'in-progress',
+                  matchUpStatus: 'IN_PROGRESS',
+                  roundNumber: 2,
+                  roundPosition: 1,
+                  sides: [{ sideNumber: 1 }, { sideNumber: 2 }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe('wrapMatchResultsReport — sparse completed matchUps', () => {
+  const result: any = wrapMatchResultsReport({ tournamentRecord: sparseTournament });
+  const rowFor = (matchUpId: string) => result.rows.find((row: any) => row.matchUpId === matchUpId);
+
+  it('reports only completed matchUps', () => {
+    expect(result.error).toBeUndefined();
+    expect(result.reportId).toEqual(MATCH_RESULTS_REPORT);
+    expect(result.rows.map((row: any) => row.matchUpId).sort()).toEqual([
+      'ids-only',
+      'nested-participants',
+      'unordered',
+    ]);
+  });
+
+  it('orders unordered matchUps first rather than throwing on missing round numbers', () => {
+    expect(result.rows[0].matchUpId).toEqual('unordered');
+  });
+
+  it('resolves side ids from a bare participantId and falls back to empty strings', () => {
+    const row = rowFor('ids-only');
+    expect(row.side1ParticipantId).toEqual('p1');
+    expect(row.side2ParticipantId).toEqual('p2');
+    expect(row.winningParticipantId).toEqual('p1');
+    // no hydrated participant, so no displayable names
+    expect(row.side1).toEqual('');
+    expect(row.side2).toEqual('');
+    expect(row.winnerName).toEqual('');
+    expect(row.score).toEqual('');
+  });
+
+  it('resolves side ids and names from a nested participant', () => {
+    const row = rowFor('nested-participants');
+    expect(row.side1ParticipantId).toEqual('p3');
+    expect(row.side2ParticipantId).toEqual('p4');
+    expect(row.winningParticipantId).toEqual('p4');
+    expect(row.side1).toEqual('Player Three');
+    expect(row.side2).toEqual('Player Four');
+    expect(row.winnerName).toEqual('Player Four');
+    expect(row.score).toEqual('6-1 6-2');
+    expect(row.roundName).toEqual('Named Round');
+  });
+
+  it('synthesizes a roundName from roundNumber when none is present', () => {
+    expect(rowFor('unordered').roundName).toEqual('R');
+    expect(rowFor('ids-only').roundName).toBeTruthy();
+  });
+
+  it('leaves winningParticipantId empty when there is no winningSide', () => {
+    expect(rowFor('unordered').winningParticipantId).toEqual('');
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -15,6 +15,10 @@ export default defineConfig({
     testTimeout: 30000, // 30 seconds for slow tests
     onConsoleLog: () => {},
     environment: 'node',
+    // Persist transformed modules under node_modules/.vitest-cache so a rerun skips
+    // the transform pass. Transform was ~30% of tracked time on a cold local run.
+    // The cache lives inside node_modules, so a reinstall invalidates it.
+    fsModuleCache: true,
     include: ['src/**/*.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     // Untracked scratch tests are excluded from coverage but were still running
     // and exercising production code — inflating local % above CI's. Excluding
@@ -71,13 +75,21 @@ export default defineConfig({
       //    50% floor and the 70% target. Lifting them is incremental work —
       //    see scripts/verify/ if you want to gate a tighter floor for new
       //    files only.
+      //
+      //    The floor was expressed as a `'src/**/*.{...}'` glob group carrying
+      //    `perFile: true` until the 2026-09-06 vitest 5 upgrade. It never ran:
+      //    vitest 4 read `perFile` only off the TOP-LEVEL thresholds object
+      //    (`this.options.thresholds?.perFile`), so a `perFile` nested inside a
+      //    glob group was ignored and the group was scored as an aggregate —
+      //    which the 95% global already passed. Vitest 5 resolves `perFile` per
+      //    group and supports the object form below, which states the two tiers
+      //    without a glob and cannot be silently downgraded to an aggregate.
       thresholds: {
         statements: 95,
         functions: 95,
         branches: 85,
         lines: 95,
-        'src/**/*.{ts,mts,cts,js,mjs,cjs}': {
-          perFile: true,
+        perFile: {
           statements: 50,
           functions: 50,
           branches: 50,


### PR DESCRIPTION
Upgrades vitest 4.1.11 → 5.0.0 and lands the two things the upgrade surfaces. Built on top of the Renovate branch's bump commit, so merging this closes `renovate/major-vitest-monorepo`.

## 1. `clearMocks` now defaults to `true`

vitest 5 calls `vi.clearAllMocks()` before every test, so a spy's call history no longer carries between `it` blocks. `devContextLogging.test.ts` counted cumulatively — the `2` it expected after one `getEvent()` included the `sample output` call logged by the previous test.

Fixed by clearing the spy in `beforeEach` and making the counts per-test, so the spec holds on 4.x and 5.x alike rather than encoding whichever default is active. Setting `clearMocks: false` would have made the file pass while keeping exactly the order-dependence the new default exists to remove; it is also the only spec in 1,130 files that had it.

## 2. The per-file coverage floor has been inert, and vitest 5 makes it real

The floor was expressed as a `'src/**/*.{ts,...}'` threshold group carrying `perFile: true`. vitest 4 read `perFile` only off the **top-level** thresholds object (`this.options.thresholds?.perFile`), so a `perFile` nested inside a group was ignored and the group was scored as an aggregate — which the 95% global threshold already passed. Every individual-file regression the config comment promised to catch would have gone through.

vitest 5 resolves `perFile` per group and accepts it as an object of thresholds, so the two tiers are now stated without a glob and cannot be silently downgraded again. Verified live rather than assumed: a single-spec run reports 4,342 per-file threshold errors under the new form where the old form reported none.

With the floor enforced, two files fail it. Both have been under 50% for as long as the floor has existed; neither is newly regressed, and both are covered rather than waived:

| file | before | after |
|---|---|---|
| `src/assemblies/generators/drawDefinitions/getDrawFormat.ts` | functions 33.33% | 100% on all four metrics |
| `src/query/reports/wrappers/wrapMatchResultsReport.ts` | branches 45.94% | branches 86.48% |

`getDrawFormat` — the two lookups in the middle of the TEAM tieFormat precedence chain (the MAIN-structure `find` and the `tieFormatId` `find`) were never invoked by any spec. They are the arms an operator hits when regenerating a draw in an event that already carries formats, which is where a silent precedence change would do damage. The new spec asserts the precedence order rather than just executing it.

`wrapMatchResultsReport` — every cell is built with a `??` fallback and the populated-tournament spec reaches none of them, because mocked tournaments hydrate participants, scores and round names for every matchUp. The new spec drives a record whose completed matchUps carry bare participantIds, no score and no roundName: the shape that arrives from conversion or from a draw whose positions were never assigned. What remains uncovered is unreachable — `!matchUps`, and the `matchUpStatus ?? ''` fallback that sits behind a filter on `matchUpStatus`.

## Also in this PR

- `fsModuleCache: true` — persists transformed modules under `node_modules/.vitest-cache`. Transform was ~30% of tracked time on a cold run; a reinstall invalidates the cache.
- `coverage-headroom.mjs` read the global floors by cutting the thresholds block at the last `{` before `perFile`, which the object form leaves empty. It now cuts at `perFile` itself, which parses both forms.
- `.gitignore` — vitest 5 writes artifacts to `.vitest/`, not `html/`.

## Verification

Full `pnpm verify` locally on node 22.20:

| gate | result |
|---|---|
| `verify:generated` / `verify:types` / `verify:lint` / `verify:format` / `verify:attr-audit` | pass |
| `verify:coverage` | pass — 1,130 files, 11,722 tests, exit 0 |
| `verify:coverage-headroom` | pass — tightest is statements at 159 items |
| `verify:server` | pass — 9 files, 12 tests |

Coverage totals are effectively unmoved by the runner change (95.34% → 95.35% statements; vitest 5's include/exclude path matching shifts the statement total by 7). The headroom baseline is deliberately **not** updated — the gain is local and local coverage runs read above CI.

`vitest run --coverage` measured ~9% faster than 4.1.11 on the same machine (199.8s → 181.5s).

## Not adopted

vitest's runner hint suggests `isolate: false` (it estimated ~282s off the CI run). Measured rather than assumed: `vitest run --no-isolate` finishes in 48s instead of 130s and **fails 55 tests across 29 files** — the suite shares the `syncEngine` singleton, so evaluating modules once per worker lets one file's `setState` survive into the next file in that worker. The hint is arithmetic on import counts; it cannot see shared state. Not adopted.
