### PR TITLE
fix(scales): rank drawSize and drawSizes identically for profile specificity

### DIFF
--- a/documentation/docs/policies/rankingPolicy.md
+++ b/documentation/docs/policies/rankingPolicy.md
@@ -254,12 +254,15 @@ awardProfiles: [
 }
 ```
 
-> **`drawSize` vs `drawSizes`.** Both are honoured, and `drawSizes: [32]` says the same
-> thing as `drawSize: 32`. Prefer the plural: only `drawSizes` participates in
-> [specificity scoring](/docs/scale-engine/ranking-points-pipeline#profile-selection).
-> A profile narrowed by the singular `drawSize` scores zero for it, so it ties with a
-> catch-all profile and the tie is broken by declaration order — which is rarely what
-> a policy author intends.
+> **`drawSize` vs `drawSizes`.** Both are honoured, they say the same thing, and they
+> now rank the same: each contributes one point of
+> [specificity](/docs/scale-engine/ranking-points-pipeline#profile-selection), so which
+> spelling a policy author reaches for no longer decides which profile is selected.
+> `drawSizes` remains the preferred form because it also expresses a set (`[32, 64]`).
+>
+> This is a change: the singular previously scored zero, so a profile narrowed by
+> `drawSize` tied with a catch-all and the tie fell to declaration order. A policy that
+> relied on losing that tie now selects the narrower profile instead.
 
 ## Position Value Resolution
 

--- a/documentation/docs/scale-engine/ranking-points-pipeline.md
+++ b/documentation/docs/scale-engine/ranking-points-pipeline.md
@@ -39,21 +39,22 @@ Profiles are scored by counting their populated scope fields. A profile that spe
 
 **Scored fields** (1 point each):
 
-| Field                | Matches Against                             |
-| -------------------- | ------------------------------------------- |
-| `eventTypes`         | `event.eventType`                           |
-| `drawTypes`          | `drawDefinition.drawType`                   |
-| `drawSizes`          | `drawDefinition.drawSize`                   |
-| `maxDrawSize`        | `drawDefinition.drawSize <= maxDrawSize`    |
-| `stages`             | `structureParticipation.rankingStage`       |
-| `stageSequences`     | `structureParticipation.stageSequence`      |
-| `levels`             | `level` parameter                           |
-| `maxLevel`           | `level <= maxLevel`                         |
-| `flights`            | `structureParticipation.flightNumber`       |
-| `maxFlightNumber`    | `flightNumber <= maxFlightNumber`           |
-| `participationOrder` | `structureParticipation.participationOrder` |
-| `dateRanges`         | `startDate`/`endDate` within range          |
-| `category.*`         | Each populated CategoryScope field          |
+| Field                | Matches Against                                  |
+| -------------------- | ------------------------------------------------ |
+| `eventTypes`         | `event.eventType`                                |
+| `drawTypes`          | `drawDefinition.drawType`                        |
+| `drawSizes`          | `drawDefinition.drawSize`                        |
+| `drawSize`           | `drawDefinition.drawSize` (exact)                |
+| `maxDrawSize`        | `drawDefinition.drawSize <= maxDrawSize`         |
+| `stages`             | `structureParticipation.rankingStage`            |
+| `stageSequences`     | scored, but **not** currently matched — see note |
+| `levels`             | `level` parameter                                |
+| `maxLevel`           | `level <= maxLevel`                              |
+| `flights`            | `structureParticipation.flightNumber`            |
+| `maxFlightNumber`    | `flightNumber <= maxFlightNumber`                |
+| `participationOrder` | `structureParticipation.participationOrder`      |
+| `dateRanges`         | `startDate`/`endDate` within range               |
+| `category.*`         | Each populated CategoryScope field               |
 
 **Priority override:** If any matching profile has an explicit `priority` number, the highest priority wins regardless of specificity score.
 
@@ -61,7 +62,16 @@ Profiles are scored by counting their populated scope fields. A profile that spe
 
 :::note
 
-`matchesProfile` reads a singular `profile.drawSize` as well as `drawSizes`. Nothing in the factory's own fixtures sets it, but ranking policies are runtime data loaded from a policy service, so an external policy can set it and have it honoured — it is declared on `AwardProfileScope` for that reason. See [`drawSize` vs `drawSizes`](/docs/policies/rankingPolicy#full-profile) for why the plural is preferred.
+`matchesProfile` reads a singular `profile.drawSize` as well as `drawSizes`. Nothing in the factory's own fixtures sets it, but ranking policies are runtime data loaded from a policy service, so an external policy can set it and have it honoured — it is declared on `AwardProfileScope` for that reason. Both spellings score one point of specificity; see [`drawSize` vs `drawSizes`](/docs/policies/rankingPolicy#full-profile).
+
+:::
+
+:::caution
+
+`stageSequences` is the mirror case, and it is **not** resolved. It is scored — a profile declaring it
+gains a point and wins ties — but `matchesProfile` never reads it, so it narrows nothing: such a profile
+applies to every stage sequence while outranking a catch-all. `stages` is matched; `stageSequences` is
+not. Prefer `stages` until this is settled, and do not rely on `stageSequences` to restrict a profile.
 
 :::
 

--- a/src/constants/rankingConstants.ts
+++ b/src/constants/rankingConstants.ts
@@ -34,6 +34,7 @@ export const PROFILE_SCOPE_FIELDS = [
   'eventTypes',
   'drawTypes',
   'drawSizes',
+  'drawSize',
   'maxDrawSize',
   'stages',
   'stageSequences',

--- a/src/tests/queries/scales/awardProfileSelection.test.ts
+++ b/src/tests/queries/scales/awardProfileSelection.test.ts
@@ -339,8 +339,10 @@ describe('profileName in output', () => {
 
 // `AwardProfileScope.drawSize` (singular, exact match) was read by matchesProfile
 // but undeclared on the type, so a policy could set it and have it honoured while
-// the type said it did not exist. Now declared — these pin the behaviour that
-// justified declaring it rather than deleting the clause.
+// the type said it did not exist. Declaring it then exposed a second gap: it was
+// matched but absent from PROFILE_SCOPE_FIELDS, so it narrowed a profile without
+// making it more specific and the two spellings of one constraint ranked
+// differently. Both are closed now — these pin matching AND scoring.
 describe('AwardProfileScope drawSize', () => {
   const exact = { profileName: 'Exactly 32', drawSize: 32, finishingPositionRanges: { 1: 999 } };
   const catchAll = { profileName: 'Any', finishingPositionRanges: { 1: 10 } };
@@ -360,19 +362,43 @@ describe('AwardProfileScope drawSize', () => {
     expect(awardProfile.profileName).toEqual('Any');
   });
 
-  it('does NOT contribute to specificity, so a catch-all declared first beats it', () => {
-    // Both match a 32 draw. `drawSize` is absent from PROFILE_SCOPE_FIELDS, so the
-    // narrower profile scores 0 exactly like the catch-all, and the array-order
-    // tie-break awards it to whichever came first. Pinned deliberately: this is
-    // current behaviour, and it is a wart — `drawSizes: [32]` DOES score, so the
-    // two spellings of the same constraint rank differently.
+  it('contributes to specificity, so it beats a catch-all declared first', () => {
+    // Both match a 32 draw, and neither declares a priority, so selection falls to
+    // specificity scoring. `drawSize` is in PROFILE_SCOPE_FIELDS, so the narrower
+    // profile scores 1 against the catch-all's 0 and wins regardless of where it
+    // sits in the array. Declaration order only breaks a genuine tie.
     const { awardProfile }: any = getAwardProfile({ awardProfiles: [catchAll, exact], drawSize: 32 });
-    expect(awardProfile.profileName).toEqual('Any');
+    expect(awardProfile.profileName).toEqual('Exactly 32');
   });
 
-  it('drawSizes, by contrast, does score and wins against a catch-all declared first', () => {
+  it('drawSizes scores identically and also wins against a catch-all declared first', () => {
     const viaList = { profileName: 'viaList', drawSizes: [32], finishingPositionRanges: { 1: 2 } };
     const { awardProfile }: any = getAwardProfile({ awardProfiles: [catchAll, viaList], drawSize: 32 });
     expect(awardProfile.profileName).toEqual('viaList');
+  });
+
+  it('ranks the singular and the plural spelling identically', () => {
+    // The point of the change: `drawSize: 32` and `drawSizes: [32]` express the same
+    // constraint, so which one a policy author reached for must not decide selection.
+    // Each is put up against the same catch-all in the same array position.
+    const viaSingular = { profileName: 'narrower', drawSize: 32, finishingPositionRanges: { 1: 999 } };
+    const viaPlural = { profileName: 'narrower', drawSizes: [32], finishingPositionRanges: { 1: 999 } };
+
+    const singular: any = getAwardProfile({ awardProfiles: [catchAll, viaSingular], drawSize: 32 });
+    const plural: any = getAwardProfile({ awardProfiles: [catchAll, viaPlural], drawSize: 32 });
+
+    expect(singular.awardProfile.profileName).toEqual(plural.awardProfile.profileName);
+    expect(singular.awardProfile.profileName).toEqual('narrower');
+  });
+
+  it('still loses to a higher explicit priority, which outranks specificity', () => {
+    // Specificity is the fallback, not an override: an explicit priority anywhere in
+    // the matching set decides selection before scoring is consulted at all.
+    const prioritisedCatchAll = { profileName: 'Any', priority: 10, finishingPositionRanges: { 1: 10 } };
+    const { awardProfile }: any = getAwardProfile({
+      awardProfiles: [prioritisedCatchAll, exact],
+      drawSize: 32,
+    });
+    expect(awardProfile.profileName).toEqual('Any');
   });
 });

--- a/src/types/rankingTypes.ts
+++ b/src/types/rankingTypes.ts
@@ -135,9 +135,9 @@ export interface AwardProfileScope {
    * and `maxDrawSize`, and declared here because it was already being read —
    * a policy could set it and have it matched while the type denied it existed.
    *
-   * `drawSizes: [64]` expresses the same thing and is the preferred form. Note
-   * that this field is NOT in `PROFILE_SCOPE_FIELDS`, so unlike `drawSizes` it
-   * contributes nothing to specificity scoring when two profiles tie.
+   * `drawSizes: [64]` expresses the same thing and is the preferred form, but the
+   * two spellings now rank identically: `drawSize` is in `PROFILE_SCOPE_FIELDS`,
+   * so a profile narrowed by either form scores the same point of specificity.
    */
   drawSize?: number;
 


### PR DESCRIPTION
Closes punch-list item **D2** (`Mentat/planning/DESIGN_FLAWS_PUNCH_LIST.md`). CA decided option 1 on 2026-09-08.

## The defect

`getAwardProfile` honours **both** `drawSizes: [32]` and the singular `drawSize: 32` — they express the same constraint. But only `drawSizes` was in `PROFILE_SCOPE_FIELDS`, which is what `getSpecificityScore` iterates. So a profile narrowed by the singular scored **0** for it, tied with a catch-all that declares no scope at all, and the tie fell to **declaration order in the policy array**:

```
[catchAll, {drawSize: 32}]    -> selected the CATCH-ALL
[catchAll, {drawSizes: [32]}] -> selected the narrower profile
```

Same intent, opposite outcome, decided by which spelling the policy author reached for. A scope field that narrows a profile but does not make it more specific is a rule nobody would write on purpose.

**How it surfaced:** `drawSize` was read by `matchesProfile` but *undeclared* on `AwardProfileScope` until #4761 — honoured-but-invisible, the same declared-vs-real class as the `RankingListEntry` split in #4756. Declaring it exposed the scoring asymmetry underneath.

## The change

One line: `drawSize` joins `PROFILE_SCOPE_FIELDS`.

`getSpecificityScore` needed **no** change — its profile loop already counts non-array values (`maxDrawSize`, `maxLevel` and `participationOrder` are all numbers and all already score), so a numeric `drawSize` scores correctly the moment it is listed. The category loop needed nothing either: it counts only non-empty arrays, and `CategoryScope` has no draw-size field to mirror. (The two loops *are* asymmetric — the profile loop counts any non-null value, the category loop only non-empty arrays — but nothing here is implicated by that.)

## This is a deliberate behaviour change

It moves profile **selection**, and ranking policies are runtime data loaded from the policy service, which is why it was raised as a decision rather than simply fixed.

- **In-repo blast radius is nil.** Every `drawSize:` in `src/fixtures/` sits inside a seeding policy or a `PositionValue`/threshold array, never an award-profile scope. Nothing in this repo sets the singular.
- **External radius is the accepted cost.** A federation policy that sets the singular *and* relies on losing a tie to an earlier catch-all will now select the narrower profile instead.

## Test change is deliberate and approved

`src/tests/queries/scales/awardProfileSelection.test.ts` carried a test named **`does NOT contribute to specificity, so a catch-all declared first beats it`**, which pinned the old behaviour *on purpose* and named itself for the wart. Per Test Integrity it is **inverted, not deleted or weakened** — the profile declaring the constraint now wins — and joined by two more:

- `ranks the singular and the plural spelling identically` — the actual point of the change, asserting the two spellings produce the same selection against the same catch-all in the same array position.
- `still loses to a higher explicit priority, which outranks specificity` — pins that specificity remains the fallback, not an override.

Both new assertions were confirmed to **fail against the unmodified constant** (`expected 'Any' to deeply equal 'Exactly 32'` / `'narrower'`) before the fix landed.

## Adjacent: a documentation defect, corrected without changing behaviour

Found while working D2. `stageSequences` is the mirror case: it is declared on `AwardProfileScope` **and** in `PROFILE_SCOPE_FIELDS`, so it scores and wins tie-breaks — but `matchesProfile` never reads it, so it narrows nothing. A profile scoped `stageSequences: [2]` outranks a catch-all while applying to every stage sequence.

The pipeline doc made it worse than a code gap: its scored-fields table asserted `stageSequences` matches `structureParticipation.stageSequence` — **documentation describing matching the code does not perform**. That line now states today's truth without prejudging the fix, and a caution tells policy authors to prefer `stages` meanwhile.

**The behaviour is untouched here.** Both fix directions (match it, or unscore it) move selection on the same policy data we do not hold, so CA chose to record it rather than spend that budget twice in one PR. It is registered as **D3** in the punch list with its options.

## Gate

`pnpm verify` — all 16 steps green.

- **11,730 tests** passed (1 skipped), 1131 files
- Coverage clear of all four floors: statements 95.35% (floor 95), branches 87.28% (85), functions 98.11% (95), lines 97.78% (95)
- `verify:surface` — 1533 exports, none removed
- `verify:attr-audit`, `verify:publint`, `verify:runtime`, `verify:shakeable`, `verify:bundle-size`, `verify:pack` all OK

The `pnpm-lock.yaml` churn that `pnpm verify` re-introduces (`@pnpm/exe` under pnpm 12) is deliberately **not** in this PR.
