### PR TITLE
ci: guard the lockfile, and drop the @pnpm/exe block from documentation/

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -57,6 +57,32 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # A pnpm that does not match this repo's `packageManager` pin writes an `@pnpm/exe` block
+      # into the lockfile; a pnpm that DOES match strips it out again. Committed, it makes every
+      # correctly-provisioned checkout permanently dirty and drowns real work in `git status`. It was
+      # cleaned out of six repos on 2026-09-08 and reappeared in two working trees the same
+      # afternoon, so the committed state needs a guard rather than vigilance.
+      #
+      # The pattern excludes `@pnpm/exe.<platform>` — those are legitimate optional deps of `pnpm`
+      # itself and every clean lockfile holds 24 of them, so the obvious grep fails every repo.
+      - name: Lockfiles must not carry an @pnpm/exe block
+        run: |
+          locks=$(git ls-files '*pnpm-lock.yaml')
+          if [ -z "$locks" ]; then
+            echo "::error::no tracked pnpm-lock.yaml found — this check would pass vacuously"
+            exit 1
+          fi
+          bad=0
+          while IFS= read -r f; do
+            if grep -qE "@pnpm/exe[^.]" "$f"; then
+              echo "::error file=$f::$f carries an @pnpm/exe block, written only by a pnpm that does not match this repo's packageManager pin. Reinstall with the pinned pnpm and commit the lockfile."
+              bad=1
+            fi
+          done <<LOCKS
+          $locks
+          LOCKS
+          exit $bad
+
       - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}

--- a/documentation/pnpm-lock.yaml
+++ b/documentation/pnpm-lock.yaml
@@ -6,9 +6,6 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 12.3.4
-        version: 12.3.4
       pnpm:
         specifier: 12.3.4
         version: 12.3.4
@@ -59,11 +56,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@pnpm/exe@12.3.4':
-    resolution: {integrity: sha512-Rq7JokWAyYF9IFfn8zofB/q2AgnZlmoMuH5fMHB2+Ta61I9aD7sNm+woZpx6iH+5vb38chdSoYRvOtSqlH72YQ==}
-    engines: {node: '>=18.*'}
-    hasBin: true
-
   pnpm@12.3.4:
     resolution: {integrity: sha512-lhqkH7B32joEpEHZ+OFevAyW2o73ELLrZ7+e58sGEOq9SPH9hfUc/+c4RnhfoPh8VqOocqHYk/hEZ0G1zORUVw==}
     engines: {node: '>=18.*'}
@@ -94,17 +86,6 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.3.4':
     optional: true
-
-  '@pnpm/exe@12.3.4':
-    optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.3.4
-      '@pnpm/exe.darwin-x64': 12.3.4
-      '@pnpm/exe.linux-arm64': 12.3.4
-      '@pnpm/exe.linux-arm64-musl': 12.3.4
-      '@pnpm/exe.linux-x64': 12.3.4
-      '@pnpm/exe.linux-x64-musl': 12.3.4
-      '@pnpm/exe.win32-arm64': 12.3.4
-      '@pnpm/exe.win32-x64': 12.3.4
 
   pnpm@12.3.4:
     optionalDependencies:


### PR DESCRIPTION
## What

Adds the lockfile guard to `verify.yml`, and removes an `@pnpm/exe` block from **`documentation/pnpm-lock.yaml`**.

## The guard found this repo's own violation on its first run

Which is the argument for having it.

The 2026-09-08 sweep cleaned that block out of six repos and verified "0 on every default branch" — but it only ever looked at **root** lockfiles. `documentation/pnpm-lock.yaml` carried it the whole time and survived a cleanup that believed itself complete. The guard walks `git ls-files '*pnpm-lock.yaml'`, so nested lockfiles are in scope, and it failed here immediately.

The lockfile change is a pure deletion (`+0 −17`), no resolution change — it is simply what `pnpm install` with the pinned 12.3.4 produces.

## Why guard it at all

The block is written only by a pnpm that does **not** match the `packageManager` pin; a pnpm that does match strips it again. Committed, it leaves every correctly-provisioned checkout permanently dirty and buries real work in `git status`. It reappeared in two working trees on 2026-09-08 after being cleaned, one of them from nothing more than `pnpm test:run`.

Two details, both found by testing the guard rather than reasoning about it:

- **The obvious pattern fails every repo.** `grep '@pnpm/exe'` also matches `@pnpm/exe.darwin-arm64` and friends — legitimate optional deps of `pnpm` itself. A *clean* lockfile scores **24**. This matches `@pnpm/exe[^.]`: clean **0**, dirty **3**.
- **It fails when it finds no lockfile at all**, rather than passing vacuously.

Part of an ecosystem-wide rollout; piloted in `#150(pdf-factory)`.
