### PR TITLE
fix: treat a pending propagated exit as inactive on non-feed rounds

### DIFF
--- a/src/query/drawDefinition/isActiveDownstream.ts
+++ b/src/query/drawDefinition/isActiveDownstream.ts
@@ -57,6 +57,12 @@ export function isActiveDownstream(params) {
   // through into the empty winner slot and advanced — is genuinely active and must
   // block. Only a PENDING/produced exit (empty winner slot) is excluded below. This
   // mirrors the winnerAssigned check in isActiveMatchUp.
+  // NOTE: a normally scored exit always has a participant on its winning side
+  // (checkParticipants requires two participants unless propagateExitStatus), so an
+  // exit with an unoccupied winning side can only be a pending propagated exit. The
+  // cascade can deposit one on a natural (non-feed) round -- e.g. a COMPASS back draw,
+  // where the exit advances through BYEs into a round that halves -- so this must not
+  // be conditioned on feedRound.
   const winnerSideResolved = !!winnerMatchUp?.sides?.find((s: any) => s?.sideNumber === winnerMatchUp.winningSide)
     ?.participant;
 
@@ -67,7 +73,7 @@ export function isActiveDownstream(params) {
     ((loserMatchUp?.winningSide && !loserMatchUpExit) ||
       (winnerMatchUp?.winningSide &&
         winnerDrawPositionsCount === 2 &&
-        (!winnerMatchUp.feedRound || !isExit(winnerMatchUp?.matchUpStatus) || winnerSideResolved)))
+        (!isExit(winnerMatchUp?.matchUpStatus) || winnerSideResolved)))
   ) {
     return true;
   }

--- a/src/tests/mutations/drawDefinitions/setMatchUpStatus/propagateExitStatus.test.ts
+++ b/src/tests/mutations/drawDefinitions/setMatchUpStatus/propagateExitStatus.test.ts
@@ -1082,3 +1082,101 @@ test('FMLC real-match fall-through: winningSide and exit code follow the partici
   expect(exit.matchUpStatusCodes?.[loserSide.sideNumber - 1]).toEqual('W1');
   expect(exit.matchUpStatusCodes?.[winnerSide.sideNumber - 1] || '').toEqual('');
 });
+// COMPASS back draws are fed only at round 1 and halve thereafter, so no round is a
+// feedRound. A propagated exit that advances through back-draw BYEs therefore comes to
+// rest as a PENDING exit (empty winning slot) on a natural round.
+test('COMPASS: a pending exit on a non-feed back-draw round does not block scoring the matchUp that feeds it', () => {
+  const drawId = 'drawId';
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ drawId, drawSize: 16, participantsCount: 10, drawType: COMPASS, idPrefix: 'm' }],
+    setState: true,
+  });
+
+  const drawMatchUps = () => tournamentEngine.allDrawMatchUps({ drawId, inContext: true }).matchUps;
+
+  // 16 drawPositions / 10 participants leaves exactly two contested East round 1 matchUps
+  const contested = drawMatchUps().filter(
+    (m) => m.structureName === 'East' && m.roundNumber === 1 && m.sides.filter((s) => s.participant).length === 2,
+  );
+  expect(contested.length).toEqual(2);
+  const [exitMatchUp, feederMatchUp] = contested;
+  const retiredParticipantId = exitMatchUp.sides.find((s) => s.sideNumber === 2).participantId;
+
+  let result = tournamentEngine.setMatchUpStatus({
+    outcome: { matchUpStatus: RETIRED, winningSide: 1, matchUpStatusCodes: ['RJ'] },
+    matchUpId: exitMatchUp.matchUpId,
+    propagateExitStatus: true,
+    drawId,
+  });
+  expect(result.success).toEqual(true);
+
+  // the retiring participant advanced through two West BYEs, depositing a pending exit
+  const pendingExit = drawMatchUps().find(
+    (m) =>
+      m.matchUpStatus === WALKOVER &&
+      m.winningSide &&
+      !m.sides.find((s) => s.sideNumber === m.winningSide)?.participant,
+  );
+  expect(pendingExit).toBeDefined();
+  expect(pendingExit.structureName).toEqual('West');
+  expect(pendingExit.feedRound).toBeFalsy();
+  expect(pendingExit.sides.find((s) => s.sideNumber !== pendingExit.winningSide).participantId).toEqual(
+    retiredParticipantId,
+  );
+
+  // the loser of the second contested matchUp is the participant who will fall through
+  // into that empty winning slot; scoring it must be allowed
+  const fallThroughParticipantId = feederMatchUp.sides.find((s) => s.sideNumber === 2).participantId;
+  const { outcome } = mocksEngine.generateOutcomeFromScoreString({ scoreString: '6-3 6-3', winningSide: 1 });
+  result = tournamentEngine.setMatchUpStatus({ matchUpId: feederMatchUp.matchUpId, outcome, drawId });
+  expect(result.success).toEqual(true);
+
+  // and the pending exit auto-resolves onto the participant who fell through
+  const resolved = drawMatchUps().find((m) => m.matchUpId === pendingExit.matchUpId);
+  expect(resolved.matchUpStatus).toEqual(WALKOVER);
+  expect(resolved.sides.find((s) => s.sideNumber === resolved.winningSide).participantId).toEqual(
+    fallThroughParticipantId,
+  );
+  expect(resolved.sides.find((s) => s.sideNumber !== resolved.winningSide).participantId).toEqual(retiredParticipantId);
+});
+
+test('COMPASS: once the back-draw exit has RESOLVED, resetting the fall-through source is still blocked', () => {
+  const drawId = 'drawId';
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ drawId, drawSize: 16, participantsCount: 10, drawType: COMPASS, idPrefix: 'm' }],
+    setState: true,
+  });
+
+  const drawMatchUps = () => tournamentEngine.allDrawMatchUps({ drawId, inContext: true }).matchUps;
+  const contested = drawMatchUps().filter(
+    (m) => m.structureName === 'East' && m.roundNumber === 1 && m.sides.filter((s) => s.participant).length === 2,
+  );
+  const [exitMatchUp, feederMatchUp] = contested;
+
+  let result = tournamentEngine.setMatchUpStatus({
+    outcome: { matchUpStatus: RETIRED, winningSide: 1, matchUpStatusCodes: ['RJ'] },
+    matchUpId: exitMatchUp.matchUpId,
+    propagateExitStatus: true,
+    drawId,
+  });
+  expect(result.success).toEqual(true);
+
+  const { outcome } = mocksEngine.generateOutcomeFromScoreString({ scoreString: '6-3 6-3', winningSide: 1 });
+  result = tournamentEngine.setMatchUpStatus({ matchUpId: feederMatchUp.matchUpId, outcome, drawId });
+  expect(result.success).toEqual(true);
+
+  // the exit is now resolved downstream, so the source may no longer be cleared or flipped
+  result = tournamentEngine.setMatchUpStatus({
+    outcome: { score: { scoreStringSide1: '', scoreStringSide2: '' }, matchUpStatus: TO_BE_PLAYED },
+    matchUpId: feederMatchUp.matchUpId,
+    drawId,
+  });
+  expect(result.success).not.toEqual(true);
+
+  result = tournamentEngine.setMatchUpStatus({
+    matchUpId: feederMatchUp.matchUpId,
+    outcome: { winningSide: 2 },
+    drawId,
+  });
+  expect(result.success).not.toEqual(true);
+});


### PR DESCRIPTION
## Problem

`isActiveDownstream` gates its pending-exit exemption behind `winnerMatchUp.feedRound`:

```ts
(!winnerMatchUp.feedRound || !isExit(winnerMatchUp?.matchUpStatus) || winnerSideResolved)
```

`feedRound` is only set on a round whose matchUp count equals the previous round's
(`getRoundMatchUps`). COMPASS/OLYMPIC back draws are fed only at round 1 and halve
thereafter, so **no round in them is ever a `feedRound`**.

When a propagated exit advances through back-draw BYEs it comes to rest on one of those
natural rounds as a *pending* exit — a matchUp marked WALKOVER whose `winningSide` points
at a still-empty feed slot awaiting whoever falls through. There, `!feedRound` is `true`
and short-circuits the `||` chain before `winnerSideResolved` is ever consulted, so the
pending exit is reported as active downstream.

The consequence is that scoring the matchUp whose loser feeds that empty slot is refused
with `CANNOT_CHANGE_WINNING_SIDE` — `setMatchUpState` routes to
`winningSideWithDownstreamDependencies`, which only permits re-asserting an existing
`winningSide`. The result becomes unrecordable.

## Fix

Drop the `feedRound` conjunct. A normally scored exit always has a participant on its
winning side (`checkParticipants` requires two participants unless `propagateExitStatus`),
so an exit whose winning side is unoccupied can only be a pending propagated exit —
`feedRound` is unnecessary to tell the two apart, and it also aligns this with
`isActiveMatchUp`, whose equivalent `winnerAssigned` check has no such condition.

## Scope — not COMPASS-specific

Measured with a sweep that plants an exit and then attempts to score every other fresh,
fully-populated matchUp, comparing the pre-fix and post-fix implementations. 18 configs /
400 exit scenarios / 2623 scoring attempts per draw type:

| draw type | pre-fix spurious blocks | post-fix |
|---|---|---|
| COMPASS | 183 | 0 |
| OLYMPIC | 183 | 0 |
| FIRST_ROUND_LOSER_CONSOLATION | 63 | 0 |
| CURTIS_CONSOLATION | 12 | 0 |
| FEED_IN_CHAMPIONSHIP | 3 | 0 |
| FIRST_MATCH_LOSER_CONSOLATION | 0 | 0 |

FMLC scoring zero pre-fix is the tell: that is the draw type this mechanism was built and
tested against, which is why the gate went unnoticed.

## Tests

here is a harness folder to exercise the problem we spotted 
[harness.zip](https://github.com/user-attachments/files/32004476/harness.zip)


Two COMPASS regression tests in `propagateExitStatus.test.ts`, both of which fail without
this change:

- the matchUp feeding the pending exit can be scored, and the pending exit auto-resolves
  onto the participant who falls through;
- a **resolved** exit still blocks resetting that source — guarding against the fix
  over-relaxing the active-downstream rule.

Broader verification: `src/tests/mutations` + `src/tests/queries` green at 771 files /
5631 tests, `tsc --noEmit` clean. A wider sweep over 12 draw types, sizes 8/16/32, five
exit statuses and reduced participant counts (to force the BYE cascades) shows 0 spurious
blocks across 31,476 scoring attempts, with pending exits produced in 10 of the 12 types
so the machinery is genuinely exercised.


