### PR TITLE
fix: guard absent paired previous matchUp in doubleExitAdvancement

### DIFF
--- a/src/mutate/drawDefinitions/positionGovernor/doubleExitAdvancement.ts
+++ b/src/mutate/drawDefinitions/positionGovernor/doubleExitAdvancement.ts
@@ -330,9 +330,13 @@ function conditionallyAdvanceDrawPosition(params) {
     walkoverWinningSide,
   });
 
-  const inContextPairedPreviousMatchUp = inContextDrawMatchUps.find(
-    (candidate) => candidate.matchUpId === pairedPreviousMatchUp.matchUpId,
-  );
+  // a fed target round has no paired previous matchUp within this structure: its other
+  // side arrives over a feed link from another structure. sourceSideNumber is then
+  // derived by inferSourceSideNumber's feedRound branch, so undefined is expected here,
+  // not exceptional.
+  const inContextPairedPreviousMatchUp = pairedPreviousMatchUp
+    ? inContextDrawMatchUps.find((candidate) => candidate.matchUpId === pairedPreviousMatchUp.matchUpId)
+    : undefined;
 
   const sourceSideNumber = inferSourceSideNumber({
     inContextPairedPreviousMatchUp,

--- a/src/tests/mutations/matchUps/matchUpStatus/doubleExitConsolation.test.ts
+++ b/src/tests/mutations/matchUps/matchUpStatus/doubleExitConsolation.test.ts
@@ -6,7 +6,13 @@ import { expect, test } from 'vitest';
 
 // constants and fixtures
 import { BYE, COMPLETED, DOUBLE_WALKOVER, TO_BE_PLAYED, WALKOVER } from '@Constants/matchUpStatusConstants';
-import { CONSOLATION, FIRST_MATCH_LOSER_CONSOLATION, MAIN } from '@Constants/drawDefinitionConstants';
+import {
+  CONSOLATION,
+  DOUBLE_ELIMINATION,
+  FEED_IN_CHAMPIONSHIP,
+  FIRST_MATCH_LOSER_CONSOLATION,
+  MAIN,
+} from '@Constants/drawDefinitionConstants';
 import { toBePlayed } from '@Fixtures/scoring/outcomes/toBePlayed';
 import { MODIFY_MATCHUP } from '@Constants/topicConstants';
 
@@ -418,3 +424,61 @@ test.each(scenarios)('Double Exit produces exit in consolation', (params) => {
   // reset
   setDevContext();
 });
+// A fed consolation final has no paired previous matchUp inside the consolation: its
+// other side arrives over a feed link from the MAIN structure. doubleExitAdvancement
+// dereferenced that absent pairing and threw a TypeError, leaving the source mutated
+// to DOUBLE_WALKOVER with no advancement performed.
+test.each([FEED_IN_CHAMPIONSHIP, DOUBLE_ELIMINATION])(
+  'double exit into a fed consolation final advances the fed participant (%s)',
+  (drawType) => {
+    const drawId = 'drawId';
+    mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawId, drawSize: 8, participantsCount: 8, drawType, idPrefix: 'm' }],
+      setState: true,
+    });
+
+    const allMatchUps = () => tournamentEngine.allDrawMatchUps({ drawId, inContext: true }).matchUps;
+    const scoreable = () =>
+      allMatchUps().filter(
+        (matchUp) =>
+          !matchUp.winningSide &&
+          [TO_BE_PLAYED, 'IN_PROGRESS'].includes(matchUp.matchUpStatus) &&
+          matchUp.sides?.filter((side) => side.participant).length === 2,
+      );
+
+    const { outcome } = mocksEngine.generateOutcomeFromScoreString({ scoreString: '6-3 6-3', winningSide: 1 });
+
+    // play forward until the consolation semi-final is contested
+    for (let i = 0; i < 60; i++) {
+      const targets = scoreable();
+      if (targets.some(({ matchUpId }) => matchUpId === 'm-c-3-1')) break;
+      expect(targets.length).toBeGreaterThan(0);
+      tournamentEngine.setMatchUpStatus({ matchUpId: targets[0].matchUpId, outcome, drawId });
+    }
+
+    const sourceMatchUp = allMatchUps().find(({ matchUpId }) => matchUpId === 'm-c-3-1');
+    const targetMatchUpId = sourceMatchUp.winnerMatchUpId;
+    const fedParticipantId = allMatchUps()
+      .find(({ matchUpId }) => matchUpId === targetMatchUpId)
+      .sides.find((side) => side.participant)?.participantId;
+    expect(fedParticipantId).toBeDefined();
+
+    const result = tournamentEngine.setMatchUpStatus({
+      outcome: { matchUpStatus: DOUBLE_WALKOVER },
+      propagateExitStatus: true,
+      matchUpId: 'm-c-3-1',
+      drawId,
+    });
+    expect(result.success).toEqual(true);
+
+    expect(allMatchUps().find(({ matchUpId }) => matchUpId === 'm-c-3-1').matchUpStatus).toEqual(DOUBLE_WALKOVER);
+
+    // nobody advances out of a double exit, so the fed participant takes the final by walkover
+    const targetMatchUp = allMatchUps().find(({ matchUpId }) => matchUpId === targetMatchUpId);
+    expect(targetMatchUp.matchUpStatus).toEqual(WALKOVER);
+    const winningSideParticipantId = targetMatchUp.sides.find(
+      (side) => side.sideNumber === targetMatchUp.winningSide,
+    )?.participantId;
+    expect(winningSideParticipantId).toEqual(fedParticipantId);
+  },
+);


### PR DESCRIPTION
## Problem

`conditionallyAdvanceDrawPosition` dereferences `pairedPreviousMatchUp.matchUpId`
unconditionally:

```ts
const inContextPairedPreviousMatchUp = inContextDrawMatchUps.find(
  (candidate) => candidate.matchUpId === pairedPreviousMatchUp.matchUpId,
);
```

A fed consolation final has no paired previous matchUp inside its own structure — its
other side arrives over a feed link from MAIN — so `getPairedPreviousMatchUpIsDoubleExit`
returns `undefined` and this throws:

```
TypeError: Cannot read properties of undefined (reading 'matchUpId')
  at doubleExitAdvancement.ts  (conditionallyAdvanceDrawPosition)
  at attemptToSetMatchUpStatus -> noDownstreamDependencies -> setMatchUpState
```

`inferSourceSideNumber` already optional-chains that same object throughout
(`inContextPairedPreviousMatchUp?.structureId`, `pairedPreviousMatchUp?.roundPosition`),
so `undefined` is clearly an expected input — the guard is just missing at the call site.

**The failure is worse than a rejected mutation.** `setMatchUpStatus` returns the TypeError
as its error string *while the source matchUp has already been written to
`DOUBLE_WALKOVER`*, so callers observe a failure over partially mutated state with the
advancement never performed.

## Reproduction

`FEED_IN_CHAMPIONSHIP` and `DOUBLE_ELIMINATION`, drawSize 8, full field: play forward
until the consolation semi-final is contested, then set `DOUBLE_WALKOVER` on it.

## Fix

Guard the lookup. `sourceSideNumber` then falls through to `inferSourceSideNumber`'s
existing `feedRound` branch, which is already correct for this shape: the fed position is
side 1 and the consolation-internal source is side 2. The fed participant awaiting in the
final takes it by walkover, with the produced WALKOVER attributed to side 2.

## Tests

Two regression tests (`FEED_IN_CHAMPIONSHIP`, `DOUBLE_ELIMINATION`) asserting the mutation
succeeds **and** that the winning side of the final is the specific fed participant — not
merely that nothing threw, so a fix that swallowed the exception but derived the wrong
`sourceSideNumber` would still fail. Both fail without this change.

Broader verification: `src/tests/mutations` + `src/tests/queries` green at 771 files /
5631 tests, `tsc --noEmit` clean.

Found by a fuzz sweep across draw types; independent of the pending-exit issue in the
companion PR (reproduces with that change reverted).
