### PR TITLE
fix(constants)!: rename particicipantsRequiredMatchUpStatuses

### DIFF
--- a/documentation/docs/migration-7.0.0.md
+++ b/documentation/docs/migration-7.0.0.md
@@ -1,0 +1,33 @@
+---
+title: Migration 6.x to 7.0.0
+---
+
+This document is for **consumers** of the factory (TMX, courthive-components, the server, downstream
+tools). It catalogues the breaking changes in 7.0.0 and the exact steps to adopt them.
+
+## Breaking changes at a glance
+
+| Change                                                                                   | Who is affected                        | Action required   |
+| ---------------------------------------------------------------------------------------- | -------------------------------------- | ----------------- |
+| `particicipantsRequiredMatchUpStatuses` renamed to `participantsRequiredMatchUpStatuses` | Anyone importing that constant by name | Rename the import |
+
+## 1. `participantsRequiredMatchUpStatuses` — a spelling fix
+
+The exported constant was misspelled **`particicipantsRequiredMatchUpStatuses`** (an extra `ici`)
+since it was introduced. It is a published top-level export, so correcting it is a breaking change
+and 7.0.0 is the first opportunity to make it.
+
+```diff
+- import { particicipantsRequiredMatchUpStatuses } from 'tods-competition-factory';
++ import { participantsRequiredMatchUpStatuses } from 'tods-competition-factory';
+```
+
+### What to do
+
+Rename the import. Nothing else changes — the value, the type and the semantics are identical. The
+constant lists the `matchUpStatus` values that require participants to be present on the matchUp,
+and it is consumed internally by `setMatchUpState`.
+
+**No deprecated alias is provided.** Keeping one would preserve the misspelling in the public API
+indefinitely, which is the thing this release exists to fix. A survey of the CourtHive ecosystem
+found no consumer importing the old name, so the practical migration cost is zero.

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -51,7 +51,7 @@ export {
   directingMatchUpStatuses,
   matchUpStatusConstants,
   nonDirectingMatchUpStatuses,
-  particicipantsRequiredMatchUpStatuses,
+  participantsRequiredMatchUpStatuses,
   recoveryTimeRequiredMatchUpStatuses,
   upcomingMatchUpStatuses,
   validMatchUpStatuses,

--- a/src/constants/matchUpStatusConstants.ts
+++ b/src/constants/matchUpStatusConstants.ts
@@ -32,7 +32,7 @@ export const recoveryTimeRequiredMatchUpStatuses: MatchUpStatusUnion[] = [
   SUSPENDED,
 ];
 
-export const particicipantsRequiredMatchUpStatuses: MatchUpStatusUnion[] = [
+export const participantsRequiredMatchUpStatuses: MatchUpStatusUnion[] = [
   AWAITING_RESULT,
   COMPLETED,
   DEFAULTED,

--- a/src/mutate/matchUps/matchUpStatus/setMatchUpState.ts
+++ b/src/mutate/matchUps/matchUpStatus/setMatchUpState.ts
@@ -58,7 +58,7 @@ import {
   DOUBLE_WALKOVER,
   IN_PROGRESS,
   INCOMPLETE,
-  particicipantsRequiredMatchUpStatuses,
+  participantsRequiredMatchUpStatuses,
   SUSPENDED,
   TO_BE_PLAYED,
   validMatchUpStatuses,
@@ -793,7 +793,7 @@ function checkParticipants({
   ) {
     return { ...SUCCESS };
   }
-  if (matchUpStatus && particicipantsRequiredMatchUpStatuses.includes(matchUpStatus) && !requiredParticipants) {
+  if (matchUpStatus && participantsRequiredMatchUpStatuses.includes(matchUpStatus) && !requiredParticipants) {
     return decorateResult({
       info: 'matchUpStatus requires assigned participants',
       context: { matchUpStatus, requiredParticipants },


### PR DESCRIPTION
The published top-level export `particicipantsRequiredMatchUpStatuses` carries an extra `ici`. It is part of the public API, so correcting it is a breaking change and 7.0.0 is the first opportunity.

```diff
- import { particicipantsRequiredMatchUpStatuses } from 'tods-competition-factory';
+ import { participantsRequiredMatchUpStatuses } from 'tods-competition-factory';
```

Value, type and semantics are identical — only the spelling moves.

**No deprecated alias**, deliberately. Keeping one would preserve the misspelling in the public API indefinitely, which is what this rename exists to fix. A survey across the CourtHive ecosystem found **no consumer importing the old name**; the only hits outside this repo are copies of the factory itself (a preserved test harness and a worktree). Practical migration cost is zero.

Adds `documentation/docs/migration-7.0.0.md`, following the existing `migration-N.0.0` convention.

**Verification:** 11,733 tests pass, lint and `check-types` clean.