### PR TITLE
docs: name the four calendar intents, and complete the 7.0.0 migration guide

### DIFF
--- a/documentation/docs/concepts/date-time-handling.md
+++ b/documentation/docs/concepts/date-time-handling.md
@@ -15,6 +15,29 @@ The Competition Factory handles dates and times across several domains: tourname
 | Time-of-day (scheduling)                         | `HH:MM`                | `'14:30'`                |
 | IANA timezone identifiers                        | Region/City            | `'America/New_York'`     |
 
+### Four Questions, Not One
+
+"A date" is four different questions, and answering the wrong one is the most common source of
+off-by-an-hour and off-by-a-day bugs in competition data. The factory names each one:
+
+| Question                     | Type of answer             | Module                | Depends on a zone? |
+| ---------------------------- | -------------------------- | --------------------- | ------------------ |
+| Which calendar day?          | `2026-09-09`               | `tools.plainDate`     | no                 |
+| What time on the clock?      | `14:00`                    | `tools.plainTime`     | no                 |
+| Which moment, at this venue? | day + clock + zone         | `tools.zonedDateTime` | **yes**            |
+| Which absolute instant?      | `2026-09-09T18:00:00.000Z` | ISO string with `Z`   | already resolved   |
+
+The distinction is not academic. A tournament's `startDate` is a calendar day — it does not begin at
+an instant, and asking "what time is `2026-09-09`" has no answer. A `scheduledTime` of `14:00` is a
+wall clock — it is 14:00 at the venue, and which instant that is depends on where the venue is and
+whether daylight saving is in force that week. Mixing the two without an explicit conversion produces
+a figure wrong by the venue's UTC offset, which in a report measured in minutes is worse than showing
+nothing at all.
+
+`tools.dateTime` predates this split and spans the first two questions. It remains fully supported and
+its behaviour is unchanged — it re-exports from the intent modules, so there is exactly one
+implementation of each helper — but new code should reach for the module that names the intent.
+
 ### Where Dates Appear
 
 **Tournament Record:**
@@ -307,21 +330,55 @@ All temporal records use ISO 8601 format. `createdAt` is auto-generated with tim
 
 See [Time Items](/docs/concepts/timeItems) for the complete temporal data reference.
 
-## Future: Temporal API
+## Temporal API
 
-The factory's zero-dependency approach to date/time handling is built on `Date` and `Intl.DateTimeFormat` — APIs available in every JavaScript runtime. The [TC39 Temporal proposal](https://tc39.es/proposal-temporal/docs/) is expected to reach Stage 4 and ship in major runtimes by 2027, providing first-class support for timezone-aware dates, wall-clock times, and duration arithmetic directly in the language.
+[TC39 Temporal](https://tc39.es/proposal-temporal/docs/) reached **Stage 4 in March 2026** and is part
+of **ES2026**. It provides first-class timezone-aware dates, wall-clock times, and duration arithmetic
+in the language itself.
 
-When Temporal becomes widely available, the factory's timezone utilities will be updated to use `Temporal.ZonedDateTime` and `Temporal.PlainDate` internally, providing:
+| Runtime                       | Native support       |
+| ----------------------------- | -------------------- |
+| Node.js 26+ (official builds) | shipping, unflagged  |
+| Firefox 139+                  | shipping             |
+| Chrome / Edge 144+            | shipping             |
+| Deno 2.7                      | stable               |
+| **Safari / iOS Safari**       | **not yet shipping** |
 
-- More precise DST transition handling at boundary cases
-- Native duration and calendar arithmetic
-- Cleaner API surface without the quirks of the legacy `Date` object
+Safari is the remaining gap, so Temporal is not yet "Baseline". A browser application that must run on
+iOS supplies a polyfill (`temporal-polyfill` or `@js-temporal/polyfill`), which populates
+`globalThis.Temporal`; the factory itself will never bundle one, in keeping with the zero-dependency
+policy.
 
-This transition will be **non-breaking** — the factory's public API (`wallClockToUTC`, `utcToWallClock`, `toEmbargoUTC`, etc.) will remain the same, with Temporal powering the implementation under the hood. The zero-dependency philosophy is maintained: Temporal is a language built-in, not a library.
+:::note Node version is not the whole story
+Whether `Temporal` exists in a given Node build depends on how that build was **compiled**, not only on
+its version number. Check with:
+
+```bash
+node -p "[process.version, typeof Temporal, process.config.variables.v8_enable_temporal_support].join(' | ')"
+# want: v26.x.y | object | 1
+```
+
+Some distributions compile Temporal out. In that case the flag `--harmony-temporal` is accepted but has
+no effect, because the code is absent rather than disabled.
+:::
+
+### What changes when the factory adopts it
+
+The calendar-intent modules were named after Temporal's types deliberately: `plainDate`, `plainTime`
+and `zonedDateTime` map onto `Temporal.PlainDate`, `Temporal.PlainTime` and `Temporal.ZonedDateTime`,
+so adoption becomes a substitution of implementations rather than a redesign of the API.
+
+Signatures stay strings in and strings out, and the wire format does not change — records on disk and
+on the wire remain ISO strings. Two internal things improve:
+
+- The two-pass offset guess that `zonedDateTime` uses to resolve a wall clock is a `Date` workaround.
+  `Temporal.PlainDateTime.from(…).toZonedDateTime(tz, { disambiguation })` does it in one step.
+- The ambiguous hour that a fall-back DST transition repeats is currently settled by a consistent but
+  arbitrary rule. Temporal makes it an explicit `disambiguation` choice.
 
 ## Related Documentation
 
 - **[Time Items](/docs/concepts/timeItems)** — Temporal records on CODES document elements
 - **[Embargo and Scheduled Rounds](/docs/concepts/publishing/publishing-embargo)** — Time-based visibility gates
 - **[Scheduling Overview](/docs/concepts/scheduling-overview)** — Match scheduling concepts
-- **[Tools API](/docs/tools/tools-api)** — Complete function reference for `dateTime` and `timeZone`
+- **[Tools API](/docs/tools/tools-api)** — Complete function reference for `plainDate`, `plainTime`, `zonedDateTime`, `dateTime` and `timeZone`

--- a/documentation/docs/migration-7.0.0.md
+++ b/documentation/docs/migration-7.0.0.md
@@ -7,9 +7,11 @@ tools). It catalogues the breaking changes in 7.0.0 and the exact steps to adopt
 
 ## Breaking changes at a glance
 
-| Change                                                                                   | Who is affected                        | Action required   |
-| ---------------------------------------------------------------------------------------- | -------------------------------------- | ----------------- |
-| `particicipantsRequiredMatchUpStatuses` renamed to `participantsRequiredMatchUpStatuses` | Anyone importing that constant by name | Rename the import |
+| Change                                                                                              | Who is affected                        | Action required        |
+| --------------------------------------------------------------------------------------------------- | -------------------------------------- | ---------------------- |
+| `particicipantsRequiredMatchUpStatuses` renamed to `participantsRequiredMatchUpStatuses`            | Anyone importing that constant by name | Rename the import      |
+| `tools.timeZone.getTimeZoneOffsetMinutes` now returns `number \| undefined`                         | Anyone reading a zone offset           | Handle `undefined`     |
+| `wallClockToUTC` / `utcToWallClock` / `toEmbargoUTC` return `{ error }` where they previously threw | Anyone wrapping these in `try`/`catch` | Check the return value |
 
 ## 1. `participantsRequiredMatchUpStatuses` — a spelling fix
 
@@ -31,3 +33,63 @@ and it is consumed internally by `setMatchUpState`.
 **No deprecated alias is provided.** Keeping one would preserve the misspelling in the public API
 indefinitely, which is the thing this release exists to fix. A survey of the CourtHive ecosystem
 found no consumer importing the old name, so the practical migration cost is zero.
+
+## 2. `tools.timeZone` — failures are values, not throws
+
+The zoned conversion helpers had two implementations in the factory: a public one (`tools.timeZone`)
+and an internal one that carried every live conversion. They were **numerically identical** on valid
+input — a sweep of 420,480 wall clocks across 12 zones and every day of 2026 found zero disagreements,
+including both DST boundaries — but they disagreed entirely on how they failed. 7.0.0 consolidates them
+onto one implementation, now also exported as
+[`tools.zonedDateTime`](/docs/tools/tools-api#toolszoneddatetime).
+
+Nothing changes for a call that succeeds. What changes is what a _failing_ call does.
+
+### `getTimeZoneOffsetMinutes` returns `number | undefined`
+
+```diff
+- const offset = tools.timeZone.getTimeZoneOffsetMinutes(timeZone);
++ const offset = tools.timeZone.getTimeZoneOffsetMinutes(timeZone);
++ if (offset === undefined) return; // unrecognised or absent zone
+```
+
+Previously it **threw an uncaught `RangeError`** for an unrecognised zone, from a function typed
+`number`. Worse, calling it with no zone at all returned **the host machine's UTC offset**, so the same
+call answered differently on a server in New York and one in London. Neither behaviour was documented
+or tested, so no correct caller can have depended on it.
+
+### Three functions return `{ error }` instead of throwing
+
+`wallClockToUTC`, `utcToWallClock` and `toEmbargoUTC` are typed
+`string | { error: … }`, but a malformed date or time escaped as a `RangeError` rather than the error
+object the signature promised. They now return one, and distinguish the cause:
+
+```js
+tools.timeZone.wallClockToUTC('2026-06-20', '03:00', 'Invalid/Zone'); // { error: INVALID_TIME_ZONE }
+tools.timeZone.wallClockToUTC('not-a-date', '03:00', 'America/New_York'); // { error: INVALID_DATE }
+tools.timeZone.wallClockToUTC('2026-06-20', 'noon', 'America/New_York'); // { error: INVALID_TIME }
+```
+
+### What to do about the throws
+
+If you wrapped any of these in a `try`/`catch`, the `catch` is now dead code — check the return value
+instead. If you did not wrap them, you had an unhandled crash path and now have a value to branch on.
+
+A survey of the CourtHive ecosystem found **zero** consumers of `tools.timeZone`, so the practical
+migration cost is zero. The change is released as breaking because the published types change, not
+because a known consumer breaks.
+
+### An unrecognised zone is now refused, not substituted
+
+The internal implementation used to fall back to a caller-supplied fixed offset when it did not
+recognise a zone. That silently answered in a different frame: in the recovery-time report it turned a
+90-minute figure into 330 minutes, still labelled as measured. A zone the system cannot honour is now
+refused everywhere.
+
+`tools.zonedDateTime` makes the frame explicit rather than leaving it to be assumed:
+
+| `timeZone`            | result                                      | `source`   |
+| --------------------- | ------------------------------------------- | ---------- |
+| absent                | the caller's `utcOffsetMinutes` (default 0) | `'offset'` |
+| present, unrecognised | refused                                     | —          |
+| present, recognised   | resolved per instant                        | `'zone'`   |

--- a/documentation/docs/tools/tools-api.md
+++ b/documentation/docs/tools/tools-api.md
@@ -305,9 +305,85 @@ tools.isOdd(4); // false
 
 ## Date & Time
 
+Four different questions hide inside "a date", and answering the wrong one is the most common source
+of off-by-an-hour and off-by-a-day bugs in competition data:
+
+| Question                         | Module                                       | Example                                                    |
+| -------------------------------- | -------------------------------------------- | ---------------------------------------------------------- |
+| Which calendar day?              | [`tools.plainDate`](#toolsplaindate)         | `2026-09-09` — the same day in Auckland and Los Angeles    |
+| What time on the clock?          | [`tools.plainTime`](#toolsplaintime)         | `14:00` — not a moment until a day and a zone are supplied |
+| Which actual moment, at a venue? | [`tools.zonedDateTime`](#toolszoneddatetime) | `2026-09-09` + `14:00` + `America/New_York`                |
+| Which absolute instant?          | ISO strings with `Z`                         | `2026-09-09T18:00:00.000Z`                                 |
+
+`tools.dateTime` predates that split and spans the first two. It is fully supported and its behaviour
+is unchanged — it now re-exports from the intent modules, so there is exactly one implementation of
+each helper — but **new code should reach for the module that names the intent**. A reader of
+`plainDate.extractDate(x)` knows no zone was involved; a reader of `dateTime.extractDate(x)` has to go
+and check.
+
+The names are the [TC39 Temporal](https://tc39.es/proposal-temporal/docs/) ones on purpose. When
+`Temporal.PlainDate` and `Temporal.PlainTime` are available on every runtime the factory supports,
+these become one-for-one substitutions rather than a rename.
+
+### tools.plainDate
+
+A calendar day: no clock, no zone. Takes and returns ISO date strings (`YYYY-MM-DD`); `Date` appears
+only as internal arithmetic.
+
+```js
+import { tools } from 'tods-competition-factory';
+
+// The calendar day, whatever the instant was wearing
+tools.plainDate.extractDate('2026-09-09T14:00:00+05:30'); // '2026-09-09'
+tools.plainDate.extractDate('not-a-date'); // '' — never throws
+
+tools.plainDate.generateDateRange('2026-09-09', '2026-09-12');
+// ['2026-09-09', '2026-09-10', '2026-09-11', '2026-09-12']  (inclusive both ends)
+
+tools.plainDate.addDays('2026-09-28', 5); // '2026-10-03'
+tools.plainDate.addWeek('2026-09-09'); // '2026-09-16'
+tools.plainDate.sameDay('2026-09-09T01:00', '2026-09-09T23:00'); // true
+tools.plainDate.isISODateString('tomorrow'); // false
+```
+
+Also available: `formatDate`, `isValidDateString`, `dateStringDaysChange`, `getDateByWeek`,
+`dateFromDay`, `subtractWeek`, `weekdays`, `isDateInPast`, `localizeDate`.
+
+Nothing in `plainDate` resolves an offset. Anything that needs one belongs in
+[`tools.zonedDateTime`](#toolszoneddatetime).
+
+### tools.plainTime
+
+A wall clock: no day, no zone. `14:00` is a `plainTime`; it is not a moment until a day and a zone are
+supplied.
+
+```js
+tools.plainTime.extractTime('2026-09-09T14:00'); // '14:00'
+tools.plainTime.extractTime('2026-09-09'); // undefined — no clock to read
+
+tools.plainTime.timeStringMinutes('14:30'); // 870 — minutes since midnight
+tools.plainTime.dayMinutesToTimeString(870); // '14:30'
+tools.plainTime.dayMinutesToTimeString(1500); // '01:00' — wraps rather than overflowing
+
+tools.plainTime.convertTime('14:00'); // '2:00 PM'
+tools.plainTime.convertTime('2:00 PM', true); // '14:00'
+tools.plainTime.isTimeString('24:00'); // false — no wall clock shows that
+```
+
+Also available: `tidyTime`, `validTimeValue`, `splitTime`, `militaryTime`, `regularTime`, `timeSort`,
+`HHMMSS`.
+
+`timeSort` is a comparator, so pass it to `.sort()` rather than calling it directly:
+
+```js
+['14:00', '09:30', '23:15'].sort(tools.plainTime.timeSort);
+// ['09:30', '14:00', '23:15']
+```
+
 ### dateTime
 
-Object containing date/time utility functions.
+Object containing date/time utility functions. Spans the calendar-day and wall-clock intents; see the
+table above for which module to prefer in new code.
 
 ```js
 // Get ISO date string

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -447,7 +447,14 @@ module.exports = {
         {
           type: 'category',
           label: 'Migration Guides',
-          items: ['migration-6.0.0', 'migration-5.0.0', 'migration-4.0.0', 'migration-3.0.0', 'migration'],
+          items: [
+            'migration-7.0.0',
+            'migration-6.0.0',
+            'migration-5.0.0',
+            'migration-4.0.0',
+            'migration-3.0.0',
+            'migration',
+          ],
         },
       ],
     },

--- a/src/tests/tools/plainDate.test.ts
+++ b/src/tests/tools/plainDate.test.ts
@@ -70,3 +70,17 @@ test('the legacy dateTime surface delegates to plainDate rather than duplicating
   expect(dateTime.sameDay).toBe(plainDate.sameDay);
   expect(dateTime.formatDate).toBe(plainDate.formatDate);
 });
+
+test('isDateInPast compares a calendar day against now', () => {
+  expect(plainDate.isDateInPast('2020-01-01')).toEqual(true);
+  expect(plainDate.isDateInPast('2999-01-01')).toEqual(false);
+});
+
+test('localizeDate renders a calendar day in a locale, and refuses a non-date', () => {
+  const localized = plainDate.localizeDate('2026-01-15T12:00:00Z', undefined, 'en-US');
+  // Default localization is weekday + long month + numeric day and year. Asserting
+  // the parts rather than the exact string keeps this stable across ICU revisions.
+  expect(localized).toContain('2026');
+  expect(localized).toContain('January');
+  expect(plainDate.localizeDate('not-a-date', undefined, 'en-US')).toBeUndefined();
+});


### PR DESCRIPTION
Documentation follow-up to #4783, which shipped `tools.plainDate`, `tools.plainTime` and `tools.zonedDateTime` with no documentation and an incomplete migration guide.

## What this fixes

**`plainDate` and `plainTime` were undocumented.** They are public exports on `tools` and appeared nowhere in the docs. Both Docusaurus pages now open on the distinction that motivates the split — which calendar day, what time on the clock, which moment at a venue, which absolute instant — with only the third depending on a zone. `tools.dateTime` is documented as supported and unchanged rather than deprecated, with a pointer to the module to prefer in new code.

**The 7.0.0 migration guide omitted the zoned breaking change.** `migration-7.0.0.md` listed only the `particicipantsRequiredMatchUpStatuses` spelling fix. A consumer reading it would have found nothing about `getTimeZoneOffsetMinutes` widening to `number | undefined`, nor about `wallClockToUTC` / `utcToWallClock` / `toEmbargoUTC` returning `{ error }` where they previously threw an uncaught `RangeError`. Now documented, including the distinct `INVALID_DATE` / `INVALID_TIME` causes and what to do with a now-dead `try`/`catch`.

**The migration page was unreachable.** `sidebars.js` listed `migration-6.0.0` down to the original and never gained a `7.0.0` entry, so the page existed but nothing linked to it.

**The Temporal section was materially out of date.** It said Stage 4 and runtime support were "expected by 2027" — Temporal reached Stage 4 in March 2026, is part of ES2026, and ships unflagged in Node 26, Chrome/Edge 144, Firefox 139 and Deno 2.7, with Safari the remaining gap. It also promised the eventual transition would be non-breaking, which #4783 had already made false. Adds the build-variable check, since a Node version number does not answer whether Temporal is present — some distributions compile it out, and there `--harmony-temporal` is accepted but does nothing.

## Coverage

Closes the two uncovered functions in `plainDate.ts` — `isDateInPast` and `localizeDate`, both untested before the split carried them over from `dateTime.ts`. The locale assertion checks rendered parts rather than an exact string so it does not break on an ICU revision.

## Verification

`pnpm verify` green: 12,722 tests, coverage thresholds held, `verify:surface` reporting no exports removed, `verify:pack` confirming the published `.d.ts` compiles.

Docs were verified **past** the build rather than by it — Docusaurus is configured `onBrokenLinks: 'warn'`, so neither the missing sidebar entry nor a bad anchor would have failed anything. Built the site and confirmed in the generated HTML that every anchor I link to exists, and that `migration-7.0.0` now appears in sibling sidebars as "Migration 6.x to 7.0.0".