### PR TITLE
fix(propagation): the walkover went to the empty side, and the winner never reached the Decider

### DIFF
--- a/src/mutate/drawDefinitions/matchUpGovernor/getExitWinningSide.ts
+++ b/src/mutate/drawDefinitions/matchUpGovernor/getExitWinningSide.ts
@@ -19,10 +19,18 @@ export function getExitWinningSide({ inContextDrawMatchUps, drawPosition, matchU
 
   const feedRound = matchUp.feedRound;
 
-  return feedRound
-    ? 1
-    : sourceMatchUps.reduce((sideNumber, sourceMatchUp, index) => {
-        if (sourceMatchUp.drawPositions?.includes(drawPosition)) return index + 1;
-        return sideNumber;
-      }, undefined);
+  // On a fed round the matchUp's OWN derived sides are the authority on which side a drawPosition
+  // occupies. `feedRound => 1` is a topology proxy for that fact: it holds while the position being
+  // advanced is the one that arrived over the feed link, and fails when the position arrived from
+  // the previous round of the SAME structure. Measured across the 600-cell exit-propagation matrix,
+  // the proxy is consulted 47 times and disagrees with the derived side 4 times — every one of them
+  // the DOUBLE_ELIMINATION Main final, where the undefeated main-bracket winner sits on side 2 and
+  // the empty fed slot is side 1, so the proxy handed the walkover to a side holding nobody.
+  // The proxy is kept as a fallback for a matchUp whose sides do not yet carry the drawPosition.
+  if (feedRound) return targetSide?.sideNumber ?? 1;
+
+  return sourceMatchUps.reduce((sideNumber, sourceMatchUp, index) => {
+    if (sourceMatchUp.drawPositions?.includes(drawPosition)) return index + 1;
+    return sideNumber;
+  }, undefined);
 }

--- a/src/mutate/drawDefinitions/positionGovernor/doubleExitAdvancement.ts
+++ b/src/mutate/drawDefinitions/positionGovernor/doubleExitAdvancement.ts
@@ -4,6 +4,7 @@ import { getPairedPreviousMatchUpIsDoubleExit } from '../../../query/matchUps/ge
 import { getExitWinningSide } from '@Mutate/drawDefinitions/matchUpGovernor/getExitWinningSide';
 import { getPositionAssignments } from '@Query/drawDefinition/positionsGetter';
 import { modifyMatchUpScore } from '@Mutate/matchUps/score/modifyMatchUpScore';
+import { directWinner } from '@Mutate/matchUps/drawPositions/directWinner';
 import { decorateResult } from '@Functions/global/decorateResult';
 import { positionTargets } from '@Query/matchUp/positionTargets';
 import { definedAttributes } from '@Tools/definedAttributes';
@@ -629,13 +630,27 @@ function advanceByeAdvancedDrawPosition({
     });
     if (result.error) return decorateResult({ result, stack });
 
-    return advanceDrawPosition({
+    const advanceResult = advanceDrawPosition({
       drawPositionToAdvance: nextDrawPositionToAdvance,
       matchUpId: noContextNextWinnerMatchUp.matchUpId,
       inContextDrawMatchUps,
       drawDefinition,
       matchUpsMap,
     });
+    if (advanceResult?.error) return decorateResult({ result: advanceResult, stack });
+
+    directExitWinnerAcrossLink({
+      drawPositionToAdvance: nextDrawPositionToAdvance,
+      sourceMatchUp: noContextNextWinnerMatchUp,
+      sourceStructureId: nextWinnerMatchUp.structureId,
+      inContextDrawMatchUps,
+      targetData: nextTargetData,
+      drawDefinition,
+      matchUpsMap,
+      params,
+    });
+
+    return advanceResult;
   } else if (isExit(nextWinnerMatchUp.matchUpStatus)) {
     // if the next targetMatchUp is a double walkover or double default
     const result = doubleExitAdvancement({
@@ -648,6 +663,60 @@ function advanceByeAdvancedDrawPosition({
   }
 
   return decorateResult({ result: { ...SUCCESS }, stack });
+}
+
+/**
+ * Direct the winner of a cascade-resolved exit into a winner target in ANOTHER structure.
+ *
+ * `advanceDrawPosition` advances a winner only when the winner target belongs to the same
+ * structure; a target reached over a WINNER link falls through it silently. That left the matchUp
+ * decided with a winner who never appeared in the linked structure — the state the repo's own
+ * `getDrawInconsistencies` reports as DROPPED_PROGRESSION.
+ *
+ * Measured over the 600-cell exit-propagation matrix, this is reached 4 times out of 2107
+ * `advanceDrawPosition` calls, and every one is the DOUBLE_ELIMINATION Main final feeding the
+ * Decider after a Backdraw double-exit cascade resolved it as a walkover.
+ *
+ * `directWinner` is the engine's own link-direction path — the one `directParticipants` uses for a
+ * scored result — so the placement rules are not re-derived here. A BYE or unassigned position is
+ * excluded: it has no participant to direct, and `directWinnerViaLink`'s terminal branch would
+ * report an unavailable target for it.
+ */
+function directExitWinnerAcrossLink({
+  drawPositionToAdvance,
+  inContextDrawMatchUps,
+  sourceStructureId,
+  drawDefinition,
+  sourceMatchUp,
+  matchUpsMap,
+  targetData,
+  params,
+}) {
+  const { winnerMatchUp } = targetData.targetMatchUps;
+  const { winnerTargetLink } = targetData.targetLinks;
+  if (!winnerMatchUp || !winnerTargetLink) return;
+  if (winnerMatchUp.structureId === sourceStructureId) return;
+
+  const { structure } = findStructure({ drawDefinition, structureId: sourceStructureId });
+  const { positionAssignments } = getPositionAssignments({ structure });
+  const assignment = positionAssignments?.find(({ drawPosition }) => drawPosition === drawPositionToAdvance);
+  if (!assignment?.participantId || assignment.bye) return;
+
+  directWinner({
+    winnerMatchUpDrawPositionIndex: targetData.targetMatchUps.winnerMatchUpDrawPositionIndex,
+    sourceMatchUpStatus: sourceMatchUp.matchUpStatus,
+    winningDrawPosition: drawPositionToAdvance,
+    sourceMatchUpId: sourceMatchUp.matchUpId,
+    tournamentRecord: params.tournamentRecord,
+    projectedWinningSide: undefined,
+    dualMatchUp: undefined,
+    inContextDrawMatchUps,
+    winnerTargetLink,
+    drawDefinition,
+    winnerMatchUp,
+    matchUpsMap,
+    event: params.event,
+  });
 }
 
 function advanceByeToLoserMatchUp(params) {

--- a/src/tests/mutations/drawDefinitions/doubleEliminationDeciderProgression.test.ts
+++ b/src/tests/mutations/drawDefinitions/doubleEliminationDeciderProgression.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression cover for the DOUBLE_ELIMINATION Main-final -> Decider progression.
+ *
+ * A double-exit cascade in the Backdraw can leave the Main final with only one real participant:
+ * the undefeated main-bracket winner, waiting on a Backdraw winner who will now never arrive. The
+ * engine resolves that as a walkover, and two independent defects made the result wrong.
+ *
+ *  1. `getExitWinningSide` answered "which side is this drawPosition" with the topology proxy
+ *     `feedRound => 1`. On the Main final the fed slot IS side 1, so the walkover was awarded to
+ *     the empty side and the only participant in the match was recorded as the LOSER.
+ *  2. `advanceDrawPosition` advanced a winner only when the winner target was in the SAME
+ *     structure. The Decider is a different structure reached over a WINNER link, so the branch
+ *     fell through silently and the winner never appeared in it.
+ *
+ * Together they produced a draw the repo's own `getDrawInconsistencies` reports as
+ * DROPPED_PROGRESSION. Both are asserted here, and each fails on its own if either fix is reverted.
+ */
+import { nextPlayable, playForward, step } from '@Tests/testHarness/exitPropagation/driver';
+import { getExitWinningSide } from '@Mutate/drawDefinitions/matchUpGovernor/getExitWinningSide';
+import { getDrawInconsistencies } from '@Query/drawDefinition/getDrawInconsistencies';
+import { setSubscriptions } from '@Global/state/globalState';
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { expect, it, describe } from 'vitest';
+
+// constants
+import { DOUBLE_WALKOVER, DOUBLE_DEFAULT } from '@Constants/matchUpStatusConstants';
+import { DOUBLE_ELIMINATION } from '@Constants/drawDefinitionConstants';
+
+describe('getExitWinningSide — a fed round does not imply side 1', () => {
+  it('resolves the side from the matchUp when the advancing position is NOT the fed one', () => {
+    const matchUpId = 'm1';
+    // The shape of a DOUBLE_ELIMINATION Main final mid-cascade: the fed slot (side 1) is still
+    // empty and the position being advanced (side 2) came from the previous round of this
+    // structure. `feedRound => 1` would hand the walkover to the side holding nobody.
+    const inContextDrawMatchUps: any[] = [
+      {
+        matchUpId,
+        feedRound: true,
+        drawPositions: [9],
+        sides: [{ sideNumber: 2, drawPosition: 9, participantId: 'p9' }],
+      },
+    ];
+    expect(getExitWinningSide({ inContextDrawMatchUps, drawPosition: 9, matchUpId })).toEqual(2);
+  });
+
+  it('still answers 1 when no side carries the drawPosition (proxy retained as a fallback)', () => {
+    const matchUpId = 'm1';
+    const inContextDrawMatchUps: any[] = [{ matchUpId, feedRound: true, drawPositions: [9], sides: [] }];
+    expect(getExitWinningSide({ inContextDrawMatchUps, drawPosition: 9, matchUpId })).toEqual(1);
+  });
+});
+
+describe.each([DOUBLE_WALKOVER, DOUBLE_DEFAULT])(
+  'DOUBLE_ELIMINATION 16 — %s cascade into the Main final',
+  (exitStatus) => {
+    it.each([true, false])('directs the walkover winner into the Decider (propagate=%s)', (propagateExitStatus) => {
+      setSubscriptions({});
+      const drawId = `decider-progression-${exitStatus}-${propagateExitStatus}`;
+      // nonRandom seeds mocksEngine's placement. 97 is the seed the exit-propagation matrix uses
+      // for this cell, so this test and the matrix drive the identical draw.
+      const { drawIds } = mocksEngine.generateTournamentRecord({
+        drawProfiles: [{ drawId, drawType: DOUBLE_ELIMINATION, drawSize: 16, participantsCount: 16 }],
+        nonRandom: 97,
+        setState: true,
+      });
+      expect(drawIds).toContain(drawId);
+
+      const outcome = { matchUpStatus: exitStatus };
+      const target = nextPlayable(drawId);
+      step({ propagateExitStatus, matchUpId: target.matchUpId, drawId, outcome });
+      playForward({ propagateExitStatus, exitOutcome: outcome, drawId });
+
+      const { drawDefinition } = tournamentEngine.getEvent({ drawId });
+      const structureNamed = (name: string) => drawDefinition.structures.find((s: any) => s.structureName === name);
+      const { matchUps } = tournamentEngine.allDrawMatchUps({ inContext: true, drawId });
+
+      const mainStructureId = structureNamed('Main').structureId;
+      const mainFinal: any = matchUps.find(
+        (m: any) => m.structureId === mainStructureId && m.roundNumber === 5 && m.roundPosition === 1,
+      );
+
+      // the cascade leaves exactly one real participant in the final — the fed slot never fills
+      const occupied = (mainFinal.sides ?? []).filter((side: any) => side.participantId);
+      expect(occupied).toHaveLength(1);
+
+      // the walkover goes to the side that HOLDS someone, never to the empty fed slot
+      expect(mainFinal.winningSide).toEqual(occupied[0].sideNumber);
+
+      // and that winner is directed across the WINNER link into the Decider
+      const deciderParticipantIds = (structureNamed('Decider').positionAssignments ?? [])
+        .map((assignment: any) => assignment.participantId)
+        .filter(Boolean);
+      expect(deciderParticipantIds).toContain(occupied[0].participantId);
+
+      // the repo's own integrity checker agrees the draw is whole
+      const integrity: any = getDrawInconsistencies({ drawDefinition, drawId });
+      expect(integrity.inconsistencies).toEqual([]);
+    });
+  },
+);

--- a/src/tests/testHarness/exitPropagation/knownFailures.ts
+++ b/src/tests/testHarness/exitPropagation/knownFailures.ts
@@ -33,13 +33,6 @@ const DOUBLE_EXIT_PARTIAL_MUTATION =
   'error code at one of ~12 failure paths downstream of the first write; the partial mutation is ' +
   'untouched. See Mentat/planning/EXIT_PROPAGATION_ASSESSMENT.md §4.';
 
-const DOUBLE_EXIT_DROPPED_PROGRESSION =
-  'DOUBLE_ELIMINATION double exit at drawSize 16: getDrawInconsistencies reports DROPPED_PROGRESSION ' +
-  '— a loser eligible to feed the linked target structure is absent from it. Found by this matrix, ' +
-  'not previously recorded. Same draw type and status class as the drawSize-8 entries above, so ' +
-  'likely the same root cause surfacing later in the cascade. See ' +
-  'Mentat/planning/EXIT_PROPAGATION_ASSESSMENT.md §7.';
-
 const DOUBLE_EXIT_NOT_REVERSIBLE =
   'Applying a double exit is not reversible. After apply-then-clear, a matchUp that was BYE before ' +
   'the double walkover comes back TO_BE_PLAYED. The BYE-provenance work (db4c925f5) addressed the ' +
@@ -113,13 +106,6 @@ export const KNOWN_FAILURES: QuarantineEntry[] = [
       key: doubleEliminationCell(8, exitStatus, propagate),
       properties: ['ERROR_IMPLIES_NO_MUTATION'],
       reference: DOUBLE_EXIT_PARTIAL_MUTATION,
-    })),
-  ),
-  ...['DOUBLE_WALKOVER', 'DOUBLE_DEFAULT'].flatMap((exitStatus) =>
-    [true, false].map((propagate) => ({
-      key: doubleEliminationCell(16, exitStatus, propagate),
-      properties: ['DRAW_INCONSISTENCY'],
-      reference: DOUBLE_EXIT_DROPPED_PROGRESSION,
     })),
   ),
   ...ACTION_DISAGREEMENT_CELLS.map((cell) => ({


### PR DESCRIPTION
Closes the 4 quarantined `DRAW_INCONSISTENCY` cells — `DOUBLE_ELIMINATION 16/16`, both double-exit statuses, both `propagateExitStatus` values. Block **E4** of the exit-propagation programme.

## What was wrong

A Backdraw double-exit cascade leaves the Main final holding only the undefeated main-bracket winner, waiting on a Backdraw winner who will now never arrive. The engine resolves that as a walkover, and two independent defects made the result wrong:

```text
Main r5p1  WALKOVER  winningSide 1  drawPositions [9]
           sides: [ {empty fed slot}, {sideNumber 2, drawPosition 9, participant} ]
Decider    positionAssignments: [ {dp 1}, {dp 2} ]        <- empty
```

1. **`getExitWinningSide` answered with a topology proxy.** `feedRound => 1` stands in for "which side does this drawPosition occupy". The two coincide only while the position being advanced is the one that arrived over the feed link; on the Main final it arrived from the previous round of the *same* structure, so the proxy is inverted — the walkover was awarded to the side holding **nobody**, and the only participant in the match was recorded as the LOSER. It now consults the matchUp's own derived side, keeping the proxy as a fallback.

2. **`advanceDrawPosition` advanced a winner only within the same structure.** The Decider is reached over a WINNER link, so the branch fell through **silently** and the winner never appeared in it. `doubleExitAdvancement` now directs across the link via `directWinner` — the engine's own path, the one `directParticipants` uses for a scored result — so the placement rules are not re-derived a third time.

Both are this workstream's recurring shape: *a fact inferred from topology, and a fall-through that does nothing without saying so.*

## Blast radius, measured before either change

Both decision points were instrumented and the full 600-cell matrix run:

| decision point | reached | wrong |
|---|---|---|
| `getExitWinningSide` feedRound shortcut | 47 of 716 calls | **4** |
| `advanceDrawPosition` cross-structure winner | 4 of 2107 calls | **4** |

Both sets are exactly the 4 quarantined cells; nothing else in the matrix changes behaviour. There was never a call where the shortcut was taken and no side carried the drawPosition, so the fallback is defensive rather than load-bearing.

## Falsification

Each fix reverted **on its own**, with `tsc --noEmit` clean so the red is behavioural and not a build failure:

- revert 1 → `expected 1 to deeply equal 2` on the winningSide assertion
- revert 2 → `expected [] to include '947cc216…'` — the Decider is empty

The fallback assertion passes in both arms and is the control: it is not what discriminates.

## Where the fix is NOT, and why

It first went into `advanceDrawPosition`, the more general home. That introduced the repo's **only** circular-dependency warning (`assignDrawPositionBye -> directWinner -> positionAssignment -> assignMatchUpDrawPosition -> assignDrawPositionBye`), because `directWinner` transitively imports `assignDrawPositionBye`. Moving the call to `doubleExitAdvancement` — the only measured producer of the cross-structure case — is behaviourally identical, and the rollup output goes from 1 circular chain to 0. Confirmed by rebuilding, not by reading.

## What this does NOT close

The at-scale sweep finds far more `DRAW_INCONSISTENCY` than the 4 in-suite cells. Nine of its reproductions were replayed with these fixes and again with both reverted, to **identical** results. This closes what the canonical-order matrix reaches; the sweep's findings are a different root cause and remain open. Please don't read "E4 done" as "DRAW_INCONSISTENCY done".

## Gates

`pnpm verify` exit 0 (all 16 steps) after the rebase onto current master. Full suite 12,730 passed / 2 skipped. Zero circular-dependency warnings. New spec `doubleEliminationDeciderProgression.test.ts` pins both fixes independently of the quarantine.
