### PR TITLE
fix(propagation): the unwind asked a field the cascade had already overwritten

### DIFF
--- a/src/mutate/drawDefinitions/matchUpGovernor/removeDoubleExit.ts
+++ b/src/mutate/drawDefinitions/matchUpGovernor/removeDoubleExit.ts
@@ -265,6 +265,8 @@ export function conditionallyRemoveDrawPosition(params) {
   const matchUpStatus = getMatchUpStatus({
     pairedPreviousDoubleExit,
     noContextTargetMatchUp,
+    drawDefinition,
+    targetMatchUp,
   });
 
   const removeScore = !pairedPreviousDoubleExit;
@@ -289,10 +291,44 @@ export function conditionallyRemoveDrawPosition(params) {
   return { ...SUCCESS };
 }
 
-function getMatchUpStatus({ pairedPreviousDoubleExit, noContextTargetMatchUp }) {
+/**
+ * Does a drawPosition of this matchUp carry a BYE assignment?
+ *
+ * The positionAssignment is the DURABLE record; the matchUp's own `matchUpStatus` is not, because
+ * by the time the unwind reaches here the cascade has already overwritten a BYE matchUp with the
+ * exit it propagated (measured: `BYE` -> `WALKOVER` on apply). Asking the status therefore asks a
+ * field the cascade has clobbered, while the assignment still says `bye: true`.
+ *
+ * This is the same rule `advanceWinner` applies when it places a matchUp:
+ * `drawPositionIsBye || pairedDrawPositionIsBye ? BYE : TO_BE_PLAYED`.
+ */
+function targetDrawPositionIsBye({ drawDefinition, noContextTargetMatchUp, targetMatchUp }): boolean {
+  const drawPositions = noContextTargetMatchUp?.drawPositions?.filter(Boolean) ?? [];
+  // structureId comes from the IN-CONTEXT matchUp: a no-context matchUp does not carry one, and
+  // reading it there silently yields undefined -> no structure -> a false negative.
+  const structureId = targetMatchUp?.structureId;
+  if (!drawPositions.length || !structureId) return false;
+
+  const { structure: targetStructure } = findStructure({ drawDefinition, structureId });
+  return !!targetStructure?.positionAssignments?.some(
+    (assignment) => drawPositions.includes(assignment.drawPosition) && assignment.bye,
+  );
+}
+
+function getMatchUpStatus({ pairedPreviousDoubleExit, noContextTargetMatchUp, drawDefinition, targetMatchUp }) {
   if (noContextTargetMatchUp.matchUpStatus === BYE) return BYE;
-  if (!pairedPreviousDoubleExit) return TO_BE_PLAYED;
-  return [DOUBLE_DEFAULT, DEFAULTED].includes(noContextTargetMatchUp?.matchUpStatus) ? DEFAULTED : WALKOVER;
+  // A still-live paired double exit keeps its produced exit; that decision is unchanged and is
+  // checked BEFORE the assignment, because a BYE-held drawPosition legitimately carries a
+  // propagated exit while one is outstanding (measured: a Consolation matchUp reads DEFAULTED on a
+  // BYE drawPosition mid-cascade, and must stay that way).
+  if (pairedPreviousDoubleExit) {
+    return [DOUBLE_DEFAULT, DEFAULTED].includes(noContextTargetMatchUp?.matchUpStatus) ? DEFAULTED : WALKOVER;
+  }
+  // Otherwise the unwind is complete and the matchUp reverts. `matchUpStatus` above can already
+  // have been overwritten by the cascade being unwound (measured: BYE -> WALKOVER on apply), so it
+  // cannot answer "was this a BYE?". The positionAssignment is the durable record and still can.
+  if (targetDrawPositionIsBye({ drawDefinition, noContextTargetMatchUp, targetMatchUp })) return BYE;
+  return TO_BE_PLAYED;
 }
 
 /**

--- a/src/tests/mutations/drawDefinitions/doubleExitUnwindRestoresBye.test.ts
+++ b/src/tests/mutations/drawDefinitions/doubleExitUnwindRestoresBye.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression cover for the BYE half of the double-exit unwind.
+ *
+ * Applying a double exit and then clearing it must restore the draw. It did not: a consolation
+ * matchUp that was `BYE` beforehand came back `TO_BE_PLAYED`, while its positionAssignment still
+ * said `bye: true` — an internal contradiction that no state-level check expresses, because no
+ * invariant requires the matchUp's status to agree with its assignment.
+ *
+ * The cause was `removeDoubleExit`'s `getMatchUpStatus` asking `noContextTargetMatchUp.matchUpStatus
+ * === BYE`. By the time the unwind reaches that line the cascade has already OVERWRITTEN the BYE
+ * with the exit it propagated (measured: BYE -> WALKOVER on apply), so the question is put to a
+ * field the cascade has clobbered. The positionAssignment is the durable record and still says
+ * `bye: true`; consulting it restores the BYE.
+ *
+ * Six draw-type/size cells were quarantined for this and are now closed. The remaining
+ * DO_UNDO_IDENTITY entries are two DIFFERENT mechanisms (drawPositions and matchUpStatusCodes) —
+ * see `knownFailures.ts`.
+ */
+import { clearOutcome } from '@Tests/testHarness/exitPropagation/transitions';
+import { nextPlayable, playForward } from '@Tests/testHarness/exitPropagation/driver';
+import { setSubscriptions } from '@Global/state/globalState';
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { expect, it, describe } from 'vitest';
+
+// constants
+import { FIRST_MATCH_LOSER_CONSOLATION, CURTIS_CONSOLATION } from '@Constants/drawDefinitionConstants';
+import { DOUBLE_WALKOVER, DOUBLE_DEFAULT, BYE } from '@Constants/matchUpStatusConstants';
+
+/**
+ * The matchUps that read BYE, by id.
+ *
+ * Deliberately NOT "every matchUp on a BYE drawPosition must read BYE" — that is not an invariant.
+ * A propagated exit legitimately sits on a BYE-held drawPosition while a double exit is
+ * outstanding (measured: a Consolation matchUp reads DEFAULTED there mid-cascade). The property
+ * asserted here is the round trip: whatever was BYE before must be BYE again afterwards.
+ */
+function byeMatchUpIds(drawId: string): string[] {
+  const { drawDefinition } = tournamentEngine.getEvent({ drawId });
+  return (drawDefinition.structures ?? [])
+    .flatMap((structure: any) => structure.matchUps ?? [])
+    .filter((matchUp: any) => matchUp.matchUpStatus === BYE)
+    .map((matchUp: any) => matchUp.matchUpId)
+    .sort((a: string, b: string) => a.localeCompare(b));
+}
+
+describe.each([
+  // [drawType, drawSize, participantsCount, seed] — seeds match the exit-propagation properties matrix
+  [FIRST_MATCH_LOSER_CONSOLATION, 8, 8, 35],
+  [FIRST_MATCH_LOSER_CONSOLATION, 16, 16, 43],
+  [CURTIS_CONSOLATION, 16, 15, 111],
+])('%s %d/%d — unwinding a double exit', (drawType: any, drawSize: any, participantsCount: any, seed: any) => {
+  it.each([DOUBLE_WALKOVER, DOUBLE_DEFAULT])('restores a BYE matchUp rather than blanking it (%s)', (exitStatus) => {
+    setSubscriptions({});
+    const drawId = `unwind-bye-${drawType}-${drawSize}-${participantsCount}-${exitStatus}`;
+    const outcome = { matchUpStatus: exitStatus };
+
+    const { drawIds } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawId, drawType, drawSize, participantsCount }],
+      nonRandom: seed,
+      setState: true,
+    });
+    expect(drawIds).toContain(drawId);
+
+    playForward({ propagateExitStatus: true, exitOutcome: outcome, maxSteps: 5, drawId });
+
+    const target = nextPlayable(drawId);
+    expect(target?.matchUpId).toBeDefined();
+
+    // CONTROL: the probe is worthless unless the draw actually holds BYE matchUps at this point
+    const byesBefore = byeMatchUpIds(drawId);
+    expect(byesBefore.length).toBeGreaterThan(0);
+
+    const applied: any = tournamentEngine.setMatchUpStatus({
+      propagateExitStatus: true,
+      matchUpId: target.matchUpId,
+      drawId,
+      outcome,
+    });
+    expect(applied.error).toBeUndefined();
+
+    const cleared: any = tournamentEngine.setMatchUpStatus({
+      propagateExitStatus: true,
+      matchUpId: target.matchUpId,
+      drawId,
+      outcome: clearOutcome,
+    });
+    expect(cleared.error).toBeUndefined();
+
+    // every matchUp that was a BYE before the double exit is a BYE again after it is cleared
+    expect(byeMatchUpIds(drawId)).toEqual(byesBefore);
+  });
+});

--- a/src/tests/testHarness/exitPropagation/knownFailures.ts
+++ b/src/tests/testHarness/exitPropagation/knownFailures.ts
@@ -33,13 +33,22 @@ const DOUBLE_EXIT_PARTIAL_MUTATION =
   'error code at one of ~12 failure paths downstream of the first write; the partial mutation is ' +
   'untouched. See Mentat/planning/EXIT_PROPAGATION_ASSESSMENT.md §4.';
 
-const DOUBLE_EXIT_NOT_REVERSIBLE =
-  'Applying a double exit is not reversible. After apply-then-clear, a matchUp that was BYE before ' +
-  'the double walkover comes back TO_BE_PLAYED. The BYE-provenance work (db4c925f5) addressed the ' +
-  'positionAssignment side of this; the residue that remains is on the matchUp STATUS, which is a ' +
-  'separate mechanism and is not yet characterised. Every failing cell is a double exit and both ' +
-  'double-exit statuses fail identically in each — systematic, not noise. See ' +
-  'Mentat/planning/EXIT_PROPAGATION_ASSESSMENT.md §3 class B.';
+const DOUBLE_EXIT_DRAWPOSITION_RESIDUE =
+  'DOUBLE_ELIMINATION 8/7: apply-then-clear leaves a Main matchUp with its drawPositions REMOVED — ' +
+  '[1, null] before, absent after. The apply does not touch that matchUp at all (measured), so the ' +
+  'clear over-removes: it strips a drawPosition the cascade never placed. Distinct from the ' +
+  'matchUp-status residue fixed by consulting positionAssignment.bye in removeDoubleExit, and from ' +
+  'the matchUpStatusCodes residue below. See Mentat/planning/EXIT_PROPAGATION_ASSESSMENT.md, E1.';
+
+const DOUBLE_EXIT_STATUS_CODES_RESIDUE =
+  'FIRST_ROUND_LOSER_CONSOLATION: apply-then-clear wipes matchUpStatusCodes that were present ' +
+  'BEFORE the double exit. The matchUp carried [WALKOVER/prev DOUBLE_WALKOVER side 1, ' +
+  'TO_BE_PLAYED side 2]; the apply escalated it to DOUBLE_WALKOVER with both sides WALKOVER; the ' +
+  'clear then writes matchUpStatusCodes: [] unconditionally rather than restoring the codes that ' +
+  'pre-dated the cascade. matchUpStatus itself is restored correctly — only the provenance is lost, ' +
+  'so exitProducedByPropagation reads false for a matchUp that IS propagation-produced. Same ' +
+  'family as the hard-coded empty codes in advanceByeAdvancedDrawPosition. See ' +
+  'Mentat/planning/EXIT_PROPAGATION_ASSESSMENT.md, E1.';
 
 /**
  * Cells failing the relational properties, as [cell-without-status, properties].
@@ -50,17 +59,16 @@ const DOUBLE_EXIT_NOT_REVERSIBLE =
  *
  * IDEMPOTENT_REAPPLY was removed from every cell that carried it when the idempotence guard landed
  * in `attemptToSetMatchUpStatus` — 14 entries, deleted because the reverse guard demanded it.
+ *
+ * The DO_UNDO_IDENTITY list was 9 cells and is now 3. Diffing the round trip structurally showed
+ * the residue was never ONE mechanism: 6 cells lost a matchUp's BYE status (fixed — removeDoubleExit
+ * now reads positionAssignment.bye rather than a matchUpStatus the cascade has already overwritten),
+ * 1 loses drawPositions and 2 lose matchUpStatusCodes. Each survivor carries its own reference.
  */
-const DOUBLE_EXIT_PROPERTY_CELLS: [string, string[]][] = [
-  ['DOUBLE_ELIMINATION 8/7', ['DO_UNDO_IDENTITY']],
-  ['FIRST_MATCH_LOSER_CONSOLATION 8/8', ['DO_UNDO_IDENTITY']],
-  ['FIRST_MATCH_LOSER_CONSOLATION 16/16', ['DO_UNDO_IDENTITY']],
-  ['FIRST_MATCH_LOSER_CONSOLATION 16/15', ['DO_UNDO_IDENTITY']],
-  ['FIRST_ROUND_LOSER_CONSOLATION 8/8', ['DO_UNDO_IDENTITY']],
-  ['FIRST_ROUND_LOSER_CONSOLATION 16/16', ['DO_UNDO_IDENTITY']],
-  ['MODIFIED_FEED_IN_CHAMPIONSHIP 16/15', ['DO_UNDO_IDENTITY']],
-  ['FEED_IN_CHAMPIONSHIP 16/15', ['DO_UNDO_IDENTITY']],
-  ['CURTIS_CONSOLATION 16/15', ['DO_UNDO_IDENTITY']],
+const DOUBLE_EXIT_PROPERTY_CELLS: [string, string[], string][] = [
+  ['DOUBLE_ELIMINATION 8/7', ['DO_UNDO_IDENTITY'], DOUBLE_EXIT_DRAWPOSITION_RESIDUE],
+  ['FIRST_ROUND_LOSER_CONSOLATION 8/8', ['DO_UNDO_IDENTITY'], DOUBLE_EXIT_STATUS_CODES_RESIDUE],
+  ['FIRST_ROUND_LOSER_CONSOLATION 16/16', ['DO_UNDO_IDENTITY'], DOUBLE_EXIT_STATUS_CODES_RESIDUE],
 ];
 
 const ACTION_MUTATION_DISAGREEMENT =
@@ -113,11 +121,11 @@ export const KNOWN_FAILURES: QuarantineEntry[] = [
     properties: ['ACTION_MUTATION_AGREEMENT'],
     reference: ACTION_MUTATION_DISAGREEMENT,
   })),
-  ...DOUBLE_EXIT_PROPERTY_CELLS.flatMap(([cell, properties]) =>
+  ...DOUBLE_EXIT_PROPERTY_CELLS.flatMap(([cell, properties, reference]) =>
     ['DOUBLE_WALKOVER', 'DOUBLE_DEFAULT'].map((exitStatus) => ({
       key: `properties ${cell} ${exitStatus}`,
       properties: properties as string[],
-      reference: DOUBLE_EXIT_NOT_REVERSIBLE,
+      reference: reference as string,
     })),
   ),
 ];

--- a/src/tests/testHarness/exitPropagation/knownFailures.ts
+++ b/src/tests/testHarness/exitPropagation/knownFailures.ts
@@ -38,7 +38,9 @@ const DOUBLE_EXIT_DRAWPOSITION_RESIDUE =
   '[1, null] before, absent after. The apply does not touch that matchUp at all (measured), so the ' +
   'clear over-removes: it strips a drawPosition the cascade never placed. Distinct from the ' +
   'matchUp-status residue fixed by consulting positionAssignment.bye in removeDoubleExit, and from ' +
-  'the matchUpStatusCodes residue below. See Mentat/planning/EXIT_PROPAGATION_ASSESSMENT.md, E1.';
+  'the matchUpStatusCodes residue below. DECIDED (2026-09-09, CA): the unwind will RE-DERIVE the ' +
+  'correct value from current state rather than blanking it, and no source identity is added to the ' +
+  'schema. Not yet implemented. See Mentat/planning/EXIT_PROPAGATION_ASSESSMENT.md, E1.';
 
 const DOUBLE_EXIT_STATUS_CODES_RESIDUE =
   'FIRST_ROUND_LOSER_CONSOLATION: apply-then-clear wipes matchUpStatusCodes that were present ' +
@@ -47,7 +49,10 @@ const DOUBLE_EXIT_STATUS_CODES_RESIDUE =
   'clear then writes matchUpStatusCodes: [] unconditionally rather than restoring the codes that ' +
   'pre-dated the cascade. matchUpStatus itself is restored correctly — only the provenance is lost, ' +
   'so exitProducedByPropagation reads false for a matchUp that IS propagation-produced. Same ' +
-  'family as the hard-coded empty codes in advanceByeAdvancedDrawPosition. See ' +
+  'family as the hard-coded empty codes in advanceByeAdvancedDrawPosition. DECIDED (2026-09-09, CA): ' +
+  'RE-DERIVE the codes on unwind from the current upstream state instead of writing []. Source ' +
+  'identity is deliberately NOT added to matchUpStatusCodes — they are published on every matchUp, ' +
+  'so the published surface stays fixed. Not yet implemented. See ' +
   'Mentat/planning/EXIT_PROPAGATION_ASSESSMENT.md, E1.';
 
 /**


### PR DESCRIPTION
Closes 12 of the 18 quarantined `DO_UNDO_IDENTITY` entries. Block **E1** of the exit-propagation programme — **partial**, deliberately, with the remainder characterised and a decision recorded.

## The block's premise was wrong, and finding that out was most of the work

The quarantine carried one shared reference: *"the residue that remains is on the matchUp STATUS ... not yet characterised."* Diffing the round trip **structurally** — per structure, per positionAssignment, per matchUp field — rather than through the harness's string-offset message, shows every one of the 18 entries has **exactly one** residual difference, in **three** shapes:

| shape | entries | residue | status |
|---|---|---|---|
| matchUp `matchUpStatus` | 12 | `BYE` → `TO_BE_PLAYED` | **fixed here** |
| matchUp `matchUpStatusCodes` | 4 | codes that pre-dated the cascade are wiped | open |
| matchUp `drawPositions` | 2 | `[1, null]` → removed | open |

So the shared reference was accurate for two thirds of the list and wrong for the rest. Each survivor now carries its own.

## What is fixed

`removeDoubleExit`'s `getMatchUpStatus` decided the restored status from `noContextTargetMatchUp.matchUpStatus === BYE`. Snapshotting between the two mutations shows why that cannot work:

```text
before      BYE
after apply WALKOVER      <- the cascade overwrote it
after clear TO_BE_PLAYED  <- so "is it a BYE?" answers no, and the default wins
```

The question is put to a field the cascade has already clobbered. The positionAssignment is the durable record, is untouched, and still says `bye: true`. It is now consulted — the same rule `advanceWinner` already applies when it places a matchUp (`drawPositionIsBye || pairedDrawPositionIsBye ? BYE : TO_BE_PLAYED`), rather than a fourth re-derivation.

**Ordering is deliberate.** The assignment is consulted only where `TO_BE_PLAYED` would otherwise be returned, *after* the paired-double-exit branch, because **"a BYE drawPosition implies a BYE matchUp" is not an invariant**: while a double exit is outstanding, a propagated exit legitimately sits on a BYE-held drawPosition. That was found by writing the stronger assertion first and watching it fail on the **pre-state**, before the test's own mutations. The spec therefore asserts the round trip (what was BYE before is BYE again), not the global rule.

## A measurement note worth keeping

The first attempt **changed nothing**, which looked like a wrong theory. It resolved the structure from `noContextTargetMatchUp.structureId` — and a no-context matchUp does not carry one. Undefined id → no structure → a silent false negative. The in-context `targetMatchUp` is the one that knows.

## What remains, and why it is a decision rather than a fix

Verified against source: a `matchUpStatusCodes` entry is `{matchUpStatus, previousMatchUpStatus, sideNumber}` and carries **no source identity anywhere**. The unwind therefore cannot tell a code *this* cascade wrote from one that pre-dated it, and blanks both — the same gap already recorded for the idempotence bug.

**Decided (CA, 2026-09-09): re-derive the correct value on unwind from current state; do NOT add source identity to the codes**, since they are published on every matchUp and the surface should stay fixed. Recorded on the quarantine entries themselves so the next reader who trips the reverse guard sees it. Not implemented here.

## Gates

`pnpm verify` exit 0 (all 16 steps). Full suite 12,728 passed / 2 skipped against a **same-branch baseline of 12,722 re-measured with the change stashed** — the delta is exactly the 6 new regression tests. Falsified: reverting turns all 6 red with `tsc` clean.
