### PR TITLE
fix(propagation): a foreign drawPosition, reported as an occupied one, after four writes

### DIFF
--- a/src/mutate/drawDefinitions/positionGovernor/doubleExitAdvancement.ts
+++ b/src/mutate/drawDefinitions/positionGovernor/doubleExitAdvancement.ts
@@ -544,6 +544,29 @@ function advanceFromTarget({
       });
     }
 
+    // A winner target in ANOTHER structure has its OWN drawPosition space. The Decider of a
+    // DOUBLE_ELIMINATION holds drawPositions 1 and 2; handing it a Main-draw position is not an
+    // occupied slot but a FOREIGN one, and `assignMatchUpDrawPosition` has no way to say so — it
+    // reports "drawPosition already assigned", and it reports it AFTER this cascade has written
+    // four structures. Measured on DOUBLE_ELIMINATION 8/8: target Decider r1p1, existing
+    // drawPositions [1, 2], requested drawPosition 3.
+    //
+    // Cross-structure progression is the link's job, so it goes through directWinner like any
+    // other linked advancement rather than through a raw drawPosition assignment.
+    if (nextWinnerMatchUp.structureId !== targetMatchUp.structureId) {
+      directExitWinnerAcrossLink({
+        sourceStructureId: targetMatchUp.structureId,
+        sourceMatchUp: noContextTargetMatchUp,
+        drawPositionToAdvance,
+        inContextDrawMatchUps,
+        drawDefinition,
+        matchUpsMap,
+        targetData,
+        params,
+      });
+      return decorateResult({ result: { ...SUCCESS }, stack });
+    }
+
     return assignMatchUpDrawPosition({
       matchUpId: nextWinnerMatchUp.matchUpId,
       drawPosition: drawPositionToAdvance,

--- a/src/tests/mutations/drawDefinitions/doubleExitCrossStructureAdvance.test.ts
+++ b/src/tests/mutations/drawDefinitions/doubleExitCrossStructureAdvance.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression cover for the partial mutation that started this workstream.
+ *
+ * Applying a DOUBLE_WALKOVER to a DOUBLE_ELIMINATION Backdraw final returned
+ * ERR_EXISTING_POSITION_ASSIGNMENT **after writing four structures** — the Main final, the source
+ * matchUp, a BYE into the Decider, and the Decider matchUp. An error over already-mutated state
+ * means the caller sees a failure while the draw has already changed.
+ *
+ * The error message was also misleading. Measured at the refusal:
+ *
+ *     target Decider r1p1, existing drawPositions [1, 2], requested drawPosition 3
+ *
+ * The Decider holds drawPositions 1 and 2 — its OWN position space. drawPosition 3 is a Main-draw
+ * position, so this is not an occupied slot but a FOREIGN one, and `assignMatchUpDrawPosition` has
+ * no vocabulary for that. Cross-structure progression is the link's job; it now goes through
+ * `directWinner` like any other linked advancement.
+ *
+ * NOTE the retry half of the original finding is already fixed: the quarantine reference said "a
+ * retry errors AND mutates again", and by the time this was picked up the idempotence guard from
+ * #4782 had made the retry a clean no-op. Only the partial mutation survived.
+ */
+import { getDrawInconsistencies } from '@Query/drawDefinition/getDrawInconsistencies';
+import { hash, getDrawMatchUps } from '@Tests/testHarness/exitPropagation/transitions';
+import { firstPlayable, nextPlayable } from '@Tests/testHarness/exitPropagation/driver';
+import { getDrawDefinition } from '@Tests/testHarness/exitPropagation/transitions';
+import { setSubscriptions } from '@Global/state/globalState';
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { expect, it, describe } from 'vitest';
+
+// constants
+import { DOUBLE_WALKOVER, DOUBLE_DEFAULT } from '@Constants/matchUpStatusConstants';
+import { DOUBLE_ELIMINATION } from '@Constants/drawDefinitionConstants';
+
+describe.each([
+  [DOUBLE_WALKOVER, 67],
+  [DOUBLE_DEFAULT, 69],
+])('DOUBLE_ELIMINATION 8/8 — %s cascade reaching the Decider', (exitStatus: any, seed: any) => {
+  it('never returns an error over an already-mutated draw', () => {
+    setSubscriptions({});
+    const drawId = `cross-structure-${exitStatus}`;
+    const outcome = { matchUpStatus: exitStatus };
+
+    const { drawIds } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawId, drawType: DOUBLE_ELIMINATION, drawSize: 8, participantsCount: 8 }],
+      nonRandom: seed,
+      setState: true,
+    });
+    expect(drawIds).toContain(drawId);
+
+    // the schedule the exit-propagation matrix drives: one planted exit, then forward with a
+    // periodic exit, which is what reaches the Backdraw final while the Decider is half-filled
+    const lead = nextPlayable(drawId);
+    tournamentEngine.setMatchUpStatus({ propagateExitStatus: true, matchUpId: lead.matchUpId, drawId, outcome });
+
+    const skip = new Set<string>();
+    const errorsOverMutation: string[] = [];
+    let steps = 0;
+
+    for (let taken = 0; taken < 200; taken++) {
+      const target = firstPlayable(getDrawMatchUps(drawId), skip);
+      if (!target) break;
+      steps++;
+      const applied = taken % 3 === 2 ? outcome : { winningSide: 1 };
+
+      const before = hash(getDrawDefinition(drawId));
+      const result: any = tournamentEngine.setMatchUpStatus({
+        propagateExitStatus: true,
+        matchUpId: target.matchUpId,
+        drawId,
+        outcome: applied,
+      });
+      const after = hash(getDrawDefinition(drawId));
+
+      if (result?.error && before !== after) {
+        errorsOverMutation.push(
+          `${target.structureName} r${target.roundNumber}p${target.roundPosition}: ` +
+            `${JSON.stringify(result.error)} returned after mutating the draw`,
+        );
+      }
+      if (result?.error) skip.add(target.matchUpId);
+    }
+
+    // CONTROL: a schedule that stopped immediately would satisfy the assertion vacuously
+    expect(steps).toBeGreaterThan(5);
+    expect(errorsOverMutation).toEqual([]);
+
+    // and the draw the cascade produced is whole, not merely error-free
+    const drawDefinition = getDrawDefinition(drawId);
+    const integrity: any = getDrawInconsistencies({ drawDefinition, drawId });
+    expect(integrity.inconsistencies).toEqual([]);
+  });
+});

--- a/src/tests/testHarness/exitPropagation/knownFailures.ts
+++ b/src/tests/testHarness/exitPropagation/knownFailures.ts
@@ -25,14 +25,6 @@ export type QuarantineEntry = {
   reference: string;
 };
 
-const DOUBLE_EXIT_PARTIAL_MUTATION =
-  'DOUBLE_ELIMINATION double exit: setMatchUpStatus returns ERR_EXISTING_POSITION_ASSIGNMENT after ' +
-  'writing four structures (backdraw final, main final, a BYE into the Decider, and a position ' +
-  'assignment), and the call is not idempotent — a retry errors AND mutates again. On master the ' +
-  'same sequence throws the #4779 TypeError instead, so #4779 converted the crash into a clean ' +
-  'error code at one of ~12 failure paths downstream of the first write; the partial mutation is ' +
-  'untouched. See Mentat/planning/EXIT_PROPAGATION_ASSESSMENT.md §4.';
-
 const DOUBLE_EXIT_DRAWPOSITION_RESIDUE =
   'DOUBLE_ELIMINATION 8/7: apply-then-clear leaves a Main matchUp with its drawPositions REMOVED — ' +
   '[1, null] before, absent after. The apply does not touch that matchUp at all (measured), so the ' +
@@ -110,17 +102,7 @@ const ACTION_DISAGREEMENT_CELLS = [
   'OLYMPIC 16/15',
 ];
 
-const doubleEliminationCell = (drawSize: number, exitStatus: string, propagate: boolean) =>
-  `matrix DOUBLE_ELIMINATION ${drawSize}/${drawSize} ${exitStatus} propagate=${propagate}`;
-
 export const KNOWN_FAILURES: QuarantineEntry[] = [
-  ...['DOUBLE_WALKOVER', 'DOUBLE_DEFAULT'].flatMap((exitStatus) =>
-    [true, false].map((propagate) => ({
-      key: doubleEliminationCell(8, exitStatus, propagate),
-      properties: ['ERROR_IMPLIES_NO_MUTATION'],
-      reference: DOUBLE_EXIT_PARTIAL_MUTATION,
-    })),
-  ),
   ...ACTION_DISAGREEMENT_CELLS.map((cell) => ({
     key: `agreement ${cell} WALKOVER`,
     properties: ['ACTION_MUTATION_AGREEMENT'],


### PR DESCRIPTION
Closes the 4 quarantined `ERROR_IMPLIES_NO_MUTATION` cells — `DOUBLE_ELIMINATION 8/8`, both double-exit statuses, both `propagateExitStatus` values. Block **E3**, and the finding that started the exit-propagation workstream.

## What was wrong

Applying a `DOUBLE_WALKOVER` to the Backdraw final returned `ERR_EXISTING_POSITION_ASSIGNMENT` **after writing four structures**:

```text
matchUp  Main      TO_BE_PLAYED -> WALKOVER (winningSide 1, with propagation codes)
matchUp  Backdraw  TO_BE_PLAYED -> DOUBLE_WALKOVER          (the source itself)
assign   Decider   dp1 {} -> { bye: true, byeFromPropagation: true }
matchUp  Decider   TO_BE_PLAYED -> BYE
```

An error returned over mutated state means the caller sees a failure while the draw has already changed.

## The error message was the misdirection

Instrumenting the refusal rather than trusting its text:

```text
target Decider r1p1, existing drawPositions [1, 2], requested drawPosition 3
Decider positionAssignments: [[1, bye], [2, empty]]
```

The Decider holds drawPositions **1 and 2** — its own position space. **drawPosition 3 is a Main-draw position.** This was never an occupied slot; it was a **foreign** one. `assignMatchUpDrawPosition` has no vocabulary for that: `getUpdatedDrawPositions` can only report that two positions are present and neither matches, which surfaces as "drawPosition already assigned".

`advanceFromTarget` was handing a source-structure drawPosition to a winner target in a different structure. Cross-structure progression is the link's job, so it now routes through `directWinner`.

## Same shape as #4788, and measured NOT to be the same code path

**#4788** (now merged) fixed a *silent* cross-structure fall-through in `advanceDrawPosition`; this is a *loud* one in `advanceFromTarget`. It is tempting to assume one fix covers both — it does not. Running this reproduction on the #4788 branch left the error **byte-identical**. Two call paths, one root cause; this reuses that PR's `directExitWinnerAcrossLink` rather than duplicating it in the same function.

## Two corrections to the quarantine reference this deletes

Both would have sent the next reader hunting something already fixed:

- It said *"the call is not idempotent — a retry errors AND mutates again"*. **Measured now: the retry returns no error and does not mutate.** The idempotence guard in #4782 had already closed that half and the reference was never updated.
- It described the failure as a position-assignment conflict. It is a **structure-scope violation**.

`doubleEliminationCell` is deleted along with the last entry that used it.

## Falsification

The E3 hunk reverted **alone**, with the base helper left in place and `tsc --noEmit` clean, so the red is behavioural: both regression tests fail with the original `drawPosition already assigned ... returned after mutating the draw`.

## Gates

`pnpm verify` exit 0 (all 16 steps). Full suite 12,730 passed / 2 skipped. Zero circular-dependency warnings. The new spec asserts both that no error is returned over a mutated draw **and** that `getDrawInconsistencies` reports the resulting draw whole — error-free is not the same as correct — and carries a step-count control so a schedule that stopped early cannot satisfy it vacuously.
