### PR TITLE
ci(docs): gate the docs site build, and make the gate able to fail

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,81 @@
+name: Docs
+
+# Builds the Docusaurus site so a broken docs build fails at PR time instead of at
+# `pnpm docs:publish`.
+#
+# Until this existed, `documentation/` was covered by NOTHING: a grep for "documentation"
+# across .github/workflows/ returned no hits, and `verify.yml` cannot cover it even
+# incidentally — `documentation/` is its own pnpm install root (its own package.json,
+# pnpm-lock.yaml and pnpm-workspace.yaml, and it is not a member of the root workspace),
+# so `pnpm install --frozen-lockfile` at the repo root never installs Docusaurus at all.
+#
+# Deliberately a SEPARATE workflow rather than a 17th step in `verify`:
+#   - `verify` already runs 17-22 minutes; docs breakage should not queue behind coverage.
+#   - the install roots differ, so it would need its own install + cache inside one job anyway.
+#   - path filtering keeps it off PRs that do not touch docs, instead of taxing every PR.
+#
+# The two failure modes this catches are different mechanisms, and only one of them needed
+# a config change:
+#   - a bad `sidebars.js` document id fails the build on its own (config validation), so it
+#     is caught here regardless of link settings;
+#   - a broken link in prose only fails because `onBrokenLinks`/`onBrokenMarkdownLinks` were
+#     moved from 'warn' to 'throw'. Under 'warn' the build exits 0 with broken links in it,
+#     which would have made this job report clean for a broken site.
+# Both were verified by planting each defect and watching this build go red.
+
+on:
+  pull_request:
+    paths:
+      - 'documentation/**'
+      - '.github/workflows/docs.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'documentation/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: docs site build
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      # pnpm via corepack, driven by `packageManager` in package.json. The repo's
+      # allowed-actions policy blocks third-party actions, so no pnpm/action-setup.
+      - run: corepack enable
+
+      - name: Resolve pnpm store path
+        run: echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+
+      # Keyed on documentation/pnpm-lock.yaml specifically: the docs tree is a
+      # different dependency graph from the root, and sharing the root's key would
+      # thrash both caches.
+      - uses: actions/cache@v6
+        with:
+          path: ${{ env.PNPM_STORE_PATH }}
+          key: ${{ runner.os }}-docs-pnpm-${{ hashFiles('documentation/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-docs-pnpm-
+
+      - name: install (documentation)
+        working-directory: documentation
+        run: pnpm install --frozen-lockfile
+
+      # `docusaurus build` is the whole gate. It fails on an unresolvable sidebar id and —
+      # since onBrokenLinks is 'throw' — on any broken internal link.
+      - name: build the docs site
+        working-directory: documentation
+        run: pnpm build

--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -11,14 +11,21 @@ module.exports = {
   // under the default. `true` re-bases them under the current page (404s);
   // `false` switches to flat .html output so the slash target has no folder.
   // Silencing the warning would require rewriting those relative links repo-wide.
-  onBrokenLinks: 'warn',
+  //
+  // onBrokenLinks is 'throw' so the CI docs job can actually fail. Under 'warn' the build
+  // still exits 0 with broken links in it, which makes a "docs build" gate report clean for a
+  // site that is broken — a check that cannot report dirty is not a check. Verified at the time
+  // of the change: the site builds clean under 'throw', so this fails only on NEW breakage.
+  onBrokenLinks: 'throw',
   favicon: 'img/favicon.ico',
   organizationName: 'CourtHive',
   projectName: 'competition-factory',
   markdown: {
     mermaid: true,
     hooks: {
-      onBrokenMarkdownLinks: 'warn',
+      // 'throw' for the same reason as onBrokenLinks above: a markdown link to a file that does
+      // not exist is a defect, and warning about it lets it ship.
+      onBrokenMarkdownLinks: 'throw',
     },
   },
   themeConfig: {


### PR DESCRIPTION
Closes the gap found while surveying the exit-propagation docs: **`grep -rl documentation .github/workflows/` returns nothing.** The Docusaurus build is gated nowhere, so a broken sidebar id or link surfaces only at `pnpm docs:publish`.

**#4785** — merged last night — added a doc file *and* edited `sidebars.js`, which is exactly that risk shape. It happened to be clean; nothing checked.

## Why a separate workflow rather than a 17th `verify` step

`verify.yml` cannot cover this even incidentally. **`documentation/` is its own pnpm install root** — its own `package.json`, `pnpm-lock.yaml` and `pnpm-workspace.yaml` (`packages: []`), and the root workspace has no `packages:` key — so `pnpm install --frozen-lockfile` at the repo root never puts Docusaurus on disk.

So it needs its own install and its own cache key regardless. Making it a separate, path-filtered job also keeps it off the 17–22 minute verify matrix and off PRs that touch no docs.

## The order matters, and it is the point of the PR

`onBrokenLinks` was `'warn'`. **Under `'warn'` the build exits 0 with broken links in it** — so a CI job on its own would have been a check that cannot report dirty, the false-all-clear shape `coding-standards.md` warns about. Sequence used:

1. flip `onBrokenLinks` and `onBrokenMarkdownLinks` to `'throw'`;
2. **control** — build under `'throw'`: exit 0. The site is already clean, so this gate fails only on *new* breakage, never on a pre-existing backlog;
3. **falsify** both failure modes;
4. only then wire the job.

## Falsification

| planted defect | exit | error |
|---|---|---|
| broken markdown link in `concepts/exit-propagation.md` | **1** | `Docusaurus found broken links!`, naming the source page |
| `sidebars.js` id `testing/exit-propagation-harness-TYPO` | **1** | `Invalid sidebar file … These sidebar document ids do not exist` |

Both reverted; the restored build exits 0.

**These are two different mechanisms and it is worth keeping them straight.** A bad sidebar id is *config validation* and fails on its own — any docs build catches it, even under `'warn'`. A broken link in prose fails **only** because of the `'throw'` flip. The job and the config change each catch something the other does not.

## Scope

`'throw'` also applies to `pnpm docs:publish`, so a deploy carrying a broken link now fails instead of publishing a broken site. Intended.

Deliberately **only** the gate. The docs *content* gaps found in the same survey — four shipped behaviours that are undocumented, a missing "known limitations" section, and a published guarantee that a one-seed local run refutes — are held until E2 is settled, at the maintainer's instruction.

## Gates

`pnpm verify` exit 0 (12,736 passed / 2 skipped). Nothing under `src/` changed, but measured rather than assumed. Workflow YAML parsed and asserted: 7 steps, path filters as intended.
