### PR TITLE
feat(ladder): put the challenge lifecycle on the engine, and document 7.0.0

### DIFF
--- a/documentation/docs/concepts/draw-types/ladder.md
+++ b/documentation/docs/concepts/draw-types/ladder.md
@@ -18,6 +18,11 @@ and `drawPosition` reads as **rank**, where 1 is the top.
 Ask `isLadder(drawType)` wherever that difference matters. `isAdHocType(drawType)` is true for a
 ladder and answers a different question — whether the structure has bracket geometry.
 
+Every example below is a `tournamentEngine` call taking `drawId`. The engine resolves the
+drawDefinition, the ladder's structure, and — where one is named — the matchUp, so a caller never
+holds any of them. Passing a `drawDefinition` or `structure` explicitly still works and wins over
+resolution.
+
 ## What a ladder is made of
 
 | piece        | where it lives                                                 |
@@ -39,11 +44,11 @@ arrives from a draw, which is why eligibility is enforced when the challenge is 
 when a draw is generated — nothing upstream decided these two would meet.
 
 ```js
-const { matchUpId } = issueChallenge({
+const { matchUpId } = tournamentEngine.issueChallenge({
   challengerParticipantId: 'p9',
   defenderParticipantId: 'p7',
   issuedAt: '2026-03-01T10:00:00.000Z',
-  drawDefinition,
+  drawId,
 });
 ```
 
@@ -80,9 +85,9 @@ different facts, and conflating them would let one participant reorder the ladde
 a win nobody contradicted.
 
 ```js
-submitResult({ participantId: 'p9', outcome: { winningSide: 1 }, submittedAt, drawDefinition, matchUpId });
+tournamentEngine.submitResult({ participantId: 'p9', outcome: { winningSide: 1 }, submittedAt, matchUpId, drawId });
 // score is recorded; matchUpStatus becomes AWAITING_RESULT
-confirmResult({ participantId: 'p7', confirmedAt, drawDefinition, matchUpId });
+tournamentEngine.confirmResult({ participantId: 'p7', confirmedAt, matchUpId, drawId });
 // matchUpStatus becomes COMPLETED — and only now can the standing move
 ```
 
@@ -106,7 +111,7 @@ writes cannot diverge between paths.
 It takes a **trigger** rather than an outcome, and derives the rest:
 
 ```js
-applyLadderMovement({ trigger: 'RESULT', matchUpId, drawDefinition, structure, appliedAt });
+tournamentEngine.applyLadderMovement({ trigger: 'RESULT', matchUpId, appliedAt, drawId });
 ```
 
 | trigger   | requires                                                                                                                                      |
@@ -148,7 +153,7 @@ Under `RATING`, `positionAssignments` becomes a projection rather than the sourc
 rather than assuming `positionAssignments`.
 
 ```js
-const standing = getLadderStanding({ tournamentRecord, drawDefinition, structure });
+const standing = tournamentEngine.getLadderStanding({ drawId });
 // [{ position: 1, participantId: 'p3', ratingValue: 12.5 }, …]
 ```
 
@@ -185,7 +190,7 @@ worth knowing: _inactivity_ here means unresponsive to challenges, never "has no
 participant nobody challenges never lapses.
 
 ```js
-const { count, exceeded, consequence } = getLapses({ participantId, asOf, structure, drawDefinition });
+const { count, exceeded, consequence } = tournamentEngine.getLapses({ participantId, asOf, drawId });
 ```
 
 Windows: `SEASON` counts everything, `ROLLING` forgets beyond `windowDays`, and `CONSECUTIVE` is
@@ -204,7 +209,7 @@ Because a participant nobody challenges never lapses, there is no automatic rout
 has left the club, is injured for the season, or has died. `removeLadderParticipant` is that route:
 
 ```js
-removeLadderParticipant({ participantId, reason: 'left the club', removedAt, drawDefinition });
+tournamentEngine.removeLadderParticipant({ participantId, reason: 'left the club', removedAt, drawId });
 ```
 
 It closes the ladder up beneath them — a ladder with a hole in it is not a ranking — and records the
@@ -251,7 +256,7 @@ because absent is not "best". Direction is honoured here as everywhere: on a WTN
 number seats higher.
 
 ```js
-addLadderParticipant({ participantId, addedAt, drawDefinition, tournamentRecord });
+tournamentEngine.addLadderParticipant({ participantId, addedAt, drawId });
 ```
 
 Under `RATING` ordering placement is moot — the participant is appended and `getLadderStanding`
@@ -273,7 +278,7 @@ standing re-derives.
 **External.** Ratings belong to a provider. An operator refreshes them in bulk:
 
 ```js
-refreshLadderRatings({ ratings: { [participantId]: 12.4 }, refreshedAt, drawDefinition, tournamentRecord });
+tournamentEngine.refreshLadderRatings({ ratings: { [participantId]: 12.4 }, refreshedAt, drawId });
 ```
 
 Between refreshes the standing **holds still**, and that is not a block on play: a participant

--- a/documentation/docs/migration-7.0.0.md
+++ b/documentation/docs/migration-7.0.0.md
@@ -2,8 +2,14 @@
 title: Migration 6.x to 7.0.0
 ---
 
+Version 7.0.0 of the Competition Factory is a **major** release driven by breaking changes in three
+areas — exit propagation, time-zone conversion, and one constant rename. The headline _feature_, the
+[LADDER draw type](./whats-new-7.0.0#the-headline-feature--the-ladder-draw-type), is purely additive
+and requires no migration.
+
 This document is for **consumers** of the factory (TMX, courthive-components, the server, downstream
-tools). It catalogues the breaking changes in 7.0.0 and the exact steps to adopt them.
+tools). It catalogues the breaking changes in 7.0.0 and the exact steps to adopt them. For the
+feature tour and the full list of 7.0.0 additions, see [What's New in 7.0.0](./whats-new-7.0.0).
 
 ## Breaking changes at a glance
 
@@ -137,6 +143,12 @@ to infer it.
 
 `plainDate`, `plainTime` and `zonedDateTime` are new published exports, completing the calendar
 intent set. `zonedTime` was never published, so its rename is not a breaking change.
+
+The `LADDER` drawType is generatable and its lifecycle is on the engine as eighteen new methods —
+`issueChallenge`, `acceptChallenge`, `declineChallenge`, `submitResult`, `confirmResult`,
+`disputeResult`, `applyLadderMovement`, `addLadderParticipant`, `removeLadderParticipant`,
+`refreshLadderRatings`, and eight `get*` queries. All are additive; see
+[What's New in 7.0.0](./whats-new-7.0.0#driving-a-ladder).
 
 `PositionAssignment.byeFromPropagation` is a new optional boolean recording that a BYE was placed by
 an exit cascade rather than by draw generation or by hand. It is visible in stored tournament

--- a/documentation/docs/whats-new-7.0.0.md
+++ b/documentation/docs/whats-new-7.0.0.md
@@ -1,0 +1,161 @@
+---
+title: What's New in 7.0.0
+---
+
+Version 7.0.0 of the Competition Factory ships **three areas of breaking change** — exit propagation, time-zone conversion, and one constant rename — and one headline feature: the **LADDER draw type**, a continuous challenge-driven competition with an enforced `CHALLENGED` status, an attestation gate on self-reported results, `RANK` or `RATING` ordering, and eighteen new engine methods to drive it.
+
+For upgrade mechanics — the five breaking-change rows and the exact steps to adopt them — see the [6.x to 7.0.0 migration guide](./migration-7.0.0).
+
+For the full per-commit changelog see [CHANGELOG.md](https://github.com/CourtHive/competition-factory/blob/master/CHANGELOG.md).
+
+## The headline changes
+
+Three changes break the surface and need consumer attention. All are covered in detail in the [migration guide](./migration-7.0.0).
+
+### 1. Exit propagation is idempotent, atomic, and correct
+
+`WALKOVER` and `DEFAULTED` statuses cascade through a draw, placing BYEs and advancing participants ahead of a match that will never be played. 7.0.0 corrects a cluster of defects in that cascade, found by a new test harness and an at-scale sweep. Two of the fixes change behaviour a caller could have been relying on.
+
+**Re-applying the same double exit now does nothing.** Previously the second call re-ran the cascade, read its own earlier work as a _second_ source exiting into the same target, escalated the produced `WALKOVER` to a `DOUBLE_WALKOVER`, and cascaded a round further. Both calls reported success, so a client retry or a double-click corrupted the draw progressively and silently.
+
+**A rejected mutation leaves the draw unchanged.** `setMatchUpStatus` now validates a bare `{ winningSide }` outcome _before_ any removal runs, so a refused call leaves the draw byte-identical. Previously such an outcome skipped the early participant check — it carries no `matchUpStatus` — and was caught only after the existing result had already been unwound. A rejected call could therefore destroy a recorded result.
+
+The rest correct wrong answers rather than change a contract: a topology proxy that awarded a walkover to the side holding nobody, a cross-structure winner that fell through silently and never reached the Decider, an unwind that asked a field the cascade had already overwritten, a source-structure `drawPosition` handed to a target in another structure, and an unguarded `participantId === undefined` that matched the first empty slot rather than nothing.
+
+→ [Exit Propagation](./concepts/exit-propagation), [migration §2](./migration-7.0.0#2-re-applying-a-double-exit-is-now-idempotent), [migration §3](./migration-7.0.0#3-a-rejected-mutation-leaves-the-draw-unchanged).
+
+### 2. Time-zone conversions refuse rather than throw or guess
+
+The zoned calendar intent had two implementations — a published `timeZone.ts` and an internal `zonedTime.ts` that carried every live conversion in the repo. On valid input they were measured to be numerically identical: 420,480 wall clocks across 12 zones and every day of 2026, plus all 418 IANA zones from 1970 onward, produced zero disagreements. DST was never the difference.
+
+The difference was failure handling, and each was fail-open on a different axis. `timeZone.ts` **threw an uncaught `RangeError`** from functions typed `string | { error }`, and omitting the zone returned the _host machine's_ offset — so the same published call answered differently on a New York server and a London one. `zonedTime.ts` never threw, but silently substituted the caller's offset for an unrecognised zone.
+
+`zonedDateTime` is now the single implementation and `timeZone` is an adapter over it with no arithmetic of its own. Three inputs get three answers, and never a substituted number:
+
+| Input             | Result                                                   |
+| ----------------- | -------------------------------------------------------- |
+| zone absent       | the caller's `utcOffsetMinutes`, with `source: 'offset'` |
+| zone unrecognised | refused — `{ error: INVALID_TIME_ZONE }`                 |
+| zone recognised   | resolved per instant, with `source: 'zone'`              |
+
+`getTimeZoneOffsetMinutes` also changes shape, from `number` to `number | undefined` — the one change in this area that alters a published **type**, so a TypeScript consumer sees it at compile time rather than at runtime.
+
+→ [migration §4](./migration-7.0.0#4-time-zone-conversions-refuse-rather-than-throw-or-guess), [tools.zonedDateTime](./tools/tools-api#toolszoneddatetime).
+
+### 3. `participantsRequiredMatchUpStatuses` — a spelling fix
+
+The exported constant was misspelled `particicipantsRequiredMatchUpStatuses` (an extra `ici`) since it was introduced. Rename the import; the value, the type and the semantics are identical. No deprecated alias is provided, and a survey of the CourtHive ecosystem found no consumer importing the old name.
+
+→ [migration §1](./migration-7.0.0#1-participantsrequiredmatchupstatuses--a-spelling-fix).
+
+## The headline feature — the LADDER draw type
+
+A **ladder** is a continuous, challenge-driven competition. Participants occupy an ordered **standing**, a participant may **challenge** someone above them, and the result rearranges the standing. There are no rounds, no bracket, no fixed field, and often no end date.
+
+`LADDER` shares the `AD_HOC` _structure shape_ — matchUps carry neither `roundPosition` nor `drawPosition` — but not its meaning: an `AD_HOC` draw's `positionAssignments` are a roster, while a ladder's **are the standing** and `drawPosition` reads as **rank**, where 1 is the top. `isAdHocType('LADDER')` is therefore `true`; ask `isLadder` wherever the difference matters.
+
+The full walkthrough is the [Ladder concepts page](./concepts/draw-types/ladder). What follows is what is new about it.
+
+### Driving a ladder
+
+`drawType: LADDER` generates a structure with no matchUps and no positionAssignments — every matchUp is created by a challenge, and every position is a rank that `addLadderParticipant` assigns. The lifecycle is on the engine as eighteen methods, and each resolves the ladder from `drawId` alone:
+
+```js
+tournamentEngine.addLadderParticipant({ participantId, addedAt, drawId });
+
+const { matchUpId } = tournamentEngine.issueChallenge({
+  challengerParticipantId,
+  defenderParticipantId,
+  issuedAt,
+  drawId,
+});
+
+tournamentEngine.acceptChallenge({ matchUpId, respondedAt, drawId });
+tournamentEngine.submitResult({ participantId, outcome: { winningSide: 1 }, submittedAt, matchUpId, drawId });
+tournamentEngine.confirmResult({ participantId, confirmedAt, matchUpId, drawId });
+tournamentEngine.applyLadderMovement({ trigger: 'RESULT', appliedAt, matchUpId, drawId });
+
+const standing = tournamentEngine.getLadderStanding({ drawId });
+// [{ position: 1, participantId: 'p9' }, …]
+```
+
+Three internal helpers are deliberately **not** on the engine. `mirrorStandingToScale` must stay a side effect of the position mutation, or a caller could move a standing without writing its history; `applyLapseConsequence` is invoked by `declineChallenge` _after_ the lapse is counted, so calling it directly would apply a penalty nothing counted.
+
+### The challenge is the only fixture a participant creates
+
+Everything else in the factory arrives from a draw. Eligibility is consequently enforced when the challenge is **issued** rather than when a draw is generated — nothing upstream decided these two would meet. A downward challenge, a self-challenge, a participant not seated on the ladder, a challenge outside the policy's range, and any drawType that is not `LADDER` are all refused.
+
+Expiry is **derived, never stored**, so a challenge nobody looked at does not sit in the record claiming to be pending.
+
+→ [The challenge](./concepts/draw-types/ladder#the-challenge).
+
+### `CHALLENGED` is the first matchUpStatus whose context is enforced
+
+`CHALLENGED` is valid only in a `LADDER` drawType; `setMatchUpStatus` returns `ERR_MATCHUP_STATUS_OUT_OF_SCOPE` anywhere else. The mechanism is general — `matchUpStatusScopes` declares where a status may be used and `getMatchUpStatusScopeViolation` enforces it — rather than an `if` in one setter. `DEAD_RUBBER`, meaningful only inside a team tie, is the obvious second adopter and is declared but deliberately left inactive, since enforcing it could reject data that is legal today.
+
+`CHALLENGED` joins `validMatchUpStatuses`, `participantsRequiredMatchUpStatuses`, `nonDirectingMatchUpStatuses` and **`upcomingMatchUpStatuses`**. That last one widens the meaning of "upcoming" from _will happen_ to _is expected to happen_, since a challenge may be declined or expire — a deliberate trade, because a challenge missing from every upcoming-match view is invisible to exactly the people who must act on it.
+
+→ [Scope enforcement](./concepts/draw-types/ladder#challenged-is-scoped-to-ladder-and-the-scope-is-enforced).
+
+### An attestation gate on self-reported results
+
+A ladder result is reported by the people who played it, so movement is gated on an **attested** result in code rather than in a comment. `POLICY_LADDER`'s `resultValidation` decides what counts: `PEER` (the opponent confirms), `OPERATOR` (an official does), or `EITHER`. A submitted result that has been **disputed** is blocked from moving the standing.
+
+→ [Reporting a result](./concepts/draw-types/ladder#reporting-a-result).
+
+### Declines, silence and no-shows are one mechanism
+
+Declining a challenge, ignoring one until it expires, and accepting then not turning up are treated as a single **lapse**, not three separate rules — from the challenger's side they are the same offence, being unavailable to the people below you, and clubs already treat them that way. A unified `lapsePolicy` decides the consequence.
+
+Because consequences are evaluated when a challenge **resolves** rather than by a periodic sweep, a participant nobody challenges never lapses. An operator removal escape hatch exists for exactly that case.
+
+→ [Lapses](./concepts/draw-types/ladder#lapses), [Removing someone by hand](./concepts/draw-types/ladder#removing-someone-by-hand).
+
+### Ordering is `RANK` or `RATING`, and direction is read rather than assumed
+
+Under `RANK` (the default) the standing is `positionAssignments`, mutated by the movement rules — `SWAP` or `INSERTION`, which are genuinely different competitions. Under `RATING` the standing is derived from each participant's rating, `positionAssignments` becomes a projection, and movement does nothing because the ordering already _is_ the scale.
+
+`ratingsParameters[ratingType].ascending` decides which end is the top: `WTN`, `BWF` and `USAR` are lower-is-better, while `UTR`, `ELO`, `DUPR` and `PSA` are higher-is-better. Hardcoding "higher wins" would invert an entire WTN ladder and raise no error. An unrated participant sorts **last** — absent is not "best" — and an unknown `ratingType` returns the stored order with no `ratingValue` rather than presenting a misconfiguration as a working ladder.
+
+Every rank change is mirrored to a dated `ScaleItem` as a **side effect** of the position mutation, never as a separate call a caller might skip, so "where was I in March" is an ordinary scale lookup rather than a second store.
+
+→ [Ordering](./concepts/draw-types/ladder#ordering-rank-or-rating), [Movement](./concepts/draw-types/ladder#movement), [History](./concepts/draw-types/ladder#history).
+
+### What the factory deliberately does not do
+
+**It does not fetch ratings.** UTR, WTN and DUPR are other people's systems with their own credentials and terms; retrieving values belongs in an operator's ingest adapter, not in a competition engine. A rating-ordered ladder therefore runs either **dynamically** — the factory computes ratings from ladder results via the same `generateDynamicRatings` machinery DrawMatic uses, seeded from each participant's published rating — or from an operator's **bulk refresh**.
+
+Dispute _resolution_ is not built: a disputed result is blocked from moving the standing, but nothing resolves it yet.
+
+→ [Not yet built](./concepts/draw-types/ladder#not-yet-built).
+
+## Other 7.0.0 additions
+
+- **`SQUASH` and `BADMINTON` join the discipline vocabulary** — `DisciplineUnion` accepts any string, so both values already validated; what they lacked was membership of the **curated** set that drives autocomplete, normalization and near-match typo defense. They belong there because the [matchUpFormat grammar](./codes/matchup-format) already parses and round-trips both sports' scoring, and a discipline the engine can score should not be a stranger to the vocabulary.
+- **The four calendar intents are named and documented** — `tools.plainDate` (which calendar day), `tools.plainTime` (what time on the clock), `tools.zonedDateTime` (which moment at a venue) and an absolute instant. Only the third depends on a zone, and mixing the first two without an explicit conversion produces a figure wrong by the venue's UTC offset. `plainDate`, `plainTime` and `zonedDateTime` are new published exports; `tools.dateTime` is supported and unchanged. See [Four questions, not one](./concepts/date-time-handling#four-questions-not-one).
+- **The Temporal status is corrected** — Temporal reached Stage 4 in March 2026, is part of ES2026, and ships unflagged in Node 26, Chrome/Edge 144, Firefox 139 and Deno 2.7. Safari remains the gap, so it is not yet Baseline. See [Temporal API](./concepts/date-time-handling#temporal-api).
+- **`PositionAssignment.byeFromPropagation`** — a new optional boolean recording that a BYE was placed by an exit cascade rather than by draw generation or by hand. It replaces a topology inference (`feedRound || roundNumber === 1`) with a first-class fact, and is visible in stored records and anything that round-trips `positionAssignments`. See [BYE provenance](./concepts/exit-propagation#bye-provenance-byefrompropagation).
+- **An exit-propagation test harness** — a cross-product matrix, relational property suites (do/undo, idempotence, monotonicity), two agreement oracles, and a quarantine registry enforced in both directions so a fixed failure fails the run until its entry is removed. An at-scale randomized sweep with delta-debugging runs on demand. It exists because `isActiveDownstream` was at 100% branch coverage when it shipped 444 spurious refusals. See [Exit Propagation Harness](./testing/exit-propagation-harness).
+
+## Upgrading checklist
+
+1. **Read [the migration guide](./migration-7.0.0)** for the five breaking-change rows.
+2. **Rename `particicipantsRequiredMatchUpStatuses`** to `participantsRequiredMatchUpStatuses` at every import site.
+3. **Handle the error return** from `wallClockToUTC`, `utcToWallClock` and `toEmbargoUTC`, and branch on `undefined` from `getTimeZoneOffsetMinutes`. Remove any `try`/`catch` that was there to catch a throw.
+4. **Delete compensating logic** that re-read or repaired state after a `setMatchUpStatus` error — a rejected call no longer alters the draw. Note the error code for the bare-`{ winningSide }` case moved from `ERR_MISSING_ASSIGNMENTS` to `ERR_INVALID_MATCHUP_STATUS`; match on behaviour rather than on that code.
+5. **Stop relying on re-application as repair.** Re-sending an identical double exit no longer nudges a draw whose advancement is missing. Detect that state with `getDrawInconsistencies` and repair it deliberately.
+6. **Add cases for `CHALLENGED` and for `SQUASH` / `BADMINTON`** if you `switch` exhaustively over `MatchUpStatusEnum` or `DisciplineEnum` with no `default`.
+7. **Check any branch on `isAdHocType`** — it now includes `LADDER`. Use `isLadder` where a roster and a standing must be told apart.
+8. **Adopt the ladder at your own pace** — the draw type and its eighteen engine methods are purely additive; no action is required to keep existing code working.
+
+## Where to go from here
+
+| If you want…                                          | Read                                                                                         |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| The full upgrade walkthrough                          | [6.x to 7.0.0 migration](./migration-7.0.0)                                                  |
+| To run a continuous challenge-driven competition      | [Ladder](./concepts/draw-types/ladder)                                                       |
+| To understand how a walkover travels through a draw   | [Exit Propagation](./concepts/exit-propagation)                                              |
+| To contribute to the propagation code                 | [Exit Propagation Harness](./testing/exit-propagation-harness)                               |
+| To pick the right date or time utility                | [Four questions, not one](./concepts/date-time-handling#four-questions-not-one)              |
+| Zoned conversion that refuses rather than guesses     | [tools.zonedDateTime](./tools/tools-api#toolszoneddatetime)                                  |
+| The previous major's feature tour                     | [What's New in 6.0.0](./whats-new-6.0.0)                                                     |

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -445,6 +445,7 @@ module.exports = {
       type: 'category',
       label: 'Release Notes & Migration',
       items: [
+        'whats-new-7.0.0',
         'whats-new-6.0.0',
         'whats-new-5.0.0',
         {

--- a/src/assemblies/generators/drawDefinitions/getGenerators.ts
+++ b/src/assemblies/generators/drawDefinitions/getGenerators.ts
@@ -21,7 +21,7 @@ import { ErrorType } from '@Constants/errorConditionConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 // prettier-ignore
 import {
-  MAIN, PLAY_OFF, FICQF, FICSF, MFIC, AD_HOC, CURTIS, FICR16, COMPASS,
+  MAIN, PLAY_OFF, FICQF, FICSF, MFIC, AD_HOC, CURTIS, FICR16, COMPASS, LADDER,
   PAGE_PLAYOFF, PLAYOFF, OLYMPIC, FEED_IN, ROUND_ROBIN,
   COMPASS_ATTRIBUTES, OLYMPIC_ATTRIBUTES, ADAPTIVE_ATTRIBUTES, ADAPTIVE, SWISS,
   SINGLE_ELIMINATION, DOUBLE_ELIMINATION,
@@ -77,6 +77,30 @@ export function getGenerators(params): { generators?: any; error?: ErrorType } {
         structureId,
         stage,
       });
+
+      return { structures: [structure], links: [], ...SUCCESS };
+    },
+    [LADDER]: () => {
+      const structure = structureTemplate({
+        finishingPosition: WIN_RATIO,
+        stageSequence,
+        structureName,
+        matchUps: [],
+        matchUpType,
+        structureId,
+        stage,
+      });
+
+      // A ladder generates NO matchUps — every one is created later by `issueChallenge` — and NO
+      // positionAssignments either, which is where it parts company with SWISS above.
+      //
+      // A ladder drawPosition is a RANK, not a slot. Pre-creating `drawSize` empty positions the
+      // way SWISS does would put phantom ranks 1..n at the TOP of the standing and seat the first
+      // real member below all of them, because `addLadderParticipant` appends after the highest
+      // existing position. Rank 1 would belong to nobody.
+      //
+      // So the standing starts empty and members are seated by `addLadderParticipant`, which is
+      // also the only thing that can rank them: `drawSize` and entry order are not a ranking.
 
       return { structures: [structure], links: [], ...SUCCESS };
     },

--- a/src/assemblies/governors/index.ts
+++ b/src/assemblies/governors/index.ts
@@ -3,6 +3,7 @@ export * as drawsGovernor from './drawsGovernor';
 export * as entriesGovernor from './entriesGovernor';
 export * as eventGovernor from './eventGovernor';
 export * as generationGovernor from './generationGovernor';
+export * as ladderGovernor from './ladderGovernor';
 export * as matchUpFormatGovernor from './matchUpFormatGovernor';
 export * as matchUpGovernor from './matchUpGovernor';
 export * as mocksGovernor from './mocksGovernor';

--- a/src/assemblies/governors/ladderGovernor/index.ts
+++ b/src/assemblies/governors/ladderGovernor/index.ts
@@ -1,0 +1,5 @@
+export * as mutate from './mutate';
+export * as query from './query';
+
+export * from './mutate';
+export * from './query';

--- a/src/assemblies/governors/ladderGovernor/mutate.ts
+++ b/src/assemblies/governors/ladderGovernor/mutate.ts
@@ -1,0 +1,7 @@
+export { submitResult, confirmResult, disputeResult } from '@Mutate/ladder/reportResult';
+export { acceptChallenge, declineChallenge } from '@Mutate/ladder/respondToChallenge';
+export { removeLadderParticipant } from '@Mutate/ladder/removeLadderParticipant';
+export { refreshLadderRatings } from '@Mutate/ladder/refreshLadderRatings';
+export { applyLadderMovement } from '@Mutate/ladder/applyLadderMovement';
+export { addLadderParticipant } from '@Mutate/ladder/addLadderParticipant';
+export { issueChallenge } from '@Mutate/ladder/issueChallenge';

--- a/src/assemblies/governors/ladderGovernor/query.ts
+++ b/src/assemblies/governors/ladderGovernor/query.ts
@@ -1,0 +1,10 @@
+export {
+  getLadderPolicy,
+  getLadderOrdering,
+  getLadderMovement,
+  isChallengeInRange,
+} from '@Query/ladder/getLadderPolicy';
+export { getResultAttestation } from '@Query/ladder/getResultAttestation';
+export { getChallengeState } from '@Query/ladder/getChallengeState';
+export { getLadderStanding } from '@Query/ladder/getLadderStanding';
+export { getLapses } from '@Query/ladder/getLapses';

--- a/src/mutate/ladder/applyLadderMovement.ts
+++ b/src/mutate/ladder/applyLadderMovement.ts
@@ -1,3 +1,4 @@
+import { resolveLadderStructure } from '@Query/ladder/resolveLadderContext';
 import { getLadderMovement, getLadderOrdering, getLadderPolicy } from '@Query/ladder/getLadderPolicy';
 import { isLadder } from '@Query/drawDefinition/isLadder';
 
@@ -36,7 +37,9 @@ type MovementArgs = {
   challengerParticipantId?: string;
   tournamentRecord?: any;
   drawDefinition: any;
-  structure: any;
+  /** Optional: resolved from `drawDefinition` when absent, so an engine caller can pass `drawId`. */
+  structure?: any;
+  structureId?: string;
   event?: any;
 };
 
@@ -48,7 +51,8 @@ type MovementArgs = {
  * left to the call site. A caller cannot assert a win it has not evidenced.
  */
 function resolveTrigger(params: MovementArgs): any {
-  const { trigger, structure, matchUpId } = params;
+  const { trigger, matchUpId } = params;
+  const structure = resolveLadderStructure(params);
 
   if (trigger === FORFEIT) {
     const { challengerParticipantId, defenderParticipantId } = params;
@@ -98,7 +102,8 @@ function resolveTrigger(params: MovementArgs): any {
  * return is why `getLadderOrdering` had to exist before any of this was written.
  */
 export function applyLadderMovement(params: MovementArgs): ResultType & { moved?: boolean; ratingsUpdated?: boolean } {
-  const { appliedAt, drawDefinition, structure } = params;
+  const { appliedAt, drawDefinition } = params;
+  const structure = resolveLadderStructure(params);
 
   if (typeof drawDefinition !== 'object') return { error: MISSING_DRAW_DEFINITION };
   if (!isLadder(drawDefinition.drawType)) return { error: INVALID_VALUES, info: 'requires a LADDER drawType' };

--- a/src/query/ladder/getChallengeState.ts
+++ b/src/query/ladder/getChallengeState.ts
@@ -1,3 +1,6 @@
+import { resolveLadderMatchUp } from '@Query/ladder/resolveLadderContext';
+import { getLadderPolicy } from '@Query/ladder/getLadderPolicy';
+
 import { CHALLENGE_ACCEPTED, CHALLENGE_DECLINED, CHALLENGE_ISSUED } from '@Constants/ladderConstants';
 import { ACCEPTED, DECLINED, EXPIRED, PENDING } from '@Constants/ladderConstants';
 import type { ChallengeState } from '@Constants/ladderConstants';
@@ -6,8 +9,14 @@ import type { LadderPolicy } from '@Types/ladderTypes';
 type ChallengeStateArgs = {
   /** The instant to evaluate against. REQUIRED — see below. */
   asOf: string;
-  policy: LadderPolicy;
-  matchUp: any;
+  /** Optional: resolved from `drawDefinition` when absent, so an engine caller can pass `drawId`. */
+  policy?: LadderPolicy;
+  matchUp?: any;
+  matchUpId?: string;
+  tournamentRecord?: any;
+  drawDefinition?: any;
+  structure?: any;
+  event?: any;
 };
 
 const itemDateOf = (matchUp: any, itemType: string): string | undefined =>
@@ -33,10 +42,13 @@ export function addDaysIso(iso: string, days: number): string {
  * bury a conversion the factory's Temporal migration will have to find. The caller supplies the
  * instant; this stays pure.
  */
-export function getChallengeState({ matchUp, policy, asOf }: ChallengeStateArgs): {
+export function getChallengeState(params: ChallengeStateArgs): {
   state: ChallengeState;
   expiresAt?: string;
 } {
+  const { asOf } = params;
+  const matchUp = params.matchUp ?? resolveLadderMatchUp(params).matchUp;
+  const policy = params.policy ?? getLadderPolicy(params);
   if (itemDateOf(matchUp, CHALLENGE_DECLINED)) return { state: DECLINED };
   if (itemDateOf(matchUp, CHALLENGE_ACCEPTED)) return { state: ACCEPTED };
 

--- a/src/query/ladder/getLadderPolicy.ts
+++ b/src/query/ladder/getLadderPolicy.ts
@@ -53,16 +53,17 @@ export function getLadderMovement(params: LadderPolicyArgs): LadderMovement {
  * A challenge is upward only — challenging someone below you is not a ladder move — and bounded by
  * the policy's range. `ANY` permits anyone above.
  */
-export function isChallengeInRange({
-  defenderPosition,
-  challengerPosition,
-  policy,
-}: {
-  defenderPosition: number;
-  challengerPosition: number;
-  policy: LadderPolicy;
-}): boolean {
+export function isChallengeInRange(
+  params: LadderPolicyArgs & {
+    defenderPosition: number;
+    challengerPosition: number;
+    /** Optional: resolved from `drawDefinition` when absent, so an engine caller can pass `drawId`. */
+    policy?: LadderPolicy;
+  },
+): boolean {
+  const { defenderPosition, challengerPosition } = params;
   if (!(defenderPosition < challengerPosition)) return false; // upward only; equal is not a challenge
+  const policy = params.policy ?? getLadderPolicy(params);
   const range = policy.challengeRange ?? DEFAULTS.challengeRange;
   if (range === 'ANY') return true;
   return typeof range === 'number' && challengerPosition - defenderPosition <= range;

--- a/src/query/ladder/getLadderStanding.ts
+++ b/src/query/ladder/getLadderStanding.ts
@@ -1,3 +1,4 @@
+import { resolveLadderStructure } from '@Query/ladder/resolveLadderContext';
 import { participantScaleItem } from '@Query/participant/participantScaleItem';
 import { getLadderPolicy, getLadderOrdering } from '@Query/ladder/getLadderPolicy';
 import ratingsParameters from '@Fixtures/ratings/ratingsParameters';
@@ -10,7 +11,9 @@ import { RANK, RATING } from '@Constants/ladderConstants';
 type StandingArgs = {
   tournamentRecord?: any;
   drawDefinition: any;
-  structure: any;
+  /** Optional: resolved from `drawDefinition` when absent, so an engine caller can pass `drawId`. */
+  structure?: any;
+  structureId?: string;
   event?: any;
 };
 
@@ -44,7 +47,8 @@ function readScale({ participant, scaleName, scaleAccessor, eventType }: any) {
  * a rating-ordered ladder without every member holding a current published rating.
  */
 export function getLadderStanding(params: StandingArgs): LadderStanding {
-  const { structure, tournamentRecord } = params;
+  const { tournamentRecord } = params;
+  const structure = resolveLadderStructure(params);
   const assignments = (structure?.positionAssignments ?? []).filter((a: any) => a.participantId);
 
   if (getLadderOrdering(params) !== RATING) {

--- a/src/query/ladder/getLapses.ts
+++ b/src/query/ladder/getLapses.ts
@@ -1,3 +1,4 @@
+import { resolveLadderStructure } from '@Query/ladder/resolveLadderContext';
 import { getChallengeState } from '@Query/ladder/getChallengeState';
 import { addDaysIso } from '@Query/ladder/getChallengeState';
 import { getLadderPolicy } from '@Query/ladder/getLadderPolicy';
@@ -14,7 +15,9 @@ type LapsesArgs = {
   participantId: string;
   tournamentRecord?: any;
   drawDefinition?: any;
-  structure: any;
+  /** Optional: resolved from `drawDefinition` when absent, so an engine caller can pass `drawId`. */
+  structure?: any;
+  structureId?: string;
   event?: any;
 };
 
@@ -54,7 +57,8 @@ function effectiveLapsePolicy(policy: LadderPolicy): LapsePolicy {
  * defender simply never answers, and nothing is recorded against them.
  */
 export function getLapses(params: LapsesArgs): Lapses {
-  const { asOf, participantId, structure } = params;
+  const { asOf, participantId } = params;
+  const structure = resolveLadderStructure(params);
   const policy = getLadderPolicy(params);
   const lapsePolicy = effectiveLapsePolicy(policy);
   const kinds: LapseKind[] = lapsePolicy.countsAsLapse ?? [DECLINE, EXPIRY, UNPLAYED];

--- a/src/query/ladder/getResultAttestation.ts
+++ b/src/query/ladder/getResultAttestation.ts
@@ -1,3 +1,6 @@
+import { resolveLadderMatchUp } from '@Query/ladder/resolveLadderContext';
+import { getLadderPolicy } from '@Query/ladder/getLadderPolicy';
+
 import {
   EITHER,
   OPERATOR,
@@ -8,7 +11,16 @@ import {
 } from '@Constants/ladderConstants';
 import type { LadderPolicy } from '@Types/ladderTypes';
 
-type AttestationArgs = { matchUp: any; policy: LadderPolicy };
+type AttestationArgs = {
+  matchUp?: any;
+  /** Optional: resolved from `drawDefinition` when absent, so an engine caller can pass `drawId`. */
+  policy?: LadderPolicy;
+  matchUpId?: string;
+  tournamentRecord?: any;
+  drawDefinition?: any;
+  structure?: any;
+  event?: any;
+};
 
 export type Attestation = {
   /** True only when the policy's validation requirement is satisfied. */
@@ -37,7 +49,9 @@ const latest = (matchUp: any, itemType: string) =>
  * Peer acceptance and operator validation are the SAME transition with a different attestor; the
  * policy decides which attestors count.
  */
-export function getResultAttestation({ matchUp, policy }: AttestationArgs): Attestation {
+export function getResultAttestation(params: AttestationArgs): Attestation {
+  const matchUp = params.matchUp ?? resolveLadderMatchUp(params).matchUp;
+  const policy = params.policy ?? getLadderPolicy(params);
   const submitted = latest(matchUp, RESULT_SUBMITTED);
   const confirmed = latest(matchUp, RESULT_CONFIRMED);
   const disputed = latest(matchUp, RESULT_DISPUTED);

--- a/src/query/ladder/resolveLadderContext.ts
+++ b/src/query/ladder/resolveLadderContext.ts
@@ -1,0 +1,40 @@
+/**
+ * Resolution shared by the ladder queries and mutations that the engine exposes.
+ *
+ * A ladder function needs a `structure` — and sometimes a `matchUp` — but an ENGINE caller supplies
+ * neither. `paramsMiddleware` resolves `drawId` into `drawDefinition` and stops there; nothing
+ * downstream of it knows which structure a ladder keeps its standing in.
+ *
+ * So resolution lives here rather than in a governor wrapper. A wrapper would give every one of
+ * these functions two call shapes — the internal one taking `structure` and the engine one taking
+ * `drawId` — and the two would drift. `refreshLadderRatings` already resolves this way; these
+ * helpers make it the rule instead of the exception.
+ *
+ * An EXPLICIT `structure` or `matchUp` always wins. Existing internal callers pass one and must not
+ * pay a lookup, and a caller holding a structure the drawDefinition does not contain is doing so on
+ * purpose.
+ */
+export function resolveLadderStructure(params: any): any {
+  if (params?.structure) return params.structure;
+  const structures = params?.drawDefinition?.structures ?? [];
+  if (params?.structureId) return structures.find((s: any) => s.structureId === params.structureId);
+  // A ladder is a single structure by construction; falling back to the first is not a guess.
+  return structures[0];
+}
+
+/**
+ * The matchUp a challenge or a reported result lives on, plus the structure holding it.
+ *
+ * Searches every structure rather than assuming the first, because the caller identified the
+ * matchUp and not the structure — answering from the wrong one would be a silent mismatch.
+ */
+export function resolveLadderMatchUp(params: any): { matchUp?: any; structure?: any } {
+  if (params?.matchUp) return { matchUp: params.matchUp, structure: resolveLadderStructure(params) };
+  const matchUpId = params?.matchUpId;
+  if (!matchUpId) return {};
+  for (const structure of params?.drawDefinition?.structures ?? []) {
+    const matchUp = structure.matchUps?.find((m: any) => m.matchUpId === matchUpId);
+    if (matchUp) return { matchUp, structure };
+  }
+  return {};
+}

--- a/src/tests/ladder/ladderEngineReachability.test.ts
+++ b/src/tests/ladder/ladderEngineReachability.test.ts
@@ -1,0 +1,194 @@
+import { expect, test, describe } from 'vitest';
+
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+
+import { LADDER } from '@Constants/drawDefinitionConstants';
+import { ACCEPTED, PENDING, RESULT } from '@Constants/ladderConstants';
+
+/**
+ * The ladder lifecycle exists to be driven from OUTSIDE the factory.
+ *
+ * Every other ladder suite imports the functions by module path, which proves the logic but not the
+ * reach: #4787 shipped the whole lifecycle with no governor, so none of it was on an engine and no
+ * consumer could call any of it. A module-path test would have stayed green throughout.
+ *
+ * So this suite calls `tournamentEngine.*` exclusively and passes `drawId` — never a drawDefinition,
+ * never a structure, never a matchUp object. If a function stops being exported, or starts needing
+ * a param an engine caller cannot supply, this goes red where the others do not.
+ */
+const ISO = (day: number) => `2026-03-${String(day).padStart(2, '0')}T10:00:00.000Z`;
+
+function ladderWithFourSeated() {
+  const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ drawType: LADDER, drawSize: 4 }],
+    setState: true,
+  });
+  const { drawId } = tournamentRecord.events[0].drawDefinitions[0];
+  const participantIds = tournamentRecord.participants.slice(0, 4).map((p: any) => p.participantId);
+
+  // Seating is `addLadderParticipant`'s job, not the generator's: a ladder position is a rank, and
+  // the generator has no basis on which to rank an entry list.
+  participantIds.forEach((participantId: string) => {
+    const result: any = tournamentEngine.addLadderParticipant({ participantId, addedAt: ISO(1), drawId });
+    expect(result.success).toEqual(true);
+  });
+
+  return { drawId, participantIds };
+}
+
+describe('the ladder lifecycle is reachable through the engine', () => {
+  test('every ladder method is present on the engine surface', () => {
+    // The gap #4787 left: implemented, tested, and unreachable.
+    const methods = [
+      'issueChallenge',
+      'acceptChallenge',
+      'declineChallenge',
+      'submitResult',
+      'confirmResult',
+      'disputeResult',
+      'applyLadderMovement',
+      'addLadderParticipant',
+      'removeLadderParticipant',
+      'refreshLadderRatings',
+      'getLadderStanding',
+      'getChallengeState',
+      'getLapses',
+      'getResultAttestation',
+      'getLadderPolicy',
+      'getLadderOrdering',
+      'getLadderMovement',
+      'isChallengeInRange',
+    ];
+    methods.forEach((method) => expect(typeof tournamentEngine[method]).toEqual('function'));
+  });
+
+  test('the three internal helpers are deliberately NOT reachable', () => {
+    // mirrorStandingToScale must stay a side effect of the position mutation — exposing it would
+    // let a caller move a standing without writing the history, or write history without moving.
+    // applyLapseConsequence is called by declineChallenge AFTER the lapse is counted; called
+    // directly it applies a penalty nothing counted. addDaysIso is date arithmetic, not ladder API.
+    ['mirrorStandingToScale', 'applyLapseConsequence', 'addDaysIso'].forEach((method) =>
+      expect(tournamentEngine[method]).toBeUndefined(),
+    );
+  });
+
+  test('a ladder draw generates a standing and no matchUps', () => {
+    const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawType: LADDER, drawSize: 4 }],
+      setState: true,
+    });
+    const structure = tournamentRecord.events[0].drawDefinitions[0].structures[0];
+
+    // Every ladder matchUp is created by a challenge; there is nothing to generate up front.
+    expect(structure.matchUps.length).toEqual(0);
+
+    // And NO positionAssignments: a ladder drawPosition is a rank. Pre-creating `drawSize` empty
+    // ones (as SWISS does) would put phantom ranks above every real member — rank 1 held by nobody.
+    expect(structure.positionAssignments ?? []).toEqual([]);
+  });
+
+  test('challenge, accept, report, confirm and move — all through drawId alone', () => {
+    const { drawId, participantIds } = ladderWithFourSeated();
+
+    const standing: any = tournamentEngine.getLadderStanding({ drawId });
+    expect(standing.length).toEqual(4);
+    // Seating starts at rank 1, not behind a block of generated placeholders.
+    expect(standing.map((s: any) => s.position)).toEqual([1, 2, 3, 4]);
+    const defenderParticipantId = standing[0].participantId;
+    const challengerParticipantId = standing[1].participantId;
+    expect(participantIds).toContain(defenderParticipantId);
+
+    const issued: any = tournamentEngine.issueChallenge({
+      challengerParticipantId,
+      defenderParticipantId,
+      issuedAt: ISO(1),
+      drawId,
+    });
+    expect(issued.success).toEqual(true);
+    const { matchUpId } = issued;
+
+    // The engine resolves the matchUp from matchUpId — the caller never holds a matchUp object.
+    const pending: any = tournamentEngine.getChallengeState({ matchUpId, asOf: ISO(2), drawId });
+    expect(pending.state).toEqual(PENDING);
+
+    expect(tournamentEngine.acceptChallenge({ matchUpId, respondedAt: ISO(2), drawId }).success).toEqual(true);
+    expect(tournamentEngine.getChallengeState({ matchUpId, asOf: ISO(3), drawId }).state).toEqual(ACCEPTED);
+
+    // A submitted score is not an agreed one: AWAITING_RESULT, and the standing must not move.
+    const submitted: any = tournamentEngine.submitResult({
+      participantId: challengerParticipantId,
+      outcome: { winningSide: 1 },
+      submittedAt: ISO(4),
+      matchUpId,
+      drawId,
+    });
+    expect(submitted.success).toEqual(true);
+    expect(tournamentEngine.getResultAttestation({ matchUpId, drawId }).attested).toEqual(false);
+
+    const blocked: any = tournamentEngine.applyLadderMovement({
+      trigger: RESULT,
+      appliedAt: ISO(4),
+      matchUpId,
+      drawId,
+    });
+    expect(blocked.error).toBeDefined();
+
+    expect(
+      tournamentEngine.confirmResult({
+        participantId: defenderParticipantId,
+        confirmedAt: ISO(5),
+        matchUpId,
+        drawId,
+      }).success,
+    ).toEqual(true);
+    expect(tournamentEngine.getResultAttestation({ matchUpId, drawId }).attested).toEqual(true);
+
+    const moved: any = tournamentEngine.applyLadderMovement({
+      trigger: RESULT,
+      appliedAt: ISO(5),
+      matchUpId,
+      drawId,
+    });
+    expect(moved.success).toEqual(true);
+    expect(moved.moved).toEqual(true);
+
+    // The challenger prevailed, so they now hold position 1 and the defender holds 2.
+    const after: any = tournamentEngine.getLadderStanding({ drawId });
+    expect(after[0].participantId).toEqual(challengerParticipantId);
+    expect(after[1].participantId).toEqual(defenderParticipantId);
+  });
+
+  test('an out-of-range challenge is refused through the engine, naming the range', () => {
+    const { drawId } = ladderWithFourSeated();
+    const standing: any = tournamentEngine.getLadderStanding({ drawId });
+
+    // Default challengeRange is 3, so position 4 challenging position 1 is in range; make it not.
+    const inRange: any = tournamentEngine.isChallengeInRange({
+      challengerPosition: 4,
+      defenderPosition: 1,
+      drawId,
+    });
+    expect(inRange).toEqual(true);
+
+    const downward: any = tournamentEngine.issueChallenge({
+      challengerParticipantId: standing[0].participantId,
+      defenderParticipantId: standing[3].participantId,
+      issuedAt: ISO(1),
+      drawId,
+    });
+    expect(downward.error).toBeDefined();
+  });
+
+  test('getLapses and getLadderPolicy answer from drawId alone', () => {
+    const { drawId, participantIds } = ladderWithFourSeated();
+
+    const policy: any = tournamentEngine.getLadderPolicy({ drawId });
+    expect(policy.challengeRange).toEqual(3);
+    expect(tournamentEngine.getLadderOrdering({ drawId })).toEqual('RANK');
+
+    const lapses: any = tournamentEngine.getLapses({ participantId: participantIds[0], asOf: ISO(9), drawId });
+    expect(lapses.count).toEqual(0);
+    expect(lapses.exceeded).toEqual(false);
+  });
+});

--- a/src/types/factoryEngineMethods.ts
+++ b/src/types/factoryEngineMethods.ts
@@ -6,6 +6,7 @@
  */
 export type FactoryEngineMethod =
   | 'abandonTournamentMatchUps'
+  | 'acceptChallenge'
   | 'addAdHocMatchUps'
   | 'addCertification'
   | 'addCertificationRequirement'
@@ -33,6 +34,7 @@ export type FactoryEngineMethod =
   | 'addFlight'
   | 'addGoesTo'
   | 'addIndividualParticipantIds'
+  | 'addLadderParticipant'
   | 'addLinkedConsolationStructure'
   | 'addMatchUpCourtOrder'
   | 'addMatchUpEndTime'
@@ -87,6 +89,7 @@ export type FactoryEngineMethod =
   | 'anonymizeTournamentRecord'
   | 'applyAvailabilityToTournamentRecord'
   | 'applyDerivedRankings'
+  | 'applyLadderMovement'
   | 'applyLineUps'
   | 'applyScheduleScenario'
   | 'applyTournamentRankingPoints'
@@ -146,6 +149,7 @@ export type FactoryEngineMethod =
   | 'competitionScheduleMatchUps'
   | 'completeDrawMatchUps'
   | 'computePlanItemId'
+  | 'confirmResult'
   | 'copyTournamentRecord'
   | 'courtDayKey'
   | 'courtGridRows'
@@ -157,6 +161,7 @@ export type FactoryEngineMethod =
   | 'createTeamsFromParticipantAttributes'
   | 'createTournamentRecord'
   | 'credits'
+  | 'declineChallenge'
   | 'deduceMatchUpFormat'
   | 'deleteAdHocMatchUps'
   | 'deleteCourt'
@@ -176,6 +181,7 @@ export type FactoryEngineMethod =
   | 'disableCourts'
   | 'disableTieAutoCalc'
   | 'disableVenues'
+  | 'disputeResult'
   | 'drawMatchUps'
   | 'drawMatic'
   | 'dryRun'
@@ -247,6 +253,7 @@ export type FactoryEngineMethod =
   | 'getAwardPoints'
   | 'getAwardProfile'
   | 'getCategoryAgeDetails'
+  | 'getChallengeState'
   | 'getCheckedInParticipantIds'
   | 'getCompetitionDateRange'
   | 'getCompetitionFormat'
@@ -295,6 +302,11 @@ export type FactoryEngineMethod =
   | 'getFlightProfile'
   | 'getHighestSeverity'
   | 'getHomeParticipantId'
+  | 'getLadderMovement'
+  | 'getLadderOrdering'
+  | 'getLadderPolicy'
+  | 'getLadderStanding'
+  | 'getLapses'
   | 'getLinkedTournamentIds'
   | 'getLuckyDrawRoundStatus'
   | 'getMatchUpCompetitiveProfile'
@@ -347,6 +359,7 @@ export type FactoryEngineMethod =
   | 'getQuickStats'
   | 'getRandomQualifierList'
   | 'getRegistrationProfile'
+  | 'getResultAttestation'
   | 'getRoundMatchUps'
   | 'getRounds'
   | 'getRoundVisibilityState'
@@ -417,11 +430,13 @@ export type FactoryEngineMethod =
   | 'intervalsOverlap'
   | 'isAdHoc'
   | 'isAggregateFormat'
+  | 'isChallengeInRange'
   | 'isComplete'
   | 'isCompletedStructure'
   | 'isEmbargoed'
   | 'isIndeterminateFee'
   | 'isScheduleLocked'
+  | 'issueChallenge'
   | 'isValid'
   | 'isValidForQualifying'
   | 'isValidMatchUpFormat'
@@ -505,6 +520,7 @@ export type FactoryEngineMethod =
   | 'rangesOverlap'
   | 'rebaseScheduleScenario'
   | 'refreshEventDrawOrder'
+  | 'refreshLadderRatings'
   | 'regenerateParticipantNames'
   | 'remapDrawDefinitionMatchUpIds'
   | 'removeCertification'
@@ -522,6 +538,7 @@ export type FactoryEngineMethod =
   | 'removeEventMatchUpFormatTiming'
   | 'removeExtension'
   | 'removeIndividualParticipantIds'
+  | 'removeLadderParticipant'
   | 'removeMatchUpCourtAssignment'
   | 'removeMatchUpOutcome'
   | 'removeMatchUpScorekeeper'
@@ -628,6 +645,7 @@ export type FactoryEngineMethod =
   | 'sortEdges'
   | 'stringify'
   | 'stringifyMatchUpFormat'
+  | 'submitResult'
   | 'substituteParticipant'
   | 'suggestFormatPlans'
   | 'swapAdHocRounds'
@@ -682,6 +700,7 @@ export type FactoryEngineMethod =
 
 export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'abandonTournamentMatchUps',
+  'acceptChallenge',
   'addAdHocMatchUps',
   'addCertification',
   'addCertificationRequirement',
@@ -709,6 +728,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'addFlight',
   'addGoesTo',
   'addIndividualParticipantIds',
+  'addLadderParticipant',
   'addLinkedConsolationStructure',
   'addMatchUpCourtOrder',
   'addMatchUpEndTime',
@@ -763,6 +783,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'anonymizeTournamentRecord',
   'applyAvailabilityToTournamentRecord',
   'applyDerivedRankings',
+  'applyLadderMovement',
   'applyLineUps',
   'applyScheduleScenario',
   'applyTournamentRankingPoints',
@@ -822,6 +843,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'competitionScheduleMatchUps',
   'completeDrawMatchUps',
   'computePlanItemId',
+  'confirmResult',
   'copyTournamentRecord',
   'courtDayKey',
   'courtGridRows',
@@ -833,6 +855,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'createTeamsFromParticipantAttributes',
   'createTournamentRecord',
   'credits',
+  'declineChallenge',
   'deduceMatchUpFormat',
   'deleteAdHocMatchUps',
   'deleteCourt',
@@ -852,6 +875,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'disableCourts',
   'disableTieAutoCalc',
   'disableVenues',
+  'disputeResult',
   'drawMatchUps',
   'drawMatic',
   'dryRun',
@@ -923,6 +947,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'getAwardPoints',
   'getAwardProfile',
   'getCategoryAgeDetails',
+  'getChallengeState',
   'getCheckedInParticipantIds',
   'getCompetitionDateRange',
   'getCompetitionFormat',
@@ -971,6 +996,11 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'getFlightProfile',
   'getHighestSeverity',
   'getHomeParticipantId',
+  'getLadderMovement',
+  'getLadderOrdering',
+  'getLadderPolicy',
+  'getLadderStanding',
+  'getLapses',
   'getLinkedTournamentIds',
   'getLuckyDrawRoundStatus',
   'getMatchUpCompetitiveProfile',
@@ -1023,6 +1053,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'getQuickStats',
   'getRandomQualifierList',
   'getRegistrationProfile',
+  'getResultAttestation',
   'getRoundMatchUps',
   'getRounds',
   'getRoundVisibilityState',
@@ -1093,11 +1124,13 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'intervalsOverlap',
   'isAdHoc',
   'isAggregateFormat',
+  'isChallengeInRange',
   'isComplete',
   'isCompletedStructure',
   'isEmbargoed',
   'isIndeterminateFee',
   'isScheduleLocked',
+  'issueChallenge',
   'isValid',
   'isValidForQualifying',
   'isValidMatchUpFormat',
@@ -1181,6 +1214,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'rangesOverlap',
   'rebaseScheduleScenario',
   'refreshEventDrawOrder',
+  'refreshLadderRatings',
   'regenerateParticipantNames',
   'remapDrawDefinitionMatchUpIds',
   'removeCertification',
@@ -1198,6 +1232,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'removeEventMatchUpFormatTiming',
   'removeExtension',
   'removeIndividualParticipantIds',
+  'removeLadderParticipant',
   'removeMatchUpCourtAssignment',
   'removeMatchUpOutcome',
   'removeMatchUpScorekeeper',
@@ -1304,6 +1339,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'sortEdges',
   'stringify',
   'stringifyMatchUpFormat',
+  'submitResult',
   'substituteParticipant',
   'suggestFormatPlans',
   'swapAdHocRounds',

--- a/src/types/methodSignatures.ts
+++ b/src/types/methodSignatures.ts
@@ -358,6 +358,7 @@ import type { getTournamentPointAwards } from '@Query/scales/getTournamentPointA
 import type { mergeParticipants } from '@Mutate/participants/mergeParticipants';
 import type { modifyDrawName } from '@Mutate/drawDefinitions/modifyDrawName';
 import type { modifyParticipant } from '@Mutate/participants/modifyParticipant';
+import type { removeLadderParticipant } from '@Mutate/ladder/removeLadderParticipant';
 import type { removeMatchUpOutcome } from '@Generators/mocks/removeMatchUpOutcome';
 import type { removeRoundMatchUps } from '@Mutate/structures/removeRoundMatchUps';
 import type {
@@ -423,6 +424,7 @@ import type { removeSuspension } from '@Mutate/officiating/removeSuspension';
 import type { stringify } from '@Helpers/matchUpFormatCode/stringify';
 import type { validateScheduleScenario } from '@Validators/validateScheduleScenario';
 import type { addAdHocMatchUps } from '@Mutate/structures/addAdHocMatchUps';
+import type { addLadderParticipant } from '@Mutate/ladder/addLadderParticipant';
 import type { addParticipant } from '@Mutate/participants/addParticipant';
 import type { allEventMatchUps } from '@Query/matchUps/getAllEventMatchUps';
 import type { calculateWinCriteria } from '@Query/matchUp/calculateWinCriteria';
@@ -440,10 +442,12 @@ import type { getTournamentIds } from '@Query/tournaments/getTournamentIds';
 import type { inferServeSide } from '@Mutate/scoring/serveSideCalculator';
 import type { linkTournaments, unlinkTournament, unlinkTournaments } from '@Mutate/tournaments/tournamentLinks';
 import type { modifyEntriesStatus } from '@Mutate/entries/modifyEntriesStatus';
+import type { refreshLadderRatings } from '@Mutate/ladder/refreshLadderRatings';
 import type { addCourtGridBooking } from '@Mutate/venues/addCourtGridBooking';
 import type { addEventEntryPairs } from '@Mutate/entries/addEventEntryPairs';
 import type { allDrawMatchUps } from '@Query/matchUps/getAllDrawMatchUps';
 import type { applyDerivedRankings } from '@Query/scales/applyDerivedRankings';
+import type { applyLadderMovement } from '@Mutate/ladder/applyLadderMovement';
 import type { assignOfficial } from '@Mutate/officiating/assignOfficial';
 import type { assignSeedPositions } from '@Mutate/events/assignSeedPositions';
 import type { attachFlightProfile } from '@Mutate/events/attachFlightProfile';
@@ -454,10 +458,12 @@ import type { getCategoryAgeDetails } from '@Query/event/getCategoryAgeDetails';
 import type { getEventPublishStatus } from '@Query/event/getEventPublishStatus';
 import type { getMaxEntryPosition } from '@Query/entries/getMaxEntryPosition';
 import type { getParticipantPoints } from '@Query/scales/getParticipantPoints';
+import type { getResultAttestation } from '@Query/ladder/getResultAttestation';
 import type { getTierMovement } from '@Query/tournaments/getTierMovement';
 import type { modifyEventEntries } from '@Mutate/entries/modifyEventEntries';
 import type { removeEventEntries } from '@Mutate/entries/removeEventEntries';
 import type { removeExtension } from '@Mutate/extensions/removeExtension';
+import type { acceptChallenge, declineChallenge } from '@Mutate/ladder/respondToChallenge';
 import type { addEvaluation } from '@Mutate/officiating/addEvaluation';
 import type { addSuspension } from '@Mutate/officiating/addSuspension';
 import type { buildReportContext } from '@Query/reports/buildReportContext';
@@ -507,7 +513,9 @@ import type { analyzeDraws } from '@Query/tournaments/analyzeDraws';
 import type { categoryCanContain } from '@Query/event/categoryCanContain';
 import type { drawMatchUps } from '@Query/matchUps/getDrawMatchUps';
 import type { getAllowedDrawTypes, getAllowedMatchUpFormats } from '@Query/tournaments/allowedTypes';
+import type { getChallengeState } from '@Query/ladder/getChallengeState';
 import type { getEventProperties } from '@Query/event/getEventProperties';
+import type { getLadderStanding } from '@Query/ladder/getLadderStanding';
 import type { getParticipantSignInStatus } from '@Query/participant/signInStatus';
 import type { isScheduleLocked, matchUpScheduleLocked } from '@Query/matchUp/isScheduleLocked';
 import type { publishEvent } from '@Mutate/publishing/publishEvent';
@@ -542,11 +550,18 @@ import type { createMatchUp } from '@Mutate/scoring/createMatchUp';
 import type { generateReport } from '@Query/reports/generateReport';
 import type { getAwardProfile } from '@Query/scales/getAwardProfile';
 import type { getFlightProfile } from '@Query/event/getFlightProfile';
+import type {
+  getLadderMovement,
+  getLadderOrdering,
+  getLadderPolicy,
+  isChallengeInRange,
+} from '@Query/ladder/getLadderPolicy';
 import type { getMatchUpType } from '@Query/matchUp/getMatchUpType';
 import type { getScaledEntries } from '@Query/event/getScaledEntries';
 import type { hasLuckyRounds } from '@Query/drawDefinition/isLucky';
 import type { isAdHoc } from '@Query/drawDefinition/isAdHoc';
 import type { isEmbargoed, isVisiblyPublished } from '@Query/publishing/isEmbargoed';
+import type { issueChallenge } from '@Mutate/ladder/issueChallenge';
 import type { removeSeeding } from '@Mutate/entries/removeSeeding';
 import type { validateTieFormat } from '@Validators/validateTieFormat';
 import type { disableCourts } from '@Mutate/venues/disableCourts';
@@ -560,6 +575,7 @@ import type { setEventDates, setEventEndDate, setEventStartDate } from '@Mutate/
 import type { validateCategory } from '@Validators/validateCategory';
 import type { addNotes, removeNotes } from '@Mutate/base/addRemoveNotes';
 import type { analyzeScore } from '@Query/matchUp/analyzeScore';
+import type { confirmResult, disputeResult, submitResult } from '@Mutate/ladder/reportResult';
 import type { enableCourts } from '@Mutate/venues/enableCourts';
 import type { enableVenues } from '@Mutate/venues/enableVenues';
 import type { publicFindDrawDefinition } from '@Acquire/findDrawDefinition';
@@ -589,6 +605,7 @@ import type { addVenue } from '@Mutate/venues/addVenue';
 import type { findVenue, publicFindVenue } from '@Query/venues/findVenue';
 import type { getCourts } from '@Query/venues/getCourts';
 import type { getEvents } from '@Query/events/getEvents';
+import type { getLapses } from '@Query/ladder/getLapses';
 import type { getScore } from '@Query/scoring/getScore';
 import type { parseScoreString } from '@Tools/parseScoreString';
 import type { publicFindCourt } from '@Query/venues/findCourt';
@@ -610,6 +627,7 @@ import type { credits } from '@Fixtures/credits';
 
 export interface MethodSignatures {
   abandonTournamentMatchUps: EngineMethod<typeof abandonTournamentMatchUps>;
+  acceptChallenge: EngineMethod<typeof acceptChallenge>;
   addAdHocMatchUps: EngineMethod<typeof addAdHocMatchUps>;
   addCertification: EngineMethod<typeof addCertification>;
   addCertificationRequirement: EngineMethod<typeof addCertificationRequirement>;
@@ -637,6 +655,7 @@ export interface MethodSignatures {
   addFlight: EngineMethod<typeof addFlight>;
   addGoesTo: EngineMethod<typeof addGoesTo>;
   addIndividualParticipantIds: EngineMethod<typeof addIndividualParticipantIds>;
+  addLadderParticipant: EngineMethod<typeof addLadderParticipant>;
   addLinkedConsolationStructure: EngineMethod<typeof addLinkedConsolationStructure>;
   addMatchUpCourtOrder: EngineMethod<typeof addMatchUpCourtOrder>;
   addMatchUpEndTime: EngineMethod<typeof addMatchUpEndTime>;
@@ -690,6 +709,7 @@ export interface MethodSignatures {
   analyzeTournament: EngineMethod<typeof analyzeTournament>;
   anonymizeTournamentRecord: EngineMethod<typeof anonymizeTournamentRecord>;
   applyDerivedRankings: EngineMethod<typeof applyDerivedRankings>;
+  applyLadderMovement: EngineMethod<typeof applyLadderMovement>;
   applyLineUps: EngineMethod<typeof applyLineUps>;
   applyScheduleScenario: EngineMethod<typeof applyScheduleScenario>;
   applyTournamentRankingPoints: EngineMethod<typeof applyTournamentRankingPoints>;
@@ -739,6 +759,7 @@ export interface MethodSignatures {
   compareTieFormats: EngineMethod<typeof compareTieFormats>;
   competitionScheduleMatchUps: EngineMethod<typeof competitionScheduleMatchUps>;
   completeDrawMatchUps: EngineMethod<typeof completeDrawMatchUps>;
+  confirmResult: EngineMethod<typeof confirmResult>;
   copyTournamentRecord: EngineMethod<typeof copyTournamentRecord>;
   courtGridRows: EngineMethod<typeof courtGridRows>;
   createGroupParticipant: EngineMethod<typeof createGroupParticipant>;
@@ -747,6 +768,7 @@ export interface MethodSignatures {
   createTeamsFromParticipantAttributes: EngineMethod<typeof createTeamsFromParticipantAttributes>;
   createTournamentRecord: EngineMethod<typeof createTournamentRecord>;
   credits: EngineMethod<typeof credits>;
+  declineChallenge: EngineMethod<typeof declineChallenge>;
   deduceMatchUpFormat: EngineMethod<typeof deduceMatchUpFormat>;
   deleteAdHocMatchUps: EngineMethod<typeof deleteAdHocMatchUps>;
   deleteCourt: EngineMethod<typeof deleteCourt>;
@@ -763,6 +785,7 @@ export interface MethodSignatures {
   disableCourts: EngineMethod<typeof disableCourts>;
   disableTieAutoCalc: EngineMethod<typeof disableTieAutoCalc>;
   disableVenues: EngineMethod<typeof disableVenues>;
+  disputeResult: EngineMethod<typeof disputeResult>;
   drawMatchUps: EngineMethod<typeof drawMatchUps>;
   drawMatic: EngineMethod<typeof drawMatic>;
   enableCourts: EngineMethod<typeof enableCourts>;
@@ -823,6 +846,7 @@ export interface MethodSignatures {
   getAwardPoints: EngineMethod<typeof getAwardPoints>;
   getAwardProfile: EngineMethod<typeof getAwardProfile>;
   getCategoryAgeDetails: EngineMethod<typeof getCategoryAgeDetails>;
+  getChallengeState: EngineMethod<typeof getChallengeState>;
   getCheckedInParticipantIds: EngineMethod<typeof getCheckedInParticipantIds>;
   getCompetitionDateRange: EngineMethod<typeof getCompetitionDateRange>;
   getCompetitionFormat: EngineMethod<typeof getCompetitionFormat>;
@@ -869,6 +893,11 @@ export interface MethodSignatures {
   getEventTimeItem: EngineMethod<typeof getEventTimeItem>;
   getFlightProfile: EngineMethod<typeof getFlightProfile>;
   getHomeParticipantId: EngineMethod<typeof getHomeParticipantId>;
+  getLadderMovement: EngineMethod<typeof getLadderMovement>;
+  getLadderOrdering: EngineMethod<typeof getLadderOrdering>;
+  getLadderPolicy: EngineMethod<typeof getLadderPolicy>;
+  getLadderStanding: EngineMethod<typeof getLadderStanding>;
+  getLapses: EngineMethod<typeof getLapses>;
   getLinkedTournamentIds: EngineMethod<typeof getLinkedTournamentIds>;
   getLuckyDrawRoundStatus: EngineMethod<typeof getLuckyDrawRoundStatus>;
   getMatchUpCompetitiveProfile: EngineMethod<typeof getMatchUpCompetitiveProfile>;
@@ -921,6 +950,7 @@ export interface MethodSignatures {
   getQuickStats: EngineMethod<typeof getQuickStats>;
   getRandomQualifierList: EngineMethod<typeof getRandomQualifierList>;
   getRegistrationProfile: EngineMethod<typeof getRegistrationProfile>;
+  getResultAttestation: EngineMethod<typeof getResultAttestation>;
   getRoundMatchUps: EngineMethod<typeof getRoundMatchUps>;
   getRounds: EngineMethod<typeof getRounds>;
   getRoundVisibilityState: EngineMethod<typeof getRoundVisibilityState>;
@@ -981,11 +1011,13 @@ export interface MethodSignatures {
   initializeDraft: EngineMethod<typeof initializeDraft>;
   isAdHoc: EngineMethod<typeof isAdHoc>;
   isAggregateFormat: EngineMethod<typeof isAggregateFormat>;
+  isChallengeInRange: EngineMethod<typeof isChallengeInRange>;
   isComplete: EngineMethod<typeof isComplete>;
   isCompletedStructure: EngineMethod<typeof isCompletedStructure>;
   isEmbargoed: EngineMethod<typeof isEmbargoed>;
   isIndeterminateFee: EngineMethod<typeof isIndeterminateFee>;
   isScheduleLocked: EngineMethod<typeof isScheduleLocked>;
+  issueChallenge: EngineMethod<typeof issueChallenge>;
   isValid: EngineMethod<typeof isValidMatchUpFormat>;
   isValidForQualifying: EngineMethod<typeof isValidForQualifying>;
   isValidMatchUpFormat: EngineMethod<typeof isValidMatchUpFormat>;
@@ -1058,6 +1090,7 @@ export interface MethodSignatures {
   queryOfficialRecord: EngineMethod<typeof queryOfficialRecord>;
   rebaseScheduleScenario: EngineMethod<typeof rebaseScheduleScenario>;
   refreshEventDrawOrder: EngineMethod<typeof refreshEventDrawOrder>;
+  refreshLadderRatings: EngineMethod<typeof refreshLadderRatings>;
   regenerateParticipantNames: EngineMethod<typeof regenerateParticipantNames>;
   remapDrawDefinitionMatchUpIds: EngineMethod<typeof remapDrawDefinitionMatchUpIds>;
   removeCertification: EngineMethod<typeof removeCertification>;
@@ -1075,6 +1108,7 @@ export interface MethodSignatures {
   removeEventMatchUpFormatTiming: EngineMethod<typeof removeEventMatchUpFormatTiming>;
   removeExtension: EngineMethod<typeof removeExtension>;
   removeIndividualParticipantIds: EngineMethod<typeof removeIndividualParticipantIds>;
+  removeLadderParticipant: EngineMethod<typeof removeLadderParticipant>;
   removeMatchUpCourtAssignment: EngineMethod<typeof removeMatchUpCourtAssignment>;
   removeMatchUpOutcome: EngineMethod<typeof removeMatchUpOutcome>;
   removeMatchUpScorekeeper: EngineMethod<typeof removeMatchUpScorekeeper>;
@@ -1164,6 +1198,7 @@ export interface MethodSignatures {
   shotSplitter: EngineMethod<typeof shotSplitter>;
   stringify: EngineMethod<typeof stringify>;
   stringifyMatchUpFormat: EngineMethod<typeof stringify>;
+  submitResult: EngineMethod<typeof submitResult>;
   substituteParticipant: EngineMethod<typeof substituteParticipant>;
   suggestFormatPlans: EngineMethod<typeof suggestFormatPlans>;
   swapAdHocRounds: EngineMethod<typeof swapAdHocRounds>;


### PR DESCRIPTION
Follow-up to #4787. Two gaps and one missing doc.

## The ladder was unreachable

#4787 shipped the LADDER drawType, the challenge lifecycle, the attestation gate, the lapse policy and the movement rules — and none of it was callable.

- **No governor.** Nothing was on any engine. `verify:surface` reported no change *because* nothing was published, and all 213 ladder tests passed because every one of them imports by module path.
- **`drawType: LADDER` was ungeneratable.** It was in `generatedDrawTypes` but had no entry in `getGenerators`, so `generateDrawDefinition` returned `ERR_UNRECOGNIZED_DRAW_TYPE`. A ladder nobody can create is not reachable either.

Both were invisible to the workstream's own evidence. A green suite and a clean surface diff read as confirmation here when they were the symptom.

## What this adds

`ladderGovernor` — 10 mutations, 8 queries. `verify:surface` reports 22 additions, 0 removals.

Three modules are deliberately **not** exposed, with a test that keeps them off:

| held back | why |
|---|---|
| `mirrorStandingToScale` | must stay a side effect of the position mutation — exposed, a caller could move a standing without writing its history |
| `applyLapseConsequence` | `declineChallenge` calls it *after* the lapse is counted; called directly it applies a penalty nothing counted |
| `addDaysIso` | date arithmetic, not ladder API |

### The generator, and the part that was not obvious

A ladder generates no matchUps (every one comes from `issueChallenge`) and **no positionAssignments**. Modelling it on SWISS — which pre-creates `drawSize` empty positions — put phantom ranks 1..n at the top of the standing and seated the first real member at rank 5 of 8, because `addLadderParticipant` appends after the highest existing position. Rank 1 belonged to nobody.

Measured, not reasoned: the first run of the lifecycle test returned a standing of positions `[5,6,7,8]`.

### Context resolution

Five functions required a `structure`, `matchUp` or `policy` an engine caller cannot supply — `paramsMiddleware` resolves `drawId` into `drawDefinition` and stops there. Rather than wrap them in the governor (two call shapes that then drift), they resolve their own context via `resolveLadderContext`, the pattern `refreshLadderRatings` already used. An explicitly-passed value always wins, so the module-path callers are unaffected: 213 ladder tests pass unchanged.

`isChallengeInRange` needed the same and was missed until the engine test called it — it read `policy.challengeRange` off an undefined policy and threw.

### The test that would have caught all of this

`ladderEngineReachability.test.ts` calls `tournamentEngine.*` exclusively and passes `drawId` — never a drawDefinition, structure or matchUp. It drives challenge → accept → submit → confirm → move → standing, and asserts the attestation gate blocks movement on an unconfirmed result. A module-path test stays green through every gap above; this one goes red.

## Documentation

`whats-new-7.0.0.md` — 5.0.0 and 6.0.0 each have a "what's new" companion; 7.0.0 had only the migration guide. Mirrors the 6.x structure exactly and adds the reciprocal pointer `migration-7.0.0.md` was missing.

Two deliberate absences:

- **No defect count** for the exit-propagation work. The commit messages support 6, 9, 10 or 12 depending on whether you count #4782's merged PRs and whether you trust its subject line over its five-item body. A number that cannot be derived from the log goes stale and falsifies the paragraph around it.
- The lifecycle is documented as **callable**, which it is as of the first commit here. Landing the doc first would have described an API nobody could reach.

`concepts/draw-types/ladder.md` — all nine examples were bare module calls a reader could not make. Now `tournamentEngine.*` with `drawId`.

## Verification

- `pnpm verify` — all 16 steps, exit 0. `attr-audit` exit 0; `coverage-headroom` OK, tightest is statements at **147 items** headroom against a 25-per-change budget.
- `verify:surface` — 22 added, **0 removed**.
- Docs links verified **past** the build, not by it: `onBrokenLinks` is `warn`, so Docusaurus exits 0 with broken anchors. Every internal link across the three touched pages resolved against the generated HTML — page present and `id="…"` present for each anchor.
- `lint:md` clean for all three docs.

## Release note

This targets **7.0.0**, not 7.1.0 — release-please #4777 is being held so the major does not ship a LADDER nobody can drive.