### PR TITLE
style(ladder): bring the ladder surface into line with the import-ordering standard

### DIFF
--- a/src/assemblies/governors/ladderGovernor/mutate.ts
+++ b/src/assemblies/governors/ladderGovernor/mutate.ts
@@ -2,6 +2,6 @@ export { submitResult, confirmResult, disputeResult } from '@Mutate/ladder/repor
 export { acceptChallenge, declineChallenge } from '@Mutate/ladder/respondToChallenge';
 export { removeLadderParticipant } from '@Mutate/ladder/removeLadderParticipant';
 export { refreshLadderRatings } from '@Mutate/ladder/refreshLadderRatings';
-export { applyLadderMovement } from '@Mutate/ladder/applyLadderMovement';
 export { addLadderParticipant } from '@Mutate/ladder/addLadderParticipant';
+export { applyLadderMovement } from '@Mutate/ladder/applyLadderMovement';
 export { issueChallenge } from '@Mutate/ladder/issueChallenge';

--- a/src/assemblies/governors/ladderGovernor/query.ts
+++ b/src/assemblies/governors/ladderGovernor/query.ts
@@ -1,10 +1,10 @@
+export { getResultAttestation } from '@Query/ladder/getResultAttestation';
+export { getChallengeState } from '@Query/ladder/getChallengeState';
+export { getLadderStanding } from '@Query/ladder/getLadderStanding';
+export { getLapses } from '@Query/ladder/getLapses';
 export {
   getLadderPolicy,
   getLadderOrdering,
   getLadderMovement,
   isChallengeInRange,
 } from '@Query/ladder/getLadderPolicy';
-export { getResultAttestation } from '@Query/ladder/getResultAttestation';
-export { getChallengeState } from '@Query/ladder/getChallengeState';
-export { getLadderStanding } from '@Query/ladder/getLadderStanding';
-export { getLapses } from '@Query/ladder/getLapses';

--- a/src/constants/matchUpStatusScopes.ts
+++ b/src/constants/matchUpStatusScopes.ts
@@ -1,6 +1,6 @@
+import type { MatchUpStatusUnion } from '@Types/tournamentTypes';
 import { LADDER } from './drawDefinitionConstants';
 import { CHALLENGED } from './matchUpStatusValues';
-import type { MatchUpStatusUnion } from '@Types/tournamentTypes';
 
 /**
  * Where a matchUpStatus is allowed to be used.

--- a/src/mutate/ladder/addLadderParticipant.ts
+++ b/src/mutate/ladder/addLadderParticipant.ts
@@ -1,16 +1,16 @@
-import { mirrorStandingToScale } from '@Mutate/ladder/mirrorStandingToScale';
-import { participantScaleItem } from '@Query/participant/participantScaleItem';
 import { getLadderOrdering, getLadderPolicy } from '@Query/ladder/getLadderPolicy';
+import { participantScaleItem } from '@Query/participant/participantScaleItem';
+import { mirrorStandingToScale } from '@Mutate/ladder/mirrorStandingToScale';
 import ratingsParameters from '@Fixtures/ratings/ratingsParameters';
 import { isLadder } from '@Query/drawDefinition/isLadder';
 import { isObject } from '@Tools/objects';
 
-import { BOTTOM, RANK } from '@Constants/ladderConstants';
+import { EXISTING_PARTICIPANT, INVALID_VALUES, MISSING_DRAW_DEFINITION } from '@Constants/errorConditionConstants';
 import { DYNAMIC, RATING as RATING_SCALE } from '@Constants/scaleConstants';
+import { BOTTOM, RANK } from '@Constants/ladderConstants';
 import { SINGLES_EVENT } from '@Constants/eventConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 import { ResultType } from '@Types/factoryTypes';
-import { EXISTING_PARTICIPANT, INVALID_VALUES, MISSING_DRAW_DEFINITION } from '@Constants/errorConditionConstants';
 
 type AddArgs = {
   /** The instant of joining — the scaleDate of any positions this shifts. */

--- a/src/mutate/ladder/applyLadderMovement.ts
+++ b/src/mutate/ladder/applyLadderMovement.ts
@@ -1,9 +1,9 @@
-import { resolveLadderStructure } from '@Query/ladder/resolveLadderContext';
 import { getLadderMovement, getLadderOrdering, getLadderPolicy } from '@Query/ladder/getLadderPolicy';
+import { resolveLadderStructure } from '@Query/ladder/resolveLadderContext';
 import { isLadder } from '@Query/drawDefinition/isLadder';
 
-import { mirrorStandingToScale } from '@Mutate/ladder/mirrorStandingToScale';
 import { generateDynamicRatings } from '@Generators/scales/generateDynamicRatings';
+import { mirrorStandingToScale } from '@Mutate/ladder/mirrorStandingToScale';
 import { getResultAttestation } from '@Query/ladder/getResultAttestation';
 
 import { FORFEIT, INSERTION, RANK, RESULT, movementTriggers } from '@Constants/ladderConstants';

--- a/src/mutate/ladder/applyLapseConsequence.ts
+++ b/src/mutate/ladder/applyLapseConsequence.ts
@@ -1,14 +1,14 @@
-import { mirrorStandingToScale } from '@Mutate/ladder/mirrorStandingToScale';
 import { removeLadderParticipant } from '@Mutate/ladder/removeLadderParticipant';
+import { mirrorStandingToScale } from '@Mutate/ladder/mirrorStandingToScale';
 import { applyLadderMovement } from '@Mutate/ladder/applyLadderMovement';
 import { getLadderOrdering } from '@Query/ladder/getLadderPolicy';
 import { getLapses } from '@Query/ladder/getLapses';
 
 import { DROP, FORFEIT, FORFEIT_POSITION, RANK, REMOVE } from '@Constants/ladderConstants';
+import { INVALID_VALUES, PARTICIPANT_NOT_FOUND } from '@Constants/errorConditionConstants';
 import type { LapseConsequence } from '@Constants/ladderConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 import { ResultType } from '@Types/factoryTypes';
-import { INVALID_VALUES, PARTICIPANT_NOT_FOUND } from '@Constants/errorConditionConstants';
 
 type ConsequenceArgs = {
   /** The instant the consequence takes effect, and the instant lapses are counted at. */

--- a/src/mutate/ladder/mirrorStandingToScale.ts
+++ b/src/mutate/ladder/mirrorStandingToScale.ts
@@ -1,6 +1,6 @@
 import { setParticipantScaleItem } from '@Mutate/participants/scaleItems/addScaleItems';
-import { RANKING } from '@Constants/scaleConstants';
 import { SINGLES_EVENT } from '@Constants/eventConstants';
+import { RANKING } from '@Constants/scaleConstants';
 
 /**
  * Writes each changed rank as a dated `ScaleItem`, which is what makes a ladder's history queryable

--- a/src/mutate/ladder/refreshLadderRatings.ts
+++ b/src/mutate/ladder/refreshLadderRatings.ts
@@ -3,12 +3,12 @@ import { getLadderOrdering, getLadderPolicy } from '@Query/ladder/getLadderPolic
 import ratingsParameters from '@Fixtures/ratings/ratingsParameters';
 import { isLadder } from '@Query/drawDefinition/isLadder';
 
+import { INVALID_VALUES, MISSING_DRAW_DEFINITION, MISSING_TOURNAMENT_RECORD } from '@Constants/errorConditionConstants';
 import { RATING as RATING_ORDERING } from '@Constants/ladderConstants';
 import { RATING as RATING_SCALE } from '@Constants/scaleConstants';
 import { SINGLES_EVENT } from '@Constants/eventConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 import { ResultType } from '@Types/factoryTypes';
-import { INVALID_VALUES, MISSING_DRAW_DEFINITION, MISSING_TOURNAMENT_RECORD } from '@Constants/errorConditionConstants';
 
 type RefreshArgs = {
   /** `{ participantId: ratingValue }` — supplied by the caller, not fetched here. */

--- a/src/mutate/ladder/removeLadderParticipant.ts
+++ b/src/mutate/ladder/removeLadderParticipant.ts
@@ -3,11 +3,11 @@ import { getLadderOrdering } from '@Query/ladder/getLadderPolicy';
 import { addTimeItem } from '@Mutate/timeItems/addTimeItem';
 import { isLadder } from '@Query/drawDefinition/isLadder';
 
-import { LADDER_PARTICIPANT_REMOVED, RANK } from '@Constants/ladderConstants';
-import { RANKING } from '@Constants/scaleConstants';
-import { SUCCESS } from '@Constants/resultConstants';
-import { ResultType } from '@Types/factoryTypes';
 import { INVALID_VALUES, MISSING_DRAW_DEFINITION, PARTICIPANT_NOT_FOUND } from '@Constants/errorConditionConstants';
+import { LADDER_PARTICIPANT_REMOVED, RANK } from '@Constants/ladderConstants';
+import { SUCCESS } from '@Constants/resultConstants';
+import { RANKING } from '@Constants/scaleConstants';
+import { ResultType } from '@Types/factoryTypes';
 
 type RemoveArgs = {
   /** Why — recorded, because a manual override with no reason is indistinguishable from a mistake. */

--- a/src/mutate/ladder/reportResult.ts
+++ b/src/mutate/ladder/reportResult.ts
@@ -3,11 +3,11 @@ import { getLadderPolicy } from '@Query/ladder/getLadderPolicy';
 import { addTimeItem } from '@Mutate/timeItems/addTimeItem';
 import { isLadder } from '@Query/drawDefinition/isLadder';
 
+import { INVALID_VALUES, MATCHUP_NOT_FOUND, MISSING_DRAW_DEFINITION } from '@Constants/errorConditionConstants';
 import { RESULT_CONFIRMED, RESULT_DISPUTED, RESULT_SUBMITTED } from '@Constants/ladderConstants';
 import { AWAITING_RESULT, COMPLETED, TO_BE_PLAYED } from '@Constants/matchUpStatusConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 import { ResultType } from '@Types/factoryTypes';
-import { INVALID_VALUES, MATCHUP_NOT_FOUND, MISSING_DRAW_DEFINITION } from '@Constants/errorConditionConstants';
 
 type ReportArgs = {
   tournamentRecord?: any;

--- a/src/mutate/ladder/respondToChallenge.ts
+++ b/src/mutate/ladder/respondToChallenge.ts
@@ -4,11 +4,11 @@ import { getLadderPolicy } from '@Query/ladder/getLadderPolicy';
 import { addTimeItem } from '@Mutate/timeItems/addTimeItem';
 import { isLadder } from '@Query/drawDefinition/isLadder';
 
+import { INVALID_VALUES, MATCHUP_NOT_FOUND, MISSING_DRAW_DEFINITION } from '@Constants/errorConditionConstants';
 import { CHALLENGE_ACCEPTED, CHALLENGE_DECLINED, EXPIRED, PENDING } from '@Constants/ladderConstants';
 import { CHALLENGED, TO_BE_PLAYED } from '@Constants/matchUpStatusConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 import { ResultType } from '@Types/factoryTypes';
-import { INVALID_VALUES, MATCHUP_NOT_FOUND, MISSING_DRAW_DEFINITION } from '@Constants/errorConditionConstants';
 
 type RespondArgs = {
   /** The instant of the response, and the instant expiry is judged against. */

--- a/src/query/ladder/getLadderPolicy.ts
+++ b/src/query/ladder/getLadderPolicy.ts
@@ -1,9 +1,9 @@
-import { getPolicyDefinitions } from '@Query/extensions/getAppliedPolicies';
 import { POLICY_LADDER_DEFAULT } from '@Fixtures/policies/POLICY_LADDER_DEFAULT';
+import { getPolicyDefinitions } from '@Query/extensions/getAppliedPolicies';
 
+import type { LadderMovement, LadderOrdering } from '@Constants/ladderConstants';
 import { POLICY_TYPE_LADDER } from '@Constants/policyConstants';
 import { RANK, SWAP } from '@Constants/ladderConstants';
-import type { LadderMovement, LadderOrdering } from '@Constants/ladderConstants';
 import type { LadderPolicy } from '@Types/ladderTypes';
 
 type LadderPolicyArgs = {

--- a/src/query/ladder/getLadderStanding.ts
+++ b/src/query/ladder/getLadderStanding.ts
@@ -1,6 +1,6 @@
-import { resolveLadderStructure } from '@Query/ladder/resolveLadderContext';
-import { participantScaleItem } from '@Query/participant/participantScaleItem';
 import { getLadderPolicy, getLadderOrdering } from '@Query/ladder/getLadderPolicy';
+import { participantScaleItem } from '@Query/participant/participantScaleItem';
+import { resolveLadderStructure } from '@Query/ladder/resolveLadderContext';
 import ratingsParameters from '@Fixtures/ratings/ratingsParameters';
 import { isObject } from '@Tools/objects';
 

--- a/src/query/ladder/getLapses.ts
+++ b/src/query/ladder/getLapses.ts
@@ -1,11 +1,10 @@
+import { addDaysIso, getChallengeState } from '@Query/ladder/getChallengeState';
 import { resolveLadderStructure } from '@Query/ladder/resolveLadderContext';
-import { getChallengeState } from '@Query/ladder/getChallengeState';
-import { addDaysIso } from '@Query/ladder/getChallengeState';
 import { getLadderPolicy } from '@Query/ladder/getLadderPolicy';
 
-import { CHALLENGE_ACCEPTED, CHALLENGE_DECLINED, CHALLENGE_ISSUED } from '@Constants/ladderConstants';
 import { CONSECUTIVE, DECLINE, EXPIRY, FORFEIT_POSITION, ROLLING, UNPLAYED } from '@Constants/ladderConstants';
 import { AWAITING_RESULT, CHALLENGED, COMPLETED, TO_BE_PLAYED } from '@Constants/matchUpStatusConstants';
+import { CHALLENGE_ACCEPTED, CHALLENGE_DECLINED, CHALLENGE_ISSUED } from '@Constants/ladderConstants';
 import type { LapseConsequence, LapseKind } from '@Constants/ladderConstants';
 import type { LadderPolicy, LapsePolicy } from '@Types/ladderTypes';
 

--- a/src/query/ladder/getResultAttestation.ts
+++ b/src/query/ladder/getResultAttestation.ts
@@ -1,6 +1,7 @@
 import { resolveLadderMatchUp } from '@Query/ladder/resolveLadderContext';
 import { getLadderPolicy } from '@Query/ladder/getLadderPolicy';
 
+import type { LadderPolicy } from '@Types/ladderTypes';
 import {
   EITHER,
   OPERATOR,
@@ -9,7 +10,6 @@ import {
   RESULT_DISPUTED,
   RESULT_SUBMITTED,
 } from '@Constants/ladderConstants';
-import type { LadderPolicy } from '@Types/ladderTypes';
 
 type AttestationArgs = {
   matchUp?: any;

--- a/src/tests/ladder/challengeLifecycle.test.ts
+++ b/src/tests/ladder/challengeLifecycle.test.ts
@@ -5,8 +5,8 @@ import { getChallengeState } from '@Query/ladder/getChallengeState';
 import { issueChallenge } from '@Mutate/ladder/issueChallenge';
 
 import { ACCEPTED, DECLINED, EXPIRED, PENDING } from '@Constants/ladderConstants';
-import { CHALLENGED, TO_BE_PLAYED } from '@Constants/matchUpStatusConstants';
 import { LADDER, SINGLE_ELIMINATION } from '@Constants/drawDefinitionConstants';
+import { CHALLENGED, TO_BE_PLAYED } from '@Constants/matchUpStatusConstants';
 
 const ISSUED = '2026-03-01T10:00:00.000Z';
 const policy = { acceptanceDays: 5, challengeRange: 3 };

--- a/src/tests/ladder/ladderDrawType.test.ts
+++ b/src/tests/ladder/ladderDrawType.test.ts
@@ -6,10 +6,10 @@ import { isLadder } from '@Query/drawDefinition/isLadder';
 import mocksEngine from '@Assemblies/engines/mock';
 import tournamentEngine from '@Engines/syncEngine';
 
-import { matchUpStatusScopes } from '@Constants/matchUpStatusScopes';
-import { MATCHUP_STATUS_OUT_OF_SCOPE } from '@Constants/errorConditionConstants';
 import { AD_HOC, LADDER, SINGLE_ELIMINATION } from '@Constants/drawDefinitionConstants';
 import { CHALLENGED, COMPLETED, TO_BE_PLAYED } from '@Constants/matchUpStatusConstants';
+import { MATCHUP_STATUS_OUT_OF_SCOPE } from '@Constants/errorConditionConstants';
+import { matchUpStatusScopes } from '@Constants/matchUpStatusScopes';
 import {
   nonDirectingMatchUpStatuses,
   participantsRequiredMatchUpStatuses,

--- a/src/tests/ladder/ladderEngineReachability.test.ts
+++ b/src/tests/ladder/ladderEngineReachability.test.ts
@@ -3,8 +3,8 @@ import { expect, test, describe } from 'vitest';
 import mocksEngine from '@Assemblies/engines/mock';
 import tournamentEngine from '@Engines/syncEngine';
 
-import { LADDER } from '@Constants/drawDefinitionConstants';
 import { ACCEPTED, PENDING, RESULT } from '@Constants/ladderConstants';
+import { LADDER } from '@Constants/drawDefinitionConstants';
 
 /**
  * The ladder lifecycle exists to be driven from OUTSIDE the factory.

--- a/src/tests/ladder/ladderGuards.test.ts
+++ b/src/tests/ladder/ladderGuards.test.ts
@@ -1,20 +1,20 @@
 import { expect, test, describe } from 'vitest';
 
-import { acceptChallenge, declineChallenge } from '@Mutate/ladder/respondToChallenge';
 import { confirmResult, disputeResult, submitResult } from '@Mutate/ladder/reportResult';
+import { acceptChallenge, declineChallenge } from '@Mutate/ladder/respondToChallenge';
 import { removeLadderParticipant } from '@Mutate/ladder/removeLadderParticipant';
-import { addLadderParticipant } from '@Mutate/ladder/addLadderParticipant';
 import { applyLapseConsequence } from '@Mutate/ladder/applyLapseConsequence';
+import { mirrorStandingToScale } from '@Mutate/ladder/mirrorStandingToScale';
+import { addLadderParticipant } from '@Mutate/ladder/addLadderParticipant';
 import { refreshLadderRatings } from '@Mutate/ladder/refreshLadderRatings';
 import { applyLadderMovement } from '@Mutate/ladder/applyLadderMovement';
-import { mirrorStandingToScale } from '@Mutate/ladder/mirrorStandingToScale';
-import { issueChallenge } from '@Mutate/ladder/issueChallenge';
 import { getChallengeState } from '@Query/ladder/getChallengeState';
+import { issueChallenge } from '@Mutate/ladder/issueChallenge';
 
 import { FORFEIT, FORFEIT_POSITION, RANK, RATING, RESULT, SWAP } from '@Constants/ladderConstants';
+import { LADDER, SINGLE_ELIMINATION } from '@Constants/drawDefinitionConstants';
 import { CHALLENGED, COMPLETED } from '@Constants/matchUpStatusConstants';
 import { POLICY_TYPE_LADDER } from '@Constants/policyConstants';
-import { LADDER, SINGLE_ELIMINATION } from '@Constants/drawDefinitionConstants';
 import { UTR } from '@Constants/ratingConstants';
 
 const AT = '2026-04-01T00:00:00.000Z';

--- a/src/tests/ladder/ladderMovement.test.ts
+++ b/src/tests/ladder/ladderMovement.test.ts
@@ -3,6 +3,10 @@ import { expect, test, describe } from 'vitest';
 import { removeLadderParticipant } from '@Mutate/ladder/removeLadderParticipant';
 import { applyLadderMovement } from '@Mutate/ladder/applyLadderMovement';
 
+import { CHALLENGED, COMPLETED } from '@Constants/matchUpStatusConstants';
+import { RESULT_NOT_VALIDATED } from '@Constants/errorConditionConstants';
+import { POLICY_TYPE_LADDER } from '@Constants/policyConstants';
+import { LADDER } from '@Constants/drawDefinitionConstants';
 import {
   FORFEIT,
   INSERTION,
@@ -15,10 +19,6 @@ import {
   RESULT_SUBMITTED,
   SWAP,
 } from '@Constants/ladderConstants';
-import { CHALLENGED, COMPLETED } from '@Constants/matchUpStatusConstants';
-import { RESULT_NOT_VALIDATED } from '@Constants/errorConditionConstants';
-import { POLICY_TYPE_LADDER } from '@Constants/policyConstants';
-import { LADDER } from '@Constants/drawDefinitionConstants';
 
 const AT = '2026-03-10T09:00:00.000Z';
 

--- a/src/tests/ladder/ladderPolicy.test.ts
+++ b/src/tests/ladder/ladderPolicy.test.ts
@@ -1,16 +1,16 @@
 import { expect, test, describe } from 'vitest';
 
+import { POLICY_LADDER_DEFAULT } from '@Fixtures/policies/POLICY_LADDER_DEFAULT';
+import mocksEngine from '@Assemblies/engines/mock';
 import {
   getLadderMovement,
   getLadderOrdering,
   getLadderPolicy,
   isChallengeInRange,
 } from '@Query/ladder/getLadderPolicy';
-import { POLICY_LADDER_DEFAULT } from '@Fixtures/policies/POLICY_LADDER_DEFAULT';
-import mocksEngine from '@Assemblies/engines/mock';
 
-import { POLICY_TYPE_LADDER } from '@Constants/policyConstants';
 import { ANY, INSERTION, RANK, RATING, SWAP } from '@Constants/ladderConstants';
+import { POLICY_TYPE_LADDER } from '@Constants/policyConstants';
 
 describe('POLICY_LADDER defaults', () => {
   test('an unconfigured ladder runs on defaults rather than erroring', () => {

--- a/src/tests/ladder/ladderStanding.test.ts
+++ b/src/tests/ladder/ladderStanding.test.ts
@@ -3,10 +3,10 @@ import { expect, test, describe } from 'vitest';
 import { getLadderStanding } from '@Query/ladder/getLadderStanding';
 
 import { DYNAMIC, RATING as RATING_SCALE, SCALE } from '@Constants/scaleConstants';
-import { ELO, UTR, WTN } from '@Constants/ratingConstants';
 import { POLICY_TYPE_LADDER } from '@Constants/policyConstants';
-import { RANK, RATING } from '@Constants/ladderConstants';
 import { LADDER } from '@Constants/drawDefinitionConstants';
+import { ELO, UTR, WTN } from '@Constants/ratingConstants';
+import { RANK, RATING } from '@Constants/ladderConstants';
 import { SINGLES_EVENT } from '@Constants/eventConstants';
 
 // A scale item lives on the participant as a timeItem keyed

--- a/src/tests/ladder/lapsePolicy.test.ts
+++ b/src/tests/ladder/lapsePolicy.test.ts
@@ -2,9 +2,9 @@ import { expect, test, describe } from 'vitest';
 
 import { getLapses } from '@Query/ladder/getLapses';
 
-import { CHALLENGE_ACCEPTED, CHALLENGE_DECLINED } from '@Constants/ladderConstants';
 import { CONSECUTIVE, DECLINE, DROP, EXPIRY, FORFEIT_POSITION, ROLLING, UNPLAYED } from '@Constants/ladderConstants';
 import { CHALLENGED, COMPLETED, TO_BE_PLAYED } from '@Constants/matchUpStatusConstants';
+import { CHALLENGE_ACCEPTED, CHALLENGE_DECLINED } from '@Constants/ladderConstants';
 import { POLICY_TYPE_LADDER } from '@Constants/policyConstants';
 import { LADDER } from '@Constants/drawDefinitionConstants';
 


### PR DESCRIPTION
Coding-standards review of what #4787 and #4793 merged.

## The finding

The ladder surface violates the longest-first import rule in `standards/coding-standards.md` at **more than twice the repo's rate**:

| surface | import groups | out of order |
|---|---:|---:|
| ladder (32 files) | 53 | **30 (56%)** |
| factory, non-ladder (2,574 files) | 3,522 | 812 (23%) |

Both PRs merged with it because **nothing enforces it**: `eslint.config.mjs` wires sonarjs but has no import-order rule, so `pnpm lint --max-warnings 0` is green either way. Some of them are mine — inserting `resolveLadderContext` at the top of three files put a 76-char line above a 102-char one.

After this PR the ladder surface is **0 of 53**.

## One correction to the audit that produced this

The first pass measured multi-line destructured imports by their widest line, and flagged several files that were already compliant — `reportResult.ts` and `applyLapseConsequence.ts` among them. The actual rule is *singles sorted longest-first, then multi-line destructured last*. The count came to 30 either way, but they were **30 different groups**. Anyone re-running this should measure multi-line units by position, not width.

## Scope

Imports and exports only. `git diff -U0` shows no changed line outside an import/export block; 46 insertions against 47 deletions, the net −1 being `getChallengeState` + `addDaysIso` consolidated from two lines to one (same module, which the standard also calls out).

This is **not** a free edit — import order changes module evaluation order and therefore circular-import behaviour, which has bitten this repo before (#4788 hit the only circular-dependency warning in the tree). The rollup build is the real control there.

## What I deliberately did NOT change

The **14 `.includes()` membership checks** the standards would have as `Set.has()`. There are **1,086 `.includes()` calls in non-test factory source**, and the constant-list form (`completedMatchUpStatuses.includes(...)`) is the house pattern in core paths including `setMatchUpState`. Converting only the ladder would make it the outlier rather than the exemplar. That is an ecosystem sweep and a separate decision.

Also unchanged: `.sort()` usage. Every sorted array on the ladder surface is one the function just created (`[]` accumulator, `.map()`, `.slice()`, spread), so the `.toSorted()` rule does not bite.

## Verification

- `pnpm verify` — all 16 steps, **exit 0**
- `verify:build` re-run alone: exit 0, **zero circular-dependency warnings**
- `verify:surface` — 22 added, 0 removed (unchanged by this PR)
- types, lint, format clean; 213 ladder tests pass

Rebased onto #4792 so it runs under the new docs-site gate.