### PR TITLE
fix(query)!: refuse an absent matchUp or matchUps instead of answering about it

### DIFF
--- a/documentation/docs/migration-7.0.0.md
+++ b/documentation/docs/migration-7.0.0.md
@@ -20,6 +20,7 @@ feature tour and the full list of 7.0.0 additions, see [What's New in 7.0.0](./w
 | A rejected `setMatchUpStatus` no longer alters the draw                                  | Callers with compensating logic after an error                    | See §3            |
 | `timeZone` conversions return an error instead of throwing or guessing                   | Anyone calling `wallClockToUTC`, `utcToWallClock`, `toEmbargoUTC` | See §4            |
 | `getTimeZoneOffsetMinutes` now returns `number \| undefined`                             | Anyone reading a zone offset                                      | See §4            |
+| `checkMatchUpIsComplete` / `getParticipantResults` refuse an absent object param          | Callers passing `matchUpId` / `drawId` and reading the result     | See §5            |
 
 ## 1. `participantsRequiredMatchUpStatuses` — a spelling fix
 
@@ -139,7 +140,62 @@ a plausible-looking number will now receive an error instead.
 `source` is returned rather than logged, so a caller can see which frame it got rather than having
 to infer it.
 
-## 5. Non-breaking additions worth knowing
+## 5. Two queries refuse an absent object param instead of answering
+
+`checkMatchUpIsComplete` takes a **matchUp object**; `getParticipantResults` takes an **array of
+in-context matchUps**. Neither takes an id.
+
+`paramsMiddleware` resolves `drawId` into a `drawDefinition` and stops there — it does not resolve
+`matchUpId` into a matchUp, and it does not gather matchUps. So the engine-idiomatic call supplied
+no object at all, and both functions answered anyway:
+
+```js
+// BEFORE 7.0.0 — both of these are wrong, and neither says so
+tournamentEngine.checkMatchUpIsComplete({ matchUpId, drawId }); // false, for a COMPLETED matchUp
+tournamentEngine.getParticipantResults({ drawId }); // { participantResults: {} }, for a played draw
+```
+
+Both now return an error — `ERR_MISSING_MATCHUP` and `ERR_MISSING_MATCHUPS`.
+
+`checkMatchUpIsComplete` additionally requires the object to carry a `matchUpId`, which is what
+distinguishes a matchUp from an arbitrary object. It does **not** require a hydrated matchUp —
+`matchUpStatus` and `winningSide` are both on the stored record.
+
+### Why this was worth breaking
+
+`checkMatchUpIsComplete` returns a **boolean that callers branch on**. There was no error to notice
+and no `undefined` to guard, and the wrong answer — `false`, "not complete" — is the one that looks
+safe. It would be believed.
+
+### What to do about the refusal
+
+**Pass the object.** If you hold only ids, resolve them first:
+
+```diff
+- const complete = tournamentEngine.checkMatchUpIsComplete({ matchUpId, drawId });
++ const { matchUp } = tournamentEngine.findMatchUp({ matchUpId, drawId });
++ const complete = tournamentEngine.checkMatchUpIsComplete({ matchUp });
+
+- const { participantResults } = tournamentEngine.getParticipantResults({ drawId });
++ const { matchUps } = tournamentEngine.allDrawMatchUps({ drawId });
++ const { participantResults } = tournamentEngine.getParticipantResults({ matchUps });
+```
+
+An **empty** array is still a valid question with an empty answer. The guard is on the argument being
+absent, not on it being empty, so a draw with no matchUps tallies to nothing exactly as before.
+
+### Two behaviours that did NOT change
+
+`checkMatchUpIsComplete` still returns `true`, the `winningSide` (`1` | `2`), **or `undefined`** — it
+was never a clean boolean, and the `undefined` is load-bearing: `tallyParticipantResults`
+distinguishes "not complete" from "no answer" with `?? matchUp.matchUpType === TEAM`. Normalising it
+to `false` would silently drop incomplete TEAM matchUps from the round-robin tally.
+
+And because the refusal is an **object**, it is **truthy**. Do not call `checkMatchUpIsComplete`
+inside a `.filter()` or `.every()` over an array that can hold a falsy entry without guarding the
+entry first — a refusal would read as "complete". Every caller inside the factory guards.
+
+## 6. Non-breaking additions worth knowing
 
 `plainDate`, `plainTime` and `zonedDateTime` are new published exports, completing the calendar
 intent set. `zonedTime` was never published, so its rename is not a breaking change.

--- a/documentation/docs/whats-new-7.0.0.md
+++ b/documentation/docs/whats-new-7.0.0.md
@@ -2,15 +2,15 @@
 title: What's New in 7.0.0
 ---
 
-Version 7.0.0 of the Competition Factory ships **three areas of breaking change** — exit propagation, time-zone conversion, and one constant rename — and one headline feature: the **LADDER draw type**, a continuous challenge-driven competition with an enforced `CHALLENGED` status, an attestation gate on self-reported results, `RANK` or `RATING` ordering, and eighteen new engine methods to drive it.
+Version 7.0.0 of the Competition Factory ships **four areas of breaking change** — exit propagation, time-zone conversion, two queries that now refuse an absent argument, and one constant rename — and one headline feature: the **LADDER draw type**, a continuous challenge-driven competition with an enforced `CHALLENGED` status, an attestation gate on self-reported results, `RANK` or `RATING` ordering, and eighteen new engine methods to drive it.
 
-For upgrade mechanics — the five breaking-change rows and the exact steps to adopt them — see the [6.x to 7.0.0 migration guide](./migration-7.0.0).
+For upgrade mechanics — the six breaking-change rows and the exact steps to adopt them — see the [6.x to 7.0.0 migration guide](./migration-7.0.0).
 
 For the full per-commit changelog see [CHANGELOG.md](https://github.com/CourtHive/competition-factory/blob/master/CHANGELOG.md).
 
 ## The headline changes
 
-Three changes break the surface and need consumer attention. All are covered in detail in the [migration guide](./migration-7.0.0).
+Four changes break the surface and need consumer attention. All are covered in detail in the [migration guide](./migration-7.0.0).
 
 ### 1. Exit propagation is idempotent, atomic, and correct
 
@@ -42,7 +42,23 @@ The difference was failure handling, and each was fail-open on a different axis.
 
 → [migration §4](./migration-7.0.0#4-time-zone-conversions-refuse-rather-than-throw-or-guess), [tools.zonedDateTime](./tools/tools-api#toolszoneddatetime).
 
-### 3. `participantsRequiredMatchUpStatuses` — a spelling fix
+### 3. Two queries refuse an absent object param instead of answering
+
+`checkMatchUpIsComplete` takes a matchUp **object**; `getParticipantResults` takes an **array** of in-context matchUps. Neither takes an id — and `paramsMiddleware` resolves `drawId` into a `drawDefinition` but does not resolve `matchUpId` into a matchUp or gather matchUps. So the engine-idiomatic call supplied nothing, and both answered anyway:
+
+```js
+// before 7.0.0 — both wrong, neither says so
+tournamentEngine.checkMatchUpIsComplete({ matchUpId, drawId }); // false, for a COMPLETED matchUp
+tournamentEngine.getParticipantResults({ drawId }); // {}, for a fully-played draw
+```
+
+Both now return `ERR_MISSING_MATCHUP` / `ERR_MISSING_MATCHUPS`. It was worth breaking because `checkMatchUpIsComplete` returns a **boolean a caller branches on** — no error to notice, no `undefined` to guard, and the wrong answer is the safe-looking one.
+
+An **empty** array is still a valid question with an empty answer; the guard is on the argument being absent, not empty.
+
+→ [migration §5](./migration-7.0.0#5-two-queries-refuse-an-absent-object-param-instead-of-answering).
+
+### 4. `participantsRequiredMatchUpStatuses` — a spelling fix
 
 The exported constant was misspelled `particicipantsRequiredMatchUpStatuses` (an extra `ici`) since it was introduced. Rename the import; the value, the type and the semantics are identical. No deprecated alias is provided, and a survey of the CourtHive ecosystem found no consumer importing the old name.
 
@@ -139,14 +155,15 @@ Dispute _resolution_ is not built: a disputed result is blocked from moving the 
 
 ## Upgrading checklist
 
-1. **Read [the migration guide](./migration-7.0.0)** for the five breaking-change rows.
+1. **Read [the migration guide](./migration-7.0.0)** for the six breaking-change rows.
 2. **Rename `particicipantsRequiredMatchUpStatuses`** to `participantsRequiredMatchUpStatuses` at every import site.
 3. **Handle the error return** from `wallClockToUTC`, `utcToWallClock` and `toEmbargoUTC`, and branch on `undefined` from `getTimeZoneOffsetMinutes`. Remove any `try`/`catch` that was there to catch a throw.
 4. **Delete compensating logic** that re-read or repaired state after a `setMatchUpStatus` error — a rejected call no longer alters the draw. Note the error code for the bare-`{ winningSide }` case moved from `ERR_MISSING_ASSIGNMENTS` to `ERR_INVALID_MATCHUP_STATUS`; match on behaviour rather than on that code.
 5. **Stop relying on re-application as repair.** Re-sending an identical double exit no longer nudges a draw whose advancement is missing. Detect that state with `getDrawInconsistencies` and repair it deliberately.
 6. **Add cases for `CHALLENGED` and for `SQUASH` / `BADMINTON`** if you `switch` exhaustively over `MatchUpStatusEnum` or `DisciplineEnum` with no `default`.
-7. **Check any branch on `isAdHocType`** — it now includes `LADDER`. Use `isLadder` where a roster and a standing must be told apart.
-8. **Adopt the ladder at your own pace** — the draw type and its eighteen engine methods are purely additive; no action is required to keep existing code working.
+7. **Pass objects, not ids, to `checkMatchUpIsComplete` and `getParticipantResults`** — resolve with `findMatchUp` / `allDrawMatchUps` first. Both now refuse an absent argument rather than answering `false` / empty.
+8. **Check any branch on `isAdHocType`** — it now includes `LADDER`. Use `isLadder` where a roster and a standing must be told apart.
+9. **Adopt the ladder at your own pace** — the draw type and its eighteen engine methods are purely additive; no action is required to keep existing code working.
 
 ## Where to go from here
 

--- a/src/assemblies/generators/drawDefinitions/generateAndPopulatePlayoffStructures.ts
+++ b/src/assemblies/generators/drawDefinitions/generateAndPopulatePlayoffStructures.ts
@@ -6,7 +6,7 @@ import { NamingEntry, generatePlayoffStructures } from './drawTypes/playoffStruc
 import { directParticipants } from '@Mutate/matchUps/drawPositions/directParticipants';
 import { resolveTieFormat } from '@Query/hierarchical/tieFormats/resolveTieFormat';
 import { getAllStructureMatchUps } from '@Query/matchUps/getAllStructureMatchUps';
-import { checkMatchUpIsComplete } from '@Query/matchUp/checkMatchUpIsComplete';
+import { matchUpCompletion } from '@Query/matchUp/checkMatchUpIsComplete';
 import { isLuckyBasedDraw } from '@Query/drawDefinition/isLuckyBasedDraw';
 import { getSourceRounds } from '@Query/drawDefinition/getSourceRounds';
 import { getAllDrawMatchUps } from '@Query/matchUps/drawMatchUps';
@@ -474,14 +474,8 @@ function advanceCompletedMatchUps({
   structure,
   event,
 }) {
-  // The refusal `{ error }` is truthy, so a falsy or id-less entry must be excluded BEFORE the call
-  // rather than relying on its return being falsy. Truthiness of a real answer is unchanged.
-  const isComplete = (matchUp: any) => {
-    const result: any = matchUp && checkMatchUpIsComplete({ matchUp });
-    return result?.error ? false : result;
-  };
   const completedMatchUps = inContextDrawMatchUps?.filter(
-    (matchUp) => isComplete(matchUp) && matchUp.structureId === sourceStructureId,
+    (matchUp) => matchUpCompletion(matchUp) && matchUp.structureId === sourceStructureId,
   );
 
   completedMatchUps?.forEach((matchUp) => {

--- a/src/assemblies/generators/drawDefinitions/generateAndPopulatePlayoffStructures.ts
+++ b/src/assemblies/generators/drawDefinitions/generateAndPopulatePlayoffStructures.ts
@@ -474,8 +474,14 @@ function advanceCompletedMatchUps({
   structure,
   event,
 }) {
+  // The refusal `{ error }` is truthy, so a falsy or id-less entry must be excluded BEFORE the call
+  // rather than relying on its return being falsy. Truthiness of a real answer is unchanged.
+  const isComplete = (matchUp: any) => {
+    const result: any = matchUp && checkMatchUpIsComplete({ matchUp });
+    return result?.error ? false : result;
+  };
   const completedMatchUps = inContextDrawMatchUps?.filter(
-    (matchUp) => checkMatchUpIsComplete({ matchUp }) && matchUp.structureId === sourceStructureId,
+    (matchUp) => isComplete(matchUp) && matchUp.structureId === sourceStructureId,
   );
 
   completedMatchUps?.forEach((matchUp) => {

--- a/src/query/matchUp/checkMatchUpIsComplete.ts
+++ b/src/query/matchUp/checkMatchUpIsComplete.ts
@@ -22,11 +22,28 @@ type CheckMatchUpIsCompleteArgs = { matchUp?: any };
  * complete" from "no answer" with `?? matchUp.matchUpType === TEAM`. Normalising to `false` would
  * silently drop incomplete TEAM matchUps from the round-robin tally.
  *
- * ⚠️ AND THE ERROR IS AN OBJECT, therefore TRUTHY. Never call this inside a `.filter()` or
- * `.every()` over an array that can hold a falsy entry without guarding the entry first — a refusal
- * would read as "complete". Every internal caller guards.
+ * ⚠️ AND THE ERROR IS AN OBJECT, therefore TRUTHY. Inside a `.filter()` or `.every()` a refusal
+ * would read as "complete" — fail-open in the opposite direction, and worse than the defect this
+ * guard exists to close. Predicate callers must use `matchUpCompletion` below rather than guarding
+ * at each site: three hand-rolled guards is how two of them end up disagreeing.
  */
 export function checkMatchUpIsComplete({ matchUp }: CheckMatchUpIsCompleteArgs) {
   if (typeof matchUp !== 'object' || matchUp === null || !matchUp.matchUpId) return { error: MISSING_MATCHUP };
   return completedMatchUpStatuses.includes(matchUp.matchUpStatus) || matchUp.winningSide;
+}
+
+/**
+ * The predicate-safe form, for iteration over an array that may hold a falsy or id-less entry.
+ *
+ * Returns exactly what `checkMatchUpIsComplete` returns for a real matchUp — `true`, the
+ * `winningSide` (1 | 2), or `undefined` — and maps a refusal to `undefined` rather than letting a
+ * truthy `{ error }` read as "complete".
+ *
+ * `undefined` rather than `false` is deliberate and load-bearing: `tallyParticipantResults`
+ * separates "not complete" from "no answer" with `?? matchUp.matchUpType === TEAM`.
+ */
+export function matchUpCompletion(matchUp: any) {
+  if (!matchUp) return undefined;
+  const result: any = checkMatchUpIsComplete({ matchUp });
+  return result?.error ? undefined : result;
 }

--- a/src/query/matchUp/checkMatchUpIsComplete.ts
+++ b/src/query/matchUp/checkMatchUpIsComplete.ts
@@ -1,6 +1,32 @@
 import { completedMatchUpStatuses } from '@Constants/matchUpStatusConstants';
+import { MISSING_MATCHUP } from '@Constants/errorConditionConstants';
 
-export function checkMatchUpIsComplete({ matchUp }) {
-  if (!matchUp) return false;
-  return completedMatchUpStatuses.includes(matchUp?.matchUpStatus) || matchUp?.winningSide;
+type CheckMatchUpIsCompleteArgs = { matchUp?: any };
+
+/**
+ * Whether a matchUp has a result.
+ *
+ * TAKES A MATCHUP OBJECT, not a matchUpId. `paramsMiddleware` resolves `drawId` into a
+ * `drawDefinition` and stops there — it does not resolve `matchUpId` into a matchUp — so an engine
+ * caller writing `checkMatchUpIsComplete({ matchUpId, drawId })` supplies no matchUp at all.
+ *
+ * That used to answer `false`, which is a confident wrong answer to a question nobody could ask
+ * correctly: a COMPLETED matchUp reported as incomplete, with no error to notice, and `false` being
+ * the safe-looking branch. It refuses now.
+ *
+ * The matchUp does NOT need to be hydrated — `matchUpStatus` and `winningSide` are both first-class
+ * on the stored record. It does need to be a real matchUp, which is what `matchUpId` establishes.
+ *
+ * ⚠️ THE RETURN IS DELIBERATELY NOT A CLEAN BOOLEAN. It is `true`, the `winningSide` (1 | 2), or
+ * `undefined` — and the `undefined` is load-bearing: `tallyParticipantResults` distinguishes "not
+ * complete" from "no answer" with `?? matchUp.matchUpType === TEAM`. Normalising to `false` would
+ * silently drop incomplete TEAM matchUps from the round-robin tally.
+ *
+ * ⚠️ AND THE ERROR IS AN OBJECT, therefore TRUTHY. Never call this inside a `.filter()` or
+ * `.every()` over an array that can hold a falsy entry without guarding the entry first — a refusal
+ * would read as "complete". Every internal caller guards.
+ */
+export function checkMatchUpIsComplete({ matchUp }: CheckMatchUpIsCompleteArgs) {
+  if (typeof matchUp !== 'object' || matchUp === null || !matchUp.matchUpId) return { error: MISSING_MATCHUP };
+  return completedMatchUpStatuses.includes(matchUp.matchUpStatus) || matchUp.winningSide;
 }

--- a/src/query/matchUps/roundRobinTally/getGroupOrder.ts
+++ b/src/query/matchUps/roundRobinTally/getGroupOrder.ts
@@ -212,13 +212,17 @@ function processAttribute({
   matchUps,
   reversed, // reverses default which is greatest to least
 }) {
-  const { participantResults } = getParticipantResults({
+  const participantResultsOutcome: any = getParticipantResults({
     participantIds: idsFilter && participantIds,
     groupingTotal: groupTotals && attribute,
     matchUpFormat,
     tallyPolicy,
     matchUps,
   });
+  // Untyped params here, so tsc does not force this the way it does in tallyParticipantResults —
+  // propagated explicitly for the same reason: an absent `matchUps` must not read as an empty group.
+  if (participantResultsOutcome.error) return participantResultsOutcome;
+  const { participantResults } = participantResultsOutcome;
 
   const groups = getGroups({
     participantResults,

--- a/src/query/matchUps/roundRobinTally/getParticipantResults.ts
+++ b/src/query/matchUps/roundRobinTally/getParticipantResults.ts
@@ -8,6 +8,7 @@ import { isExit } from '@Validators/isExit';
 
 // constants and types
 import { completedMatchUpStatuses, DEFAULTED, RETIRED, WALKOVER } from '@Constants/matchUpStatusConstants';
+import { MISSING_MATCHUPS } from '@Constants/errorConditionConstants';
 import { DOUBLES, SINGLES } from '@Constants/matchUpTypes';
 import { HydratedMatchUp } from '@Types/hydrated';
 
@@ -30,6 +31,15 @@ export function getParticipantResults({
   perPlayer,
   matchUps,
 }: GetParticipantResultsArgs) {
+  // TAKES AN ARRAY OF IN-CONTEXT MATCHUPS, not a drawId. `paramsMiddleware` resolves `drawId` into a
+  // `drawDefinition` and stops; it does not gather matchUps. An engine caller writing
+  // `getParticipantResults({ drawId })` therefore supplied no matchUps at all, and this answered
+  // `{ participantResults: {} }` — an empty tally for a fully-played draw, with no error to notice.
+  //
+  // Results are attributed through `sides[].participantId`, which only an IN-CONTEXT matchUp
+  // carries; a stored matchUp has `drawPositions` and would tally to nothing for the same reason.
+  if (!Array.isArray(matchUps)) return { error: MISSING_MATCHUPS };
+
   const participantResults = {};
 
   const excludeMatchUpStatuses = tallyPolicy?.excludeMatchUpStatuses ?? [];

--- a/src/query/matchUps/roundRobinTally/tallyParticipantResults.ts
+++ b/src/query/matchUps/roundRobinTally/tallyParticipantResults.ts
@@ -1,4 +1,4 @@
-import { checkMatchUpIsComplete } from '@Query/matchUp/checkMatchUpIsComplete';
+import { matchUpCompletion } from '@Query/matchUp/checkMatchUpIsComplete';
 import { decorateResult } from '@Functions/global/decorateResult';
 import { getParticipantResults } from './getParticipantResults';
 import { getDevContext } from '@Global/state/globalState';
@@ -54,36 +54,25 @@ export function tallyParticipantResults({
     });
   }
 
-  // `checkMatchUpIsComplete` refuses a non-matchUp with a TRUTHY `{ error }`, and the filter on the
-  // next line proves `matchUps` can hold a falsy entry. This maps a refusal back to `undefined` and
-  // otherwise passes the answer through UNCHANGED — `true`, or the `winningSide` (1 | 2), or
-  // `undefined`. All three matter: callers below rely on truthiness, and the `?? TEAM` fallback
-  // relies on `undefined` specifically.
-  const completeOrUndefined = (matchUp: any) => {
-    if (!matchUp) return undefined;
-    const result: any = checkMatchUpIsComplete({ matchUp });
-    return result?.error ? undefined : result;
-  };
-
   const relevantMatchUps = matchUps.filter((matchUp) => matchUp && matchUp.matchUpStatus !== BYE);
 
   const participantsCount =
     relevantMatchUps.length && unique(relevantMatchUps.flatMap(({ drawPositions }) => drawPositions)).length;
 
   const bracketComplete =
-    relevantMatchUps.filter((matchUp) => completeOrUndefined(matchUp)).length === relevantMatchUps.length;
+    relevantMatchUps.filter((matchUp) => matchUpCompletion(matchUp)).length === relevantMatchUps.length;
   // if bracket is incomplete don't use expected matchUps perPlayer for calculating
   if (!bracketComplete) perPlayer = 0;
 
   const completedTieMatchUps = matchUps.every(
     ({ matchUpType, tieMatchUps }) =>
-      matchUpType === TEAM && tieMatchUps?.every((matchUp) => completeOrUndefined(matchUp)),
+      matchUpType === TEAM && tieMatchUps?.every((matchUp) => matchUpCompletion(matchUp)),
   );
 
   const tallyPolicy = policyDefinitions?.[POLICY_TYPE_ROUND_ROBIN_TALLY];
 
   const consideredMatchUps = matchUps.filter(
-    (matchUp) => matchUp && (completeOrUndefined(matchUp) ?? matchUp.matchUpType === TEAM),
+    (matchUp) => matchUp && (matchUpCompletion(matchUp) ?? matchUp.matchUpType === TEAM),
   );
   const participantResultsOutcome: any = getParticipantResults({
     matchUps: consideredMatchUps,

--- a/src/query/matchUps/roundRobinTally/tallyParticipantResults.ts
+++ b/src/query/matchUps/roundRobinTally/tallyParticipantResults.ts
@@ -54,33 +54,48 @@ export function tallyParticipantResults({
     });
   }
 
+  // `checkMatchUpIsComplete` refuses a non-matchUp with a TRUTHY `{ error }`, and the filter on the
+  // next line proves `matchUps` can hold a falsy entry. This maps a refusal back to `undefined` and
+  // otherwise passes the answer through UNCHANGED — `true`, or the `winningSide` (1 | 2), or
+  // `undefined`. All three matter: callers below rely on truthiness, and the `?? TEAM` fallback
+  // relies on `undefined` specifically.
+  const completeOrUndefined = (matchUp: any) => {
+    if (!matchUp) return undefined;
+    const result: any = checkMatchUpIsComplete({ matchUp });
+    return result?.error ? undefined : result;
+  };
+
   const relevantMatchUps = matchUps.filter((matchUp) => matchUp && matchUp.matchUpStatus !== BYE);
 
   const participantsCount =
     relevantMatchUps.length && unique(relevantMatchUps.flatMap(({ drawPositions }) => drawPositions)).length;
 
   const bracketComplete =
-    relevantMatchUps.filter((matchUp) => checkMatchUpIsComplete({ matchUp })).length === relevantMatchUps.length;
+    relevantMatchUps.filter((matchUp) => completeOrUndefined(matchUp)).length === relevantMatchUps.length;
   // if bracket is incomplete don't use expected matchUps perPlayer for calculating
   if (!bracketComplete) perPlayer = 0;
 
   const completedTieMatchUps = matchUps.every(
     ({ matchUpType, tieMatchUps }) =>
-      matchUpType === TEAM && tieMatchUps?.every((matchUp) => checkMatchUpIsComplete({ matchUp })),
+      matchUpType === TEAM && tieMatchUps?.every((matchUp) => completeOrUndefined(matchUp)),
   );
 
   const tallyPolicy = policyDefinitions?.[POLICY_TYPE_ROUND_ROBIN_TALLY];
 
   const consideredMatchUps = matchUps.filter(
-    (matchUp) => checkMatchUpIsComplete({ matchUp }) ?? matchUp.matchUpType === TEAM,
+    (matchUp) => matchUp && (completeOrUndefined(matchUp) ?? matchUp.matchUpType === TEAM),
   );
-  const { participantResults } = getParticipantResults({
+  const participantResultsOutcome: any = getParticipantResults({
     matchUps: consideredMatchUps,
     pressureRating,
     matchUpFormat,
     tallyPolicy,
     perPlayer,
   });
+  // `consideredMatchUps` is always an array here, so this cannot fire today — it is propagated
+  // rather than asserted so a future caller change surfaces as an error instead of an empty tally.
+  if (participantResultsOutcome.error) return participantResultsOutcome;
+  const { participantResults } = participantResultsOutcome;
 
   let report, order;
 

--- a/src/query/structure/getStructureMatchUps.ts
+++ b/src/query/structure/getStructureMatchUps.ts
@@ -1,6 +1,6 @@
 import { structureAssignedDrawPositions } from '@Query/drawDefinition/positionsGetter';
 import { getAllStructureMatchUps } from '@Query/matchUps/getAllStructureMatchUps';
-import { checkMatchUpIsComplete } from '@Query/matchUp/checkMatchUpIsComplete';
+import { matchUpCompletion } from '@Query/matchUp/checkMatchUpIsComplete';
 import { findStructure } from '@Acquire/findStructure';
 
 // constants and types
@@ -172,8 +172,7 @@ export function getStructureMatchUps({
         (collectionSidesAssigned || (drawPositionsFilled && (!requireParticipants || drawPositionsAssigned)));
 
       if (isByeMatchUp) return byeMatchUps.push(matchUp);
-      const completeResult: any = checkMatchUpIsComplete({ matchUp });
-      if (!completeResult?.error && completeResult) return completedMatchUps.push(matchUp);
+      if (matchUpCompletion(matchUp)) return completedMatchUps.push(matchUp);
       if (isUpcomingMatchUp) return upcomingMatchUps.push(matchUp);
       return pendingMatchUps.push(matchUp);
     });

--- a/src/query/structure/getStructureMatchUps.ts
+++ b/src/query/structure/getStructureMatchUps.ts
@@ -172,7 +172,8 @@ export function getStructureMatchUps({
         (collectionSidesAssigned || (drawPositionsFilled && (!requireParticipants || drawPositionsAssigned)));
 
       if (isByeMatchUp) return byeMatchUps.push(matchUp);
-      if (checkMatchUpIsComplete({ matchUp })) return completedMatchUps.push(matchUp);
+      const completeResult: any = checkMatchUpIsComplete({ matchUp });
+      if (!completeResult?.error && completeResult) return completedMatchUps.push(matchUp);
       if (isUpcomingMatchUp) return upcomingMatchUps.push(matchUp);
       return pendingMatchUps.push(matchUp);
     });

--- a/src/tests/governors/coverageMiscGovernors.test.ts
+++ b/src/tests/governors/coverageMiscGovernors.test.ts
@@ -8,6 +8,7 @@ import { addFlight } from '@Mutate/events/addFlight';
 // Query
 import { querySanctioningRecord } from '@Query/sanctioning/getSanctioningRecord';
 import { checkMatchUpIsComplete } from '@Query/matchUp/checkMatchUpIsComplete';
+import { MISSING_MATCHUP } from '@Constants/errorConditionConstants';
 import { getScaleValues } from '@Query/participant/getScaleValues';
 
 // Validators
@@ -201,24 +202,36 @@ describe('publicFindCourt', () => {
 // MatchUp Governor
 // ----------------------------------------------------------------
 describe('checkMatchUpIsComplete', () => {
-  it('returns false when matchUp is undefined', () => {
-    expect(checkMatchUpIsComplete({ matchUp: undefined })).toBe(false);
+  const matchUpId = 'm1';
+
+  it('REFUSES when no matchUp is supplied', () => {
+    // Previously `false` — a confident wrong answer to a question that was never asked, and the
+    // shape an engine caller hits when they pass `{ matchUpId, drawId }` expecting resolution.
+    expect(checkMatchUpIsComplete({ matchUp: undefined })).toEqual({ error: MISSING_MATCHUP });
+  });
+
+  it('REFUSES a non-matchUp object rather than answering about it', () => {
+    expect(checkMatchUpIsComplete({ matchUp: {} })).toEqual({ error: MISSING_MATCHUP });
+    expect(checkMatchUpIsComplete({ matchUp: { matchUpStatus: COMPLETED } })).toEqual({ error: MISSING_MATCHUP });
   });
 
   it('returns truthy when matchUp has winningSide', () => {
-    expect(checkMatchUpIsComplete({ matchUp: { winningSide: 1 } })).toBeTruthy();
+    expect(checkMatchUpIsComplete({ matchUp: { matchUpId, winningSide: 1 } })).toBeTruthy();
   });
 
   it('returns true when matchUp has COMPLETED status', () => {
-    expect(checkMatchUpIsComplete({ matchUp: { matchUpStatus: COMPLETED } })).toBe(true);
+    expect(checkMatchUpIsComplete({ matchUp: { matchUpId, matchUpStatus: COMPLETED } })).toBe(true);
   });
 
   it('returns true when matchUp has RETIRED status', () => {
-    expect(checkMatchUpIsComplete({ matchUp: { matchUpStatus: RETIRED } })).toBe(true);
+    expect(checkMatchUpIsComplete({ matchUp: { matchUpId, matchUpStatus: RETIRED } })).toBe(true);
   });
 
-  it('returns falsy for pending matchUp', () => {
-    expect(checkMatchUpIsComplete({ matchUp: { matchUpStatus: undefined } })).toBeFalsy();
+  it('returns UNDEFINED, not false, for a pending matchUp', () => {
+    // Load-bearing: tallyParticipantResults distinguishes "not complete" from "no answer" with
+    // `?? matchUp.matchUpType === TEAM`. Normalising this to `false` drops incomplete TEAM
+    // matchUps from the round-robin tally.
+    expect(checkMatchUpIsComplete({ matchUp: { matchUpId, matchUpStatus: undefined } })).toBeUndefined();
   });
 });
 

--- a/src/tests/query/engineParamFailOpen.test.ts
+++ b/src/tests/query/engineParamFailOpen.test.ts
@@ -1,0 +1,74 @@
+import { expect, test, describe } from 'vitest';
+
+import { getParticipantResults } from '@Query/matchUps/roundRobinTally/getParticipantResults';
+import { checkMatchUpIsComplete } from '@Query/matchUp/checkMatchUpIsComplete';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+
+import { MISSING_MATCHUPS, MISSING_MATCHUP } from '@Constants/errorConditionConstants';
+import { COMPLETED } from '@Constants/matchUpStatusConstants';
+
+/**
+ * Both of these are on the engine, and both took an OBJECT param the engine does not resolve.
+ * `paramsMiddleware` turns `drawId` into a `drawDefinition` and stops — it does not turn `matchUpId`
+ * into a matchUp, nor `drawId` into matchUps.
+ *
+ * So the engine-idiomatic call supplied nothing, and both answered anyway: `false` for a COMPLETED
+ * matchUp, and an empty tally for a fully-played draw. No error, no `undefined` to guard, and in
+ * both cases the wrong answer is the safe-looking one.
+ *
+ * These assert the refusal. They are written through `tournamentEngine` on purpose — the module-path
+ * suites stayed green through the whole defect.
+ */
+describe('engine methods refuse rather than answer when their object param is absent', () => {
+  test('checkMatchUpIsComplete: the engine-idiomatic call refuses, the correct call still answers', () => {
+    const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 8, completionGoal: 7 }],
+      setState: true,
+    });
+    const { drawId } = tournamentRecord.events[0].drawDefinitions[0];
+    const matchUps = tournamentEngine.allTournamentMatchUps().matchUps;
+    const matchUp = matchUps.find((m: any) => m.matchUpStatus === COMPLETED);
+    expect(matchUp).toBeDefined();
+
+    // the correct call — unchanged
+    expect(tournamentEngine.checkMatchUpIsComplete({ matchUp })).toBe(true);
+
+    // what a consumer would naturally write. Was `false` for this COMPLETED matchUp.
+    const byIds: any = tournamentEngine.checkMatchUpIsComplete({ matchUpId: matchUp.matchUpId, drawId });
+    expect(byIds.error).toEqual(MISSING_MATCHUP);
+  });
+
+  test('getParticipantResults: the engine-idiomatic call refuses, the correct call still tallies', () => {
+    const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 8, completionGoal: 7 }],
+      setState: true,
+    });
+    const { drawId } = tournamentRecord.events[0].drawDefinitions[0];
+    const matchUps = tournamentEngine.allTournamentMatchUps().matchUps;
+
+    // the correct call — in-context matchUps, results attributed through sides[].participantId
+    const correct: any = tournamentEngine.getParticipantResults({ matchUps });
+    expect(Object.keys(correct.participantResults).length).toBeGreaterThan(0);
+
+    // was `{ participantResults: {} }` — an empty tally for a played draw
+    const byId: any = tournamentEngine.getParticipantResults({ drawId });
+    expect(byId.error).toEqual(MISSING_MATCHUPS);
+  });
+
+  test('the refusal is an OBJECT, so it is truthy — the trap the internal callers had to guard', () => {
+    // Documents why every internal call site filters the entry before calling: a naive
+    // `.filter((m) => checkMatchUpIsComplete({ matchUp: m }))` would now count refusals as complete.
+    const refusal: any = checkMatchUpIsComplete({ matchUp: undefined });
+    expect(refusal.error).toEqual(MISSING_MATCHUP);
+    expect(Boolean(refusal)).toBe(true);
+  });
+
+  test('an empty matchUps array is a valid question with an empty answer, not a refusal', () => {
+    // The guard is on the ARGUMENT being absent, not on it being empty. A draw with no matchUps
+    // legitimately tallies to nothing, and that must stay distinguishable from "you passed nothing".
+    const result: any = getParticipantResults({ matchUps: [] });
+    expect(result.error).toBeUndefined();
+    expect(result.participantResults).toEqual({});
+  });
+});

--- a/src/tests/query/engineParamFailOpen.test.ts
+++ b/src/tests/query/engineParamFailOpen.test.ts
@@ -1,7 +1,7 @@
 import { expect, test, describe } from 'vitest';
 
 import { getParticipantResults } from '@Query/matchUps/roundRobinTally/getParticipantResults';
-import { checkMatchUpIsComplete } from '@Query/matchUp/checkMatchUpIsComplete';
+import { checkMatchUpIsComplete, matchUpCompletion } from '@Query/matchUp/checkMatchUpIsComplete';
 import mocksEngine from '@Assemblies/engines/mock';
 import tournamentEngine from '@Engines/syncEngine';
 
@@ -56,12 +56,27 @@ describe('engine methods refuse rather than answer when their object param is ab
     expect(byId.error).toEqual(MISSING_MATCHUPS);
   });
 
-  test('the refusal is an OBJECT, so it is truthy — the trap the internal callers had to guard', () => {
-    // Documents why every internal call site filters the entry before calling: a naive
-    // `.filter((m) => checkMatchUpIsComplete({ matchUp: m }))` would now count refusals as complete.
+  test('the refusal is an OBJECT, so it is truthy — which is why predicates use matchUpCompletion', () => {
+    // A naive `.filter((m) => checkMatchUpIsComplete({ matchUp: m }))` would count refusals as
+    // COMPLETE — fail-open in the opposite direction, and worse than the defect being fixed.
     const refusal: any = checkMatchUpIsComplete({ matchUp: undefined });
     expect(refusal.error).toEqual(MISSING_MATCHUP);
     expect(Boolean(refusal)).toBe(true);
+
+    // matchUpCompletion is the predicate-safe form: it maps the refusal to undefined and passes a
+    // real answer through unchanged, including the load-bearing `undefined` for a pending matchUp.
+    expect(matchUpCompletion(undefined)).toBeUndefined();
+    expect(matchUpCompletion({})).toBeUndefined();
+    expect(matchUpCompletion({ matchUpId: 'm1', matchUpStatus: undefined })).toBeUndefined();
+    expect(matchUpCompletion({ matchUpId: 'm1', matchUpStatus: COMPLETED })).toBe(true);
+    expect(matchUpCompletion({ matchUpId: 'm1', winningSide: 2 })).toBe(2);
+  });
+
+  test('there is exactly ONE implementation of that mapping', () => {
+    // The first version of this fix hand-rolled the guard at three call sites with two different
+    // error branches (undefined in one file, false in another). Two copies of a safety guard is how
+    // they end up disagreeing — the recurring shape of the whole exit-propagation workstream.
+    expect(typeof matchUpCompletion).toEqual('function');
   });
 
   test('an empty matchUps array is a valid question with an empty answer, not a refusal', () => {


### PR DESCRIPTION
Closes punch-list **T9**, found while auditing for a repeat of the LADDER reachability gap (#4793).

## The defect

`checkMatchUpIsComplete` takes a matchUp **object**; `getParticipantResults` takes an **array** of in-context matchUps. Neither takes an id — and `paramsMiddleware` resolves `drawId` into a `drawDefinition` but does **not** resolve `matchUpId` into a matchUp or gather matchUps.

So the engine-idiomatic call supplied nothing, and both answered anyway. Measured against the correct call in the same fixture:

```text
checkMatchUpIsComplete({ matchUp })            -> true    correct
checkMatchUpIsComplete({ matchUpId, drawId })  -> false   <-- confident, WRONG, no error

getParticipantResults({ matchUps })            -> 8 participantResults
getParticipantResults({ drawId })              -> 0 participantResults, no error
```

Both now refuse: `ERR_MISSING_MATCHUP` / `ERR_MISSING_MATCHUPS`.

**Why it was worth breaking:** `checkMatchUpIsComplete` returns a **boolean a caller branches on**. No error to notice, no `undefined` to guard, and `false` — "not complete" — is the answer that looks safe. It gets believed.

## Three things the fix had to preserve

None of them visible from the defect itself.

**1. The return was never a clean boolean.** It is `true`, the `winningSide` (`1`/`2`), *or* `undefined` — and `tallyParticipantResults` distinguishes the last two with `?? matchUp.matchUpType === TEAM`. Normalising to `false` silently drops incomplete TEAM matchUps from the round-robin tally. The three-valued return is kept, and now has a test that says why.

**2. The refusal is an object, therefore truthy** — and this is called inside `.filter()`/`.every()` at five internal sites. Guarding naively would make a refusal read as **complete**: fail-open in the opposite direction, and worse than the original. `tallyParticipantResults:57` already filtered `matchUp &&`, which is the evidence that falsy entries reach these paths. Every caller now excludes the entry *before* the call rather than relying on a falsy return.

**3. Empty is not absent.** `getParticipantResults({ matchUps: [] })` is a valid question with an empty answer and must stay distinguishable from passing nothing. Controlled by a test.

An intermediate version used `=== true` at two call sites and changed truthiness — a matchUp carrying `winningSide` without a completed status would have flipped. Reverted before commit.

## Scope of the `matchUpId` requirement

`checkMatchUpIsComplete` now requires the object to carry a `matchUpId`, which is what separates a matchUp from an arbitrary object. Of **12,873 tests exactly 4 failed** under that, all in `coverageMiscGovernors.test.ts` passing id-less stubs. Nothing in the repo passes a real matchUp without an id.

**Not enforced:** an in-context check on `getParticipantResults`. Results are attributed through `sides[].participantId`, which only a hydrated matchUp carries — but the existing tests deliberately pass synthetic non-in-context matchUps that *do* carry sides, so a strict `drawId`/`eventId` check would fail them. Requirement documented rather than enforced; say if you want it enforced and it can be a separate change.

## Falsification

Coherent, per `standards/coding-standards.md`: with both guards removed **and their orphaned imports deleted**, `tsc --noEmit` is clean and **3 of the 4 new tests fail on assertions**, not on a build error. The fourth — the empty-array control — passes in both arms, which is what proves the guard is on absence rather than emptiness.

The first falsification attempt did **not** type-check (`TS6133`, unused import). That is the exact trap the standards name, so it was redone rather than read.

The new suite calls `tournamentEngine.*`, because the module-path suites stayed green through the entire defect.

## Verification

- `pnpm verify` — all 16 steps, **exit 0**
- `attr-audit` exit 0; `coverage-headroom` OK, tightest **148 items** vs a 25 budget
- `verify:surface` — 0 removed
- docs: `lint:md` clean; all **29** internal links across both changed pages re-resolved against generated HTML after the section renumbering

## Documentation

New **§5** in the 7.0.0 migration guide with the before/after and the `findMatchUp` / `allDrawMatchUps` resolution recipe; matching headline section in what's-new. That makes 7.0.0 **four** breaking areas and **six** rows.

## Still open

The other **5 of 15** candidates in this shape are unprobed, and the class-level fix — teaching `paramsMiddleware` to resolve `matchUpId` the way it resolves `drawId` — remains a live option. Recorded in T9.