### PR TITLE
fix(query)!: stop returning a participant named 'foo', and refuse the input that produced it

### DIFF
--- a/documentation/docs/migration-7.0.0.md
+++ b/documentation/docs/migration-7.0.0.md
@@ -21,6 +21,7 @@ feature tour and the full list of 7.0.0 additions, see [What's New in 7.0.0](./w
 | `timeZone` conversions return an error instead of throwing or guessing                   | Anyone calling `wallClockToUTC`, `utcToWallClock`, `toEmbargoUTC` | See §4            |
 | `getTimeZoneOffsetMinutes` now returns `number \| undefined`                             | Anyone reading a zone offset                                      | See §4            |
 | `checkMatchUpIsComplete` / `getParticipantResults` refuse an absent object param          | Callers passing `matchUpId` / `drawId` and reading the result     | See §5            |
+| `getParticipantResults` refuses a matchUp that claims a winner but carries no `sides`      | Callers passing STORED (non-hydrated) matchUps                    | See §5            |
 
 ## 1. `participantsRequiredMatchUpStatuses` — a spelling fix
 
@@ -183,6 +184,30 @@ safe. It would be believed.
 
 An **empty** array is still a valid question with an empty answer. The guard is on the argument being
 absent, not on it being empty, so a draw with no matchUps tallies to nothing exactly as before.
+
+### Stored matchUps are refused too, and this one replaces a fabricated participant
+
+`getParticipantResults` attributes every result through `sides[].participantId`. A **stored** matchUp
+has `drawPositions` and no participant sides, so there is nothing to attribute to.
+
+Until 7.0.0 the helper that reads a side returned the **literal string `'foo'`** when `sides` was
+absent — and `'foo'` is a participantId as far as everything downstream is concerned. A round robin
+tallied from stored matchUps therefore returned results keyed `foo` rather than failing:
+
+```js
+getParticipantResults({ matchUps: inContextMatchUps }); // { 'p1': {…}, 'p2': {…}, 'p3': {…}, 'p4': {…} }
+getParticipantResults({ matchUps: storedMatchUps }); // BEFORE: { 'foo': {…} }   AFTER: { error: INVALID_MATCHUP }
+```
+
+Two `console.log` calls shipped alongside it. Both are gone.
+
+The check is scoped to matchUps that claim a `winningSide`, since that is the only path that reads a
+side — a pending or BYE matchUp carries no participantIds and still tallies to nothing, unchanged.
+It requires **both** side indices, because the winner is read from index 0 and the loser from index 1.
+
+**What to do:** pass in-context matchUps — `allDrawMatchUps`, `allStructureMatchUps`,
+`allTournamentMatchUps` all return them. If you were reading a `foo` key out of the result, that was
+never a participant.
 
 ### Two behaviours that did NOT change
 

--- a/documentation/docs/whats-new-7.0.0.md
+++ b/documentation/docs/whats-new-7.0.0.md
@@ -56,6 +56,8 @@ Both now return `ERR_MISSING_MATCHUP` / `ERR_MISSING_MATCHUPS`. It was worth bre
 
 An **empty** array is still a valid question with an empty answer; the guard is on the argument being absent, not empty.
 
+`getParticipantResults` also refuses a **stored** (non-hydrated) matchUp that claims a winner. Results are attributed through `sides[].participantId`, and until 7.0.0 the helper that reads a side returned the literal string `'foo'` when `sides` was absent — so a round robin tallied from stored matchUps returned results keyed `foo` rather than failing. That sentinel, and the two `console.log` calls beside it, are gone.
+
 → [migration §5](./migration-7.0.0#5-two-queries-refuse-an-absent-object-param-instead-of-answering).
 
 ### 4. `participantsRequiredMatchUpStatuses` — a spelling fix

--- a/src/query/matchUps/roundRobinTally/getParticipantResults.ts
+++ b/src/query/matchUps/roundRobinTally/getParticipantResults.ts
@@ -8,7 +8,7 @@ import { isExit } from '@Validators/isExit';
 
 // constants and types
 import { completedMatchUpStatuses, DEFAULTED, RETIRED, WALKOVER } from '@Constants/matchUpStatusConstants';
-import { MISSING_MATCHUPS } from '@Constants/errorConditionConstants';
+import { INVALID_MATCHUP, MISSING_MATCHUPS } from '@Constants/errorConditionConstants';
 import { DOUBLES, SINGLES } from '@Constants/matchUpTypes';
 import { HydratedMatchUp } from '@Types/hydrated';
 
@@ -39,6 +39,20 @@ export function getParticipantResults({
   // Results are attributed through `sides[].participantId`, which only an IN-CONTEXT matchUp
   // carries; a stored matchUp has `drawPositions` and would tally to nothing for the same reason.
   if (!Array.isArray(matchUps)) return { error: MISSING_MATCHUPS };
+
+  // A matchUp that claims a winner but carries no `sides` is incoherent, not empty. Results are
+  // attributed through `sides[].participantId` — which only an IN-CONTEXT matchUp has — so a stored
+  // matchUp reaches `getSideId` with nothing to read. Both indices are required because
+  // getWinningSideId and getLosingSideId read index 0 and index 1 respectively.
+  const incoherent = matchUps.some(
+    (matchUp: any) => matchUp?.winningSide && !(matchUp.sides?.[0] && matchUp.sides?.[1]),
+  );
+  if (incoherent) {
+    return {
+      error: INVALID_MATCHUP,
+      info: 'a matchUp claims a winningSide but carries no sides; in-context matchUps are required',
+    };
+  }
 
   const participantResults = {};
 
@@ -339,17 +353,19 @@ function getLosingSideId(matchUp) {
   return getSideId(matchUp, loserIndex);
 }
 
+/**
+ * The participantId on one side of a decided matchUp.
+ *
+ * Returned `'foo'` — a literal string — when `sides` or the indexed side was absent, from 2021
+ * until 7.0.0. That is a participantId as far as everything downstream is concerned, so a tally run
+ * over stored (non-hydrated) matchUps keyed every result to a participant named `foo` rather than
+ * failing. Two `console.log` calls shipped with it.
+ *
+ * The caller now refuses that input up front, so this returning `undefined` is unreachable defence
+ * rather than a fallback anyone should rely on.
+ */
 function getSideId(matchUp, index) {
-  if (!matchUp?.sides) {
-    console.log('no sides:', { matchUp });
-    return 'foo';
-  }
-  const Side = matchUp.sides[index];
-  if (!Side) {
-    console.log('No Side', { matchUp, index });
-    return 'foo';
-  }
-  return Side.participantId;
+  return matchUp?.sides?.[index]?.participantId;
 }
 
 function checkInitializeParticipant(participantResults, participantId) {

--- a/src/query/matchUps/scheduling/schedulingUtils.ts
+++ b/src/query/matchUps/scheduling/schedulingUtils.ts
@@ -58,12 +58,12 @@ export function getRoundTiming({ round, matchUps, events, tournamentRecords }) {
 
 export function getFinishingPositionDetails(matchUps) {
   return (matchUps ?? []).reduce(
-    (foo, matchUp) => {
+    (best, matchUp) => {
       const sum = (matchUp.finishingPositionRange?.winner ?? []).reduce((a, b) => a + b, 0);
       const winnerFinishingPositionRange = (matchUp.finishingPositionRange?.winner ?? []).join('-') || '';
-      return !foo.minFinishingSum || sum < foo.minFinishingSum
+      return !best.minFinishingSum || sum < best.minFinishingSum
         ? { minFinishingSum: sum, winnerFinishingPositionRange }
-        : foo;
+        : best;
     },
     { minFinishingSum: 0, winnerFinishingPositionRange: '' },
   );

--- a/src/tests/query/engineParamFailOpen.test.ts
+++ b/src/tests/query/engineParamFailOpen.test.ts
@@ -1,7 +1,7 @@
 import { expect, test, describe } from 'vitest';
 
-import { getParticipantResults } from '@Query/matchUps/roundRobinTally/getParticipantResults';
 import { checkMatchUpIsComplete, matchUpCompletion } from '@Query/matchUp/checkMatchUpIsComplete';
+import { getParticipantResults } from '@Query/matchUps/roundRobinTally/getParticipantResults';
 import mocksEngine from '@Assemblies/engines/mock';
 import tournamentEngine from '@Engines/syncEngine';
 

--- a/src/tests/query/engineParamFailOpen.test.ts
+++ b/src/tests/query/engineParamFailOpen.test.ts
@@ -5,7 +5,7 @@ import { checkMatchUpIsComplete, matchUpCompletion } from '@Query/matchUp/checkM
 import mocksEngine from '@Assemblies/engines/mock';
 import tournamentEngine from '@Engines/syncEngine';
 
-import { MISSING_MATCHUPS, MISSING_MATCHUP } from '@Constants/errorConditionConstants';
+import { INVALID_MATCHUP, MISSING_MATCHUPS, MISSING_MATCHUP } from '@Constants/errorConditionConstants';
 import { COMPLETED } from '@Constants/matchUpStatusConstants';
 
 /**
@@ -77,6 +77,45 @@ describe('engine methods refuse rather than answer when their object param is ab
     // error branches (undefined in one file, false in another). Two copies of a safety guard is how
     // they end up disagreeing — the recurring shape of the whole exit-propagation workstream.
     expect(typeof matchUpCompletion).toEqual('function');
+  });
+
+  test('a matchUp claiming a winner with no sides is REFUSED, not attributed to a participant named foo', () => {
+    // From 2021 until 7.0.0 `getSideId` returned the literal string 'foo' when `sides` was absent —
+    // a participantId as far as everything downstream is concerned. A round robin tallied from
+    // STORED (non-hydrated) matchUps keyed every result to `foo` rather than failing.
+    const storedShape: any = [{ matchUpId: 'm1', winningSide: 1, drawPositions: [1, 2], score: { sets: [] } }];
+    const result: any = getParticipantResults({ matchUps: storedShape });
+
+    expect(result.error).toEqual(INVALID_MATCHUP);
+    expect(Object.keys(result.participantResults ?? {})).not.toContain('foo');
+  });
+
+  test('...and so is one whose sides array is short of the losing index', () => {
+    // getWinningSideId reads index 0, getLosingSideId reads index 1 — the second `getSideId` branch.
+    // A guard on `!sides` alone would let this through to the same fabrication.
+    const oneSided: any = [
+      { matchUpId: 'm1', winningSide: 1, sides: [{ sideNumber: 1, participantId: 'p1' }], score: { sets: [] } },
+    ];
+    expect(getParticipantResults({ matchUps: oneSided }).error).toEqual(INVALID_MATCHUP);
+  });
+
+  test('a matchUp with NO winner is not refused — nothing reads a side from it', () => {
+    // The guard is scoped to `winningSide`, because that is the only path into getSideId. A pending
+    // matchUp legitimately carries sides with no participantId yet and must still tally to nothing.
+    const noWinner: any = [
+      {
+        matchUpId: 'm1',
+        matchUpStatus: 'TO_BE_PLAYED',
+        sides: [
+          { sideNumber: 1, drawPosition: 1 },
+          { sideNumber: 2, drawPosition: 2 },
+        ],
+        score: { sets: [] },
+      },
+    ];
+    const result: any = getParticipantResults({ matchUps: noWinner });
+    expect(result.error).toBeUndefined();
+    expect(result.participantResults).toEqual({});
   });
 
   test('an empty matchUps array is a valid question with an empty answer, not a refusal', () => {


### PR DESCRIPTION
Three changes, one small PR. A + B + the rename, as agreed.

## The defect

`getSideId` returned the **literal string `'foo'`** when a matchUp had no `sides`, or none at the index being read. `'foo'` is a participantId as far as everything downstream is concerned, so a round robin tallied from **stored** (non-hydrated) matchUps keyed every result to a participant named `foo` rather than failing. Measured on a 4-player round robin:

```text
getParticipantResults({ matchUps: inContextMatchUps })  ->  4 real participantIds
getParticipantResults({ matchUps: storedMatchUps })     ->  ["foo"]
```

Two `console.log` calls shipped beside it. Introduced **2021-01-22** in `ffe0f5dfa`, present in every tag from `2.0.0-beta.2` — six years.

## Latent, not live — and worth stating precisely

All **seven** internal callers of `tallyParticipantResults` / `getParticipantResults` pass in-context matchUps (six via `inContext: true`, `getDrawData` via `context: { drawId }`), so **no path inside the factory could reach it**. It was reachable only through the exposed engine methods, which a consumer can call with stored matchUps.

The write path was safe for a second reason: `updateAssignmentParticipantResults` only writes a tally for a participantId **already seated**, so `'foo'` could never persist. The failure mode there would have been a real participant's tally silently *missing*, not corrupt.

## The three changes

**A — `getSideId` returns `undefined`**, console.logs deleted. On its own this only downgrades a fabrication to a silent empty result, which is the same fail-open class 7.0.0 is closing elsewhere. It does not ship alone.

**B — `getParticipantResults` refuses the input.** A matchUp claiming a `winningSide` while carrying no usable `sides` is *incoherent*, not empty.

Scoped to `winningSide`, because that is the only path into `getSideId` — a pending or BYE matchUp has no participantIds and must still tally to nothing.

**Requires both side indices.** `getWinningSideId` reads index 0 and `getLosingSideId` reads index 1, so a guard on `!sides` alone leaves the second branch reachable and a one-sided matchUp still fabricates. I measured both forms:

| guard | full-suite cost |
|---|---|
| weak (`!sides`) | 0 failures |
| **strong (both indices)** | **0 failures** |

Strong was free, so strong it is. There is a test for each branch.

**C — the rename.** `getFinishingPositionDetails` in `schedulingUtils` named its reduce accumulator `foo`. Purely a name, no behaviour — now `best`, which is what it holds.

A sweep of all **2,609** non-test source files found only these two `'foo'` occurrences. Not a pattern.

## Falsification

Coherent: with A and B reverted **and the orphaned import removed**, `tsc --noEmit` is clean and exactly the two new guard tests fail on assertions rather than on a build error.

## Verification

- `pnpm verify` — all 16 steps, **exit 0**
- 12,880 tests pass; `coverage-headroom` tightest **153 items** vs a 25 budget
- `lint:md` clean on both changed docs

## Not fixed here — found by one of the new tests

`processScore` does `sides.forEach` with no guard, so a matchUp with **neither** `winningSide` nor `sides` throws:

```text
TypeError: Cannot read properties of undefined (reading 'forEach')
  ❯ processScore              getParticipantResults.ts:414
  ❯ processNoWinnerMatchUp    …:196
```

**Pre-existing** — `git diff` confirms neither `processScore` nor `processNoWinnerMatchUp` is touched here — and its reachability is unaffected either way, since this guard only fires when a winner *is* claimed. Adding `?? []` would convert a crash into a silent empty, which is the direction 7.0.0 is moving away from; that deserves its own change rather than a third behaviour change to this function in one commit. Left for a decision.

## Documentation

Extends **§5** of the 7.0.0 migration guide (same class as #4796) with the before/after and the "pass in-context matchUps" fix, plus a table row and a matching note in what's-new.