### PR TITLE
feat(types): declare enforcePolicyLimits on GenerateDrawDefinitionArgs

### DIFF
--- a/src/tests/mutations/policies/enforcePolicyLimits.test.ts
+++ b/src/tests/mutations/policies/enforcePolicyLimits.test.ts
@@ -1,0 +1,70 @@
+import POLICY_SEEDING_DEFAULT from '@Fixtures/policies/POLICY_SEEDING_DEFAULT';
+import { ROUND_ROBIN } from '@Constants/drawDefinitionConstants';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { expect, it } from 'vitest';
+
+// `enforcePolicyLimits` decides only whether the SEEDING POLICY's threshold clamps a requested
+// seedsCount. Structural limits — drawSize, and the count of entries in the stage — apply either
+// way. These tests pin that boundary, because consumers reach for the flag precisely when a
+// national rule seeds more deeply than the ITF/USTA thresholds allow.
+
+function seedLimitFor(drawProfile: any): number {
+  const { tournamentRecord } = mocksEngine.generateTournamentRecord({ drawProfiles: [drawProfile] });
+  tournamentEngine.setState(tournamentRecord);
+  const drawId = tournamentRecord.events?.[0]?.drawDefinitions?.[0]?.drawId;
+  const result: any = tournamentEngine.getEvent({ drawId });
+  return result.drawDefinition.structures[0].seedLimit;
+}
+
+it('clamps seedsCount to the policy threshold by default', () => {
+  // POLICY_SEEDING_DEFAULT allows 8 seeds at drawSize 32; 16 is requested and refused.
+  expect(
+    seedLimitFor({
+      policyDefinitions: POLICY_SEEDING_DEFAULT,
+      participantsCount: 32,
+      seedsCount: 16,
+      drawSize: 32,
+    }),
+  ).toEqual(8);
+});
+
+it('honors a seedsCount above the policy threshold when enforcePolicyLimits is false', () => {
+  expect(
+    seedLimitFor({
+      policyDefinitions: POLICY_SEEDING_DEFAULT,
+      enforcePolicyLimits: false,
+      participantsCount: 32,
+      seedsCount: 16,
+      drawSize: 32,
+    }),
+  ).toEqual(16);
+});
+
+it('still clamps to the entry count when enforcePolicyLimits is false', () => {
+  // Structural, not policy: there is no 16th participant to seed.
+  expect(
+    seedLimitFor({
+      policyDefinitions: POLICY_SEEDING_DEFAULT,
+      enforcePolicyLimits: false,
+      participantsCount: 10,
+      seedsCount: 16,
+      drawSize: 32,
+    }),
+  ).toEqual(10);
+});
+
+it('accepts a non-power-of-two seedsCount, as round robin group counts require', () => {
+  // 15 participants in groups of 3 is 5 groups, and one seed per group is 5 seeds.
+  expect(
+    seedLimitFor({
+      structureOptions: { groupSize: 3 },
+      policyDefinitions: POLICY_SEEDING_DEFAULT,
+      enforcePolicyLimits: false,
+      drawType: ROUND_ROBIN,
+      participantsCount: 15,
+      seedsCount: 5,
+      drawSize: 15,
+    }),
+  ).toEqual(5);
+});

--- a/src/types/factoryTypes.ts
+++ b/src/types/factoryTypes.ts
@@ -707,6 +707,15 @@ export type GenerateDrawDefinitionArgs = {
     structureId?: string;
   };
   enforceMinimumDrawSize?: boolean;
+  /**
+   * Defaults to `true`. When `true`, a requested `seedsCount` is clamped down to the maximum the
+   * active seeding policy's `seedsCountThresholds` allow for the draw size and participant count.
+   * Set `false` to let an explicit `seedsCount` stand above that threshold — an operator override
+   * of the policy, not of the structure. The structural limits still apply either way:
+   * `seedsCount` is capped at the stage's entry count and at `drawSize`, and exceeding the
+   * structure's position count raises `SEEDSCOUNT_GREATER_THAN_DRAW_SIZE`.
+   */
+  enforcePolicyLimits?: boolean;
   ignoreAllowedDrawTypes?: boolean;
   qualifyingPlaceholder?: boolean;
   considerEventEntries?: boolean; // defaults to true; look for entries in event.entries when drawEntries not provided


### PR DESCRIPTION
`enforcePolicyLimits` has been honored at runtime for as long as seeding policies have had thresholds — `prepareStage` reads it, `initializeStructureSeedAssignments` acts on it — and it is documented in the generation governor. It was never declared on `GenerateDrawDefinitionArgs`, so every consumer reaching for it was passing an undeclared param and only getting away with it by holding the options object as `any`.

This declares it, and documents the boundary it actually draws.

## What the flag does, and does not do

It governs the **seeding policy's** threshold clamp and nothing else:

```ts
if (maxSeedsCount && appliedPolicies?.[POLICY_TYPE_SEEDING] && seedsCount > maxSeedsCount && enforcePolicyLimits) {
  seedsCount = maxSeedsCount;
}
```

The structural limits are untouched either way — `getSeedsCountAndStageEntries` still caps at `drawSize` and at the stage's entry count, and overrunning the structure's positions still raises `SEEDSCOUNT_GREATER_THAN_DRAW_SIZE`.

That distinction is the entire reason a caller reaches for the flag. A federation whose rules seed more deeply than the ITF/USTA thresholds wants the policy ceiling lifted and the structural ones kept. Nothing in the type said so.

## Tests

Four cases in `src/tests/mutations/policies/enforcePolicyLimits.test.ts`:

| request | flag | seedLimit |
| --- | --- | --- |
| 16 seeds, 32 draw, 32 entries | default | **8** (policy) |
| 16 seeds, 32 draw, 32 entries | `false` | **16** |
| 16 seeds, 32 draw, 10 entries | `false` | **10** (structural, still enforced) |
| 5 seeds, 15 in groups of 3 | `false` | **5** |

The last one is a non-power-of-two `seedsCount`, which round robin group counts require and which nothing covered before.

Surfaced while reviewing [TMX#1429(TMX)](https://github.com/CourtHive/TMX/pull/1429), whose follow-up is [TMX#fix/seed-count-override](https://github.com/CourtHive/TMX/tree/fix/seed-count-override).