### PR TITLE
fix(query)!: require sides on every matchUp, not only on decided ones

### DIFF
--- a/documentation/docs/migration-7.0.0.md
+++ b/documentation/docs/migration-7.0.0.md
@@ -21,7 +21,7 @@ feature tour and the full list of 7.0.0 additions, see [What's New in 7.0.0](./w
 | `timeZone` conversions return an error instead of throwing or guessing                   | Anyone calling `wallClockToUTC`, `utcToWallClock`, `toEmbargoUTC` | See §4            |
 | `getTimeZoneOffsetMinutes` now returns `number \| undefined`                             | Anyone reading a zone offset                                      | See §4            |
 | `checkMatchUpIsComplete` / `getParticipantResults` refuse an absent object param          | Callers passing `matchUpId` / `drawId` and reading the result     | See §5            |
-| `getParticipantResults` refuses a matchUp that claims a winner but carries no `sides`      | Callers passing STORED (non-hydrated) matchUps                    | See §5            |
+| `getParticipantResults` refuses any matchUp carrying no `sides`                            | Callers passing STORED (non-hydrated) matchUps                    | See §5            |
 
 ## 1. `participantsRequiredMatchUpStatuses` — a spelling fix
 
@@ -201,9 +201,27 @@ getParticipantResults({ matchUps: storedMatchUps }); // BEFORE: { 'foo': {…} }
 
 Two `console.log` calls shipped alongside it. Both are gone.
 
-The check is scoped to matchUps that claim a `winningSide`, since that is the only path that reads a
-side — a pending or BYE matchUp carries no participantIds and still tallies to nothing, unchanged.
-It requires **both** side indices, because the winner is read from index 0 and the loser from index 1.
+The check requires **every** matchUp to carry both sides, played or not, and it requires **both**
+indices because the winner is read from index 0 and the loser from index 1.
+
+It is not scoped to `winningSide`, and that matters. Both code paths read `sides[].participantId` — a
+decided matchUp through `getSideId`, an undecided one through `processScore` — so scoping to the
+decided path left the same input with two different failure modes separated only by how far the draw
+had progressed:
+
+```js
+getParticipantResults({ matchUps: storedMatchUps }); // draw played     -> { error: INVALID_MATCHUP }
+getParticipantResults({ matchUps: storedMatchUps }); // not yet played  -> uncaught TypeError
+```
+
+A matchUp that legitimately has no participants yet still carries its sides — an unplayed in-context
+matchUp has `sides` with `drawPosition` and no `participantId`, and tallies to nothing exactly as
+before. What is refused is a matchUp with no sides at all, which only a stored record has.
+
+The refusal is **all-or-nothing**: one unusable matchUp refuses the whole call rather than being
+skipped. Skipping would return a tally silently missing matches, which is the failure this exists to
+prevent rather than a milder form of it. An **empty** array remains a valid question with an empty
+answer.
 
 **What to do:** pass in-context matchUps — `allDrawMatchUps`, `allStructureMatchUps`,
 `allTournamentMatchUps` all return them. If you were reading a `foo` key out of the result, that was

--- a/documentation/docs/whats-new-7.0.0.md
+++ b/documentation/docs/whats-new-7.0.0.md
@@ -56,7 +56,7 @@ Both now return `ERR_MISSING_MATCHUP` / `ERR_MISSING_MATCHUPS`. It was worth bre
 
 An **empty** array is still a valid question with an empty answer; the guard is on the argument being absent, not empty.
 
-`getParticipantResults` also refuses a **stored** (non-hydrated) matchUp that claims a winner. Results are attributed through `sides[].participantId`, and until 7.0.0 the helper that reads a side returned the literal string `'foo'` when `sides` was absent — so a round robin tallied from stored matchUps returned results keyed `foo` rather than failing. That sentinel, and the two `console.log` calls beside it, are gone.
+`getParticipantResults` also refuses any **stored** (non-hydrated) matchUp — one carrying no `sides` at all. Results are attributed through `sides[].participantId`, and until 7.0.0 the helper that reads a side returned the literal string `'foo'` when `sides` was absent — so a round robin tallied from stored matchUps returned results keyed `foo` rather than failing. That sentinel, and the two `console.log` calls beside it, are gone.
 
 → [migration §5](./migration-7.0.0#5-two-queries-refuse-an-absent-object-param-instead-of-answering).
 

--- a/src/query/matchUps/roundRobinTally/getParticipantResults.ts
+++ b/src/query/matchUps/roundRobinTally/getParticipantResults.ts
@@ -40,17 +40,24 @@ export function getParticipantResults({
   // carries; a stored matchUp has `drawPositions` and would tally to nothing for the same reason.
   if (!Array.isArray(matchUps)) return { error: MISSING_MATCHUPS };
 
-  // A matchUp that claims a winner but carries no `sides` is incoherent, not empty. Results are
-  // attributed through `sides[].participantId` — which only an IN-CONTEXT matchUp has — so a stored
-  // matchUp reaches `getSideId` with nothing to read. Both indices are required because
-  // getWinningSideId and getLosingSideId read index 0 and index 1 respectively.
-  const incoherent = matchUps.some(
-    (matchUp: any) => matchUp?.winningSide && !(matchUp.sides?.[0] && matchUp.sides?.[1]),
-  );
-  if (incoherent) {
+  // EVERY matchUp must carry both sides, whether or not it has been played.
+  //
+  // `sides[].participantId` is the only thing a tally can attribute to, and BOTH code paths read it:
+  // a decided matchUp through `getSideId`, and an undecided one through `processScore`. Scoping this
+  // to `winningSide` — as it was when first added — closed only the first, so the SAME input (stored,
+  // non-hydrated matchUps) refused once a draw had been played and threw an uncaught TypeError while
+  // it had not. One input class must not have two failure modes separated only by progress.
+  //
+  // Both indices, because getWinningSideId reads index 0 and getLosingSideId reads index 1.
+  //
+  // All-or-nothing is deliberate: skipping the offending matchUps would return a tally silently
+  // missing matches, which is the failure this guard exists to prevent rather than a milder form of
+  // it. An EMPTY array is still a valid question — the guard is on matchUps present but unusable.
+  const unusable = matchUps.some((matchUp: any) => matchUp && !(matchUp.sides?.[0] && matchUp.sides?.[1]));
+  if (unusable) {
     return {
       error: INVALID_MATCHUP,
-      info: 'a matchUp claims a winningSide but carries no sides; in-context matchUps are required',
+      info: 'a matchUp carries no sides to attribute results to; in-context matchUps are required',
     };
   }
 

--- a/src/tests/query/engineParamFailOpen.test.ts
+++ b/src/tests/query/engineParamFailOpen.test.ts
@@ -6,6 +6,7 @@ import mocksEngine from '@Assemblies/engines/mock';
 import tournamentEngine from '@Engines/syncEngine';
 
 import { INVALID_MATCHUP, MISSING_MATCHUPS, MISSING_MATCHUP } from '@Constants/errorConditionConstants';
+import { ROUND_ROBIN } from '@Constants/drawDefinitionConstants';
 import { COMPLETED } from '@Constants/matchUpStatusConstants';
 
 /**
@@ -97,6 +98,27 @@ describe('engine methods refuse rather than answer when their object param is ab
       { matchUpId: 'm1', winningSide: 1, sides: [{ sideNumber: 1, participantId: 'p1' }], score: { sets: [] } },
     ];
     expect(getParticipantResults({ matchUps: oneSided }).error).toEqual(INVALID_MATCHUP);
+  });
+
+  test('an UNPLAYED stored matchUp is refused, where it used to throw an uncaught TypeError', () => {
+    // The gap the first version of this guard left. Scoping it to `winningSide` covered the decided
+    // path (getSideId) but not the undecided one (processScore), so the SAME input — stored,
+    // non-hydrated matchUps — refused once a draw had been played and CRASHED while it had not:
+    //
+    //   TypeError: Cannot read properties of undefined (reading 'forEach')
+    //     at processScore -> processNoWinnerMatchUp -> getParticipantResults
+    const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 4, drawType: ROUND_ROBIN }], // nothing played
+      setState: true,
+    });
+    const draw = tournamentRecord.events[0].drawDefinitions[0];
+    const stored = draw.structures[0].structures?.[0]?.matchUps ?? draw.structures[0].matchUps;
+    expect(stored.length).toBeGreaterThan(0);
+    expect(stored.some((matchUp: any) => matchUp.winningSide)).toEqual(false); // the control
+    expect(stored.some((matchUp: any) => matchUp.sides)).toEqual(false);
+
+    const result: any = getParticipantResults({ matchUps: stored });
+    expect(result.error).toEqual(INVALID_MATCHUP);
   });
 
   test('a matchUp with NO winner is not refused — nothing reads a side from it', () => {


### PR DESCRIPTION
Follow-up to #4797, closing the half of the door it left open.

## What #4797 missed

Its guard was scoped to `winningSide`. But `sides[].participantId` is the only thing a tally can attribute to, and **both** code paths read it — a decided matchUp through `getSideId`, an undecided one through `processScore`. Scoping to the decided path left the same input with two different failure modes, separated only by how far the draw had progressed:

```text
stored matchUps, draw played      ->  { error: INVALID_MATCHUP }
stored matchUps, not yet played   ->  uncaught TypeError from processScore
```

The crash was raised in review of #4797 as a pre-existing bug to fix separately. **Measuring it is what showed it was not separate** — it sits on exactly the route that guard exists to close. (`processScore` has done `sides.forEach` unguarded since long before any of this.)

## Why not fix `processScore` instead

`sides ?? []` converts a crash into a silent empty tally — the fail-open class 7.0.0 is closing — and leaves the two paths disagreeing: one refuses, one quietly returns nothing. The precondition belongs at the boundary, stated once, matching the documented contract.

## Behaviour

- **All-or-nothing** is deliberate. One unusable matchUp refuses the whole call rather than being skipped, because skipping returns a tally silently missing matches — the failure being prevented, in a milder costume.
- An **empty** array is still a valid question with an empty answer.
- An unplayed **in-context** matchUp still carries sides (`drawPosition`, no `participantId`) and tallies to nothing exactly as before. What is refused is a matchUp with **no sides at all**, which only a stored record has.

## Verification

- Measured at **zero cost across 12,881 tests** before being written.
- `pnpm verify` — all 16 steps, **exit 0**; `coverage-headroom` tightest **155 items** vs a 25 budget.
- Docs: `lint:md` clean, all **29** internal links re-resolved against generated HTML.

**One correction worth recording.** The first attempt at that zero-cost measurement reported a vacuous green — prettier had reflowed the target line, the patch silently did not apply, and the run was the unmodified baseline. Re-run with the patched line printed back before the result was trusted.

## Falsification

Reverting the predicate alone, with `tsc --noEmit` clean so the red is behavioural, fails the new test with the **original crash** rather than an assertion diff:

```text
TypeError: Cannot read properties of undefined (reading 'forEach')
```

The test asserts its own premises first — the fixture has matchUps, none carries a `winningSide`, none carries `sides` — so it cannot pass against a fixture that never exercises the path.

## Documentation

Corrects **§5** of the migration guide, which stated the check was scoped to `winningSide`. That sentence is now false, and is replaced with the two-failure-modes explanation plus the in-context/stored distinction.