### PR TITLE
refactor(schema): rename the DUAL write mode to BRIDGE

### DIFF
--- a/src/acquire/firstClassOrExtension.ts
+++ b/src/acquire/firstClassOrExtension.ts
@@ -11,7 +11,7 @@ type FirstClassOrExtensionArgs = {
  *
  * Returns the first-class attribute value if defined, otherwise falls back to
  * the legacy extension value. Used everywhere a former-extension is read so
- * that records written in any write mode (NATIVE, DUAL, LEGACY) read
+ * that records written in any write mode (NATIVE, BRIDGE, LEGACY) read
  * identically.
  *
  * When both are present the first-class field wins — that is the authority in

--- a/src/acquire/firstClassOrTimeItem.ts
+++ b/src/acquire/firstClassOrTimeItem.ts
@@ -13,7 +13,7 @@ type FirstClassOrTimeItemArgs = {
  * Returns the first-class schedule attribute when defined, otherwise falls
  * back to the latest timeItem with the matching `itemType`. Used everywhere
  * a former schedule-timeItem is read so that records written in any mode
- * (NATIVE, DUAL, LEGACY) read identically.
+ * (NATIVE, BRIDGE, LEGACY) read identically.
  *
  * Mirrors {@link firstClassOrExtension} for the timeItems plumbing.
  */

--- a/src/assemblies/generators/tournamentRecords/anonymizeTournamentRecord.ts
+++ b/src/assemblies/generators/tournamentRecords/anonymizeTournamentRecord.ts
@@ -245,7 +245,7 @@ function anonymizeEvents({ tournamentRecord, filterExtensions, idMap }) {
     if (Array.isArray(event.flightProfile?.flights)) {
       anonymizeFlightProfileFlights(event.flightProfile, idMap);
     }
-    // also anonymize the legacy extension form so DUAL / LEGACY records remain consistent
+    // also anonymize the legacy extension form so BRIDGE / LEGACY records remain consistent
     const { extension: flightProfileExt } = findExtension({ name: FLIGHT_PROFILE, element: event });
     if (Array.isArray(flightProfileExt?.value?.flights)) {
       anonymizeFlightProfileFlights(flightProfileExt.value, idMap);

--- a/src/constants/schemaWriteModeConstants.ts
+++ b/src/constants/schemaWriteModeConstants.ts
@@ -1,13 +1,13 @@
 export const NATIVE = 'native';
 export const LEGACY = 'legacy';
-export const DUAL = 'dual';
+export const BRIDGE = 'bridge';
 
-export type SchemaWriteMode = typeof NATIVE | typeof DUAL | typeof LEGACY;
+export type SchemaWriteMode = typeof NATIVE | typeof BRIDGE | typeof LEGACY;
 
-export const schemaWriteModes: SchemaWriteMode[] = [NATIVE, DUAL, LEGACY];
+export const schemaWriteModes: SchemaWriteMode[] = [NATIVE, BRIDGE, LEGACY];
 
 export const schemaWriteModeConstants = {
   NATIVE,
   LEGACY,
-  DUAL,
+  BRIDGE,
 } as const;

--- a/src/global/state/globalState.ts
+++ b/src/global/state/globalState.ts
@@ -4,7 +4,7 @@ import { intersection } from '@Tools/arrays';
 import { isNumeric } from '@Tools/math';
 
 // constants and types
-import { DUAL, LEGACY, NATIVE, SchemaWriteMode, schemaWriteModes } from '@Constants/schemaWriteModeConstants';
+import { BRIDGE, LEGACY, NATIVE, SchemaWriteMode, schemaWriteModes } from '@Constants/schemaWriteModeConstants';
 import { TournamentRecords, ResultType } from '@Types/factoryTypes';
 import { SUCCESS } from '@Constants/resultConstants';
 import {
@@ -246,11 +246,11 @@ export function getSchemaWriteMode(): SchemaWriteMode {
 }
 
 export function writeNativeEnabled(): boolean {
-  return globalState.schemaWriteMode === NATIVE || globalState.schemaWriteMode === DUAL;
+  return globalState.schemaWriteMode === NATIVE || globalState.schemaWriteMode === BRIDGE;
 }
 
 export function writeLegacyEnabled(): boolean {
-  return globalState.schemaWriteMode === LEGACY || globalState.schemaWriteMode === DUAL;
+  return globalState.schemaWriteMode === LEGACY || globalState.schemaWriteMode === BRIDGE;
 }
 
 export function setSaveDrawDeletions(flag?: boolean): { success?: boolean; error?: ErrorType } {

--- a/src/mutate/drawDefinitions/matchUpGovernor/noDownstreamDependencies.ts
+++ b/src/mutate/drawDefinitions/matchUpGovernor/noDownstreamDependencies.ts
@@ -93,7 +93,7 @@ export function noDownstreamDependencies(params) {
     return scoreModification(params);
   }
 
-  // if matchUpStatus is being changed for a DUAL MATCH and the new status is CANCELLED or ABANDONED
+  // if matchUpStatus is being changed for a BRIDGE MATCH and the new status is CANCELLED or ABANDONED
   // then winningSide of the dualMatchUp should be changed. This boolean triggers that logic in attemptToSetWinningSide
   const triggerDualWinningSide = [CANCELLED, ABANDONED].includes(matchUpStatus) && params.dualWinningSideChange;
 

--- a/src/mutate/drawDefinitions/resetDrawDefinition.ts
+++ b/src/mutate/drawDefinitions/resetDrawDefinition.ts
@@ -191,7 +191,7 @@ function resetMatchUpScore({ matchUp, isLuckyDraw, removeAssignments, roundNumbe
   }
 }
 
-// first-class schedule attributes (NATIVE / DUAL) matching the schedule timeItem types below —
+// first-class schedule attributes (NATIVE / BRIDGE) matching the schedule timeItem types below —
 // no timeItem mirror, so resetting the draw must clear these directly or the placement persists.
 const SCHEDULE_FIRST_CLASS_ATTRS = [
   'allocatedCourts',

--- a/src/mutate/extensions/setFirstClassOrExtension.ts
+++ b/src/mutate/extensions/setFirstClassOrExtension.ts
@@ -23,7 +23,7 @@ type SetFirstClassOrExtensionArgs = {
  *
  * - NATIVE: write `element[attribute] = value`; remove any stale legacy
  *   extension of the same name so reads stay consistent
- * - DUAL: write the first-class attribute first, then mirror to the legacy
+ * - BRIDGE: write the first-class attribute first, then mirror to the legacy
  *   extension (back-compat for consumers that still read `_name`)
  * - LEGACY: write only the extension; do not touch the first-class
  *   attribute (preserves pre-CODES write behavior)

--- a/src/mutate/extensions/setGroupLeafOrExtension.ts
+++ b/src/mutate/extensions/setGroupLeafOrExtension.ts
@@ -46,7 +46,7 @@ function stripExtensionByName(element: any, name: string) {
  * Mode semantics match {@link setFirstClassOrExtension}:
  * - NATIVE: write the nested attribute; strip stale legacy extension; if
  *   the group becomes empty, the group object is removed entirely.
- * - DUAL: write both.
+ * - BRIDGE: write both.
  * - LEGACY: write only the extension.
  *
  * Read with `firstClassOrGroupLeafOrExtension` (or a per-site equivalent).

--- a/src/mutate/matchUps/schedule/clearScheduledMatchUps.ts
+++ b/src/mutate/matchUps/schedule/clearScheduledMatchUps.ts
@@ -28,8 +28,8 @@ import {
   SCHEDULED_TIME,
 } from '@Constants/timeItemConstants';
 
-// Schedule-placement timeItem types (LEGACY / DUAL) and their first-class
-// `matchUp.schedule.*` counterparts (NATIVE / DUAL). Kept in lockstep so an
+// Schedule-placement timeItem types (LEGACY / BRIDGE) and their first-class
+// `matchUp.schedule.*` counterparts (NATIVE / BRIDGE). Kept in lockstep so an
 // unschedule clears the same placement regardless of the record's write mode.
 const SCHEDULE_ITEM_TYPES = new Set([
   ALLOCATE_COURTS,
@@ -162,13 +162,13 @@ function clearSchedules({
         continue;
       }
       let modified = false;
-      // LEGACY / DUAL records store schedule data as timeItems — strip them.
+      // LEGACY / BRIDGE records store schedule data as timeItems — strip them.
       matchUp.timeItems = (matchUp.timeItems ?? []).filter((timeItem) => {
         const preserve = timeItem?.itemType && !SCHEDULE_ITEM_TYPES.has(timeItem?.itemType);
         if (!preserve) modified = true;
         return preserve;
       });
-      // NATIVE / DUAL records store schedule data as first-class `matchUp.schedule.*`
+      // NATIVE / BRIDGE records store schedule data as first-class `matchUp.schedule.*`
       // attributes (CODES Phase 2) with no timeItem mirror. Without clearing these the
       // unschedule is a no-op in production NATIVE mode — the divergence that surfaced
       // as SCHEDULE_NOT_CLEARED when a date change tried to force-unschedule matchUps.

--- a/src/mutate/matchUps/schedule/removeCourtAssignment.ts
+++ b/src/mutate/matchUps/schedule/removeCourtAssignment.ts
@@ -52,7 +52,7 @@ export function removeCourtAssignment({
 
   let modified = false;
 
-  // LEGACY / DUAL: court assignment lives in timeItems
+  // LEGACY / BRIDGE: court assignment lives in timeItems
   if (matchUp.timeItems) {
     const hasCourtAssignment = matchUp.timeItems.find((candidate) =>
       [ASSIGN_COURT, ALLOCATE_COURTS].includes(candidate.itemType),
@@ -66,7 +66,7 @@ export function removeCourtAssignment({
     }
   }
 
-  // NATIVE / DUAL: court assignment is first-class schedule.courtId / schedule.allocatedCourts,
+  // NATIVE / BRIDGE: court assignment is first-class schedule.courtId / schedule.allocatedCourts,
   // with no timeItem mirror — without this, deleteCourt left the court assigned in NATIVE.
   if (matchUp.schedule && typeof matchUp.schedule === 'object') {
     if (matchUp.schedule.courtId !== undefined) {

--- a/src/mutate/matchUps/schedule/setMatchUpCalledAt.ts
+++ b/src/mutate/matchUps/schedule/setMatchUpCalledAt.ts
@@ -107,7 +107,7 @@ function calledBeforeTournamentStart({
  *  - Distinct from `scheduledTime` (plan), `courtId` (place), and the
  *    `START_TIME` timeItem (actually started). May coexist with all of them.
  *  - This is a CODES 5.0.0 NEW first-class attribute — no legacy timeItem
- *    mirror, no LEGACY/DUAL/NATIVE branching. The attribute is always
+ *    mirror, no LEGACY/BRIDGE/NATIVE branching. The attribute is always
  *    written to `matchUp.schedule.calledAt`.
  *  - A call to court cannot predate the tournament's first day. See
  *    `calledBeforeTournamentStart`.

--- a/src/mutate/matchUps/schedule/setMatchUpScheduleLock.ts
+++ b/src/mutate/matchUps/schedule/setMatchUpScheduleLock.ts
@@ -50,7 +50,7 @@ const LOCKABLE_ATTRIBUTES = new Set<string>(SCHEDULE_LOCK_ATTRIBUTES);
  *    tournament grain.
  *
  * This is a CODES first-class attribute — no legacy timeItem mirror, no
- * LEGACY/DUAL/NATIVE branching.
+ * LEGACY/BRIDGE/NATIVE branching.
  */
 export function setMatchUpScheduleLock(params: SetMatchUpScheduleLockArgs) {
   const stack = 'setMatchUpScheduleLock';

--- a/src/mutate/timeItems/setFirstClassOrTimeItem.ts
+++ b/src/mutate/timeItems/setFirstClassOrTimeItem.ts
@@ -66,7 +66,7 @@ function validateParams(params?: SetFirstClassOrTimeItemArgs): { error?: ErrorTy
  * - NATIVE: write `element[scheduleObject][attribute] = value`; strip any
  *   stale timeItem with the matching `itemType` so reads stay consistent.
  *   When `value` is `undefined`, also remove the first-class field.
- * - DUAL: write the first-class attribute AND keep the legacy timeItem
+ * - BRIDGE: write the first-class attribute AND keep the legacy timeItem
  *   append (back-compat for consumers reading `timeItems[]` directly).
  * - LEGACY: only call `addTimeItem` — preserves pre-CODES behavior.
  *
@@ -98,7 +98,7 @@ export function setFirstClassOrTimeItem(params?: SetFirstClassOrTimeItemArgs): {
 
   if (!writeLegacyEnabled()) return { ...SUCCESS };
 
-  // LEGACY (or DUAL legacy branch): always delegate to addTimeItem so that
+  // LEGACY (or BRIDGE legacy branch): always delegate to addTimeItem so that
   // its `removePriorValues` / `duplicateValues` semantics — including the
   // undefined-value-push behavior — match pre-CODES exactly.
   const result = appendLegacyTimeItem({

--- a/src/mutate/tournaments/migrateTournamentRecord.ts
+++ b/src/mutate/tournaments/migrateTournamentRecord.ts
@@ -199,7 +199,7 @@ type MigrateTournamentRecordArgs = {
  *
  * Use this when upgrading historical records that were written by a
  * factory < 5.0.0 (LEGACY-style storage). After running, the record reads
- * identically under NATIVE / DUAL / LEGACY engine write modes.
+ * identically under NATIVE / BRIDGE / LEGACY engine write modes.
  */
 function applyFlatPromotions(element: any, promotions: ExtensionPromotion[], clearLegacy: boolean): number {
   let n = 0;

--- a/src/mutate/tournaments/tournamentLinks.ts
+++ b/src/mutate/tournaments/tournamentLinks.ts
@@ -17,7 +17,7 @@ import { INVALID_VALUES, MISSING_TOURNAMENT_ID, MISSING_TOURNAMENT_RECORDS } fro
  *
  * NATIVE writes the flat `record.linkedTournamentIds` first-class attribute
  * and strips any legacy extension. LEGACY writes the legacy wrapper
- * extension `{tournamentIds: []}` and strips any first-class field. DUAL
+ * extension `{tournamentIds: []}` and strips any first-class field. BRIDGE
  * writes both. When `tournamentIds` is empty, both surfaces are cleared.
  */
 function writeRecordLinkedTournamentIds(tournamentRecord: any, tournamentIds: string[]): void {
@@ -113,7 +113,7 @@ export function unlinkTournament({ tournamentRecords, tournamentId }: UnlinkTour
     const tournamentRecord = tournamentRecords[currentTournamentId];
 
     // CODES: mode-agnostic read so 5.0.0 NATIVE-written records,
-    // pre-CODES extension-only records, and DUAL records all unlink correctly.
+    // pre-CODES extension-only records, and BRIDGE records all unlink correctly.
     const linkedTournamentIds = getRecordLinkedTournamentIds(tournamentRecord);
 
     // if there are no tournamentIds, or the only link is self, or this is

--- a/src/query/matchUp/getMatchUpScheduleDetails.ts
+++ b/src/query/matchUp/getMatchUpScheduleDetails.ts
@@ -204,7 +204,7 @@ function buildFullSchedule({
   }
 
   // CODES: prefer first-class `matchUp.schedule.*` attributes; fall back to
-  // the legacy timeItem entry. Records written in NATIVE / DUAL / LEGACY all
+  // the legacy timeItem entry. Records written in NATIVE / BRIDGE / LEGACY all
   // hydrate to the same shape.
   const firstClass = matchUp.schedule ?? {};
   const homeParticipantId = firstClass.homeParticipantId ?? timeItemMap.get(HOME_PARTICIPANT_ID);

--- a/src/query/matchUp/isScheduleLocked.ts
+++ b/src/query/matchUp/isScheduleLocked.ts
@@ -47,7 +47,7 @@ const REQUEST_KEY_TO_ATTRIBUTE: Record<string, ScheduleLockAttribute> = {
   venueId: 'venueId',
 };
 
-// LEGACY / DUAL records keep placement in `timeItems[]` rather than first-class
+// LEGACY / BRIDGE records keep placement in `timeItems[]` rather than first-class
 // `schedule.*`. The predicate reads BOTH surfaces so a lock behaves identically
 // in every schemaWriteMode — a first-class-only read would make locks silently
 // inert in LEGACY, which is the exact divergence that made unscheduling a no-op

--- a/src/tests/global/flatScalarsFirstClass.test.ts
+++ b/src/tests/global/flatScalarsFirstClass.test.ts
@@ -22,7 +22,7 @@ import { setSchemaWriteMode } from '@Global/state/globalState';
 import { findExtension } from '@Acquire/findExtension';
 
 // constants and types
-import { DUAL, LEGACY, NATIVE, SchemaWriteMode } from '@Constants/schemaWriteModeConstants';
+import { BRIDGE, LEGACY, NATIVE, SchemaWriteMode } from '@Constants/schemaWriteModeConstants';
 import {
   COMPETITION_STATE,
   DELEGATED_OUTCOME,
@@ -48,7 +48,7 @@ const promotions: Promotion[] = [
   { name: COMPETITION_STATE, attribute: 'competitionState', value: { roundStates: {} } },
 ];
 
-describe.each([NATIVE, DUAL, LEGACY] as SchemaWriteMode[])('flat scalar routing (mode=%s)', (mode) => {
+describe.each([NATIVE, BRIDGE, LEGACY] as SchemaWriteMode[])('flat scalar routing (mode=%s)', (mode) => {
   it.each(promotions)('$attribute', ({ name, attribute, value }) => {
     setSchemaWriteMode(mode);
     const element: any = {};
@@ -58,7 +58,7 @@ describe.each([NATIVE, DUAL, LEGACY] as SchemaWriteMode[])('flat scalar routing 
     if (mode === NATIVE) {
       expect(element[attribute]).toEqual(value);
       expect(ext).toBeUndefined();
-    } else if (mode === DUAL) {
+    } else if (mode === BRIDGE) {
       expect(element[attribute]).toEqual(value);
       expect(ext?.value).toEqual(value);
     } else {
@@ -70,7 +70,7 @@ describe.each([NATIVE, DUAL, LEGACY] as SchemaWriteMode[])('flat scalar routing 
 
 describe('Read symmetry', () => {
   it.each(promotions)('mode-agnostic read for $attribute', ({ name, attribute, value }) => {
-    for (const mode of [NATIVE, DUAL, LEGACY] as SchemaWriteMode[]) {
+    for (const mode of [NATIVE, BRIDGE, LEGACY] as SchemaWriteMode[]) {
       setSchemaWriteMode(mode);
       const element: any = {};
       setFirstClassOrExtension({ element, attribute, name, value });
@@ -81,7 +81,7 @@ describe('Read symmetry', () => {
 
 describe('Undefined-value removal', () => {
   it.each(promotions)('clears both surfaces for $attribute', ({ name, attribute, value }) => {
-    setSchemaWriteMode(DUAL);
+    setSchemaWriteMode(BRIDGE);
     const element: any = {};
     setFirstClassOrExtension({ element, attribute, name, value });
     expect(element[attribute]).toEqual(value);

--- a/src/tests/global/flightProfileLineUpsFirstClass.test.ts
+++ b/src/tests/global/flightProfileLineUpsFirstClass.test.ts
@@ -13,17 +13,17 @@ import { setSchemaWriteMode } from '@Global/state/globalState';
 import { findExtension } from '@Acquire/findExtension';
 
 // constants and types
-import { DUAL, LEGACY, NATIVE, SchemaWriteMode } from '@Constants/schemaWriteModeConstants';
+import { BRIDGE, LEGACY, NATIVE, SchemaWriteMode } from '@Constants/schemaWriteModeConstants';
 import { FLIGHT_PROFILE, LINEUPS } from '@Constants/extensionConstants';
 
-describe.each([NATIVE, DUAL, LEGACY] as SchemaWriteMode[])('flightProfile + lineUps routing (mode=%s)', (mode) => {
+describe.each([NATIVE, BRIDGE, LEGACY] as SchemaWriteMode[])('flightProfile + lineUps routing (mode=%s)', (mode) => {
   function assertSurfaces(element: any, attribute: string, name: string, expected: any) {
     const firstClass = element[attribute];
     const ext = findExtension({ element, name }).extension;
     if (mode === NATIVE) {
       expect(firstClass).toEqual(expected);
       expect(ext).toBeUndefined();
-    } else if (mode === DUAL) {
+    } else if (mode === BRIDGE) {
       expect(firstClass).toEqual(expected);
       expect(ext?.value).toEqual(expected);
     } else {
@@ -75,7 +75,7 @@ describe.each([NATIVE, DUAL, LEGACY] as SchemaWriteMode[])('flightProfile + line
 });
 
 describe('Read symmetry — firstClassOrExtension', () => {
-  it.each([NATIVE, DUAL, LEGACY] as SchemaWriteMode[])('mode=%s reads flightProfile', (mode) => {
+  it.each([NATIVE, BRIDGE, LEGACY] as SchemaWriteMode[])('mode=%s reads flightProfile', (mode) => {
     setSchemaWriteMode(mode);
     const event: any = { eventId: 'e1' };
     const profile = { flights: [{ drawId: 'd1', flightNumber: 1 }] };
@@ -85,7 +85,7 @@ describe('Read symmetry — firstClassOrExtension', () => {
     );
   });
 
-  it.each([NATIVE, DUAL, LEGACY] as SchemaWriteMode[])('mode=%s reads lineUps', (mode) => {
+  it.each([NATIVE, BRIDGE, LEGACY] as SchemaWriteMode[])('mode=%s reads lineUps', (mode) => {
     setSchemaWriteMode(mode);
     const drawDefinition: any = { drawId: 'd1' };
     const lineUps = { 'team-1': [{ participantId: 'p1' }] };

--- a/src/tests/global/getTally.test.ts
+++ b/src/tests/global/getTally.test.ts
@@ -39,7 +39,7 @@ describe('getTally — mode-agnostic positionAssignment.tally read', () => {
     expect(result.tally).toEqual(TALLY_VALUE);
   });
 
-  it('first-class wins when both are present (DUAL-written record)', () => {
+  it('first-class wins when both are present (BRIDGE-written record)', () => {
     setSchemaWriteMode(NATIVE);
     const result: any = tournamentEngine.getTally({
       positionAssignment: {

--- a/src/tests/global/linkedTournamentIdsMode.test.ts
+++ b/src/tests/global/linkedTournamentIdsMode.test.ts
@@ -6,7 +6,7 @@ import { findExtension } from '@Acquire/findExtension';
 import mocksEngine from '@Assemblies/engines/mock';
 
 // constants and types
-import { DUAL, LEGACY, NATIVE } from '@Constants/schemaWriteModeConstants';
+import { BRIDGE, LEGACY, NATIVE } from '@Constants/schemaWriteModeConstants';
 import { LINKED_TOURNAMENTS } from '@Constants/extensionConstants';
 
 function loadTwoTournaments() {
@@ -65,8 +65,8 @@ describe('linkedTournamentIds — schemaWriteMode shadow writes', () => {
     expect(extension?.value?.tournamentIds.length).toEqual(2);
   });
 
-  it('DUAL mode writes both surfaces', () => {
-    setSchemaWriteMode(DUAL);
+  it('BRIDGE mode writes both surfaces', () => {
+    setSchemaWriteMode(BRIDGE);
     const { tournamentIdA } = loadTwoTournaments();
 
     competitionEngine.linkTournaments();
@@ -90,8 +90,8 @@ describe('linkedTournamentIds — schemaWriteMode shadow writes', () => {
     expect(linkedTournamentIds[tournamentIdB]).toEqual([tournamentIdA]);
   });
 
-  it('unlinkTournament removes the id from both surfaces (DUAL)', () => {
-    setSchemaWriteMode(DUAL);
+  it('unlinkTournament removes the id from both surfaces (BRIDGE)', () => {
+    setSchemaWriteMode(BRIDGE);
     const { tournamentIdA, tournamentIdB } = loadTwoTournaments();
     const { tournamentRecord: c } = mocksEngine.generateTournamentRecord();
     competitionEngine.setTournamentRecord(c);
@@ -113,7 +113,7 @@ describe('linkedTournamentIds — schemaWriteMode shadow writes', () => {
   });
 
   it('unlinkTournaments clears both surfaces', () => {
-    setSchemaWriteMode(DUAL);
+    setSchemaWriteMode(BRIDGE);
     const { tournamentIdA } = loadTwoTournaments();
     competitionEngine.linkTournaments();
     competitionEngine.unlinkTournaments();

--- a/src/tests/global/matchUpScheduleFirstClass.test.ts
+++ b/src/tests/global/matchUpScheduleFirstClass.test.ts
@@ -5,7 +5,7 @@
  * ASSIGN_OFFICIAL) on matchUps.
  *
  * Verifies that the schedule writers behave consistently across NATIVE,
- * DUAL, and LEGACY modes and that buildFullSchedule reads them
+ * BRIDGE, and LEGACY modes and that buildFullSchedule reads them
  * symmetrically through the hydration shim. Lifecycle items
  * (START_TIME / STOP_TIME / RESUME_TIME / END_TIME) remain as timeItems —
  * matchUpDuration() depends on the ordered history — and are not exercised
@@ -22,7 +22,7 @@ import { getTimeItem } from '@Query/base/timeItems';
 import mocksEngine from '@Assemblies/engines/mock';
 
 // constants and types
-import { DUAL, LEGACY, NATIVE, SchemaWriteMode } from '@Constants/schemaWriteModeConstants';
+import { BRIDGE, LEGACY, NATIVE, SchemaWriteMode } from '@Constants/schemaWriteModeConstants';
 import { SINGLES } from '@Constants/eventConstants';
 import { ASSIGN_COURT, ASSIGN_VENUE, COURT_ORDER, SCHEDULED_DATE, SCHEDULED_TIME } from '@Constants/timeItemConstants';
 
@@ -53,14 +53,14 @@ function rawMatchUp(drawId: string, matchUpId: string) {
   return undefined;
 }
 
-describe.each([NATIVE, DUAL, LEGACY] as SchemaWriteMode[])('matchUp.schedule.* end-to-end (mode=%s)', (mode) => {
+describe.each([NATIVE, BRIDGE, LEGACY] as SchemaWriteMode[])('matchUp.schedule.* end-to-end (mode=%s)', (mode) => {
   function assertSurfaces(rawMu: any, attribute: string, itemType: string, expected: any) {
     const firstClass = rawMu.schedule?.[attribute];
     const ti = (rawMu.timeItems ?? []).find((t: any) => t?.itemType === itemType);
     if (mode === NATIVE) {
       expect(firstClass).toEqual(expected);
       expect(ti).toBeUndefined();
-    } else if (mode === DUAL) {
+    } else if (mode === BRIDGE) {
       expect(firstClass).toEqual(expected);
       expect(ti?.itemValue).toEqual(expected);
     } else {
@@ -130,7 +130,7 @@ describe.each([NATIVE, DUAL, LEGACY] as SchemaWriteMode[])('matchUp.schedule.* e
 });
 
 describe('Hydration shim — buildFullSchedule reads first-class then timeItem', () => {
-  it.each([NATIVE, DUAL, LEGACY] as SchemaWriteMode[])(
+  it.each([NATIVE, BRIDGE, LEGACY] as SchemaWriteMode[])(
     'mode=%s produces the same hydrated matchUp.schedule.scheduledDate',
     (mode) => {
       setSchemaWriteMode(mode);
@@ -171,13 +171,13 @@ describe('NATIVE invariant — schedule timeItems are stripped on first-class wr
 });
 
 describe('clearMatchUpSchedule wipes both surfaces', () => {
-  it('removes the timeItem AND the first-class attribute (DUAL fixture)', () => {
-    setSchemaWriteMode(DUAL);
+  it('removes the timeItem AND the first-class attribute (BRIDGE fixture)', () => {
+    setSchemaWriteMode(BRIDGE);
     const { drawId, matchUpId } = setupSingleMatchUpTournament();
     tournamentEngine.addMatchUpScheduledDate({ drawId, matchUpId, scheduledDate: '2026-01-05' });
     tournamentEngine.addMatchUpCourtOrder({ drawId, matchUpId, courtOrder: 2 });
 
-    // DUAL wrote both
+    // BRIDGE wrote both
     const before = rawMatchUp(drawId, matchUpId);
     expect(before.schedule?.scheduledDate).toEqual('2026-01-05');
     expect(before.schedule?.courtOrder).toEqual(2);

--- a/src/tests/global/schemaWriteMode.test.ts
+++ b/src/tests/global/schemaWriteMode.test.ts
@@ -6,7 +6,7 @@ import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 import tournamentEngine from '../engines/syncEngine';
 
 // constants and types
-import { DUAL, LEGACY, NATIVE } from '@Constants/schemaWriteModeConstants';
+import { BRIDGE, LEGACY, NATIVE } from '@Constants/schemaWriteModeConstants';
 
 const TALLY_NAME = 'tally';
 const TALLY_VALUE = { wins: 2, losses: 1 };
@@ -18,9 +18,9 @@ it('engine exposes schemaWriteMode setter + getter', () => {
   expect(native.success).toEqual(true);
   expect(tournamentEngine.getSchemaWriteMode()).toEqual(NATIVE);
 
-  const dual = tournamentEngine.schemaWriteMode(DUAL);
+  const dual = tournamentEngine.schemaWriteMode(BRIDGE);
   expect(dual.success).toEqual(true);
-  expect(tournamentEngine.getSchemaWriteMode()).toEqual(DUAL);
+  expect(tournamentEngine.getSchemaWriteMode()).toEqual(BRIDGE);
 
   const legacy = tournamentEngine.schemaWriteMode(LEGACY);
   expect(legacy.success).toEqual(true);
@@ -81,9 +81,9 @@ describe('NATIVE mode', () => {
   });
 });
 
-describe('DUAL mode', () => {
+describe('BRIDGE mode', () => {
   it('writes both the first-class attribute and the legacy extension', () => {
-    setSchemaWriteMode(DUAL);
+    setSchemaWriteMode(BRIDGE);
     const element: any = {};
 
     setFirstClassOrExtension({
@@ -165,8 +165,8 @@ describe('NATIVE → LEGACY round-trip read symmetry', () => {
     expect(firstClassOrExtension({ element, attribute: 'tally', name: TALLY_NAME })).toEqual(TALLY_VALUE);
   });
 
-  it('DUAL write is readable through firstClassOrExtension and prefers first-class', () => {
-    setSchemaWriteMode(DUAL);
+  it('BRIDGE write is readable through firstClassOrExtension and prefers first-class', () => {
+    setSchemaWriteMode(BRIDGE);
     const element: any = {};
     setFirstClassOrExtension({
       element,

--- a/src/tests/global/tallyFirstClass.test.ts
+++ b/src/tests/global/tallyFirstClass.test.ts
@@ -17,7 +17,7 @@ import tournamentEngine from '../engines/syncEngine';
 import mocksEngine from '@Assemblies/engines/mock';
 
 // constants and types
-import { DUAL, LEGACY, NATIVE, SchemaWriteMode } from '@Constants/schemaWriteModeConstants';
+import { BRIDGE, LEGACY, NATIVE, SchemaWriteMode } from '@Constants/schemaWriteModeConstants';
 import { ROUND_ROBIN } from '@Constants/drawDefinitionConstants';
 import { TALLY } from '@Constants/extensionConstants';
 import { SINGLES } from '@Constants/eventConstants';
@@ -92,9 +92,9 @@ describe('LEGACY mode — tally', () => {
   });
 });
 
-describe('DUAL mode — tally', () => {
+describe('BRIDGE mode — tally', () => {
   it('writes tally to both the first-class attribute and the legacy extension', () => {
-    const { positionAssignments } = buildCompletedRRTournament(DUAL);
+    const { positionAssignments } = buildCompletedRRTournament(BRIDGE);
     const dualWrites = positionAssignments.filter(
       (pa: any) => pa.tally && findExtension({ element: pa, name: TALLY }).extension !== undefined,
     );
@@ -108,7 +108,7 @@ describe('DUAL mode — tally', () => {
 });
 
 describe('Read symmetry — firstClassOrExtension yields equivalent tallies in every mode', () => {
-  it.each([NATIVE, DUAL, LEGACY] as SchemaWriteMode[])('mode=%s', (mode) => {
+  it.each([NATIVE, BRIDGE, LEGACY] as SchemaWriteMode[])('mode=%s', (mode) => {
     const { positionAssignments } = buildCompletedRRTournament(mode);
 
     const collected = positionAssignments

--- a/src/tests/global/tournamentSchedulingFirstClass.test.ts
+++ b/src/tests/global/tournamentSchedulingFirstClass.test.ts
@@ -19,7 +19,7 @@ import { setSchemaWriteMode } from '@Global/state/globalState';
 import { findExtension } from '@Acquire/findExtension';
 
 // constants and types
-import { DUAL, LEGACY, NATIVE, SchemaWriteMode } from '@Constants/schemaWriteModeConstants';
+import { BRIDGE, LEGACY, NATIVE, SchemaWriteMode } from '@Constants/schemaWriteModeConstants';
 import { SCHEDULE_LIMITS, SCHEDULE_TIMING, SCHEDULING_PROFILE } from '@Constants/extensionConstants';
 
 type Promotion = { name: string; leaf: string; value: any };
@@ -34,7 +34,7 @@ const promotions: Promotion[] = [
   },
 ];
 
-describe.each([NATIVE, DUAL, LEGACY] as SchemaWriteMode[])('scheduling group-leaf routing (mode=%s)', (mode) => {
+describe.each([NATIVE, BRIDGE, LEGACY] as SchemaWriteMode[])('scheduling group-leaf routing (mode=%s)', (mode) => {
   it.each(promotions)('$leaf routes correctly', ({ name, leaf, value }) => {
     setSchemaWriteMode(mode);
     const tournamentRecord: any = { tournamentId: 't1' };
@@ -52,7 +52,7 @@ describe.each([NATIVE, DUAL, LEGACY] as SchemaWriteMode[])('scheduling group-lea
     if (mode === NATIVE) {
       expect(fc).toEqual(value);
       expect(ext).toBeUndefined();
-    } else if (mode === DUAL) {
+    } else if (mode === BRIDGE) {
       expect(fc).toEqual(value);
       expect(ext?.value).toEqual(value);
     } else {
@@ -64,7 +64,7 @@ describe.each([NATIVE, DUAL, LEGACY] as SchemaWriteMode[])('scheduling group-lea
 
 describe('Read symmetry — firstClassGroupLeafOrExtension', () => {
   it.each(promotions)('mode-agnostic read for $leaf', ({ name, leaf, value }) => {
-    for (const mode of [NATIVE, DUAL, LEGACY] as SchemaWriteMode[]) {
+    for (const mode of [NATIVE, BRIDGE, LEGACY] as SchemaWriteMode[]) {
       setSchemaWriteMode(mode);
       const tournamentRecord: any = { tournamentId: 't1' };
       setGroupLeafOrExtension({

--- a/src/tests/mutations/scheduling/clearScheduleWriteModeParity.test.ts
+++ b/src/tests/mutations/scheduling/clearScheduleWriteModeParity.test.ts
@@ -5,7 +5,7 @@ import tournamentEngine from '@Engines/syncEngine';
 import { afterEach, expect, it } from 'vitest';
 
 import { MATCHUPS_SCHEDULED_OUTSIDE_DATES } from '@Constants/errorConditionConstants';
-import { DUAL, LEGACY, NATIVE } from '@Constants/schemaWriteModeConstants';
+import { BRIDGE, LEGACY, NATIVE } from '@Constants/schemaWriteModeConstants';
 
 /**
  * Write-mode parity for unscheduling.
@@ -16,7 +16,7 @@ import { DUAL, LEGACY, NATIVE } from '@Constants/schemaWriteModeConstants';
  * `matchUp.schedule.*` with no timeItem mirror. `clearScheduledMatchUps` used to
  * only strip timeItems, so unscheduling was a silent no-op in NATIVE — a date
  * change that force-unscheduled a matchUp returned SCHEDULE_NOT_CLEARED and left
- * the placement intact. These tests exercise NATIVE and DUAL explicitly so the
+ * the placement intact. These tests exercise NATIVE and BRIDGE explicitly so the
  * regression can't hide behind the LEGACY-pinned suite again.
  */
 
@@ -59,7 +59,7 @@ function rawMatchUp(tournamentRecord: any, matchUpId: string) {
   return undefined;
 }
 
-it.each([NATIVE, DUAL, LEGACY])('clearScheduledMatchUps clears the placement in %s write mode', (mode) => {
+it.each([NATIVE, BRIDGE, LEGACY])('clearScheduledMatchUps clears the placement in %s write mode', (mode) => {
   const { matchUpId } = scheduleOutOfRange(mode);
   // operate on (and assert against) the same record instance the function mutates
   const tournamentRecord = tournamentEngine.getTournament().tournamentRecord;
@@ -77,7 +77,7 @@ it.each([NATIVE, DUAL, LEGACY])('clearScheduledMatchUps clears the placement in 
   expect(scheduleTimeItems.length).toEqual(0);
 });
 
-it.each([NATIVE, DUAL, LEGACY])(
+it.each([NATIVE, BRIDGE, LEGACY])(
   'setTournamentDates force-unschedules an out-of-range matchUp in %s write mode',
   (mode) => {
     const { matchUpId } = scheduleOutOfRange(mode);

--- a/src/tests/mutations/scheduling/scheduleBehaviorMatrix.test.ts
+++ b/src/tests/mutations/scheduling/scheduleBehaviorMatrix.test.ts
@@ -5,7 +5,7 @@ import tournamentEngine from '@Engines/syncEngine';
 import { expect, it } from 'vitest';
 
 /**
- * Behavioral scheduling coverage across NATIVE / DUAL / LEGACY. These assert *behavior* via engine
+ * Behavioral scheduling coverage across NATIVE / BRIDGE / LEGACY. These assert *behavior* via engine
  * queries (does scheduling place matchUps, are they date/court-queryable), NOT the storage shape —
  * so one body holds in every writeMode. Storage-shape specifics live in the NATIVE specs
  * (scheduleFirstClassStorage) + their legacyMode-scoped LEGACY counterparts.

--- a/src/tests/queries/matchUps/scheduleHydrationRegression.test.ts
+++ b/src/tests/queries/matchUps/scheduleHydrationRegression.test.ts
@@ -17,7 +17,7 @@ import mocksEngine from '@Assemblies/engines/mock';
 import tournamentEngine from '@Engines/syncEngine';
 import { describe, expect, it } from 'vitest';
 
-import { NATIVE, DUAL, LEGACY, SchemaWriteMode } from '@Constants/schemaWriteModeConstants';
+import { NATIVE, BRIDGE, LEGACY, SchemaWriteMode } from '@Constants/schemaWriteModeConstants';
 
 function scheduleOneMatchUp(opts: { startDate: string }) {
   const venueProfiles = [
@@ -220,7 +220,7 @@ describe('competitionScheduleMatchUps — public API shape', () => {
  * Under LEGACY mode the source `matchUp.schedule` is undefined, so the
  * hydrated schedule from the second spread survived — which is what the
  * default vitest setup pins, and what the rest of this test file
- * exercises. Under NATIVE (production default) and DUAL the source
+ * exercises. Under NATIVE (production default) and BRIDGE the source
  * `matchUp.schedule` is non-empty, so the third spread fully replaced
  * the hydrated `schedule` — losing every derived field (`venueName`,
  * `courtName`, `venueAbbreviation`, `isoDateString`, `milliseconds`,
@@ -233,7 +233,7 @@ describe('competitionScheduleMatchUps — public API shape', () => {
  * behaviour under all three schema-write modes so the bug can't recur on
  * a future shape promotion.
  */
-describe.each([NATIVE, DUAL, LEGACY] as SchemaWriteMode[])(
+describe.each([NATIVE, BRIDGE, LEGACY] as SchemaWriteMode[])(
   'schedule hydration survives matchUp.schedule first-class clobber (mode=%s)',
   (mode) => {
     it('keeps venueName + courtName on dateMatchUps[].schedule', () => {

--- a/src/tests/queries/matchUps/scheduleReadersFirstClass.test.ts
+++ b/src/tests/queries/matchUps/scheduleReadersFirstClass.test.ts
@@ -23,7 +23,7 @@ import {
  * suite is pinned to LEGACY — so these readers were silently timeItem-only and under-returned in
  * production (schedule filters/reports returning nothing). This mode-independent spec constructs
  * each representation directly and asserts the contract: prefer first-class, fall back to the
- * legacy timeItem, first-class wins when both are present (DUAL).
+ * legacy timeItem, first-class wins when both are present (BRIDGE).
  *
  * See planning/NATIVE_WRITEMODE_COVERAGE.md.
  */
@@ -91,7 +91,7 @@ describe('schedule readers resolve first-class with timeItem fallback', () => {
     expect(result[attr]).toEqual(legacy);
   });
 
-  it.each(readers)('$name — first-class wins when both present (DUAL)', ({ fn, attr, itemType, fc, legacy }) => {
+  it.each(readers)('$name — first-class wins when both present (BRIDGE)', ({ fn, attr, itemType, fc, legacy }) => {
     const result: any = fn({
       matchUp: { schedule: { [attr]: fc }, timeItems: [{ itemType, itemValue: legacy }] },
     } as any);

--- a/src/tests/testHarness/writeModeMatrix.ts
+++ b/src/tests/testHarness/writeModeMatrix.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe } from 'vitest';
 
 import { setSchemaWriteMode } from '@Global/state/globalState';
-import { DUAL, LEGACY, NATIVE, SchemaWriteMode } from '@Constants/schemaWriteModeConstants';
+import { BRIDGE, LEGACY, NATIVE, SchemaWriteMode } from '@Constants/schemaWriteModeConstants';
 
 /**
  * Run a block of *behavioral* specs under multiple schemaWriteModes.
@@ -24,7 +24,7 @@ import { DUAL, LEGACY, NATIVE, SchemaWriteMode } from '@Constants/schemaWriteMod
  */
 export function writeModeMatrix(
   build: (mode: SchemaWriteMode) => void,
-  modes: SchemaWriteMode[] = [NATIVE, DUAL, LEGACY],
+  modes: SchemaWriteMode[] = [NATIVE, BRIDGE, LEGACY],
 ): void {
   for (const mode of modes) {
     describe(`[writeMode: ${mode}]`, () => {


### PR DESCRIPTION
Renames the `DUAL` schema write mode to `BRIDGE`. Mechanical, no behaviour change.

## Why

`DUAL` is a poor name **in this source tree**. `dualMatchUp` / `dualWinningSide` / `isDual` appear across **53 files** as a *competition* term — the TEAM tie — so a behavioural write mode called `DUAL` reads as a domain concept rather than a migration state.

`BRIDGE` names what it is for: the window in which both representations are written while a migration is in flight. `BOTH` was the runner-up and was rejected because it describes the mechanism without saying the state is temporary — and a mode nobody knows is temporary never gets removed.

## The rename is free, and that was measured

- `schemaWriteModeConstants` and `setSchemaWriteMode` are **not** on the published package surface — `require(dist).schemaWriteModeConstants` is `undefined`
- no consumer references either: competition-factory-server **0**; TMX's single hit is a comment
- **the value is runtime-only and never persisted** — no tournament record, fixture or JSON schema contains it, so `'dual'` → `'bridge'` cannot invalidate stored data

## Scope

81 identifiers across 31 files, all of them the write mode. A grep for the competition term inside the changed set returns **0**, and the unrelated `eventId: 'dual'` fixture in `readModelRows.test.ts` is untouched. Prettier touched only those 31 files — no tree-wide churn.

Full suite **12,884 passed / 2 skipped**; types and lint clean.

## Why now

Groundwork for the `matchUpStatusCodes` split, which introduces a second migration on this same mechanism and needs the vocabulary unambiguous first. Design and decisions: `Mentat/planning/MATCHUP_STATUS_CODES_PER_SIDE.md`.
