### PR TITLE
docs: record the ITF rebrand to World Tennis, and what deliberately does not change

### DIFF
--- a/documentation/docs/concepts/pro-scheduling.md
+++ b/documentation/docs/concepts/pro-scheduling.md
@@ -110,7 +110,7 @@ Match C:
 
 ### ITF Follow By Implementation
 
-The ITF (International Tennis Federation) and many national federations use a standardized follow-by system:
+World Tennis (formerly the ITF) and many national federations use a standardized follow-by system:
 
 ```js
 // ITF-style scheduling

--- a/documentation/docs/concepts/seed-withdrawal-cascade.md
+++ b/documentation/docs/concepts/seed-withdrawal-cascade.md
@@ -113,7 +113,7 @@ The `vacatedDrawPosition` in the result tells the tournament director which posi
 
 ## Timing Constraints
 
-Per ITF/ATP/WTA regulations:
+Per World Tennis (formerly the ITF), ATP and WTA regulations:
 
 - **Before order of play released**: Full cascade applies — seeds move into higher seed positions
 - **After order of play released**: No cascade — the vacancy is filled directly by an alternate or lucky loser using the standard `withdrawParticipantAtDrawPosition` action

--- a/documentation/docs/data-standards.md
+++ b/documentation/docs/data-standards.md
@@ -40,6 +40,32 @@ title: Data Standards
 
 The **Competition Factory** began as an implementation of the **[Tennis Open Data Standards (TODS)](https://itftennis.atlassian.net/wiki/spaces/TODS/overview)**, an ITF-led initiative to create a vendor-independent, JSON-based document format for tennis competition data. TODS provided the foundational data model — tournaments, events, draws, matchUps, participants, scoring, venues, and scheduling — and the factory fully supports TODS-compliant documents.
 
+### A note on the ITF and World Tennis {#world-tennis}
+
+The International Tennis Federation **rebranded as World Tennis**: its trading name changed on
+1 January 2026, with the new brand rolling out through summer 2026. It follows World Athletics,
+World Aquatics and World Rugby in dropping an acronym-based identity.
+
+Nothing in the factory's API changes because of this, deliberately:
+
+|                                                                               |                                                                                                                                                                                                         |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `POLICY_SEEDING_ITF`, `POLICY_SANCTIONING_ITF`, `POLICY_RANKING_POINTS_ITF_*` | **unchanged** — renaming an export is a breaking change with no functional benefit                                                                                                                      |
+| `ITF_JUNIOR`, `ITF_WHEELCHAIR`, `ITF_CHAIR` and peers                         | **unchanged** — enum values                                                                                                                                                                             |
+| `policyName: 'ITF SEEDING'`                                                   | **unchanged** — it is _data_. It is written into `appliedPolicies` on tournament records and consumers match attached policies on it, so changing the string would orphan every policy already attached |
+| `governingBodyId: 'itf'`                                                      | **unchanged** — persisted on `SanctioningRecord`                                                                                                                                                        |
+| `ITF W15`, `ITF M25`, `ITF J500`                                              | **unchanged** — tournament level codes in active use                                                                                                                                                    |
+
+Two things are easy to conflate and worth stating plainly:
+
+- **"World Tennis Tour" is a circuit, not the organisation.** It predates the rebrand.
+  `POLICY_RANKING_POINTS_ITF_WTT` is about that circuit. "World Tennis" alone is the governing body.
+- **TODS remains an ITF-published standard.** It was released under that name and is frozen at 0.8;
+  the factory cites it as origin rather than as a live authority. See [CODES](#codes) below.
+
+Documentation prose refers to the organisation as **World Tennis (formerly the ITF)** on first
+mention, and to circuits, certifications and level codes by the names they actually carry.
+
 ### From TODS to CODES {#codes}
 
 As the **Competition Factory** was deployed across more sports it was proven that the underlying data structures are not tennis-specific. The core concepts of participants, events, draws, matchUps, and scoring translate naturally across any sport that organizes bracket-based or round-robin competitions. The [matchUpFormat](/docs/codes/matchup-format) code capabilities were extended to support the scoring needs of almost all imaginable sports.
@@ -143,12 +169,12 @@ Because it is a third declaration it can drift from the other two, and drift her
 
 **Strictness is a stated convention, not an accident.** Of the 68 object definitions, **64 declare `additionalProperties: false`**. Four are deliberately open:
 
-| definition | why it is open |
-| --- | --- |
-| `Extension` | extensions carry caller-defined payloads by design |
-| `Tournament` | permissive pending the undeclared fields real records still carry |
-| `Venue` | as above |
-| `Organisation` | as above |
+| definition     | why it is open                                                    |
+| -------------- | ----------------------------------------------------------------- |
+| `Extension`    | extensions carry caller-defined payloads by design                |
+| `Tournament`   | permissive pending the undeclared fields real records still carry |
+| `Venue`        | as above                                                          |
+| `Organisation` | as above                                                          |
 
 Closing the three record-shaped definitions is **blocked rather than declined**: measured against the TODS fixtures, making them strict fails most of them and exposes undeclared fields carried by real records — `venueIds`, `deleted`, `Venue.parentOrganisation`, `Organisation.createdAt` / `updatedAt`, and others. Each needs a decision about whether it belongs in CODES before the definition can be closed around it.
 

--- a/documentation/docs/engines/sanctioning-engine-design.md
+++ b/documentation/docs/engines/sanctioning-engine-design.md
@@ -1,5 +1,13 @@
 # Sanctioning Engine — Design & Implementation Plan
 
+:::note Naming
+The organisation is referred to as **World Tennis (formerly the ITF)** — it rebranded on
+1 January 2026. `ITF` persists deliberately wherever it names a **policy**
+(`POLICY_SANCTIONING_ITF`), a **stored value** (`governingBodyId: 'itf'`), a **level code**
+(`ITF W15`), or a **circuit** (World Tennis Tour). See
+[the ITF and World Tennis](../data-standards#world-tennis).
+:::
+
 ## 1. Overview
 
 The Sanctioning Engine is a **state engine** that manages the lifecycle of a **sanctioning application** — the propositional object that defines what a tournament organizer intends to run, subject to approval by a governing body. The approved sanctioning object becomes the seed from which a `tournamentRecord` is generated, carrying forward all constraints (allowed categories, matchUpFormats, drawTypes, draw sizes, officials requirements, etc.) as enforceable policy.
@@ -59,7 +67,7 @@ DRAFT → SUBMITTED → UNDER_REVIEW → APPROVED | CONDITIONALLY_APPROVED | REJ
 2. National Association endorses application
 3. Application submitted to ITF (16-21 weeks before tournament week depending on level)
 4. ITF reviews — grants, refuses, grants with conditions, or downgrades
-5. Tournament appears on ITF calendar
+5. Tournament appears on the World Tennis (formerly the ITF) calendar
 6. Post-event: results reporting, financial reconciliation, compliance review
 
 **Level-driven requirements (ITF example):**
@@ -696,7 +704,7 @@ Every state transition is recorded:
 
 Real-world dual/multi-sanctioning takes three distinct forms:
 
-1. **Hierarchical (ITF + National Federation):** Not true dual-sanctioning. The national federation is the intermediary — it endorses and submits to the ITF. One application flows upward. The national sanction is the primary instrument; ITF points flow through a memorandum of understanding. USTA Level 1-3 tournaments that carry ITF ranking points operate under an MOU where USTA regulations take precedence except where they conflict with ITF tour regulations.
+1. **Hierarchical (ITF + National Federation):** Not true dual-sanctioning. The national federation is the intermediary — it endorses and submits to World Tennis. One application flows upward. The national sanction is the primary instrument; ITF points flow through a memorandum of understanding. USTA Level 1-3 tournaments that carry ITF ranking points operate under an MOU where USTA regulations take precedence except where they conflict with ITF tour regulations.
 
 2. **Parallel tours (ATP + WTA combined events):** Indian Wells, Miami, Madrid, Rome etc. carry **separate sanctions from each tour**. The tournament owner negotiates a Tournament Agreement with each tour independently. Each tour maintains independent ranking, regulatory, and sanctioning frameworks. These are effectively two tournaments sharing a venue and brand.
 
@@ -743,7 +751,7 @@ The factory's existing scheduling system (AvailabilityEngine, scheduleGovernor) 
 
 Calendar conflict detection for sanctioning requires knowledge of **all sanctioned events across a region and season** — data that no single client or tournament record holds. This is fundamentally a cross-record query.
 
-The USTA "Serve Tennis" platform and BWF's sanctioning portal both handle calendar conflict detection server-side, where the full calendar is available. The ITF similarly maintains a centralized calendar. No sport handles calendar conflicts client-side.
+The USTA "Serve Tennis" platform and BWF's sanctioning portal both handle calendar conflict detection server-side, where the full calendar is available. World Tennis similarly maintains a centralized calendar. No sport handles calendar conflicts client-side.
 
 **Recommendation: Hybrid — engine provides the algorithm, server injects the data.**
 
@@ -789,7 +797,7 @@ interface CalendarEvent {
 
 **Research findings:**
 
-In the ITF system, the national federation endorsement is **substantive, not a rubber stamp**. The national association is "ultimately responsible for the proper organisation and running" of the tournament. It must be "fully appraised of the proposed Tournament site and organisation" and satisfied that requirements are met before endorsing. A national federation can effectively veto an application by refusing to submit it — tournaments not sanctioned by the relevant national association are not considered for ITF calendar inclusion.
+In the World Tennis system, the national federation endorsement is **substantive, not a rubber stamp**. The national association is "ultimately responsible for the proper organisation and running" of the tournament. It must be "fully appraised of the proposed Tournament site and organisation" and satisfied that requirements are met before endorsing. A national federation can effectively veto an application by refusing to submit it — tournaments not sanctioned by the relevant national association are not considered for World Tennis calendar inclusion.
 
 However, the endorsement is **embedded in the application process** rather than tracked as a separate document. The national association submits the application on behalf of the organizer — the submission itself is the endorsement act. There is no separate "endorsement certificate" that exists independently.
 
@@ -842,7 +850,7 @@ Post-event compliance across sports breaks into three categories of increasing s
 
 1. **Mandatory reporting with deadlines** (universal): Results submission (24h for World Athletics, 72h for USA Swimming, 14 days for USATT), incident reports (48h for USATF), financial reconciliation (prize money paid out, sanction fees settled).
 
-2. **Structured checklists** (some sports): USATF requires a Post-Event Report Form that must be completed before new sanctions are granted. USA Swimming requires pool measurement forms, record applications, backup result files. ITF requires the Supervisor's report covering all aspects of play.
+2. **Structured checklists** (some sports): USATF requires a Post-Event Report Form that must be completed before new sanctions are granted. USA Swimming requires pool measurement forms, record applications, backup result files. World Tennis requires the Supervisor's report covering all aspects of play.
 
 3. **Financial compliance** (ITF, BWF): ITF requires a security deposit equal to full prize money, returned only after all prizes are paid. BWF sanction fee (10% of prize fund) is due within 3 weeks of tournament end.
 
@@ -973,7 +981,7 @@ interface SanctioningRecord {
 
 Real-world modification handling is remarkably consistent across sports:
 
-- **ITF**: Cannot cancel, postpone, or make substantial changes less than 9 weeks before the tournament. Violations subject to fines up to $5,000, forfeiture of fees, and denial of future applications. The ITF can downgrade a tournament application up to the entry deadline.
+- **ITF**: Cannot cancel, postpone, or make substantial changes less than 9 weeks before the tournament. Violations subject to fines up to $5,000, forfeiture of fees, and denial of future applications. World Tennis can downgrade a tournament application up to the entry deadline.
 - **BWF**: Graduated timeline — prize money can increase anytime but cannot decrease; changes fewer than 15 days before the event for high-level events are referred to the Disciplinary Committee; tournament level cannot change fewer than 90 days before.
 - **USTA**: Draw size, formats, and match formats are determined at the time of sanction approval. Play cannot continue past the last sanctioned day without prior written approval. Changes handled through direct communication, not a formal re-application.
 - **USATF**: Postponements within the same calendar year are handled by email with no additional fee. Postponements to the next year require cancellation and re-application.

--- a/documentation/docs/governors/officiating-governor.md
+++ b/documentation/docs/governors/officiating-governor.md
@@ -354,7 +354,7 @@ policy is an allow-list of checks, never a silent partial application.
 
 `POLICY_OFFICIATING_CONFLICT_OF_INTEREST` (default) blocks on `SAME_PERSON` and `DECLARED_RELATIONSHIP`,
 warns on `ORGANISATION`, and leaves `NATIONALITY` **disabled**. Shared nationality is disqualifying at
-ITF-level international events and meaningless at national ones, where every official necessarily shares
+international events at World Tennis (formerly the ITF) level and meaningless at national ones, where every official necessarily shares
 the players' nationality — enabling it by default would make the check noise at most events.
 
 `POLICY_OFFICIATING_CONFLICT_OF_INTEREST_ITF` enables all four rules at `BLOCK`.


### PR DESCRIPTION
Independent of #4803 / #4804 — no overlapping files, so this can merge in any order.

## The rebrand

The International Tennis Federation **rebranded as World Tennis**. Trading name changed **1 January 2026**; brand rollout through **summer 2026**. It follows World Athletics, World Aquatics and World Rugby in dropping an acronym identity.

Sources: [ITF announcement](https://www.itftennis.com/en/news-and-media/articles/international-tennis-federation-to-become-world-tennis-in-2026/) · [Racquet Sports Industry](https://www.tennisindustrymag.com/news/2025/10/international-tennis-federation-to-change-name-to-world-tennis-in-2026/) · [SGI Europe](https://www.sgieurope.com/sports-categories/tf-rebrands-as-world-tennis-from-january-2026/121921.article)

## Why this is not a find-and-replace

There are 219 mentions of "ITF" across 38 doc files. Replacing them would be actively harmful, because "ITF" here is **five different things** and only one is the organisation:

| what it is | examples | changed? |
|---|---|---|
| exported names | `POLICY_SEEDING_ITF`, `POLICY_SANCTIONING_ITF`, `POLICY_RANKING_POINTS_ITF_*` | **no** — breaks consumers for no gain |
| enum values | `ITF_JUNIOR`, `ITF_WHEELCHAIR`, `ITF_CHAIR` | **no** |
| **stored data** | `governingBodyId: 'itf'`, `policyName: 'ITF SEEDING'` | **no** — see below |
| level codes in active use | `ITF W15`, `ITF M25`, `ITF J500` | **no** |
| a **circuit** | World Tennis **Tour** | **no** — it predates the rebrand |
| the **organisation**, as an actor | "the ITF can downgrade an application" | **yes** |

Two of those deserve emphasis:

**`policyName: 'ITF SEEDING'` is data, not a label.** It is written into the `appliedPolicies` extension on tournament records, and consumers match an attached policy on that string — [TMX#1433](https://github.com/CourtHive/TMX/pull/1433) does exactly this. Changing it would orphan every policy already attached to a tournament.

**"World Tennis Tour" is a circuit, not the organisation.** It predates the rebrand. A blanket replacement produces "World Tennis World Tennis Tour", or worse, quietly conflates a circuit with the body that runs it. `POLICY_RANKING_POINTS_ITF_WTT` is about the circuit.

## What's in the diff

**One authoritative note** — `data-standards.md`, anchored at `#world-tennis`: the rebrand, its dates, each frozen category with its reason, the Tour/organisation distinction, and TODS attribution.

**Ten organisational-prose changes**, where the text treats the body as an actor: "ITF requires the Supervisor's report", "the national federation submits to the ITF", "the ITF can downgrade a tournament application", "not considered for ITF calendar inclusion", "the ITF maintains a centralized calendar", "Per ITF/ATP/WTA regulations", "ITF-level international events". First mention per page carries "(formerly the ITF)".

**A naming note** at the top of `sanctioning-engine-design.md`, which legitimately keeps reading "ITF" in 14 further places because there it names a policy, a stored value, a level code or a circuit — with a link to the authoritative note so the mixture isn't mistaken for an incomplete edit.

**TODS stays ITF-published.** It was released under that name and is frozen at 0.8; the factory cites it as origin rather than as a live authority.

## Deliberately out of scope

`migration-*.md` and `whats-new-*.md` — another session holds those. Nothing here touches them.

## Verification

Docs site builds clean under `onBrokenLinks: 'throw'` and `onBrokenMarkdownLinks: 'throw'`, which is what validates the new cross-page `../data-standards#world-tennis` anchor. Five files changed; prettier run per-file rather than over a glob.