### PR TITLE
fix(draws): carry the exit code onto the exiting side instead of dropping it

### DIFF
--- a/src/mutate/matchUps/drawPositions/assignMatchUpDrawPosition.ts
+++ b/src/mutate/matchUps/drawPositions/assignMatchUpDrawPosition.ts
@@ -244,6 +244,33 @@ function resolveMatchUpStatus({ isByeMatchUp, matchUpStatus, isDoubleExitExit, m
   );
 }
 
+/**
+ * The string value of a `matchUpStatusCodes` element, whatever shape it arrived in.
+ *
+ * The array holds THREE shapes, which is the root problem:
+ *   1. policy codes      `{ matchUpStatusCode, label, matchUpStatusCodeDisplay }` — the scoring
+ *                        policy's vocabulary (see POLICY_SCORING_USTA)
+ *   2. exit provenance   `{ matchUpStatus, previousMatchUpStatus, sideNumber }` — written by
+ *                        doubleExitAdvancement.buildMatchUpStatusCodes
+ *   3. wrapped codes     `{ code }` — written by updateMatchUpStatusCodes, which wraps any string
+ *                        element before stamping `previousMatchUpStatus` onto it
+ *
+ * The previous read was `code?.code`, which resolves shape 3 correctly and shapes 1 and 2 to
+ * `undefined`. Provenance is the shape this branch actually receives, so the carried code was
+ * dropped and the branch assigned an empty array rather than re-siding anything.
+ *
+ * Measured 2026-09-11 over 120 randomized sweep scenarios: the branch below ran 275 times, 81 of
+ * those with codes present, every one of them shape 2, and dropped the code in 81 of 81.
+ *
+ * Note this returns a STRING, so provenance (`previousMatchUpStatus`, `sideNumber`) is still
+ * flattened away — the surrounding contract is `string[]`. Preserving it is what the per-side
+ * provenance field is for; see Mentat/planning/MATCHUP_STATUS_CODES_PER_SIDE.md.
+ */
+function exitCodeString(code: any): string | undefined {
+  if (typeof code === 'string') return code || undefined;
+  return code?.matchUpStatusCode ?? code?.code ?? code?.matchUpStatus ?? undefined;
+}
+
 function applyPositionToMatchUp({
   updatedDrawPositions,
   sourceMatchUpStatus,
@@ -289,9 +316,7 @@ function applyPositionToMatchUp({
   // winner) — otherwise it mislabels the winner. Mirrors resolvePropagatedExitOnAdvance.
   if (advancedExitWinningSide && !isDoubleExitExit) {
     const exitSideNumber = advancedExitWinningSide === 1 ? 2 : 1;
-    const carriedCode = (matchUp.matchUpStatusCodes ?? [])
-      .map((code: any) => (typeof code === 'string' ? code : code?.code))
-      .find(Boolean);
+    const carriedCode = (matchUp.matchUpStatusCodes ?? []).map(exitCodeString).find(Boolean);
     const matchUpStatusCodes: string[] = [];
     if (carriedCode) {
       for (let i = 0; i < exitSideNumber - 1; i++) matchUpStatusCodes[i] = '';

--- a/src/query/drawDefinition/getStructureInconsistencies.ts
+++ b/src/query/drawDefinition/getStructureInconsistencies.ts
@@ -91,6 +91,24 @@ type GetStructureInconsistenciesArgs = {
   event?: Event;
 };
 
+/**
+ * String value of a `matchUpStatusCodes` element, for the EXIT_CODE_ON_WINNER_SIDE check below.
+ *
+ * Deliberately narrow. The array holds three shapes — policy codes (`matchUpStatusCode`), exit
+ * provenance (`matchUpStatus`/`previousMatchUpStatus`/`sideNumber`), and codes wrapped as `{ code }`
+ * by `updateMatchUpStatusCodes` — and this reads only strings and that last wrapper. It is left
+ * rather than widened, because widening it is measurably wrong:
+ *
+ * EXIT_CODE_ON_WINNER_SIDE means "an exit code sits on the winner's side rather than the loser's".
+ * That is a rule about POLICY codes, which belong to the match and land on the exiting side.
+ * Provenance is written to BOTH sides by `buildMatchUpStatusCodes`, so index `winningSide - 1` is
+ * always occupied for a propagation-produced matchUp and the rule cannot hold for it. Measured
+ * 2026-09-10: teaching this function to read object elements produced 717 findings, all false
+ * positives, and broke two named negative-control tests.
+ *
+ * The fix is the tenant split, not a wider read — once the array holds policy codes only, this
+ * rule is correct as written. See Mentat/planning/MATCHUP_STATUS_CODES_PER_SIDE.md.
+ */
 function codeString(code: any): string | undefined {
   const value = typeof code === 'string' ? code : code?.code;
   return value || undefined;


### PR DESCRIPTION
## The defect

`applyPositionToMatchUp` moves a carried exit code onto the exiting participant's new side when
someone advances into a pending propagated exit. Its comment is explicit:

> the carried exit code must follow the EXITING participant to its new side (opposite the advancing
> winner) — otherwise it mislabels the winner

`matchUpStatusCodes` holds **three** shapes:

| # | shape | written by |
|---|---|---|
| 1 | `{ matchUpStatusCode, label, matchUpStatusCodeDisplay }` | the scoring policy vocabulary (`POLICY_SCORING_USTA`) |
| 2 | `{ matchUpStatus, previousMatchUpStatus, sideNumber }` | `doubleExitAdvancement.buildMatchUpStatusCodes` |
| 3 | `{ code }` | `updateMatchUpStatusCodes`, wrapping a string element |

The branch read each element as `typeof code === 'string' ? code : code?.code`. That resolves **shape
3** correctly and shapes 1 and 2 to `undefined`. **Shape 2 is what this branch actually receives**, so
`carriedCode` was falsy and it fell through to assigning an **empty array** — dropping the code
rather than re-siding it.

## Measurement

Instrumented both arms of the branch, attributing each firing to its scenario:

| driver | firings | with codes present | dropped |
|---|---:|---:|---:|
| 144-cell properties matrix | **0** | — | — |
| 120 randomized sweep scenarios | **275** | **81** | **81 of 81** |

Every one of those 81 carried shape 2. **A 0% success rate** — the branch has never once carried a
code. It does not execute at all under the properties matrix, which is why no in-suite oracle has
ever observed it.

## The fix

`exitCodeString` resolves `matchUpStatusCode ?? code ?? matchUpStatus`, covering all three shapes.
Same 120 seeds, before → after:

| | with codes | dropped | carried |
|---|---:|---:|---:|
| before | 81 | **81** | 0 |
| after | 81 | **0** | **81** |

Sweep findings on those seeds are **unchanged at 24**. `pnpm verify` exit 0 — 12,861 passed / 2
skipped, coverage thresholds met, build + published-`.d.ts` pack smoke OK.

## Scope — what this does NOT do

It returns a **string**, so `previousMatchUpStatus` and `sideNumber` are still flattened away; the
surrounding contract is `string[]`. Provenance survived neither the old behaviour (dropped) nor the
new one (stringified). Preserving it is the per-side provenance field's job and is **not** attempted
here. This does not close E1, and the four quarantined `DO_UNDO_IDENTITY` cells are untouched — the
probe showed this function does not reach them at all.

## Second file: a comment only

`getStructureInconsistencies`' `codeString` is **documented rather than widened**. Widening it to read
provenance is measurably wrong: it produces **717 findings, all false positives**, and breaks two
named negative-control tests. `EXIT_CODE_ON_WINNER_SIDE` encodes a rule about *policy* codes, which
land on the exiting side; provenance is written to **both** sides, so index `winningSide - 1` is
always occupied for a propagation-produced matchUp. 18 insertions, zero code lines changed.