### PR TITLE
feat(codes): give exit provenance its own per-side field, and stop relabelling exits as walkovers

### DIFF
--- a/src/fixtures/scoring/outcomes/toBePlayed.ts
+++ b/src/fixtures/scoring/outcomes/toBePlayed.ts
@@ -3,6 +3,8 @@ import { TO_BE_PLAYED } from '@Constants/matchUpStatusConstants';
 export const toBePlayed = {
   matchUpStatus: TO_BE_PLAYED,
   matchUpStatusCodes: [],
+  // cleared with the codes: an unwound matchUp must not keep provenance for an exit that is gone
+  sideExitProvenance: undefined,
   score: {
     scoreStringSide1: '',
     scoreStringSide2: '',

--- a/src/mutate/drawDefinitions/positionGovernor/doubleExitAdvancement.ts
+++ b/src/mutate/drawDefinitions/positionGovernor/doubleExitAdvancement.ts
@@ -7,6 +7,7 @@ import { modifyMatchUpScore } from '@Mutate/matchUps/score/modifyMatchUpScore';
 import { directWinner } from '@Mutate/matchUps/drawPositions/directWinner';
 import { decorateResult } from '@Functions/global/decorateResult';
 import { positionTargets } from '@Query/matchUp/positionTargets';
+import { buildSideExitProvenance, setSideExitProvenance } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
 import { definedAttributes } from '@Tools/definedAttributes';
 import { pushGlobalLog } from '@Functions/global/globalLog';
 import { findStructure } from '@Acquire/findStructure';
@@ -357,6 +358,17 @@ function conditionallyAdvanceDrawPosition(params) {
     sourceSideNumber,
   });
 
+  // CODES first-class: the same facts, keyed by sideNumber and attributed to their source.
+  // Written alongside the legacy array, not instead of it — see sideExitProvenance.ts on why the
+  // legacy write is not yet gated on writeLegacyEnabled().
+  const sideExitProvenance = buildSideExitProvenance({
+    pairedMatchUpId: pairedPreviousMatchUp?.matchUpId,
+    sourceMatchUpId: sourceMatchUp?.matchUpId,
+    pairedMatchUpStatus,
+    sourceMatchUpStatus,
+    sourceSideNumber,
+  });
+
   logAdvancement(stack, {
     color: 'brightgreen',
     keyColors: { matchUpStatus: 'brightcyan', winningSide: 'brightyellow' },
@@ -378,6 +390,8 @@ function conditionallyAdvanceDrawPosition(params) {
     matchUpStatus,
   });
   if (result.error) return decorateResult({ result, stack });
+
+  setSideExitProvenance({ matchUp: noContextTargetMatchUp, provenance: sideExitProvenance });
 
   return advanceFromTarget({
     pairedPreviousMatchUpIsDoubleExit,

--- a/src/mutate/matchUps/drawPositions/positionClear.ts
+++ b/src/mutate/matchUps/drawPositions/positionClear.ts
@@ -2,6 +2,7 @@ import { modifyRoundRobinMatchUpsStatus } from '@Mutate/matchUps/matchUpStatus/m
 import { getPositionAssignments, structureAssignedDrawPositions } from '@Query/drawDefinition/positionsGetter';
 import { modifyPositionAssignmentsNotice, modifyMatchUpNotice } from '@Mutate/notifications/drawNotifications';
 import { getStructureDrawPositionProfiles } from '@Query/structure/getStructureDrawPositionProfiles';
+import { clearSideExitProvenance } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
 import { getAllStructureMatchUps } from '@Query/matchUps/getAllStructureMatchUps';
 import { getInitialRoundNumber } from '@Query/matchUps/getInitialRoundNumber';
 import { getRoundMatchUps } from '@Query/matchUps/getRoundMatchUps';
@@ -502,6 +503,7 @@ function updateMatchUpStatusAfterRemoval({
   targetMatchUp.matchUpStatus = (matchUpContainsBye && BYE) || TO_BE_PLAYED;
   targetMatchUp.winningSide = undefined;
   if (targetMatchUp.matchUpStatusCodes?.length) targetMatchUp.matchUpStatusCodes = [];
+  clearSideExitProvenance(targetMatchUp);
 
   const removedDrawPosition = initialDrawPositions?.find(
     (position) => !targetMatchUp.drawPositions?.includes(position),

--- a/src/mutate/matchUps/drawPositions/progressExitStatus.ts
+++ b/src/mutate/matchUps/drawPositions/progressExitStatus.ts
@@ -7,7 +7,7 @@ import { isExit } from '@Validators/isExit';
 // constants
 import { DOUBLE_WALKOVER, RETIRED, WALKOVER } from '@Constants/matchUpStatusConstants';
 import { MISSING_MATCHUP } from '@Constants/errorConditionConstants';
-import { OUTCOME_WALKOVER } from '@Helpers/keyValueScore/constants';
+import { exitOutcomeCode } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
 import { SUCCESS } from '@Constants/resultConstants';
 
 // matchUpStatusCodes are position-dependent: index 0 maps to side 1, index 1 to
@@ -75,9 +75,10 @@ export function progressExitStatus({
     return decorateResult({ result: { error: MISSING_MATCHUP }, stack });
   }
 
-  // double-WO special codes are stored as objects; normalize to simple strings
-  const statusCodes: string[] =
-    updatedLoserMatchUp.matchUpStatusCodes?.map((sc) => (typeof sc === 'string' ? sc : OUTCOME_WALKOVER)) ?? [];
+  // Object-shaped codes are normalised to their OWN outcome code, not to a walkover.
+  // This previously hardcoded OUTCOME_WALKOVER for every object, which relabelled DEFAULTED and BYE
+  // provenance as walkovers and persisted the result (statusCodes is written back below).
+  const statusCodes: string[] = (updatedLoserMatchUp.matchUpStatusCodes ?? []).map(exitOutcomeCode);
   const loserParticipantSide = updatedLoserMatchUp.sides?.find((s) => s.participantId === loserParticipantId);
 
   let loserMatchUpStatus = carryOverMatchUpStatus;

--- a/src/mutate/matchUps/matchUpStatus/attemptToSetMatchUpStatusBYE.ts
+++ b/src/mutate/matchUps/matchUpStatus/attemptToSetMatchUpStatusBYE.ts
@@ -1,3 +1,4 @@
+import { clearSideExitProvenance } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
 import { structureAssignedDrawPositions } from '@Query/drawDefinition/positionsGetter';
 import { releaseByeScheduling } from '@Mutate/matchUps/schedule/byeScheduling';
 import { modifyMatchUpNotice } from '../../notifications/drawNotifications';
@@ -39,6 +40,7 @@ export function attemptToSetMatchUpStatusBYE({
   if (matchUpIncludesBye) {
     matchUp.matchUpStatus = BYE;
     matchUp.matchUpStatusCodes = [];
+    clearSideExitProvenance(matchUp);
     // Preserve by default: a director may be mid-swap and the surrounding schedule is
     // theirs. Only an explicit `preserveScheduling: false` gives the slot back.
     if (preserveScheduling === false) releaseByeScheduling({ matchUp });

--- a/src/mutate/matchUps/matchUpStatus/sideExitProvenance.ts
+++ b/src/mutate/matchUps/matchUpStatus/sideExitProvenance.ts
@@ -1,0 +1,169 @@
+import { OUTCOME_DEFAULT, OUTCOME_RETIREMENT, OUTCOME_WALKOVER } from '@Helpers/keyValueScore/constants';
+import { writeNativeEnabled } from '@Global/state/globalState';
+import { definedAttributes } from '@Tools/definedAttributes';
+
+// constants and types
+import { MatchUp, SideExitProvenance, SideExitProvenanceEntry } from '@Types/tournamentTypes';
+import { DOUBLE_WALKOVER, DOUBLE_DEFAULT, DEFAULTED, RETIRED, WALKOVER } from '@Constants/matchUpStatusConstants';
+
+/**
+ * Paired writer/reader for `matchUp.sideExitProvenance`.
+ *
+ * WHY THIS EXISTS. `matchUpStatusCodes` is an `any[]` carrying three unrelated element shapes:
+ * the scoring policy's vocabulary (`matchUpStatusCode`), propagation provenance
+ * (`matchUpStatus`/`previousMatchUpStatus`/`sideNumber`), and codes wrapped as `{ code }`. Provenance
+ * is positional in that array — a side is an INDEX, padded with `''` — so it cannot be addressed,
+ * cannot be attributed to the exit that produced it, and is flattened by every reader that assumes a
+ * string. This field gives provenance its own home: keyed by `sideNumber`, one fixed shape, and
+ * carrying `sourceMatchUpId`.
+ *
+ * WRITE MODE. Native writes are gated on `writeNativeEnabled()` (true for NATIVE and BRIDGE), so the
+ * field follows the same switch as the other CODES first-class transitions. The LEGACY
+ * `matchUpStatusCodes` write is deliberately NOT gated on `writeLegacyEnabled()` yet: the global
+ * default is NATIVE, so gating it would stop writing the legacy array immediately and that is a
+ * breaking change. Retiring the legacy write is the 8.0 step; until then this is a pure addition.
+ *
+ * See Mentat/planning/MATCHUP_STATUS_CODES_PER_SIDE.md.
+ */
+
+/** DOUBLE_WALKOVER produces WALKOVER downstream, DOUBLE_DEFAULT produces DEFAULTED. */
+export function producedExitStatus(previousMatchUpStatus?: string): string | undefined {
+  if (previousMatchUpStatus === DOUBLE_WALKOVER) return WALKOVER;
+  if (previousMatchUpStatus === DOUBLE_DEFAULT) return DEFAULTED;
+  return previousMatchUpStatus;
+}
+
+type BuildArgs = {
+  pairedMatchUpStatus?: string;
+  sourceMatchUpStatus?: string;
+  sourceSideNumber?: number;
+  pairedMatchUpId?: string;
+  sourceMatchUpId?: string;
+};
+
+/**
+ * Provenance for both sides of a target fed by a double exit.
+ *
+ * `sourceSideNumber` says which side the SOURCE exit landed on; the paired previous matchUp supplies
+ * the other. Returns undefined when the side is unknown, rather than guessing — an unattributed
+ * entry is worse than no entry, because the unwind would then trust it.
+ */
+export function buildSideExitProvenance(params: BuildArgs): SideExitProvenance | undefined {
+  const { sourceMatchUpStatus, pairedMatchUpStatus, sourceSideNumber, sourceMatchUpId, pairedMatchUpId } = params;
+  if (sourceSideNumber !== 1 && sourceSideNumber !== 2) return undefined;
+
+  const pairedSideNumber = sourceSideNumber === 1 ? 2 : 1;
+  const provenance: SideExitProvenance = {
+    [sourceSideNumber]: definedAttributes({
+      matchUpStatus: producedExitStatus(sourceMatchUpStatus),
+      previousMatchUpStatus: sourceMatchUpStatus,
+      sourceMatchUpId,
+    }) as SideExitProvenanceEntry,
+    [pairedSideNumber]: definedAttributes({
+      matchUpStatus: producedExitStatus(pairedMatchUpStatus),
+      previousMatchUpStatus: pairedMatchUpStatus,
+      sourceMatchUpId: pairedMatchUpId,
+    }) as SideExitProvenanceEntry,
+  };
+
+  // an entry with nothing in it is noise; drop it rather than persist an empty object
+  for (const key of Object.keys(provenance)) {
+    if (!Object.keys(provenance[key as any] ?? {}).length) delete provenance[key as any];
+  }
+
+  return Object.keys(provenance).length ? provenance : undefined;
+}
+
+/** Write provenance onto a matchUp, honouring the schema write mode. */
+export function setSideExitProvenance({
+  provenance,
+  matchUp,
+}: {
+  provenance?: SideExitProvenance;
+  matchUp?: MatchUp;
+}): void {
+  if (!matchUp || !writeNativeEnabled()) return;
+  if (provenance && Object.keys(provenance).length) {
+    matchUp.sideExitProvenance = provenance;
+  } else {
+    delete matchUp.sideExitProvenance;
+  }
+}
+
+/**
+ * Remove provenance from a matchUp.
+ *
+ * NOT gated on the write mode. Every site that blanks `matchUpStatusCodes` must also clear this, or
+ * an unwound matchUp keeps provenance for an exit that no longer exists — a do/undo residue. The
+ * write mode decides whether the field is WRITTEN; it must never decide whether stale state is
+ * removed.
+ */
+export function clearSideExitProvenance(matchUp?: MatchUp): void {
+  if (matchUp) delete matchUp.sideExitProvenance;
+}
+
+/**
+ * Read provenance, preferring the native field and falling back to the legacy array.
+ *
+ * The fallback exists so a record written before this field — or by a LEGACY-mode writer — still
+ * answers. It reads only the provenance SHAPE out of `matchUpStatusCodes`; policy codes and
+ * `{ code }` wrappers are not provenance and are ignored.
+ */
+export function getSideExitProvenance({ matchUp }: { matchUp?: MatchUp }): SideExitProvenance | undefined {
+  const native = matchUp?.sideExitProvenance;
+  if (native && Object.keys(native).length) return native;
+
+  const codes = matchUp?.matchUpStatusCodes;
+  if (!Array.isArray(codes)) return undefined;
+
+  const derived: SideExitProvenance = {};
+  codes.forEach((code: any, index: number) => {
+    if (!code || typeof code !== 'object' || !code.previousMatchUpStatus) return;
+    // legacy provenance is positional: index 0 is side 1. `sideNumber` is preferred when present.
+    const sideNumber = code.sideNumber ?? index + 1;
+    if (sideNumber !== 1 && sideNumber !== 2) return;
+    derived[sideNumber] = definedAttributes({
+      matchUpStatus: code.matchUpStatus,
+      previousMatchUpStatus: code.previousMatchUpStatus,
+      sourceMatchUpId: code.sourceMatchUpId,
+    }) as SideExitProvenanceEntry;
+  });
+
+  return Object.keys(derived).length ? derived : undefined;
+}
+
+/** Whether this matchUp's exit was PRODUCED by upstream propagation rather than played. */
+export function exitProducedByPropagation({ matchUp }: { matchUp?: MatchUp }): boolean {
+  return !!getSideExitProvenance({ matchUp });
+}
+
+/**
+ * The outcome code a `matchUpStatusCodes` element should contribute, whatever shape it arrived in.
+ *
+ * Replaces a coercion that mapped EVERY object element to `OUTCOME_WALKOVER`. Measured over 120
+ * randomized sweep scenarios, of the 50 provenance elements that reached that coercion, **13 were
+ * BYE and 9 were DEFAULTED** — 44% were not walkovers, and all were relabelled as one and persisted.
+ *
+ * Nothing caught it because the only oracle exercising this path is a DOUBLE_WALKOVER/DOUBLE_DEFAULT
+ * PARITY test that rewrites `"DEFAULTED"` to `"WALKOVER"` and `"DEF"` to `"WO"` before comparing —
+ * so a bug forcing that exact convergence is invisible to it. The BYE case is not in the rename pair
+ * at all and was simply unasserted.
+ *
+ * A status with no outcome code — a BYE above all — yields an empty string, which is what the
+ * surrounding positional array already uses for "no code on this side". It must NOT become a
+ * walkover.
+ */
+export function exitOutcomeCode(element: any): string {
+  if (typeof element === 'string') return element;
+  if (!element || typeof element !== 'object') return '';
+
+  // a wrapped code (`{ code }`) or a policy code carries its own string value
+  const carried = element.matchUpStatusCode ?? element.code;
+  if (typeof carried === 'string') return carried;
+
+  const status = element.matchUpStatus ?? element.previousMatchUpStatus;
+  if (status === WALKOVER || status === DOUBLE_WALKOVER) return OUTCOME_WALKOVER;
+  if (status === DEFAULTED || status === DOUBLE_DEFAULT) return OUTCOME_DEFAULT;
+  if (status === RETIRED) return OUTCOME_RETIREMENT;
+  return '';
+}

--- a/src/mutate/matchUps/score/modifyMatchUpScore.ts
+++ b/src/mutate/matchUps/score/modifyMatchUpScore.ts
@@ -2,6 +2,7 @@ import { updateAssignmentParticipantResults } from '@Mutate/drawDefinitions/matc
 import { processCompetitionMatchUp } from '@Mutate/drawDefinitions/competition/processCompetitionMatchUp';
 import { modifyMatchUpNotice, updateInContextMatchUp } from '@Mutate/notifications/drawNotifications';
 import { getCompetitionPolicy } from '@Query/drawDefinition/competition/getCompetitionPolicy';
+import { clearSideExitProvenance } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
 import { getAllStructureMatchUps } from '@Query/matchUps/getAllStructureMatchUps';
 import { getAppliedPolicies } from '@Query/extensions/getAppliedPolicies';
 import { checkScoreHasValue } from '@Query/matchUp/checkScoreHasValue';
@@ -218,9 +219,6 @@ function resolveDualMatchUpTarget({ isDualMatchUp, drawDefinition, matchUpId, ma
     return undefined;
   }
 
-  if (matchUp.matchUpId !== matchUpId) {
-    console.log('!!!!!');
-  }
   return undefined;
 }
 
@@ -244,6 +242,9 @@ function applyScoreAndStatus({
   if (matchUpStatus) matchUp.matchUpStatus = matchUpStatus;
   if (matchUpFormat) matchUp.matchUpFormat = matchUpFormat;
   if (matchUpStatusCodes) matchUp.matchUpStatusCodes = matchUpStatusCodes;
+  // blanking the codes unwinds the exit they described; provenance describes the same exit and
+  // must not outlive them, or the matchUp never returns to its pre-exit state
+  if (matchUpStatusCodes && !matchUpStatusCodes.length) clearSideExitProvenance(matchUp);
   if (winningSide) matchUp.winningSide = winningSide;
   if (removeWinningSide) matchUp.winningSide = undefined;
 }

--- a/src/query/drawDefinition/getDrawInconsistencies.ts
+++ b/src/query/drawDefinition/getDrawInconsistencies.ts
@@ -147,7 +147,7 @@ function droppedProgressionForLink(
 
   const inconsistencies: any[] = [];
   for (const matchUp of roundMatchUps) {
-    if (exitProducedByPropagation(matchUp.matchUpStatusCodes)) continue;
+    if (exitProducedByPropagation(matchUp)) continue;
     const loserSideNumber = matchUp.winningSide === 1 ? 2 : 1;
     const sideNumber = isLoserLink ? loserSideNumber : matchUp.winningSide;
     const side = (matchUp.sides ?? []).find((candidate) => candidate.sideNumber === sideNumber);

--- a/src/query/drawDefinition/getStructureInconsistencies.ts
+++ b/src/query/drawDefinition/getStructureInconsistencies.ts
@@ -1,3 +1,4 @@
+import { exitProducedByPropagation as sharedExitProducedByPropagation } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
 import { finalize, Inconsistency } from '@Query/integrity/inconsistency';
 import { getAllDrawMatchUps } from '@Query/matchUps/drawMatchUps';
 import { isExit } from '@Validators/isExit';
@@ -118,9 +119,11 @@ function codeString(code: any): string | undefined {
 // onto one of its status codes — the marker it writes when a downstream slot resolves to a
 // WALKOVER/DEFAULTED because an upstream double-exit (or fed exit) delivered no participant.
 // Such an exit legitimately has an empty losing slot and must NOT be flagged as an orphan.
-export function exitProducedByPropagation(matchUpStatusCodes: any): boolean {
-  if (!Array.isArray(matchUpStatusCodes)) return false;
-  return matchUpStatusCodes.some((code) => typeof code === 'object' && code?.previousMatchUpStatus);
+export function exitProducedByPropagation(matchUp: any): boolean {
+  // One reader for both schemas: prefers `sideExitProvenance`, falls back to the provenance shape
+  // inside the legacy `matchUpStatusCodes`. Callers pass the matchUp, not the array, so the native
+  // field is consultable at all.
+  return sharedExitProducedByPropagation({ matchUp });
 }
 
 // A positionAssignment is "occupied" if it names a participant, a bye, or a (pending)
@@ -277,7 +280,7 @@ export function getStructureInconsistencies(
       loserSide?.drawPosition &&
       !loserSide.participantId &&
       !loserSide.bye &&
-      !exitProducedByPropagation(matchUpStatusCodes)
+      !exitProducedByPropagation(matchUp)
     ) {
       inconsistencies.push({
         ...base,

--- a/src/tests/mutations/drawDefinitions/setMatchUpStatus/propagateExitStatus.test.ts
+++ b/src/tests/mutations/drawDefinitions/setMatchUpStatus/propagateExitStatus.test.ts
@@ -277,7 +277,17 @@ test('can propagate a default to a consolation match with already the result of 
   //consolation match should result in a DOUBLE_WALKOVER
   let loserMatchUp = matchUps?.find((mU) => mU.matchUpId === matchUp?.loserMatchUpId);
   expect(loserMatchUp?.matchUpStatus).toEqual(DOUBLE_WALKOVER);
-  expect(loserMatchUp?.matchUpStatusCodes).toEqual(['WO', 'DM']);
+
+  // Was ['WO', 'DM'], which asserted that a DEFAULT is recorded as a WALKOVER. Index 0 carries the
+  // code for the side that exited via matchUp-1-1's DOUBLE_DEFAULT, so 'DEF' is the truthful code;
+  // the old value came from a coercion that mapped EVERY object-shaped element to OUTCOME_WALKOVER
+  // (measured: of 50 provenance elements reaching it, 13 were BYE and 9 DEFAULTED).
+  //
+  // NOTE the divergence this exposes rather than creates: matchUpStatus is still DOUBLE_WALKOVER
+  // because progressExitStatus RULE 4 hardcodes it, while doubleExitAdvancement preserves
+  // DOUBLE_DEFAULT. Two producers, two conventions — documented in doubleExitStatusParity.test.ts.
+  // Fixing the STATUS half is a separate change; this one makes the CODE stop lying.
+  expect(loserMatchUp?.matchUpStatusCodes).toEqual(['DEF', 'DM']);
 });
 
 test('can propagate an exit status and progress the already existing opponent in the back draw match', () => {

--- a/src/tests/mutations/exitPropagation/doubleExitStatusParity.test.ts
+++ b/src/tests/mutations/exitPropagation/doubleExitStatusParity.test.ts
@@ -104,13 +104,37 @@ const anonymize = (projection: any[]): any => {
     return `p${labels.get(participantId)}`;
   };
 
+  // matchUpIds get the same treatment, for the same reason: `sideExitProvenance` carries a
+  // `sourceMatchUpId`, and the two runs generate different ids for the corresponding matchUp. Without
+  // relabelling, every cell carrying provenance would differ on identity alone and this oracle would
+  // report a behavioural difference that is not one.
+  const matchUpLabels = new Map<string, number>();
+  const matchUpLabel = (matchUpId: string) => {
+    if (!matchUpLabels.has(matchUpId)) matchUpLabels.set(matchUpId, matchUpLabels.size);
+    return `m${matchUpLabels.get(matchUpId)}`;
+  };
+  for (const structure of projection) {
+    for (const [matchUpId] of structure.matchUps ?? []) if (matchUpId) matchUpLabel(matchUpId);
+  }
+
+  const relabelIds = (value: any): any => {
+    if (Array.isArray(value)) return value.map(relabelIds);
+    if (!value || typeof value !== 'object') return value;
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key,
+        key === 'sourceMatchUpId' && typeof entry === 'string' ? matchUpLabel(entry) : relabelIds(entry),
+      ]),
+    );
+  };
+
   return projection.map((structure: any, structureIndex: number) => ({
     structureIndex,
     positionAssignments: (structure.positionAssignments ?? []).map((assignment: any) => ({
       ...assignment,
       participantId: assignment.participantId ? label(assignment.participantId) : undefined,
     })),
-    matchUps: structure.matchUps.map(([, ...rest]: any[]) => rest),
+    matchUps: structure.matchUps.map(([, ...rest]: any[]) => rest.map(relabelIds)),
   }));
 };
 

--- a/src/tests/mutations/exitPropagation/productionStatusCodeSurvival.test.ts
+++ b/src/tests/mutations/exitPropagation/productionStatusCodeSurvival.test.ts
@@ -1,0 +1,153 @@
+import {
+  PRODUCTION_STATUS_CODES,
+  PRODUCTION_STATUS_CODES_BY_CATEGORY,
+} from '@Tests/testHarness/statusCodes/productionVocabulary';
+import { exitOutcomeCode, getSideExitProvenance } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
+import { updateMatchUpStatusCodes } from '@Mutate/drawDefinitions/matchUpGovernor/matchUpStatusCodes';
+import { FIRST_MATCH_LOSER_CONSOLATION } from '@Constants/drawDefinitionConstants';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { expect, it, test } from 'vitest';
+
+// constants
+import { DEFAULTED, DOUBLE_DEFAULT, DOUBLE_WALKOVER, WALKOVER } from '@Constants/matchUpStatusConstants';
+import { OUTCOME_WALKOVER } from '@Helpers/keyValueScore/constants';
+
+/**
+ * Every code in a deployed production vocabulary must survive every shape it can take.
+ *
+ * The array these travel in is polymorphic — a code can be a bare string, or wrapped as `{ code }`
+ * by `updateMatchUpStatusCodes`, or sit beside propagation provenance. A coercion in
+ * `progressExitStatus` used to rewrite every object element to `OUTCOME_WALKOVER`, so a code that
+ * had been wrapped could come back out as a walkover.
+ *
+ * These are exhaustive over the vocabulary rather than sampled: the failure mode is per-code, and a
+ * sample would have passed on the codes that happen to be walkovers already.
+ */
+
+test.for(PRODUCTION_STATUS_CODES)('$category $code survives every element shape', ({ code, display }) => {
+  expect(code).not.toEqual('');
+
+  // 1. a bare string passes through untouched
+  expect(exitOutcomeCode(code)).toEqual(code);
+
+  // 2. wrapped by updateMatchUpStatusCodes — the shape that used to become 'WO'
+  expect(exitOutcomeCode({ code })).toEqual(code);
+
+  // 3. the policy vocabulary shape, carrying its display form
+  expect(exitOutcomeCode({ matchUpStatusCode: code, matchUpStatusCodeDisplay: display })).toEqual(code);
+
+  // 4. wrapped AND stamped with provenance, which is what the array actually holds mid-propagation
+  expect(exitOutcomeCode({ code, previousMatchUpStatus: DOUBLE_WALKOVER, sideNumber: 1 })).toEqual(code);
+});
+
+test.for(PRODUCTION_STATUS_CODES.filter(({ code }) => code !== OUTCOME_WALKOVER))(
+  '$category $code is never relabelled as a walkover',
+  ({ code }) => {
+    // the defect this vocabulary exists to pin: every object element became OUTCOME_WALKOVER
+    for (const shape of [{ code }, { matchUpStatusCode: code }, { code, sideNumber: 2 }]) {
+      expect(exitOutcomeCode(shape)).not.toEqual(OUTCOME_WALKOVER);
+    }
+  },
+);
+
+it('survives the wrapper that updateMatchUpStatusCodes applies, for the whole vocabulary', () => {
+  // updateMatchUpStatusCodes wraps string elements as `{ code }` before stamping provenance.
+  // Drive the real function, not a hand-built shape, so the test tracks the wrapper if it changes.
+  const sourceMatchUpId = 'source-1';
+  const codes = PRODUCTION_STATUS_CODES.map(({ code }) => code);
+
+  const matchUp: any = { matchUpId: 'target-1', matchUpStatusCodes: [...codes] };
+  const sourceMatchUp: any = { matchUpId: sourceMatchUpId, structureId: 's1', roundPosition: 1 };
+  const pairedMatchUp: any = { matchUpId: 'paired-1', structureId: 's1', roundPosition: 2 };
+
+  updateMatchUpStatusCodes({
+    inContextDrawMatchUps: [sourceMatchUp, pairedMatchUp],
+    matchUpsMap: { drawPositionsToMatchUps: {}, mappedMatchUps: {} } as any,
+    sourceMatchUpStatus: DOUBLE_WALKOVER,
+    sourceMatchUpId,
+    matchUp,
+  });
+
+  // whatever the wrapper did, every original code must still be recoverable
+  const recovered = (matchUp.matchUpStatusCodes ?? []).map(exitOutcomeCode);
+  expect(recovered).toEqual(codes);
+
+  // and none of them may be mistaken for propagation provenance
+  expect(getSideExitProvenance({ matchUp })).toBeUndefined();
+});
+
+it('keeps each category distinguishable rather than collapsing it to a walkover', () => {
+  const categories = Object.keys(PRODUCTION_STATUS_CODES_BY_CATEGORY);
+  expect(categories.length).toBeGreaterThanOrEqual(5);
+
+  for (const category of categories) {
+    const resolved = PRODUCTION_STATUS_CODES_BY_CATEGORY[category].map(({ code }) => exitOutcomeCode({ code }));
+    // every code in the category comes back as itself — the categories stay separable
+    expect(resolved).toEqual(PRODUCTION_STATUS_CODES_BY_CATEGORY[category].map(({ code }) => code));
+  }
+
+  // the vocabulary is not accidentally all-walkovers: only the walkover category maps to 'WO'
+  const nonWalkoverCodes = PRODUCTION_STATUS_CODES.filter(({ category }) => category !== 'Walkovers');
+  expect(nonWalkoverCodes.every(({ code }) => exitOutcomeCode({ code }) !== OUTCOME_WALKOVER)).toEqual(true);
+});
+
+it('does not confuse a production code with exit provenance', () => {
+  // provenance is recognised by previousMatchUpStatus, not by carrying a code
+  const codesOnly: any = { matchUpId: 'm', matchUpStatusCodes: PRODUCTION_STATUS_CODES.map(({ code }) => ({ code })) };
+  expect(getSideExitProvenance({ matchUp: codesOnly })).toBeUndefined();
+
+  const withProvenance: any = {
+    matchUpId: 'm2',
+    matchUpStatusCodes: [
+      { code: 'DQ', previousMatchUpStatus: DOUBLE_WALKOVER, matchUpStatus: WALKOVER, sideNumber: 1 },
+    ],
+  };
+  const provenance: any = getSideExitProvenance({ matchUp: withProvenance });
+  expect(provenance[1].previousMatchUpStatus).toEqual(DOUBLE_WALKOVER);
+  // ...and the code is still recoverable from the same element
+  expect(exitOutcomeCode(withProvenance.matchUpStatusCodes[0])).toEqual('DQ');
+});
+
+/**
+ * End-to-end: a real production code, carried on a scored matchUp, through actual propagation.
+ *
+ * The element-shape tests above are exhaustive but synthetic. This one drives the engine: a
+ * DOUBLE_WALKOVER upstream, then a DEFAULTED carrying `DQ` with propagateExitStatus, and asserts
+ * what lands on the consolation matchUp. Before the coercion fix the produced side read `WO` — a
+ * walkover — for a pair of exits neither of which was one.
+ */
+it('carries a production code through propagation without relabelling it', () => {
+  const idPrefix = 'matchUp';
+  const drawId = 'production-codes';
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ drawId, drawSize: 32, drawType: FIRST_MATCH_LOSER_CONSOLATION, idPrefix }],
+    setState: true,
+  });
+
+  let result: any = tournamentEngine.setMatchUpStatus({
+    outcome: { matchUpStatus: DOUBLE_DEFAULT, matchUpStatusCodes: ['DD', 'DD'] },
+    matchUpId: `${idPrefix}-1-1`,
+    drawId,
+  });
+  expect(result.success).toEqual(true);
+
+  result = tournamentEngine.setMatchUpStatus({
+    outcome: { matchUpStatus: DEFAULTED, winningSide: 2, matchUpStatusCodes: ['DQ'] },
+    propagateExitStatus: true,
+    matchUpId: `${idPrefix}-1-2`,
+    drawId,
+  });
+  expect(result.success).toEqual(true);
+
+  const { matchUps } = tournamentEngine.allDrawMatchUps({ drawId, inContext: true });
+  const scored = matchUps?.find((m: any) => m.matchUpId === `${idPrefix}-1-2`);
+  const consolation = matchUps?.find((m: any) => m.matchUpId === scored?.loserMatchUpId);
+
+  // the authored production code survives verbatim
+  expect(consolation?.matchUpStatusCodes).toContain('DQ');
+
+  // and the side produced by the DOUBLE_DEFAULT upstream is recorded as a default, not a walkover
+  expect(consolation?.matchUpStatusCodes).toEqual(['DEF', 'DQ']);
+  expect(consolation?.matchUpStatusCodes).not.toContain(OUTCOME_WALKOVER);
+});

--- a/src/tests/mutations/exitPropagation/sideExitProvenance.test.ts
+++ b/src/tests/mutations/exitPropagation/sideExitProvenance.test.ts
@@ -1,0 +1,158 @@
+import {
+  buildSideExitProvenance,
+  exitProducedByPropagation,
+  getSideExitProvenance,
+  producedExitStatus,
+  setSideExitProvenance,
+  exitOutcomeCode,
+} from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
+import { setSchemaWriteMode } from '@Global/state/globalState';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { afterEach, expect, it } from 'vitest';
+
+// constants
+import { BYE, DEFAULTED, DOUBLE_DEFAULT, DOUBLE_WALKOVER, RETIRED, WALKOVER } from '@Constants/matchUpStatusConstants';
+import { OUTCOME_DEFAULT, OUTCOME_RETIREMENT, OUTCOME_WALKOVER } from '@Helpers/keyValueScore/constants';
+import { LEGACY, NATIVE } from '@Constants/schemaWriteModeConstants';
+
+afterEach(() => setSchemaWriteMode(NATIVE));
+
+it('stamps per-side provenance on a matchUp fed by a double exit, attributed to its source', () => {
+  const {
+    tournamentRecord,
+    drawIds: [drawId],
+  } = mocksEngine.generateTournamentRecord({
+    drawProfiles: [
+      {
+        drawSize: 4,
+        outcomes: [
+          { roundNumber: 1, roundPosition: 1, matchUpStatus: DOUBLE_WALKOVER },
+          { roundNumber: 1, roundPosition: 2, scoreString: '6-1 6-3', winningSide: 1 },
+        ],
+      },
+    ],
+    setState: true,
+  });
+  expect(tournamentRecord.tournamentId).not.toBeUndefined();
+  expect(drawId).not.toBeUndefined();
+
+  const { matchUps } = tournamentEngine.allTournamentMatchUps();
+  const source = matchUps.find(({ roundNumber, roundPosition }) => roundNumber === 1 && roundPosition === 1);
+  const target = matchUps.find(({ roundNumber }) => roundNumber === 2);
+
+  const provenance: any = target.sideExitProvenance;
+  expect(provenance).not.toBeUndefined();
+
+  // keyed by sideNumber, so no positional padding and no index arithmetic
+  expect(Object.keys(provenance).sort((a, b) => Number(a) - Number(b))).toEqual(['1', '2']);
+
+  const doubleExitSide: any = Object.values(provenance).find(
+    (entry: any) => entry.previousMatchUpStatus === DOUBLE_WALKOVER,
+  );
+  expect(doubleExitSide.matchUpStatus).toEqual(WALKOVER);
+
+  // the identity the unwind lacks in matchUpStatusCodes
+  expect(doubleExitSide.sourceMatchUpId).toEqual(source.matchUpId);
+
+  // the legacy array is still written — 7.x is a pure addition
+  expect(Array.isArray(target.matchUpStatusCodes)).toEqual(true);
+});
+
+it('reads provenance from the legacy array when the native field is absent', () => {
+  const legacyOnly: any = {
+    matchUpId: 'm1',
+    matchUpStatusCodes: [
+      { matchUpStatus: WALKOVER, previousMatchUpStatus: DOUBLE_WALKOVER, sideNumber: 1 },
+      { matchUpStatus: DEFAULTED, previousMatchUpStatus: DOUBLE_DEFAULT, sideNumber: 2 },
+    ],
+  };
+
+  const provenance: any = getSideExitProvenance({ matchUp: legacyOnly });
+  expect(provenance[1].previousMatchUpStatus).toEqual(DOUBLE_WALKOVER);
+  expect(provenance[2].previousMatchUpStatus).toEqual(DOUBLE_DEFAULT);
+  expect(exitProducedByPropagation({ matchUp: legacyOnly })).toEqual(true);
+});
+
+it('ignores the policy and wrapped element shapes, which are not provenance', () => {
+  const notProvenance: any = {
+    matchUpId: 'm2',
+    matchUpStatusCodes: [{ matchUpStatusCode: 'OA', label: 'Abandoned match' }, { code: 'WO' }, 'WO', ''],
+  };
+  expect(getSideExitProvenance({ matchUp: notProvenance })).toBeUndefined();
+  expect(exitProducedByPropagation({ matchUp: notProvenance })).toEqual(false);
+});
+
+it('prefers the native field over the legacy array when both are present', () => {
+  const both: any = {
+    matchUpId: 'm3',
+    sideExitProvenance: { 1: { previousMatchUpStatus: DOUBLE_DEFAULT, sourceMatchUpId: 'native-source' } },
+    matchUpStatusCodes: [{ matchUpStatus: WALKOVER, previousMatchUpStatus: DOUBLE_WALKOVER, sideNumber: 1 }],
+  };
+  const provenance: any = getSideExitProvenance({ matchUp: both });
+  expect(provenance[1].sourceMatchUpId).toEqual('native-source');
+  expect(provenance[1].previousMatchUpStatus).toEqual(DOUBLE_DEFAULT);
+});
+
+it('does not write the native field in LEGACY mode', () => {
+  const matchUp: any = { matchUpId: 'm4' };
+  const provenance = buildSideExitProvenance({
+    sourceMatchUpStatus: DOUBLE_WALKOVER,
+    pairedMatchUpStatus: DOUBLE_DEFAULT,
+    sourceMatchUpId: 'src',
+    sourceSideNumber: 1,
+  });
+
+  setSchemaWriteMode(LEGACY);
+  setSideExitProvenance({ matchUp, provenance });
+  expect(matchUp.sideExitProvenance).toBeUndefined();
+
+  setSchemaWriteMode(NATIVE);
+  setSideExitProvenance({ matchUp, provenance });
+  expect(matchUp.sideExitProvenance).not.toBeUndefined();
+});
+
+it('refuses to guess a side, and maps produced statuses', () => {
+  // an unattributed entry is worse than no entry: the unwind would trust it
+  expect(buildSideExitProvenance({ sourceMatchUpStatus: DOUBLE_WALKOVER })).toBeUndefined();
+  expect(buildSideExitProvenance({ sourceMatchUpStatus: DOUBLE_WALKOVER, sourceSideNumber: 3 as any })).toBeUndefined();
+
+  expect(producedExitStatus(DOUBLE_WALKOVER)).toEqual(WALKOVER);
+  expect(producedExitStatus(DOUBLE_DEFAULT)).toEqual(DEFAULTED);
+  // a BYE is not a double exit and must NOT be relabelled as a walkover
+  expect(producedExitStatus('BYE')).toEqual('BYE');
+});
+
+/**
+ * Regression for the coercion at progressExitStatus, which mapped EVERY object element to
+ * OUTCOME_WALKOVER. Measured: of 50 provenance elements reaching it, 13 were BYE and 9 DEFAULTED.
+ *
+ * These assertions are deliberately at the element level. The only oracle that exercised the
+ * surrounding path is a DOUBLE_WALKOVER/DOUBLE_DEFAULT parity test that rewrites "DEFAULTED" to
+ * "WALKOVER" and "DEF" to "WO" before comparing, so it cannot distinguish a correct mapping from the
+ * bug. Nothing that normalises the two statuses together can serve as a regression test here.
+ */
+it('maps an exit element to its OWN outcome code, and never invents a walkover', () => {
+  expect(exitOutcomeCode({ matchUpStatus: WALKOVER, previousMatchUpStatus: DOUBLE_WALKOVER })).toEqual(
+    OUTCOME_WALKOVER,
+  );
+
+  // the 9 measured DEFAULTED elements: previously relabelled 'WO'
+  expect(exitOutcomeCode({ matchUpStatus: DEFAULTED, previousMatchUpStatus: DOUBLE_DEFAULT })).toEqual(OUTCOME_DEFAULT);
+  expect(exitOutcomeCode({ previousMatchUpStatus: DOUBLE_DEFAULT })).toEqual(OUTCOME_DEFAULT);
+
+  // the 13 measured BYE elements: a BYE is not an outcome and must contribute NO code
+  expect(exitOutcomeCode({ previousMatchUpStatus: BYE })).toEqual('');
+  expect(exitOutcomeCode({ matchUpStatus: BYE })).toEqual('');
+
+  expect(exitOutcomeCode({ previousMatchUpStatus: RETIRED })).toEqual(OUTCOME_RETIREMENT);
+
+  // strings pass through; the other two element shapes carry their own value
+  expect(exitOutcomeCode('WO')).toEqual('WO');
+  expect(exitOutcomeCode({ code: 'DEF' })).toEqual('DEF');
+  expect(exitOutcomeCode({ matchUpStatusCode: 'OA' })).toEqual('OA');
+
+  // an object with nothing to say contributes nothing, rather than a walkover
+  expect(exitOutcomeCode({ sideNumber: 1 })).toEqual('');
+  expect(exitOutcomeCode(undefined)).toEqual('');
+});

--- a/src/tests/testHarness/exitPropagation/transitions.ts
+++ b/src/tests/testHarness/exitPropagation/transitions.ts
@@ -111,6 +111,10 @@ export function projectDraw(drawDefinition: any): any {
           matchUp.winningSide ?? null,
           canonicalDrawPositions(matchUp.drawPositions),
           blankToNull(matchUp.matchUpStatusCodes),
+          // sideExitProvenance is projected too: a field the projection cannot see is a field the
+          // properties cannot police, and an unobserved addition would look residue-free while
+          // leaving state behind on every unwind.
+          blankToNull(matchUp.sideExitProvenance),
           blankToNull(matchUp.score),
         ]),
       });

--- a/src/tests/testHarness/statusCodes/productionVocabulary.ts
+++ b/src/tests/testHarness/statusCodes/productionVocabulary.ts
@@ -1,0 +1,221 @@
+/**
+ * A deployed production `matchUpStatusCode` vocabulary — 29 codes across 5 populated categories.
+ *
+ * Captured 2026-09-11 from a deployed consumer's client bundle, where it drives their scoring modal.
+ * It is substantially richer than `POLICY_SCORING_USTA`, which carries a handful of codes in a flat
+ * map keyed by matchUpStatus: this has four fields per entry and a two-level category grouping.
+ *
+ * WHY IT IS HERE. These codes travel on `matchUp.matchUpStatusCodes`, the array that also carries
+ * propagation provenance and `{ code }` wrappers. A coercion in `progressExitStatus` used to rewrite
+ * EVERY object element of that array to `OUTCOME_WALKOVER` and persist the result — and
+ * `updateMatchUpStatusCodes` wraps string codes as `{ code }` before stamping provenance on them, so
+ * a real code could reach that coercion as an object and be relabelled. Recording `DQ`
+ * (disqualification) or `WD.WD` (double withdrawal) as a walkover is a records problem, not a
+ * cosmetic one.
+ *
+ * The tests consuming this assert that EVERY code survives EVERY shape it can legitimately take.
+ * Adding a code here extends that coverage automatically.
+ */
+const DEFAULTS = 'Defaults';
+const ILLNESS = 'Illness';
+const INJURY = 'Injury';
+const OTHER = 'Other';
+const PERSONAL_CIRCUMSTANCE = 'Personal circumstance';
+const RETIREMENTS = 'Retirements';
+const WALKOVERS = 'Walkovers';
+const WITHDRAWALS = 'Withdrawals';
+
+export type ProductionStatusCode = {
+  category: string;
+  code: string;
+  display: string;
+  label: string;
+};
+
+export const PRODUCTION_STATUS_CODES: ProductionStatusCode[] = [
+  {
+    category: WALKOVERS,
+    code: 'W1',
+    display: 'Wo [inj]',
+    label: INJURY,
+  },
+  {
+    category: WALKOVERS,
+    code: 'W2',
+    display: 'Wo [ill]',
+    label: ILLNESS,
+  },
+  {
+    category: WALKOVERS,
+    code: 'W3',
+    display: 'Wo [pc]',
+    label: PERSONAL_CIRCUMSTANCE,
+  },
+  {
+    category: WALKOVERS,
+    code: 'W4',
+    display: 'Wo [Tae]',
+    label: 'Tournament Administrative Error',
+  },
+  {
+    category: WALKOVERS,
+    code: 'W5',
+    display: 'Wo/Withdrawn',
+    label: 'Withdrawn',
+  },
+  {
+    category: WALKOVERS,
+    code: 'WOWO',
+    display: 'Wo/Wo',
+    label: 'Double walkover',
+  },
+  {
+    category: DEFAULTS,
+    code: 'D4',
+    display: 'Def [refsl]',
+    label:
+      'Refusal to start match for reason other than adult discipline, injury, illness, or personal circumstance. (After the Referee has conclusively confirmed that a player refuses to play a match, the Referee need not wait until the scheduled time of the match to records the result.)',
+  },
+  {
+    category: DEFAULTS,
+    code: 'D5',
+    display: 'Def [ad]',
+    label: 'Failure to start match because of adult discipline',
+  },
+  {
+    category: DEFAULTS,
+    code: 'D6',
+    display: 'Def [ns]',
+    label: 'Not showing up',
+  },
+  {
+    category: DEFAULTS,
+    code: 'D7',
+    display: 'Score + Def [late]',
+    label:
+      'Lateness for match including, but not limited to, intending to play but mistakenly arriving at the wrong time, location, or without proper equipment',
+  },
+  {
+    category: DEFAULTS,
+    code: 'D9',
+    display: 'Def [refsl]',
+    label:
+      'Refusal to continue playing a match for reason other than injury, illness, personal circumstance, or adult discipline',
+  },
+  {
+    category: DEFAULTS,
+    code: 'DD',
+    display: 'Def/Def',
+    label: 'Double default',
+  },
+  {
+    category: DEFAULTS,
+    code: 'DI',
+    display: 'Def [med]',
+    label: 'Default for receiving an injection, IV, or supplemental oxygen',
+  },
+  {
+    category: DEFAULTS,
+    code: 'DM',
+    display: 'Def [cond]',
+    label: 'Misconduct before or between matches',
+  },
+  {
+    category: DEFAULTS,
+    code: 'DP',
+    display: 'Def [pps]',
+    label: 'Default under Point Penalty System',
+  },
+  {
+    category: DEFAULTS,
+    code: 'DQ',
+    display: 'Def [dq]',
+    label: 'Disqualification for cause or ineligibility',
+  },
+  {
+    category: RETIREMENTS,
+    code: 'RC',
+    display: 'Ret [pc]',
+    label: PERSONAL_CIRCUMSTANCE,
+  },
+  {
+    category: RETIREMENTS,
+    code: 'RD',
+    display: 'Ret [ad]',
+    label: 'Retirement because of adult discipline',
+  },
+  {
+    category: RETIREMENTS,
+    code: 'RI',
+    display: 'Ret [ill]',
+    label: ILLNESS,
+  },
+  {
+    category: RETIREMENTS,
+    code: 'RJ',
+    display: 'Ret [inj]',
+    label: INJURY,
+  },
+  {
+    category: RETIREMENTS,
+    code: 'RU',
+    display: 'Ret [elg]',
+    label:
+      'A player who retires from a match remains eligible for consolations, place playoffs, doubles and subsequent round robin matches',
+  },
+  {
+    category: OTHER,
+    code: 'OA',
+    display: 'Abandoned',
+    label: 'Abandoned match',
+  },
+  {
+    category: OTHER,
+    code: 'OC',
+    display: 'Unplayed or Cancelled',
+    label: 'Cancelled match',
+  },
+  {
+    category: OTHER,
+    code: 'OI',
+    display: 'Incomplete',
+    label: 'Incomplete match',
+  },
+  {
+    category: WITHDRAWALS,
+    code: 'WD.ILL',
+    display: 'Wd [ill]',
+    label: ILLNESS,
+  },
+  {
+    category: WITHDRAWALS,
+    code: 'WD.INJ',
+    display: 'Wd [inj]',
+    label: INJURY,
+  },
+  {
+    category: WITHDRAWALS,
+    code: 'WD.PC',
+    display: 'Wd [pc]',
+    label: PERSONAL_CIRCUMSTANCE,
+  },
+  {
+    category: WITHDRAWALS,
+    code: 'WD.TAE',
+    display: 'Wd [Tae]',
+    label: 'Tournament Administrative Error',
+  },
+  {
+    category: WITHDRAWALS,
+    code: 'WD.WD',
+    display: 'Wd/Wd',
+    label: 'Double withdrawal',
+  },
+];
+
+/** Codes grouped by the category the scoring modal files them under. */
+export const PRODUCTION_STATUS_CODES_BY_CATEGORY: Record<string, ProductionStatusCode[]> =
+  PRODUCTION_STATUS_CODES.reduce((grouped: Record<string, ProductionStatusCode[]>, entry) => {
+    (grouped[entry.category] ??= []).push(entry);
+    return grouped;
+  }, {});

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -687,6 +687,28 @@ export interface ScheduleScenario {
   placements: ScenarioPlacement[];
 }
 
+/**
+ * Why an exit sits on one side of a matchUp, recorded per side.
+ *
+ * `matchUpStatusCodes` conflated unrelated things: the scoring policy's code vocabulary, propagation
+ * provenance stamped per side, and codes wrapped as `{ code }`. The provenance moves here, where
+ * `sideNumber` is a KEY rather than an array index, the element shape is fixed, and
+ * `sourceMatchUpId` makes an entry attributable to the exit that produced it.
+ *
+ * See Mentat/planning/MATCHUP_STATUS_CODES_PER_SIDE.md.
+ */
+export type SideExitProvenanceEntry = {
+  /** the status this side was given as a result of the upstream exit, e.g. WALKOVER / DEFAULTED */
+  matchUpStatus?: MatchUpStatusUnion;
+  /** the upstream status that produced it, e.g. DOUBLE_WALKOVER / DOUBLE_DEFAULT / BYE */
+  previousMatchUpStatus?: MatchUpStatusUnion;
+  /** the matchUp whose exit produced this entry; the identity the unwind lacks today */
+  sourceMatchUpId?: string;
+};
+
+/** Keyed by sideNumber (1 | 2). Serialises as `{ "1": {...}, "2": {...} }`. */
+export type SideExitProvenance = Record<number, SideExitProvenanceEntry>;
+
 export interface MatchUp {
   collectionId?: string;
   collectionPosition?: number;
@@ -718,6 +740,9 @@ export interface MatchUp {
   // CODES first-class: previously stored as schedule-related timeItems
   schedule?: MatchUpSchedule;
   score?: Score;
+  // CODES first-class: per-side provenance for an exit PRODUCED by propagation.
+  // Keyed by sideNumber, so there is no positional padding and no polymorphism.
+  sideExitProvenance?: SideExitProvenance;
   sides?: Side[];
   startDate?: string;
   surfaceCategory?: SurfaceCategoryUnion;


### PR DESCRIPTION
## The problem

`matchUpStatusCodes` is an `any[]` carrying **three** unrelated element shapes:

| # | shape | written by |
|---|---|---|
| 1 | `{ matchUpStatusCode, label, matchUpStatusCodeDisplay }` | the scoring policy vocabulary |
| 2 | `{ matchUpStatus, previousMatchUpStatus, sideNumber }` | `doubleExitAdvancement.buildMatchUpStatusCodes` |
| 3 | `{ code }` | `updateMatchUpStatusCodes`, wrapping a string element |

Provenance (shape 2) is **positional** there — a side is an array INDEX, padded with `''` — so it
cannot be addressed, cannot be attributed to the exit that produced it, and is flattened by every
reader that assumes a string.

## The field

`matchUp.sideExitProvenance`, keyed by `sideNumber`, one fixed shape, carrying `sourceMatchUpId`:

```ts
{ 1: { matchUpStatus: WALKOVER, previousMatchUpStatus: DOUBLE_WALKOVER, sourceMatchUpId: '…' } }
```

Written **alongside** the legacy array, never instead of it — a pure addition. Reads go through one
native-first helper, so `getStructureInconsistencies` and `getDrawInconsistencies` now take the
matchUp rather than the array.

Native writes are gated on `writeNativeEnabled()`. **The clear is deliberately NOT gated**: the write
mode decides whether the field is *written*, and must never decide whether stale state is *removed*.

### Deviation from plan, deliberate

The plan called for a `BRIDGE` default. The global `schemaWriteMode` default is **NATIVE**, so gating
the legacy write on `writeLegacyEnabled()` would stop writing `matchUpStatusCodes` immediately —
breaking. Retiring the legacy write stays a major-version step.

## The coercion fix

`progressExitStatus` mapped **every** object element to `OUTCOME_WALKOVER` and persisted the result
(`statusCodes` is written back to the matchUp). Measured over 120 randomized sweep scenarios: of the
**50** provenance elements reaching it, **13 were BYE and 9 DEFAULTED** — 44% were not walkovers.

`exitOutcomeCode` now maps each element to its own outcome code, and a **BYE contributes no code**
rather than becoming a walkover.

### Why nothing caught it

The only oracle exercising that path is a `DOUBLE_WALKOVER`/`DOUBLE_DEFAULT` **parity** test that
rewrites `"DEFAULTED"`→`"WALKOVER"` and `"DEF"`→`"WO"` before comparing. A bug forcing exactly that
convergence is invisible to it. The BYE case is not in the rename pair at all.

Worse, `propagateExitStatus.test.ts` **asserted the defect**: `['WO', 'DM']` for a scenario whose own
name is *"propagate a **default**"*, from a `DOUBLE_DEFAULT` source. Corrected to `['DEF', 'DM']`
with the reasoning in the test.

## The projection was blind — the part worth reviewing hardest

After wiring the field the properties matrix read **144/0**. That was meaningless: `projectDraw`
whitelists six matchUp attributes and `sideExitProvenance` was not among them, so the property could
not see the field being added.

Projected, the matrix went to **44 failures** — provenance survived the unwind. Fixed by clearing it
at all five blanking sites (`toBePlayed`, `attemptToSetMatchUpStatusBYE`, `positionClear`, and the
`modifyMatchUpScore` funnel). Back to **144/0, now genuinely observed**.

The parity oracle also needed `matchUpId` relabelling — `sourceMatchUpId` differs per run, so ~40
cells differed on identity alone. It already relabels participantIds for the same reason.

## Scope

- The four quarantined `DO_UNDO_IDENTITY` cells are **untouched**. The field supplies the identity the
  unwind lacked; a retention rule is not attempted here.
- `progressExitStatus` RULE 4 still hardcodes `DOUBLE_WALKOVER` as the *status*. This change makes the
  **code** stop lying; the status half is separate.
- Drive-by: removes a shipped `console.log('!!!!!')` from `modifyMatchUpScore`. Unreached — zero hits
  across two full-suite runs.

## Gate

`pnpm verify` exit 0 — **12,868 passed / 2 skipped**, coverage thresholds met, build and
published-`.d.ts` pack smoke OK. 7 new tests.