### PR TITLE
feat(scoring): export the episode + points-to types, and document what renders them

### DIFF
--- a/documentation/docs/governors/score-governor.md
+++ b/documentation/docs/governors/score-governor.md
@@ -77,6 +77,89 @@ console.log(analysis.isComplete); // boolean
 
 ---
 
+## calculatePointsTo
+
+How many points each side still needs, at the current score.
+
+**Takes positional arguments**, not a params object — it predates the destructured convention and
+`scoreGovernor` re-exports it unchanged. Calling it through an engine (`engine.calculatePointsTo({…})`)
+passes the params object as `matchUp` and yields nothing useful; import the governor instead.
+
+```js
+import { scoreGovernor } from 'tods-competition-factory';
+
+const formatStructure = scoreGovernor.parseMatchUpFormat('SET3-S:6/TB7');
+
+const needed = scoreGovernor.calculatePointsTo(
+  matchUp, // ScoringEngine.getState() — reads `matchUp.score.sets`
+  formatStructure,
+  'standard', // 'standard' | 'tiebreakOnly' | 'matchTiebreak' | 'timed'
+  formatStructure.setFormat,
+  0, // server: 0 | 1 | undefined
+);
+```
+
+Returns **`PointsToDecoration | undefined`** — a published type, so a consumer should import it
+rather than redeclare the shape:
+
+```ts
+import type { PointsToDecoration } from 'tods-competition-factory';
+```
+
+| field | meaning |
+| ----- | ------- |
+| `pointsToGame` | `[number, number]` — minimum points each side needs to win the current game |
+| `pointsToSet` | `[number, number]` — minimum points each side needs to win the current set |
+| `pointsToMatch` | `[number, number]` — minimum points each side needs to win the match |
+| `gamesToSet` | `[number, number]` — games each side needs to win the current set |
+| `isBreakpoint` | `boolean` — the receiver is one point from winning the game |
+
+"Minimum" assumes the side wins every subsequent point.
+
+`undefined` is returned for a **timed** set and when `activeSetFormat` is absent — neither has a
+point structure to count against. That is a legitimate answer, not a failure.
+
+**Most callers do not need this function directly.** `ScoringEngine.getEpisodes()` already runs it
+per point and exposes the result as `episode.needed` — see
+[getEpisodes](#getepisodes-and-episodeneeded) below.
+
+---
+
+## inferServeSide
+
+Which court side the serve comes from, at the current score. Also positional.
+
+```js
+const side = scoreGovernor.inferServeSide(matchUp, formatStructure, 'standard');
+// 'deuce' | 'ad' | undefined
+```
+
+The rule is parity, and what is counted depends on the format: total points in the game for standard
+tennis, aggregate score for aggregate formats such as INTENNSE, total tiebreak points inside a
+tiebreak. A **timed** set returns `undefined` — there is no countable point structure to take a
+parity of.
+
+---
+
+## getEpisodes and EpisodeNeeded
+
+`ScoringEngine.getEpisodes()` returns one `Episode` per point, enriched with game, set and match
+context. **`episode.needed` is `calculatePointsTo`'s output**, computed per point:
+
+```js
+const engine = new scoreGovernor.ScoringEngine({ matchUpFormat: 'SET3-S:6/TB7' });
+engine.addPoint({ winner: 0 });
+
+const episodes = engine.getEpisodes();
+episodes[0].needed; // { pointsToGame, pointsToSet, pointsToMatch, gamesToSet }
+```
+
+`Episode`, `EpisodeNeeded` and `EpisodePoint` are all published types. **This is the contract a
+points-to visualization should build against** — a renderer plotting "points needed to win the set"
+is plotting `episode.needed.pointsToSet`.
+
+---
+
 ## checkScoreHasValue
 
 Checks if a score object contains any actual scoring data.

--- a/documentation/docs/scoring-engine/visualization-applications.md
+++ b/documentation/docs/scoring-engine/visualization-applications.md
@@ -36,6 +36,26 @@ Episodes are the primary data source for building point-by-point visualizations.
 
 The ScoringEngine enables several categories of match visualization:
 
+### Points Needed — use `episode.needed`, do not recompute it
+
+`getEpisodes()` already carries, per point, how many points each side needs to win the current game,
+set and match. A chart plotting "points to win the set" is plotting `episode.needed.pointsToSet`.
+
+```js
+const episodes = engine.getEpisodes();
+const pointsToSet = episodes.map((episode) => episode.needed.pointsToSet); // [number, number][]
+```
+
+`Episode`, `EpisodeNeeded` and `PointsToDecoration` are **published types**. Import them rather than
+redeclaring the shape locally — a redeclared copy cannot be told when the factory's gains a field,
+and `pointsToMatch` is the one most often missing from hand-written copies:
+
+```ts
+import type { Episode, EpisodeNeeded } from 'tods-competition-factory';
+```
+
+→ [calculatePointsTo](../governors/score-governor#calculatepointsto), which computes it.
+
 ### Point Progression
 
 Visualize the flow of a match as a tree or Sankey diagram showing probability at each branching point. Each node represents a score state, and branches show outcomes.

--- a/scripts/verify/fixtures/pack-test/smoke.ts
+++ b/scripts/verify/fixtures/pack-test/smoke.ts
@@ -7,6 +7,15 @@
  * published artifact — caught here, before users hit it.
  */
 
+import type {
+  Episode,
+  EpisodeGame,
+  EpisodeNeeded,
+  EpisodePoint,
+  EpisodeSet,
+  PointsToDecoration,
+} from 'tods-competition-factory';
+
 import {
   tournamentEngine,
   syncEngine,
@@ -114,5 +123,27 @@ void forge;
 void factoryConstants;
 void topicConstants;
 void factoryVersion;
+
+// --- scoring types a visualization consumer imports ---
+//
+// These are declared deep in the tree and were reachable only through the `scoreGovernor` namespace,
+// which cannot be used in a named type import. `scoringVisualizations` redeclared the Episode shape
+// locally for exactly that reason and the copy drifted. Asserting them HERE — against the installed
+// tarball, under `moduleResolution: bundler`, which is what that consumer uses — is the only check
+// that reproduces how a consumer actually resolves them.
+type SmokeNeeded = EpisodeNeeded;
+type SmokeEpisode = Episode;
+type SmokeGame = EpisodeGame;
+type SmokeSet = EpisodeSet;
+type SmokePoint = EpisodePoint;
+type SmokePointsTo = PointsToDecoration;
+
+// `needed` on an Episode must BE the EpisodeNeeded type, not a look-alike.
+const neededIsEpisodeNeeded: SmokeNeeded = {} as SmokeEpisode['needed'];
+// `pointsToMatch` is the field a hand-written copy of this shape kept missing.
+const carriesPointsToMatch: SmokePointsTo['pointsToMatch'] = [0, 0];
+
+export type { SmokeGame, SmokeSet, SmokePoint };
+export { neededIsEpisodeNeeded, carriesPointsToMatch };
 
 console.log('verify:pack — smoke imports compiled');

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,5 +148,17 @@ export * from './types/enumExports';
 
 // Statistics types (top-level convenience re-exports)
 export type { StatObject, MatchStatistics, StatCounters, StatisticsOptions } from './query/scoring/statistics/types';
+
+// Episode + points-to types (top-level convenience re-exports).
+//
+// These were reachable only through the `scoreGovernor` namespace, which a consumer cannot use in a
+// named type import — so `import type { EpisodeNeeded } from 'tods-competition-factory'` failed while
+// `StatObject` (re-exported above) succeeded. scoringVisualizations redeclared the Episode shape
+// locally for exactly that reason, and the copy drifted: it has no `pointsToMatch`.
+//
+// `episode.needed` is what a points-to visualization renders, so the type it renders against has to
+// be importable.
+export type { Episode, EpisodeGame, EpisodeNeeded, EpisodePoint, EpisodeSet } from './types/scoring/types';
+export type { PointsToDecoration } from './mutate/scoring/pointsToCalculator';
 export { toStatObjects } from './query/scoring/statistics/toStatObjects';
 export { calculateMatchStatistics } from './query/scoring/statistics/standalone';


### PR DESCRIPTION
`ptsChart` in `scoringVisualizations` renders `episode.needed.pointsToSet`. That shape is the factory's — `calculatePointsTo` produces it, the ScoringEngine stamps it on each point, `getEpisodes` surfaces it as `Episode.needed`. The consumer nonetheless declares its own copy, and the copy **drifted**: it never carried `pointsToMatch`, so no chart there can plot points-to-match without someone first noticing the field exists.

## The reason it redeclared is the bug

Six types were reachable **only through the `scoreGovernor` namespace**, which cannot be used in a named type import. The compiler says it plainly once you ask:

```text
TS2459: Module 'tods-competition-factory' declares 'Episode' locally, but it is not exported.
```

`StatObject` doesn't have this problem because it already has an explicit top-level re-export (`index.ts:150`). `Episode`, `EpisodeGame`, `EpisodeNeeded`, `EpisodePoint`, `EpisodeSet` and `PointsToDecoration` now get the same treatment.

Additive — `verify:surface` reports no removals.

## Verified against the packed tarball, not the source tree

`verify:pack` installs the `.tgz` into a fixture and type-checks under **`moduleResolution: bundler`** — the same setting `scoringVisualizations` uses — so it reproduces how a consumer actually resolves these. The smoke now asserts:

- all six imports resolve
- `Episode['needed']` **is** `EpisodeNeeded`, not a structural look-alike
- `pointsToMatch` is reachable (the field the hand-written copy kept missing)

The new assertions avoid the `void` operator the standards ban, unlike the fixture's existing lines.

**Falsified** by deleting the re-exports: `verify:pack` fails with `TS2459` on all six, naming the exact defect.

## A detour worth recording

A worktree symlink is **not** a valid test bed for this. Resolving into a factory git worktree from a sibling repo fails for **every** type in the bundled export block — including long-standing ones like `DrawDefinition` — while the same import resolves fine against the shared checkout.

I proved my change wasn't the cause by reverting it, rebuilding to a byte-equivalent 395-name block, and watching `DrawDefinition` still fail. I spent a long time treating that as a packaging bug before testing the artifact instead. `verify:pack` is the right gate precisely because it tests what ships.

## Documentation

`calculatePointsTo`, `inferServeSide` and `getEpisodes` / `EpisodeNeeded` had **zero** documentation across `documentation/docs`. A consumer cannot import a type they have no way to learn exists — that is the root cause of the duplication, not carelessness downstream.

**`governors/score-governor.md`** now documents all three, including:

- both functions take **positional** arguments — calling them through an engine passes the params object as `matchUp` and yields nothing useful
- `undefined` for a timed set is a legitimate answer, not a failure
- most callers want `episode.needed`, not the function

**`scoring-engine/visualization-applications.md`** says it plainly: use `episode.needed`, don't recompute it, and import the types rather than redeclaring them.

## Verification

- `pnpm verify` — all 18 steps, **exit 0**, including the new `verify:migration-coverage`
- `lint:md` clean; docs build clean; the five new cross-links resolved against generated HTML

## Follow-on, not in this PR

`scoringVisualizations` still redeclares the shape and defaults absent fields to `[0, 0]` — which does not mean "unknown", it means "already won". That fix is prepared but **cannot be verified until this lands**, for the worktree-resolution reason above. It also won't be published until the factory publishes.