### PR TITLE
fix(codes): clear exit provenance wherever the codes it describes are blanked

### DIFF
--- a/src/mutate/matchUps/drawPositions/assignMatchUpDrawPosition.ts
+++ b/src/mutate/matchUps/drawPositions/assignMatchUpDrawPosition.ts
@@ -3,6 +3,7 @@ import { getUpdatedDrawPositions } from '@Mutate/drawDefinitions/matchUpGovernor
 import { updateMatchUpStatusCodes } from '@Mutate/drawDefinitions/matchUpGovernor/matchUpStatusCodes';
 import { getExitWinningSide } from '@Mutate/drawDefinitions/matchUpGovernor/getExitWinningSide';
 import { getMappedStructureMatchUps, getMatchUpsMap } from '@Query/matchUps/getMatchUpsMap';
+import { clearSideExitProvenance } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
 import { getPositionAssignments } from '@Query/drawDefinition/positionsGetter';
 import { getInitialRoundNumber } from '@Query/matchUps/getInitialRoundNumber';
 import { updateSideLineUp } from '@Mutate/matchUps/lineUps/updateSideLineUp';
@@ -324,6 +325,8 @@ function applyPositionToMatchUp({
       matchUpStatusCodes[exitSideNumber - 1] = carriedCode;
     }
     matchUp.matchUpStatusCodes = matchUpStatusCodes;
+    // nothing carried means the exit this matchUp recorded is gone; its provenance goes with it
+    if (!matchUpStatusCodes.length) clearSideExitProvenance(matchUp);
   } else if (matchUp?.matchUpStatusCodes) {
     updateMatchUpStatusCodes({
       inContextDrawMatchUps: refreshedMatchUps,

--- a/src/mutate/matchUps/drawPositions/removeDirectedParticipants.ts
+++ b/src/mutate/matchUps/drawPositions/removeDirectedParticipants.ts
@@ -1,4 +1,5 @@
 import { includesMatchUpStatuses } from '@Mutate/drawDefinitions/matchUpGovernor/includesMatchUpStatuses';
+import { clearSideExitProvenance } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
 import { removeSubsequentRoundsParticipant } from './removeSubsequentRoundsParticipant';
 import { structureAssignedDrawPositions } from '@Query/drawDefinition/positionsGetter';
 import { updateTieMatchUpScore } from '@Mutate/matchUps/score/updateTieMatchUpScore';
@@ -320,6 +321,10 @@ function removeDirectedLoser({
     //In case the loser matchup was not a double WO we jsut remove the status codes.
     const targetMatchUp = matchUpsMap?.drawMatchUps?.find(({ matchUpId }) => matchUpId === loserMatchUp.matchUpId);
     targetMatchUp.matchUpStatusCodes = sourceMatchUpStatus === DOUBLE_WALKOVER ? ['WO', 'WO'] : [];
+    // the codes here are rewritten wholesale for the exit that remains, so any provenance stamped
+    // for the exit being removed is stale. Provenance and codes describe the same exit; they die
+    // together or the matchUp keeps a reason for something that no longer exists.
+    clearSideExitProvenance(targetMatchUp);
   }
 
   // remove participant from seedAssignments

--- a/src/tests/testHarness/exitPropagation/invariants.ts
+++ b/src/tests/testHarness/exitPropagation/invariants.ts
@@ -39,6 +39,19 @@ function matchUpInvariants(matchUp: any): InvariantViolation[] {
   const { matchUpStatus, matchUpId, winningSide, score } = matchUp;
   const record = (rule: string, detail: string) => violations.push({ rule, matchUpId, detail });
 
+  // Provenance and the legacy codes describe the SAME exit, so they must live and die together.
+  // Every site that blanks `matchUpStatusCodes` is unwinding the exit those codes described; if
+  // provenance survives that, the matchUp keeps a reason for an exit that no longer exists — a
+  // do/undo residue that the projection would otherwise only catch in the cells it happens to reach.
+  const codes = matchUp.matchUpStatusCodes;
+  const provenance = matchUp.sideExitProvenance;
+  if (provenance && Object.keys(provenance).length && Array.isArray(codes) && !codes.length) {
+    record(
+      'PROVENANCE_OUTLIVES_CODES',
+      `sideExitProvenance ${JSON.stringify(provenance)} survives an emptied matchUpStatusCodes`,
+    );
+  }
+
   if (winningSide !== undefined && winningSide !== null && ![1, 2].includes(winningSide)) {
     record('WINNING_SIDE_DOMAIN', `winningSide is ${JSON.stringify(winningSide)}, expected 1, 2 or absent`);
   }


### PR DESCRIPTION
## A correction to #4810

That PR's description claimed provenance is cleared at **all five** blanking sites. **It was
overstated.** Two sites blank `matchUpStatusCodes` and never touch `sideExitProvenance`:

- `removeDirectedParticipants.ts` — rewrites the codes wholesale (`['WO','WO']` or `[]`)
- `assignMatchUpDrawPosition.ts` — the carry branch assigns `[]` when nothing is carried

Provenance and the codes describe the **same exit**. If provenance survives, the matchUp keeps a
reason for an exit that no longer exists — exactly the do/undo residue the field exists to avoid.

## Measured before fixing

A new harness invariant, `PROVENANCE_OUTLIVES_CODES`, asserts the two live and die together — and
was **validated to fire** before its silence was trusted:

| check | result |
|---|---|
| fires on a hand-built violation | **yes** |
| stays silent on the valid case | yes |
| 144-cell properties matrix + 1,017 exit-propagation tests | **0 violations** |
| 250 randomized sweep scenarios (44 findings) | **0 violations** |

So the asymmetry is **real in code but not demonstrably reachable**. Both sites clear anyway, because
removing stale state is unconditionally correct — unlike guessing at behaviour, which this codebase
has been punished for. The invariant means a regression is caught by a stated rule rather than by the
projection happening to reach the right cell.

## Why an invariant rather than only a fix

The property projection only sees what it whitelists. `sideExitProvenance` was invisible to it until
#4810 added it, and the matrix read a meaningless 144/0 in the meantime. An invariant states the
relationship directly, so it does not depend on a cell being reached.

## Scope

This does **not** address the larger direction CA set: propagation should stop being built on the
legacy `matchUpStatusCodes` array at all — `removeDirectedParticipants` writes a hardcoded positional
`['WO','WO']`, and `exitOutcomeCode` parses the polymorphic array to decide what to write back. Both
are transitional. The destination is propagation reading and writing provenance, with the codes array
generated as a projection. Recorded in `Mentat/planning/MATCHUP_STATUS_CODES_PER_SIDE.md`.

## Gate

`pnpm verify` exit 0 — **12,941 passed / 2 skipped**, coverage thresholds met, build and
published-`.d.ts` pack smoke OK.