### PR TITLE
fix(logging): keep syncGlobalState on console, it closed a module cycle

### DIFF
--- a/src/global/state/syncGlobalState.ts
+++ b/src/global/state/syncGlobalState.ts
@@ -1,4 +1,3 @@
-import { pushGlobalLog } from '@Functions/global/globalLog';
 import { preserveNoticeIdentity } from './noticeIdentity';
 import {
   CallListenerArgs,
@@ -225,8 +224,12 @@ export function handleCaughtError({ engineName, methodName, params, err }: Handl
     error = err.message;
   }
 
-  pushGlobalLog({
-    method: 'syncGlobalState',
+  // Engine-level error sink, like globalState's own. It must NOT route through pushGlobalLog:
+  // globalLog imports getDevContext from globalState, and globalState imports THIS module, so that
+  // edge closes a cycle (globalState -> syncGlobalState -> globalLog -> globalState) which rollup
+  // reports on every build.
+  // eslint-disable-next-line no-console
+  console.log('ERROR', {
     tournamentId: getTournamentId(),
     params: JSON.stringify(params),
     engine: engineName,


### PR DESCRIPTION
## A regression I introduced in #4813

`pnpm build` on master reports:

```
(!) Circular dependency
src/global/state/globalState.ts -> src/global/state/syncGlobalState.ts
  -> src/functions/global/globalLog.ts -> src/global/state/globalState.ts
```

The `syncGlobalState -> globalLog` edge is **new and mine**. #4813 converted that file's error sink
from `console.log` to `pushGlobalLog`; `globalLog` already imported `getDevContext` from
`globalState`, and `globalState` imports `syncGlobalState` — so the conversion closed the triangle.

Verified new rather than assumed: the file at `785d7e559~1` has no `globalLog` import.

## Why reverting this one call is the principled fix

`syncGlobalState` is the **sync counterpart of `globalState`**, which the `no-console` allowlist
already covers as *"the default log sink, and the fallback when a custom sink throws."* This is the
same engine-level error sink, one module over. It belongs in the same category, and the cycle is the
evidence: a logging sink that the logging module transitively depends on cannot route through it.

Every other conversion from the sweep stands — this is one call site, not a retreat from the change.

The reasoning is recorded in the source so the next person does not "fix" it back:

```ts
// Engine-level error sink, like globalState's own. It must NOT route through pushGlobalLog:
// globalLog imports getDevContext from globalState, and globalState imports THIS module, so that
// edge closes a cycle (globalState -> syncGlobalState -> globalLog -> globalState) which rollup
// reports on every build.
```

## Gate

`pnpm build` now reports **0 circular dependencies** (was 1, twice — once per output format).
`pnpm verify` exit 0 — **12,941 passed / 2 skipped**, coverage thresholds met, pack smoke OK.