### PR TITLE
docs(site): the tests stat reads 13,000+

### DIFF
--- a/documentation/src/pages/index.js
+++ b/documentation/src/pages/index.js
@@ -39,13 +39,13 @@ const features = [
       </svg>
     ),
     description:
-      'Written in 100% TypeScript with a Test Driven Development process. Over 5,000 tests across 600+ test files cover more than 96% of the codebase.',
+      'Written in 100% TypeScript with a Test Driven Development process. Over 13,000 tests across 1,200+ test files cover more than 97% of the lines in the codebase.',
   },
 ];
 
 const stats = [
-  { number: '10,000+', label: 'Tests' },
-  { number: '96%', label: 'Coverage' },
+  { number: '13,000+', label: 'Tests' },
+  { number: '97%', label: 'Line Coverage' },
   { number: '100%', label: 'TypeScript' },
   { number: '0', label: 'Runtime Deps' },
 ];


### PR DESCRIPTION
The landing page stated **two different test counts**: 5,000 in the feature prose and 10,000+ in the
stat tile. Both now read 13,000+, and test files go from 600+ to 1,200+.

## Counts are rounded up deliberately

Per CA: the suite is at **12,943 tests across 1,159 files** today and will pass both marks before
7.0.0 ships.

| | before | after | actual today |
|---|---|---|---|
| tests (prose) | Over 5,000 | **Over 13,000** | 12,943 |
| tests (tile) | 10,000+ | **13,000+** | 12,943 |
| test files | 600+ | **1,200+** | 1,159 |

## Coverage is NOT rounded up — and that is a deliberate difference

The same logic does not transfer, because that number does not move the same way. Measured today:

| axis | actual |
|---|---|
| lines | **97.82%** |
| statements | 95.35% |
| functions | 98.12% |
| **branches** | **87.32%** |

An unqualified *"more than 96% of the codebase"* is false on two of four axes — and unlike the test
counts it would **stay** false: the enforced branch threshold is 85%, so branches are not climbing to
96%. Rounding up there would publish a claim that never comes true.

So both the prose and the tile now name the axis they measure:

- prose: *"cover more than **97% of the lines** in the codebase"*
- tile: **97% / Line Coverage** (was 96% / Coverage)

That is the strongest honest number on the page — 97.82% is the best of the four axes, and saying
which axis it is makes it defensible rather than approximate.

Shout if you would rather the tile stayed a single unqualified "Coverage" figure; 95% would be true
of three axes out of four, but still not branches.