### PR TITLE
fix(codes): record exit provenance when an exit is carried into a fed matchUp

### DIFF
--- a/src/mutate/matchUps/drawPositions/directParticipants.ts
+++ b/src/mutate/matchUps/drawPositions/directParticipants.ts
@@ -196,8 +196,9 @@ function processDrawPositionDirecting({
     });
     if (result.context?.progressExitStatus) {
       Object.assign(context, result.context, {
-        sourceMatchUpStatus: sourceStatus,
         sourceMatchUpStatusCodes: matchUpStatusCodes ?? [],
+        sourceMatchUpStatus: sourceStatus,
+        sourceMatchUpId: matchUpId,
         loserMatchUp,
         matchUpsMap,
       });

--- a/src/mutate/matchUps/drawPositions/progressExitStatus.ts
+++ b/src/mutate/matchUps/drawPositions/progressExitStatus.ts
@@ -1,13 +1,18 @@
 import { setMatchUpState } from '@Mutate/matchUps/matchUpStatus/setMatchUpState';
 import { decorateResult } from '@Functions/global/decorateResult';
 import { getAllDrawMatchUps } from '@Query/matchUps/drawMatchUps';
+import { getMatchUpsMap } from '@Query/matchUps/getMatchUpsMap';
 import { pushGlobalLog } from '@Functions/global/globalLog';
 import { isExit } from '@Validators/isExit';
+import {
+  buildCarriedExitProvenance,
+  mergeSideExitProvenance,
+  exitOutcomeCode,
+} from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
 
 // constants
 import { DOUBLE_WALKOVER, RETIRED, WALKOVER } from '@Constants/matchUpStatusConstants';
 import { MISSING_MATCHUP } from '@Constants/errorConditionConstants';
-import { exitOutcomeCode } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
 import { SUCCESS } from '@Constants/resultConstants';
 
 // matchUpStatusCodes are position-dependent: index 0 maps to side 1, index 1 to
@@ -41,6 +46,7 @@ export function progressExitStatus({
   propagateExitStatus,
   sourceMatchUpStatus,
   loserParticipantId,
+  sourceMatchUpId,
   tournamentRecord,
   drawDefinition,
   loserMatchUp,
@@ -83,6 +89,10 @@ export function progressExitStatus({
 
   let loserMatchUpStatus = carryOverMatchUpStatus;
   let winningSide: number | undefined = undefined;
+  // CODES first-class: the side that EXITED, attributed to the matchUp whose result produced the
+  // exit. Written alongside the legacy string codes, exactly as doubleExitAdvancement does — see
+  // sideExitProvenance.ts on why the legacy write is not yet gated.
+  let exitProvenance;
 
   if (loserParticipantSide?.sideNumber) {
     const opponentSideNumber = loserParticipantSide.sideNumber === 1 ? 2 : 1;
@@ -108,6 +118,17 @@ export function progressExitStatus({
         : { progressExitStatus: true };
       return decorateResult({ result: { ...SUCCESS }, stack, context });
     }
+
+    // RULES 2, 3 and 4 all describe the same fact about this side — it holds a participant who
+    // EXITED upstream — so the provenance is built once. RULE 4 additionally leaves the opponent's
+    // entry, stamped by the earlier propagation, untouched: the write below merges rather than
+    // replaces.
+    exitProvenance = buildCarriedExitProvenance({
+      exitingSideNumber: loserParticipantSide.sideNumber,
+      previousMatchUpStatus: sourceMatchUpStatus,
+      matchUpStatus: carryOverMatchUpStatus,
+      sourceMatchUpId,
+    });
 
     const opponentEmpty = participantsCount === 1 && statusCodes.length === 0;
     if (opponentEmpty || !isExit(loserMatchUp.matchUpStatus)) {
@@ -149,5 +170,17 @@ export function progressExitStatus({
     winningSide,
     event,
   });
+  if (!result.error) {
+    // stamped AFTER the state write: setMatchUpState clears provenance wherever it blanks the codes
+    // the provenance describes (#4816), so writing first would be undone.
+    // The map is rebuilt here rather than reusing the `matchUpsMap` threaded through the
+    // propagation context: that one predates the `setMatchUpState` above, and the objects it holds
+    // can be detached from `drawDefinition.structures` by the time the write returns. Measured —
+    // stamping onto the context map wrote to an object no subsequent read could see.
+    const drawMatchUps = getMatchUpsMap({ drawDefinition })?.drawMatchUps ?? [];
+    const noContextLoserMatchUp = drawMatchUps.find((m) => m.matchUpId === loserMatchUp.matchUpId);
+    mergeSideExitProvenance({ matchUp: noContextLoserMatchUp, provenance: exitProvenance });
+  }
+
   return decorateResult({ result, stack, context: { progressExitStatus: true } });
 }

--- a/src/mutate/matchUps/matchUpStatus/setMatchUpStatus.ts
+++ b/src/mutate/matchUps/matchUpStatus/setMatchUpStatus.ts
@@ -222,6 +222,7 @@ export function setMatchUpStatus(params: SetMatchUpStatusArgs) {
         sourceMatchUpStatusCodes: result.context.sourceMatchUpStatusCodes,
         sourceMatchUpStatus: result.context.sourceMatchUpStatus,
         loserParticipantId: result.context.loserParticipantId,
+        sourceMatchUpId: result.context.sourceMatchUpId,
         propagateExitStatus,
         tournamentRecord: params.tournamentRecord,
         loserMatchUp: result.context.loserMatchUp,

--- a/src/mutate/matchUps/matchUpStatus/sideExitProvenance.ts
+++ b/src/mutate/matchUps/matchUpStatus/sideExitProvenance.ts
@@ -74,6 +74,64 @@ export function buildSideExitProvenance(params: BuildArgs): SideExitProvenance |
   return Object.keys(provenance).length ? provenance : undefined;
 }
 
+/**
+ * Provenance for the ONE side that exited, when an exit is CARRIED into a fed matchUp.
+ *
+ * `buildSideExitProvenance` above describes a target fed by a DOUBLE exit, where both sides are
+ * accounted for by a single call. A carried exit is the other half of the propagation story:
+ * `directLoser` feeds one exiting participant into a consolation slot and `progressExitStatus`
+ * stamps the status onto that matchUp. Only that participant's side has a provenance — the
+ * opponent arrived by winning, not by exiting, and giving them an entry would misattribute the
+ * exit.
+ *
+ * Without this, a carried exit is marked ONLY by a string in `matchUpStatusCodes`, which carries no
+ * `previousMatchUpStatus`, so `exitProducedByPropagation` reads false and every detector that
+ * excludes propagation-produced exits (`EXIT_WITHOUT_LOSER`, `DROPPED_PROGRESSION`) fires on a
+ * legitimate pending exit. Measured 2026-09-11: 13 of the 27 offending matchUps behind the sweep's
+ * 21 triaged seeds are this shape.
+ */
+export function buildCarriedExitProvenance({
+  previousMatchUpStatus,
+  exitingSideNumber,
+  sourceMatchUpId,
+  matchUpStatus,
+}: {
+  previousMatchUpStatus?: string;
+  exitingSideNumber?: number;
+  sourceMatchUpId?: string;
+  matchUpStatus?: string;
+}): SideExitProvenance | undefined {
+  if (exitingSideNumber !== 1 && exitingSideNumber !== 2) return undefined;
+
+  const entry = definedAttributes({
+    matchUpStatus: producedExitStatus(matchUpStatus),
+    previousMatchUpStatus,
+    sourceMatchUpId,
+  }) as SideExitProvenanceEntry;
+
+  return Object.keys(entry).length ? { [exitingSideNumber]: entry } : undefined;
+}
+
+/**
+ * Merge one side's provenance into whatever the matchUp already carries.
+ *
+ * `setSideExitProvenance` REPLACES, which is correct for a double exit: one call describes both
+ * sides. A carried exit describes one side at a time and can reach a matchUp whose OTHER side was
+ * stamped by an earlier propagation — `progressExitStatus` RULE 4, where two carried exits meet and
+ * become a DOUBLE_WALKOVER. Replacing there would discard a still-true entry.
+ */
+export function mergeSideExitProvenance({
+  provenance,
+  matchUp,
+}: {
+  provenance?: SideExitProvenance;
+  matchUp?: MatchUp;
+}): void {
+  if (!matchUp || !writeNativeEnabled()) return;
+  if (!provenance || !Object.keys(provenance).length) return;
+  matchUp.sideExitProvenance = { ...(matchUp.sideExitProvenance ?? {}), ...provenance };
+}
+
 /** Write provenance onto a matchUp, honouring the schema write mode. */
 export function setSideExitProvenance({
   provenance,

--- a/src/tests/mutations/exitPropagation/carriedExitProvenance.test.ts
+++ b/src/tests/mutations/exitPropagation/carriedExitProvenance.test.ts
@@ -1,0 +1,100 @@
+import { generateSchedule, prepareDraw, randomConfig, replay } from '@Tests/testHarness/exitPropagation/sweep';
+import { getDrawMatchUps } from '@Tests/testHarness/exitPropagation/transitions';
+import { setSubscriptions } from '@Global/state/globalState';
+import tournamentEngine from '@Assemblies/engines/sync';
+import mocksEngine from '@Assemblies/engines/mock';
+import { expect, it } from 'vitest';
+
+import { FEED_IN_CHAMPIONSHIP, MODIFIED_FEED_IN_CHAMPIONSHIP } from '@Constants/drawDefinitionConstants';
+import { WALKOVER } from '@Constants/matchUpStatusConstants';
+
+/**
+ * A CARRIED exit — one `progressExitStatus` stamps onto a fed matchUp — must record
+ * `sideExitProvenance`, not only a string in `matchUpStatusCodes`.
+ *
+ * Before this, only `doubleExitAdvancement` wrote provenance. An exit carried into a consolation by
+ * `directLoser`/`progressExitStatus` was marked by a status code string at best, and by NOTHING when
+ * the source matchUp carried no codes of its own — which is the normal shape of a
+ * directly-recorded walkover. `exitProducedByPropagation` reads provenance, so those exits looked
+ * un-propagated, and every detector that excludes a propagation-produced exit fired on a legitimate
+ * one: `EXIT_WITHOUT_LOSER` and `DROPPED_PROGRESSION` both.
+ *
+ * Measured over an independent 600-seed sweep window: 136 findings -> 127, nine seeds cleared, zero
+ * new. `DROPPED_PROGRESSION` 15 -> 8 and `EXIT_WITHOUT_LOSER` 12 -> 8; no other issueType moved.
+ */
+
+function scoreMainRoundOne({ drawId, roundPosition, outcome }) {
+  const matchUps = getDrawMatchUps(drawId);
+  const target = matchUps.find(
+    (matchUp: any) => matchUp.stage === 'MAIN' && matchUp.roundNumber === 1 && matchUp.roundPosition === roundPosition,
+  );
+  expect(target?.matchUpId).toBeDefined();
+  const result: any = tournamentEngine.setMatchUpStatus({
+    matchUpId: target.matchUpId,
+    propagateExitStatus: true,
+    drawId,
+    outcome,
+  });
+  expect(result.success).toEqual(true);
+  return target.matchUpId;
+}
+
+it.each([
+  { drawType: FEED_IN_CHAMPIONSHIP, drawSize: 8, participantsCount: 8, roundPosition: 3 },
+  { drawType: MODIFIED_FEED_IN_CHAMPIONSHIP, drawSize: 8, participantsCount: 6, roundPosition: 1 },
+])(
+  'a walkover carried into the consolation of a $drawType records provenance naming its source',
+  ({ drawType, drawSize, participantsCount, roundPosition }) => {
+    setSubscriptions({});
+    const drawId = 'carried-exit';
+    mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ participantsCount, drawSize, drawType, drawId }],
+      nonRandom: 1,
+      setState: true,
+    });
+
+    const sourceMatchUpId = scoreMainRoundOne({
+      outcome: { matchUpStatus: WALKOVER, winningSide: 2 },
+      roundPosition,
+      drawId,
+    });
+
+    const carried: any = getDrawMatchUps(drawId).filter(
+      (matchUp: any) => matchUp.stage !== 'MAIN' && matchUp.matchUpStatus === WALKOVER,
+    );
+    // the control: without a carried exit there is nothing for this test to assert about
+    expect(carried.length).toBeGreaterThan(0);
+
+    for (const matchUp of carried) {
+      const provenance = matchUp.sideExitProvenance;
+      expect(provenance).toBeDefined();
+      const entries: any[] = Object.values(provenance);
+      expect(entries.length).toBeGreaterThan(0);
+      // the exiting side is attributed to the matchUp whose result produced the exit
+      expect(entries.some((entry: any) => entry.sourceMatchUpId === sourceMatchUpId)).toEqual(true);
+      expect(entries.some((entry: any) => entry.previousMatchUpStatus === WALKOVER)).toEqual(true);
+    }
+  },
+);
+
+it.each([{ seed: 6341103 }, { seed: 6141627 }, { seed: 6141834 }, { seed: 6040627 }])(
+  'sweep seed $seed no longer reports an orphaned or dropped progression',
+  ({ seed }) => {
+    setSubscriptions({});
+    const config = randomConfig(seed);
+    // the sweep's own drawId: mocksEngine seeds the draw from `config.seed`, but the schedule is
+    // built by walking the live draw, so keeping every input identical to the sweep keeps the
+    // reproduction identical to the one the census measured
+    const drawId = `sweep-${seed}`;
+    expect(prepareDraw(config, drawId)).toEqual(true);
+
+    const steps = generateSchedule(config, drawId, 30);
+    // the control: a schedule that produced no steps would pass this test vacuously
+    expect(steps.length).toBeGreaterThan(0);
+    // `replay` runs the repo's own integrity checker at the end of the schedule, which is exactly
+    // the oracle the sweep census counts. Asserting on a re-read AFTER `replay` would be wrong: its
+    // relational tail applies a further DOUBLE_WALKOVER and inspects a state the schedule never
+    // produced.
+    expect(replay(config, steps, drawId)).toEqual(null);
+  },
+);


### PR DESCRIPTION
## What

`sideExitProvenance` was written by **exactly one site** — `doubleExitAdvancement.ts:394`. An exit carried into a consolation by `directLoser` / `progressExitStatus` was marked by a string in `matchUpStatusCodes` at best, and by **nothing at all** when the source matchUp carried no codes of its own:

```ts
// progressExitStatus.ts — RULE 2/3
const sourceCode = sourceMatchUpStatusCodes?.[0];
placeCodeAtSide(statusCodes, loserParticipantSide.sideNumber, sourceCode);
// placeCodeAtSide: `if (code === undefined) return;`
```

A directly-recorded walkover has `matchUpStatusCodes: []`, so `sourceCode` is `undefined` and the produced exit is entirely unmarked.

`exitProducedByPropagation` reads provenance, so those exits look un-propagated, and the two detectors that exclude a propagation-produced exit — `EXIT_WITHOUT_LOSER` and `DROPPED_PROGRESSION` — fire on legitimate ones. **All 15** of those offenders behind the 21 triaged sweep seeds had neither codes nor provenance.

## How

`progressExitStatus` now stamps the exiting side, attributed to the matchUp whose result produced the exit. `sourceMatchUpId` is threaded through the propagation context alongside `sourceMatchUpStatus`, which already travels that way. RULE 4 (two carried exits meeting as a `DOUBLE_WALKOVER`) **merges** rather than replaces, so the opponent's entry from the earlier propagation survives.

**No detector is changed.** The read side already consulted `exitProducedByPropagation`; it simply had nothing to read. That is deliberate — widening a detector here is what produced 717 false positives on 2026-09-10.

## Evidence

| | before | after |
|---|---:|---:|
| the 21 triaged seeds — seeds with a finding | 19 | **15** |
| independent 600-seed window (`SEED_START=9000001`) — findings | 136 | **127** |
| ...seeds closed / **new** | — | 9 / **0** |
| `DROPPED_PROGRESSION` in that window | 15 | **8** |
| `EXIT_WITHOUT_LOSER` in that window | 12 | **8** |
| every other issueType | unchanged | unchanged |

- Properties matrix `transitionProperties.test.ts`: **144 / 0** before and after.
- `pnpm verify` exit 0. Full suite **12,947 passed / 2 skipped**.
- Six new tests, **each verified RED against master first** — two assert the provenance and its `sourceMatchUpId`, four are sweep seeds that now replay clean. Each carries a control so it cannot pass vacuously.

## The first attempt moved nothing — worth recording

Stamping onto the `matchUpsMap` threaded through the propagation context **silently no-ops**: its matchUp objects are detached from `drawDefinition.structures` once `setMatchUpState` returns. The site fired 150 times and built provenance every time, and a read-back saw none of it. The map is now rebuilt after the state write.

## Not fixed here

Provenance is *also* cleared from matchUps whose exit status survives the clear — **51 of 63** clears across those draws, by `removeDirectedLoser` (38), `applyPositionToMatchUp` (9) and `applyScoreAndStatus` (10). `attemptToModifyScore` coerces an absent `matchUpStatusCodes` to `[]`, so `[]` means both "blank the codes" and "the caller supplied none", and the second meaning wipes provenance off a standing exit. That accounts for the 8 offenders this change does not close.

It is deferred because the fix has to move together with the `PROVENANCE_OUTLIVES_CODES` harness invariant, which currently asserts the premise it disproves. Tracked as R1b in [`Mentat/planning/SWEEP_20260911_DISCOVERY.md`](https://github.com/CourtHive/Mentat/blob/main/planning/SWEEP_20260911_DISCOVERY.md).