### PR TITLE
fix(draws): resetDrawDefinition clears disableLinks, which was silently dropping a participant

### DIFF
--- a/src/mutate/drawDefinitions/resetDrawDefinition.ts
+++ b/src/mutate/drawDefinitions/resetDrawDefinition.ts
@@ -1,11 +1,12 @@
 import { modifyDrawNotice, modifyMatchUpNotice } from '@Mutate/notifications/drawNotifications';
+import { removeExtension } from '@Mutate/extensions/removeExtension';
 import { getAllStructureMatchUps } from '@Query/matchUps/getAllStructureMatchUps';
 import { isLuckyBasedDraw } from '@Query/drawDefinition/isLuckyBasedDraw';
 import { getMatchUpsMap } from '@Query/matchUps/getMatchUpsMap';
 
 // constants and types
 import { MAIN, QUALIFYING, VOLUNTARY_CONSOLATION } from '@Constants/drawDefinitionConstants';
-import { DRAFT_STATE, POSITION_ACTIONS } from '@Constants/extensionConstants';
+import { DISABLE_LINKS, DRAFT_STATE, POSITION_ACTIONS } from '@Constants/extensionConstants';
 import { MISSING_DRAW_DEFINITION } from '@Constants/errorConditionConstants';
 import { toBePlayed } from '@Fixtures/scoring/outcomes/toBePlayed';
 import { BYE } from '@Constants/matchUpStatusConstants';
@@ -64,6 +65,24 @@ export function resetDrawDefinition({ tournamentRecord, removeScheduling, remove
   );
   // CODES: also wipe the first-class draftState if present
   delete drawDefinition.draftState;
+
+  // `disableLinks` marks a drawPosition whose assignment was cleared BY HAND, so link positioning
+  // must not feed it again. A reset returns the draw to its pre-play state, which makes that marker
+  // both meaningless and harmful: `getTargetMatchUp` returns `disabledDrawPosition` for such a
+  // position, so a stale flag silently blocks progression through it for the life of the draw.
+  //
+  // Cleared for EVERY structure, after the per-stage branches above, because those branches reach
+  // assignments by different routes — the lucky-draw playoff path replaces the array wholesale, the
+  // non-lucky path maps over it deleting only `participantId`, and VOLUNTARY_CONSOLATION has its own
+  // reset. A single pass is easier to prove complete than three.
+  for (const structure of drawDefinition.structures ?? []) {
+    for (const assignment of structure.positionAssignments ?? []) {
+      // not gated on the schema write mode: the mode decides whether an attribute is WRITTEN, and
+      // must never decide whether stale state is removed. Both representations go.
+      delete assignment.disableLinks;
+      if (Array.isArray(assignment.extensions)) removeExtension({ element: assignment, name: DISABLE_LINKS });
+    }
+  }
 
   const structureIds = (drawDefinition.structures ?? []).map(({ structureId }) => structureId);
 

--- a/src/tests/mutations/drawDefinitions/resetClearsDisableLinks.test.ts
+++ b/src/tests/mutations/drawDefinitions/resetClearsDisableLinks.test.ts
@@ -1,0 +1,118 @@
+import { FIRST_MATCH_LOSER_CONSOLATION } from '@Constants/drawDefinitionConstants';
+import { setSchemaWriteMode } from '@Global/state/globalState';
+import { BRIDGE, NATIVE } from '@Constants/schemaWriteModeConstants';
+import { DISABLE_LINKS } from '@Constants/extensionConstants';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { afterEach, expect, it } from 'vitest';
+
+afterEach(() => setSchemaWriteMode(NATIVE));
+
+/**
+ * `disableLinks` marks a drawPosition whose assignment was cleared BY HAND, so link positioning
+ * must not feed it again. `getTargetMatchUp` returns `disabledDrawPosition` for such a position, so
+ * the flag suppresses progression through it.
+ *
+ * A reset returns the draw to its pre-play state, which makes the marker both meaningless and
+ * harmful: left behind, it silently blocks progression through that position for the life of the
+ * draw. These tests drive the real path — play the main round, let losers feed the consolation, then
+ * clear one by hand — rather than planting the attribute, so they also pin that
+ * `conditionallyDisableLinkPositioning` still applies to a CONSOLATION structure.
+ */
+
+/** Every assignment across the draw still carrying the flag, in either representation. */
+function flaggedAssignments(drawId: string) {
+  const { drawDefinition } = tournamentEngine.getEvent({ drawId });
+  return (drawDefinition.structures ?? []).flatMap((structure: any) =>
+    (structure.positionAssignments ?? [])
+      .filter(
+        (assignment: any) =>
+          assignment.disableLinks || (assignment.extensions ?? []).some((ext: any) => ext.name === DISABLE_LINKS),
+      )
+      .map((assignment: any) => ({
+        structureName: structure.structureName,
+        drawPosition: assignment.drawPosition,
+        firstClass: !!assignment.disableLinks,
+        extension: (assignment.extensions ?? []).some((ext: any) => ext.name === DISABLE_LINKS),
+      })),
+  );
+}
+
+/** Generate, play the main round so the consolation fills, and clear one consolation position. */
+function drawWithAClearedConsolationPosition(drawId: string) {
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ drawId, drawSize: 16, drawType: FIRST_MATCH_LOSER_CONSOLATION }],
+    setState: true,
+  });
+
+  const { matchUps } = tournamentEngine.allDrawMatchUps({ drawId, inContext: true });
+  const { outcome } = mocksEngine.generateOutcomeFromScoreString({ scoreString: '6-1 6-2', winningSide: 1 });
+  for (const matchUp of matchUps.filter((m: any) => m.structureName === 'Main' && m.roundNumber === 1)) {
+    expect(tournamentEngine.setMatchUpStatus({ drawId, matchUpId: matchUp.matchUpId, outcome }).success).toEqual(true);
+  }
+
+  const { drawDefinition } = tournamentEngine.getEvent({ drawId });
+  const consolation = (drawDefinition.structures ?? []).find((s: any) => s.stage === 'CONSOLATION');
+  const occupied = (consolation?.positionAssignments ?? []).filter((a: any) => a.participantId);
+  // the feed must actually have happened, or the rest of the test proves nothing
+  expect(occupied.length).toBeGreaterThan(0);
+
+  const result = tournamentEngine.removeDrawPositionAssignment({
+    structureId: consolation.structureId,
+    drawPosition: occupied[0].drawPosition,
+    drawId,
+  });
+  expect(result.success).toEqual(true);
+
+  return { drawPosition: occupied[0].drawPosition };
+}
+
+it('resetDrawDefinition clears disableLinks left by a manual clear (first-class)', () => {
+  const drawId = 'reset-disable-links-native';
+  const { drawPosition } = drawWithAClearedConsolationPosition(drawId);
+
+  // setup assertion: the flag is really there, on the position we cleared
+  const before = flaggedAssignments(drawId);
+  expect(before).toEqual([{ structureName: 'Consolation', drawPosition, firstClass: true, extension: false }]);
+
+  expect(tournamentEngine.resetDrawDefinition({ drawId }).success).toEqual(true);
+
+  expect(flaggedAssignments(drawId)).toEqual([]);
+});
+
+it('resetDrawDefinition clears disableLinks in BOTH representations under BRIDGE', () => {
+  // BRIDGE writes the first-class attribute AND the legacy extension, so this pins that the removal
+  // is not gated on the write mode — stale state must go regardless of how it was recorded.
+  setSchemaWriteMode(BRIDGE);
+  const drawId = 'reset-disable-links-bridge';
+  const { drawPosition } = drawWithAClearedConsolationPosition(drawId);
+
+  expect(flaggedAssignments(drawId)).toEqual([
+    { structureName: 'Consolation', drawPosition, firstClass: true, extension: true },
+  ]);
+
+  expect(tournamentEngine.resetDrawDefinition({ drawId }).success).toEqual(true);
+
+  expect(flaggedAssignments(drawId)).toEqual([]);
+});
+
+it('a reset draw can be re-fed through the position that had been disabled', () => {
+  // the behavioural consequence, not just the attribute: a stale flag makes getTargetMatchUp
+  // return disabledDrawPosition, so the position never receives a fed participant again.
+  const drawId = 'reset-disable-links-refeed';
+  drawWithAClearedConsolationPosition(drawId);
+  expect(tournamentEngine.resetDrawDefinition({ drawId }).success).toEqual(true);
+
+  const { matchUps } = tournamentEngine.allDrawMatchUps({ drawId, inContext: true });
+  const { outcome } = mocksEngine.generateOutcomeFromScoreString({ scoreString: '6-1 6-2', winningSide: 1 });
+  for (const matchUp of matchUps.filter((m: any) => m.structureName === 'Main' && m.roundNumber === 1)) {
+    expect(tournamentEngine.setMatchUpStatus({ drawId, matchUpId: matchUp.matchUpId, outcome }).success).toEqual(true);
+  }
+
+  const { drawDefinition } = tournamentEngine.getEvent({ drawId });
+  const consolation = (drawDefinition.structures ?? []).find((s: any) => s.stage === 'CONSOLATION');
+  const occupied = (consolation?.positionAssignments ?? []).filter((a: any) => a.participantId);
+  // all eight first-match losers land again, including the position that had been disabled
+  expect(occupied.length).toEqual(8);
+  expect(flaggedAssignments(drawId)).toEqual([]);
+});


### PR DESCRIPTION
## The defect is not a leftover attribute

`disableLinks` marks a drawPosition whose assignment was cleared **by hand**, so link positioning
must not feed it again — `getTargetMatchUp` returns `{ disabledDrawPosition }` for such a position and
skips it. A reset returns the draw to its pre-play state, which makes the marker both meaningless and
harmful. Nothing was removing it.

Reset a draw, replay the main round, and **only 7 of 8 first-match losers reach the consolation.**
The flagged slot is skipped and that participant is silently dropped for the life of the draw.

The third test pins exactly that. Against `master` it fails with:

```
AssertionError: expected 7 to deeply equal 8
```

All three tests fail against master and pass with the fix — verified by reverting the source change
and re-running, not assumed.

## The fix

Cleared for **every** structure in one pass after the per-stage branches, because those branches
reach assignments by three different routes:

| path | how it touches assignments |
|---|---|
| lucky-draw playoff | replaces the array wholesale |
| non-lucky | maps over it deleting only `participantId` |
| `VOLUNTARY_CONSOLATION` | has its own reset |

One pass is easier to prove complete than three.

**Both representations are removed unconditionally** — `delete assignment.disableLinks` plus
`removeExtension` — rather than via `setFirstClassOrExtension(…, value: undefined)`. That helper
looks symmetric but under `LEGACY` mode `writeNativeEnabled()` is false, so it would leave the
first-class attribute behind. Removing stale state must not be gated on the write mode: the mode
decides what is *written*.

## Test design

The tests drive the real path — generate, play the main round so losers feed the consolation, then
clear one by hand — rather than planting the attribute. So they also pin that
`conditionallyDisableLinkPositioning` still applies to a `CONSOLATION` structure, which is the
behaviour that produces the flag in the first place.

The second test runs under **BRIDGE** specifically, because BRIDGE writes both forms; it asserts
`firstClass: true, extension: true` before the reset and nothing after.

## Related, deliberately out of scope

CA raised that *whether* the flag is applied should itself be policy-driven — today
`conditionallyDisableLinkPositioning` decides from a hardcoded `stage`/`stageSequence` test, the same
shape `byeFromPropagation` replaced with a first-class fact. `POLICY_TYPE_POSITION_ACTIONS` already
exists with four shipped variants. Filed as optional in `Mentat/FEATURES.md` →
`planning/DISABLE_LINKS_SHOULD_BE_POLICY.md`; current behaviour would stay the default.

## Gate

`pnpm verify` exit 0 — **12,950 passed / 2 skipped**, coverage thresholds met, build and
published-`.d.ts` pack smoke OK.