### PR TITLE
fix(draws): do not advance a participant who arrived on the exiting side of a pending exit

### DIFF
--- a/src/mutate/matchUps/drawPositions/assignMatchUpDrawPosition.ts
+++ b/src/mutate/matchUps/drawPositions/assignMatchUpDrawPosition.ts
@@ -355,79 +355,96 @@ function applyPositionToMatchUp({
   });
 }
 
-function advanceDrawPosition({
+/**
+ * Whether a participant arriving at a PENDING propagated exit landed on the EXITING side.
+ *
+ * A participant arriving at such a matchUp advances out of it only if they arrived on the WINNING
+ * side — that is the documented resolution, the exit resolving onto whoever falls through into the
+ * empty winner slot. `advanceDrawPosition` was advancing the arriving drawPosition unconditionally,
+ * and a participant can also arrive on the exiting side.
+ *
+ * That happens whenever an upstream result is RE-SCORED: the consolation seat is vacated and
+ * re-filled with the new loser, and by then the matchUp is already a propagated exit. The first fill
+ * does not trip it — at that point `progressExitStatus` has not yet turned the matchUp into one.
+ *
+ * The consequence is `WINNING_SIDE_ADVANCEMENT_MISMATCH`: the LOSER of the consolation walkover sits
+ * in the next round and the winner is dropped from the draw. Measured on FEED_IN_CHAMPIONSHIP 8/8 —
+ * the advancing position was 6 while the matchUp's winningSide pointed at 7.
+ *
+ * Deliberately narrow: it reports true only when the winning drawPosition is KNOWN and differs, so a
+ * pending exit that has no winningSide yet advances exactly as before.
+ */
+function arrivesOnExitingSide(matchUp: any, drawPosition: number): boolean {
+  const winningDrawPosition = matchUp?.winningSide ? matchUp?.drawPositions?.[matchUp.winningSide - 1] : undefined;
+  return !!winningDrawPosition && winningDrawPosition !== drawPosition;
+}
+
+/**
+ * Place `drawPosition` into the winnerMatchUp. All three advancement branches below make the same
+ * call; only the condition differs, so the call lives in one place.
+ */
+function advanceIntoWinnerMatchUp({
   inContextDrawMatchUps,
-  positionAssigned,
-  isPropagatedExit,
   tournamentRecord,
-  inContextMatchUp,
   drawDefinition,
-  matchUpStatus,
   winnerMatchUp,
   drawPosition,
-  isByeMatchUp,
-  isLuckyDraw,
   matchUpsMap,
-  matchUp,
-  structure,
   event,
 }) {
+  const result = assignMatchUpDrawPosition({
+    matchUpId: winnerMatchUp.matchUpId,
+    inContextDrawMatchUps,
+    tournamentRecord,
+    drawDefinition,
+    drawPosition,
+    matchUpsMap,
+    event,
+  });
+  return result.error ? result : undefined;
+}
+
+function advanceDrawPosition(params) {
+  const {
+    positionAssigned,
+    isPropagatedExit,
+    inContextMatchUp,
+    matchUpStatus,
+    winnerMatchUp,
+    drawPosition,
+    isByeMatchUp,
+    isLuckyDraw,
+    matchUpsMap,
+    matchUp,
+    structure,
+  } = params;
+
+  if (!winnerMatchUp) return undefined;
+
   if (positionAssigned && isByeMatchUp && !isLuckyDraw) {
-    if (winnerMatchUp) {
-      if ([BYE, DOUBLE_WALKOVER, DOUBLE_DEFAULT].includes(matchUpStatus)) {
-        const result = assignMatchUpDrawPosition({
-          event,
-          matchUpId: winnerMatchUp.matchUpId,
-          inContextDrawMatchUps,
-          tournamentRecord,
-          drawDefinition,
-          drawPosition,
-          matchUpsMap,
-        });
-        if (result.error) return result;
-      } else {
-        const { structureId } = winnerMatchUp;
-        if (structureId !== structure.structureId) {
-          pushGlobalLog({
-            method: 'assignMatchUpDrawPosition',
-            issue: 'winnerMatchUp in different structure; participant is in a different targetDrawPosition',
-          });
-        }
-      }
-    }
-  } else if (positionAssigned && isPropagatedExit) {
-    if (winnerMatchUp) {
-      const result = assignMatchUpDrawPosition({
-        event,
-        matchUpId: winnerMatchUp.matchUpId,
-        inContextDrawMatchUps,
-        tournamentRecord,
-        drawDefinition,
-        drawPosition,
-        matchUpsMap,
+    if ([BYE, DOUBLE_WALKOVER, DOUBLE_DEFAULT].includes(matchUpStatus)) return advanceIntoWinnerMatchUp(params);
+    if (winnerMatchUp.structureId !== structure.structureId) {
+      pushGlobalLog({
+        method: 'assignMatchUpDrawPosition',
+        issue: 'winnerMatchUp in different structure; participant is in a different targetDrawPosition',
       });
-      if (result.error) return result;
     }
-  } else if (winnerMatchUp && inContextMatchUp && !inContextMatchUp.feedRound) {
+    return undefined;
+  }
+
+  if (positionAssigned && isPropagatedExit) {
+    // a participant arriving on the EXITING side of a pending propagated exit has not won it
+    return arrivesOnExitingSide(matchUp, drawPosition) ? undefined : advanceIntoWinnerMatchUp(params);
+  }
+
+  if (inContextMatchUp && !inContextMatchUp.feedRound) {
     const { pairedPreviousMatchUpIsDoubleExit } = getPairedPreviousMatchUpIsDoubleExit({
       targetMatchUp: matchUp,
       drawPosition,
       matchUpsMap,
       structure,
     });
-
-    if (pairedPreviousMatchUpIsDoubleExit) {
-      const result = assignMatchUpDrawPosition({
-        event,
-        matchUpId: winnerMatchUp.matchUpId,
-        inContextDrawMatchUps,
-        tournamentRecord,
-        drawDefinition,
-        drawPosition,
-        matchUpsMap,
-      });
-      if (result.error) return result;
-    }
+    if (pairedPreviousMatchUpIsDoubleExit) return advanceIntoWinnerMatchUp(params);
   }
 
   return undefined;

--- a/src/tests/mutations/exitPropagation/pendingExitAdvancement.test.ts
+++ b/src/tests/mutations/exitPropagation/pendingExitAdvancement.test.ts
@@ -1,0 +1,104 @@
+import { getDrawInconsistencies } from '@Query/drawDefinition/getDrawInconsistencies';
+import { setSubscriptions } from '@Global/state/globalState';
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { expect, it } from 'vitest';
+
+import {
+  MODIFIED_FEED_IN_CHAMPIONSHIP,
+  FIRST_MATCH_LOSER_CONSOLATION,
+  FEED_IN_CHAMPIONSHIP_TO_SF,
+  FEED_IN_CHAMPIONSHIP,
+} from '@Constants/drawDefinitionConstants';
+import { POLICY_TYPE_SCORING } from '@Constants/policyConstants';
+import { WALKOVER } from '@Constants/matchUpStatusConstants';
+
+/**
+ * A participant arriving at a PENDING propagated exit advances out of it only if they arrived on the
+ * WINNING side.
+ *
+ * `advanceDrawPosition`'s `positionAssigned && isPropagatedExit` branch advanced the arriving
+ * drawPosition unconditionally. A participant can also arrive on the EXITING side: re-scoring an
+ * upstream matchUp swaps which participant is the loser, so the consolation seat is vacated and
+ * re-filled, and by then the matchUp is already an exit. The first fill does not trip it — at that
+ * point `progressExitStatus` has not yet turned the matchUp into one.
+ *
+ * The result is that the LOSER of the consolation walkover sits in the next round while the winner
+ * is dropped from the draw — `WINNING_SIDE_ADVANCEMENT_MISMATCH`, and visible to a tournament
+ * director on screen.
+ *
+ * Gated on `propagateExitStatus`, which nothing in the ecosystem currently sets; the policy is
+ * attached here so the scenario is reachable at all.
+ */
+
+const DRAW_ID = 'pending-exit-advancement';
+
+function mainRoundOne(roundPosition: number) {
+  return tournamentEngine
+    .allDrawMatchUps({ inContext: true, drawId: DRAW_ID })
+    .matchUps.find(
+      (matchUp: any) =>
+        matchUp.stage === 'MAIN' && matchUp.roundNumber === 1 && matchUp.roundPosition === roundPosition,
+    );
+}
+
+function issues() {
+  const drawDefinition = tournamentEngine.getEvent({ drawId: DRAW_ID }).drawDefinition;
+  const result: any = getDrawInconsistencies({ drawDefinition, drawId: DRAW_ID });
+  return (result?.inconsistencies ?? []).map((issue: any) => issue.issueType);
+}
+
+it.each([
+  { drawType: FEED_IN_CHAMPIONSHIP, first: 3 },
+  { drawType: FEED_IN_CHAMPIONSHIP_TO_SF, first: 3 },
+  { drawType: MODIFIED_FEED_IN_CHAMPIONSHIP, first: 3 },
+  { drawType: FIRST_MATCH_LOSER_CONSOLATION, first: 3 },
+])('re-scoring a walkover in a $drawType does not advance the consolation loser', ({ drawType, first }) => {
+  setSubscriptions({});
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ participantsCount: 8, drawSize: 8, drawType, drawId: DRAW_ID }],
+    nonRandom: 1,
+    setState: true,
+  });
+  tournamentEngine.attachPolicies({
+    policyDefinitions: { [POLICY_TYPE_SCORING]: { policyName: 'carry exits', propagateExitStatus: true } },
+  });
+
+  const score = (roundPosition: number, outcome: any) => {
+    const matchUp = mainRoundOne(roundPosition);
+    expect(matchUp?.matchUpId).toBeDefined();
+    const result: any = tournamentEngine.setMatchUpStatus({ matchUpId: matchUp.matchUpId, drawId: DRAW_ID, outcome });
+    expect(result.success).toEqual(true);
+  };
+
+  // 1. the walkover propagates its loser into the consolation, carrying the exit status
+  score(first, { matchUpStatus: WALKOVER, winningSide: 2 });
+  // the control: nothing is wrong yet, so a clean result at the end is about the re-score
+  expect(issues()).toEqual([]);
+
+  // 2. the re-score swaps which participant is the loser — the consolation seat is re-filled while
+  //    the matchUp is already a propagated exit
+  score(first, { winningSide: 1 });
+  expect(issues()).toEqual([]);
+
+  // 3. the sibling delivers the second consolation player, resolving the pending exit
+  score(first % 2 === 1 ? first + 1 : first - 1, { winningSide: 2 });
+  expect(issues()).toEqual([]);
+
+  // and the participant now in the consolation's second round is the one who WON the walkover
+  const consolation = tournamentEngine
+    .allDrawMatchUps({ inContext: true, drawId: DRAW_ID })
+    .matchUps.filter((matchUp: any) => matchUp.stage !== 'MAIN');
+  const decided = consolation.filter((matchUp: any) => matchUp.matchUpStatus === WALKOVER && matchUp.winningSide);
+  // the control: the scenario must actually have produced a decided consolation walkover
+  expect(decided.length).toBeGreaterThan(0);
+
+  for (const matchUp of decided) {
+    const winner = (matchUp.sides ?? []).find((side: any) => side.sideNumber === matchUp.winningSide);
+    const loser = (matchUp.sides ?? []).find((side: any) => side.sideNumber !== matchUp.winningSide);
+    if (!winner?.participantId || !loser?.participantId || !matchUp.winnerMatchUpId) continue;
+    const next = consolation.find((candidate: any) => candidate.matchUpId === matchUp.winnerMatchUpId);
+    const advanced = (next?.sides ?? []).map((side: any) => side.participantId).filter(Boolean);
+    expect(advanced).not.toContain(loser.participantId);
+  }
+});


### PR DESCRIPTION
## The defect — the losing player advances and the winner is dropped

A participant arriving at a **pending propagated exit** advances out of it only if they arrived on the **winning** side. That is the documented resolution: the exit resolves onto whoever falls through into the empty winner slot.

`advanceDrawPosition`'s `positionAssigned && isPropagatedExit` branch advanced the arriving `drawPosition` **unconditionally** — and a participant can also arrive on the **exiting** side.

That happens whenever an upstream result is **re-scored**: the consolation seat is vacated and re-filled with the new loser, and by then the matchUp is already a propagated exit. The first fill does not trip it, because `progressExitStatus` has not yet turned the matchUp into an exit — which is exactly why the existing guard in `directParticipants` covers the first write and not this one:

```ts
// A propagated exit (WALKOVER/DEFAULT) can carry a winningSide whose side is still an empty
// feed slot ... Suppress winner advancement until the real opponent arrives
const winnerSlotEmpty = isExit(matchUpStatus) && !winningSideParticipantId;
```

## Traced, not guessed

`FEED_IN_CHAMPIONSHIP` 8/8, no byes, `propagateExitStatus: true`. Consolation state after each of three main-draw actions:

| after | consolation R1P2 | consolation R2P2 |
|---|---|---|
| 1 — walkover on main R1P3 | `WALKOVER` ws 2, dp `[6,7]`, loser on dp6 | dp `[3]`, **still empty** ✅ |
| 2 — re-score main R1P3 | `WALKOVER` ws 2, new loser on dp6 | dp `[3,6]`, **the loser advanced** ❌ |
| 3 — score main R1P4 | the awaited player arrives on dp7 and wins | dp `[3,6]`, unchanged |

The probe caught a single firing: `from: Consolation R1P2, winningSide 2, drawPositions [6,7], advancingDrawPosition: 6`. The matchUp's winner is dp7; it advanced dp6.

After the fix, consolation R2P2 holds dp7 — the player who won.

## Evidence

| | before | after |
|---|---:|---:|
| 600-seed window (`SEED_START=9000001`) — findings | 127 | **103** |
| ...seeds closed / **new** | — | 24 / **0** |
| `WINNING_SIDE_ADVANCEMENT_MISMATCH` | 9 | **0** |
| `ERROR_IMPLIES_NO_MUTATION` | 97 | **78** |
| the 21 triaged sweep seeds with a finding | 15 | **12** |

Six seeds change issueType rather than clearing. **Five of those move off `ERROR_IMPLIES_NO_MUTATION`** onto a draw inconsistency that was previously masked — `replay` reports only the first failure, so removing an earlier one exposes a later one. That is unmasking, not regression: **no seed goes from clean to failing**.

- Properties matrix `transitionProperties.test.ts`: **144 / 0** before and after.
- `pnpm verify` exit 0. Full suite **12,951 passed / 2 skipped**.
- Four new tests — `FEED_IN_CHAMPIONSHIP`, `FEED_IN_CHAMPIONSHIP_TO_SF`, `MODIFIED_FEED_IN_CHAMPIONSHIP`, `FIRST_MATCH_LOSER_CONSOLATION` — **each verified RED against master first**, each carrying controls so it cannot pass vacuously.

## The refactor in the same commit

`advanceDrawPosition` was already **at** the cognitive-complexity limit of 30; adding the guard inline took it to 34. Rather than disable the rule, the guard is a module-level predicate (`arrivesOnExitingSide`) and the three branches now share one `advanceIntoWinnerMatchUp` helper instead of three identical nine-line call blocks. Behaviour-preserving — 1,027 exit-propagation tests and the 144-cell matrix are unchanged.

## Reachability — this is currently latent, not live

Gated on `propagateExitStatus`, and **nothing in the ecosystem sets it**: `POLICY_SCORING_DEFAULT` sets it `false`, TMX's scoring policy does not mention it, and TMX / competition-factory-server / courthive-components have zero references. Only `POLICY_SCORING_USTA` turns it on. So this is a correctness fix ahead of the flag being enabled, not a live production incident.

Loadable TODS reproductions (before/after) are committed at [`Mentat/fixtures/r3-advancement-mismatch/`](https://github.com/CourtHive/Mentat/tree/main/fixtures/r3-advancement-mismatch), with the walkthrough in [`Mentat/planning/R3_ADVANCEMENT_MISMATCH_REPRO.md`](https://github.com/CourtHive/Mentat/blob/main/planning/R3_ADVANCEMENT_MISMATCH_REPRO.md).