### PR TITLE
fix(codes): keep exit provenance while the exit it describes is still standing

### DIFF
--- a/src/mutate/matchUps/drawPositions/assignMatchUpDrawPosition.ts
+++ b/src/mutate/matchUps/drawPositions/assignMatchUpDrawPosition.ts
@@ -3,7 +3,7 @@ import { getUpdatedDrawPositions } from '@Mutate/drawDefinitions/matchUpGovernor
 import { updateMatchUpStatusCodes } from '@Mutate/drawDefinitions/matchUpGovernor/matchUpStatusCodes';
 import { getExitWinningSide } from '@Mutate/drawDefinitions/matchUpGovernor/getExitWinningSide';
 import { getMappedStructureMatchUps, getMatchUpsMap } from '@Query/matchUps/getMatchUpsMap';
-import { clearSideExitProvenance } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
+import { clearResolvedSideExitProvenance } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
 import { getPositionAssignments } from '@Query/drawDefinition/positionsGetter';
 import { getInitialRoundNumber } from '@Query/matchUps/getInitialRoundNumber';
 import { updateSideLineUp } from '@Mutate/matchUps/lineUps/updateSideLineUp';
@@ -325,8 +325,9 @@ function applyPositionToMatchUp({
       matchUpStatusCodes[exitSideNumber - 1] = carriedCode;
     }
     matchUp.matchUpStatusCodes = matchUpStatusCodes;
-    // nothing carried means the exit this matchUp recorded is gone; its provenance goes with it
-    if (!matchUpStatusCodes.length) clearSideExitProvenance(matchUp);
+    // Nothing carried means the exit this matchUp recorded is gone — unless the status says
+    // otherwise, in which case the provenance is still describing a live exit.
+    if (!matchUpStatusCodes.length) clearResolvedSideExitProvenance(matchUp);
   } else if (matchUp?.matchUpStatusCodes) {
     updateMatchUpStatusCodes({
       inContextDrawMatchUps: refreshedMatchUps,

--- a/src/mutate/matchUps/drawPositions/removeDirectedParticipants.ts
+++ b/src/mutate/matchUps/drawPositions/removeDirectedParticipants.ts
@@ -1,5 +1,5 @@
 import { includesMatchUpStatuses } from '@Mutate/drawDefinitions/matchUpGovernor/includesMatchUpStatuses';
-import { clearSideExitProvenance } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
+import { clearResolvedSideExitProvenance } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
 import { removeSubsequentRoundsParticipant } from './removeSubsequentRoundsParticipant';
 import { structureAssignedDrawPositions } from '@Query/drawDefinition/positionsGetter';
 import { updateTieMatchUpScore } from '@Mutate/matchUps/score/updateTieMatchUpScore';
@@ -321,10 +321,10 @@ function removeDirectedLoser({
     //In case the loser matchup was not a double WO we jsut remove the status codes.
     const targetMatchUp = matchUpsMap?.drawMatchUps?.find(({ matchUpId }) => matchUpId === loserMatchUp.matchUpId);
     targetMatchUp.matchUpStatusCodes = sourceMatchUpStatus === DOUBLE_WALKOVER ? ['WO', 'WO'] : [];
-    // the codes here are rewritten wholesale for the exit that remains, so any provenance stamped
-    // for the exit being removed is stale. Provenance and codes describe the same exit; they die
-    // together or the matchUp keeps a reason for something that no longer exists.
-    clearSideExitProvenance(targetMatchUp);
+    // The codes are rewritten wholesale here, so provenance stamped for the exit being removed is
+    // stale — but only once the status itself has resolved. While the matchUp is still an exit the
+    // provenance still describes it, and clearing it leaves an exit with no marker at all.
+    clearResolvedSideExitProvenance(targetMatchUp);
   }
 
   // remove participant from seedAssignments

--- a/src/mutate/matchUps/matchUpStatus/sideExitProvenance.ts
+++ b/src/mutate/matchUps/matchUpStatus/sideExitProvenance.ts
@@ -1,6 +1,7 @@
 import { OUTCOME_DEFAULT, OUTCOME_RETIREMENT, OUTCOME_WALKOVER } from '@Helpers/keyValueScore/constants';
 import { writeNativeEnabled } from '@Global/state/globalState';
 import { definedAttributes } from '@Tools/definedAttributes';
+import { isAnyExit } from '@Validators/isExit';
 
 // constants and types
 import { MatchUp, SideExitProvenance, SideExitProvenanceEntry } from '@Types/tournamentTypes';
@@ -158,6 +159,30 @@ export function setSideExitProvenance({
  */
 export function clearSideExitProvenance(matchUp?: MatchUp): void {
   if (matchUp) delete matchUp.sideExitProvenance;
+}
+
+/**
+ * Clear provenance ONLY when the matchUp is no longer an exit.
+ *
+ * `clearSideExitProvenance` is unconditional, which is right where the caller has just collapsed the
+ * status — clearing a position, or writing a BYE. It is WRONG as an opportunistic clear, and it was
+ * being used as one.
+ *
+ * `attemptToModifyScore` coerces an absent `matchUpStatusCodes` to `[]`, so `[]` means both "blank
+ * the codes" and "the caller supplied none". Reading the second as the first wipes provenance off a
+ * matchUp that is still the exit that provenance describes. Measured 2026-09-11 across the draws
+ * behind the 21 triaged sweep seeds: **63 clears, 51 of them leaving the matchUp still an exit** —
+ * `removeDirectedLoser` 38, `applyPositionToMatchUp` 9, `applyScoreAndStatus` 10. Those matchUps end
+ * up as exits with no marker at all, so `exitProducedByPropagation` reads false and the detectors
+ * that exclude a propagation-produced exit fire on legitimate ones.
+ *
+ * `isAnyExit`, not `isExit` — the double exits are precisely the statuses that stamp provenance.
+ *
+ * See Mentat/planning/SWEEP_20260911_DISCOVERY.md.
+ */
+export function clearResolvedSideExitProvenance(matchUp?: MatchUp): void {
+  if (!matchUp || isAnyExit(matchUp.matchUpStatus)) return;
+  clearSideExitProvenance(matchUp);
 }
 
 /**

--- a/src/mutate/matchUps/score/modifyMatchUpScore.ts
+++ b/src/mutate/matchUps/score/modifyMatchUpScore.ts
@@ -2,7 +2,8 @@ import { updateAssignmentParticipantResults } from '@Mutate/drawDefinitions/matc
 import { processCompetitionMatchUp } from '@Mutate/drawDefinitions/competition/processCompetitionMatchUp';
 import { modifyMatchUpNotice, updateInContextMatchUp } from '@Mutate/notifications/drawNotifications';
 import { getCompetitionPolicy } from '@Query/drawDefinition/competition/getCompetitionPolicy';
-import { clearSideExitProvenance } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
+import { clearResolvedSideExitProvenance } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
+import { isAnyExit } from '@Validators/isExit';
 import { getAllStructureMatchUps } from '@Query/matchUps/getAllStructureMatchUps';
 import { getAppliedPolicies } from '@Query/extensions/getAppliedPolicies';
 import { checkScoreHasValue } from '@Query/matchUp/checkScoreHasValue';
@@ -234,7 +235,16 @@ function applyScoreAndStatus({
 }) {
   const walkoverStatuses = new Set([WALKOVER, DOUBLE_WALKOVER]);
   if ((matchUpStatus && walkoverStatuses.has(matchUpStatus)) || removeScore) {
+    // `toBePlayed` is the UNWOUND-matchUp fixture, so it blanks `sideExitProvenance` along with the
+    // score. Here it is being used to clear the SCORE — a walkover has none — while the very next
+    // lines set an exit status on the same matchUp. Letting the reset take the provenance with it
+    // makes the field depend on which exit status is being written: the set above covers WALKOVER
+    // and DOUBLE_WALKOVER but not DEFAULTED or DOUBLE_DEFAULT, so a walkover lost its provenance and
+    // an otherwise identical default kept it. That asymmetry is what `doubleExitStatusParity`
+    // reports for FIRST_ROUND_LOSER_CONSOLATION 16/16.
+    const survivingProvenance = isAnyExit(matchUpStatus) ? matchUp.sideExitProvenance : undefined;
     Object.assign(matchUp, { ...toBePlayed });
+    if (survivingProvenance) matchUp.sideExitProvenance = survivingProvenance;
   } else if (score) {
     matchUp.score = score;
   }
@@ -242,9 +252,11 @@ function applyScoreAndStatus({
   if (matchUpStatus) matchUp.matchUpStatus = matchUpStatus;
   if (matchUpFormat) matchUp.matchUpFormat = matchUpFormat;
   if (matchUpStatusCodes) matchUp.matchUpStatusCodes = matchUpStatusCodes;
-  // blanking the codes unwinds the exit they described; provenance describes the same exit and
-  // must not outlive them, or the matchUp never returns to its pre-exit state
-  if (matchUpStatusCodes && !matchUpStatusCodes.length) clearSideExitProvenance(matchUp);
+  // Blanking the codes unwinds the exit they described — but ONLY when the write also resolved the
+  // status. `attemptToModifyScore` coerces an absent `matchUpStatusCodes` to `[]`, so an empty array
+  // here means either "blank them" or "the caller supplied none", and the second must not wipe the
+  // provenance of an exit that is still standing.
+  if (matchUpStatusCodes && !matchUpStatusCodes.length) clearResolvedSideExitProvenance(matchUp);
   if (winningSide) matchUp.winningSide = winningSide;
   if (removeWinningSide) matchUp.winningSide = undefined;
 }

--- a/src/tests/mutations/exitPropagation/provenanceOutlivesExit.test.ts
+++ b/src/tests/mutations/exitPropagation/provenanceOutlivesExit.test.ts
@@ -1,0 +1,54 @@
+import { generateSchedule, prepareDraw, randomConfig, replay } from '@Tests/testHarness/exitPropagation/sweep';
+import { getDrawMatchUps } from '@Tests/testHarness/exitPropagation/transitions';
+import { setSubscriptions } from '@Global/state/globalState';
+import { expect, it } from 'vitest';
+
+import { DOUBLE_WALKOVER, DOUBLE_DEFAULT, DEFAULTED, WALKOVER } from '@Constants/matchUpStatusConstants';
+
+/**
+ * Provenance must outlive the codes for as long as the EXIT it describes is still standing.
+ *
+ * `attemptToModifyScore` coerces an absent `matchUpStatusCodes` to `[]`, so `[]` means both "blank
+ * the codes" and "the caller supplied none". Three sites read the second as the first and cleared
+ * `sideExitProvenance` from a matchUp that was still a WALKOVER or DEFAULTED. Measured 2026-09-11
+ * across the draws behind the 21 triaged sweep seeds: **63 clears, 51 of them leaving the matchUp
+ * still an exit** — `removeDirectedLoser` 38, `applyPositionToMatchUp` 9, `applyScoreAndStatus` 10.
+ *
+ * Such a matchUp is an exit with no marker at all, so `exitProducedByPropagation` reads false and
+ * `EXIT_WITHOUT_LOSER` / `DROPPED_PROGRESSION` fire on a legitimate pending exit.
+ *
+ * These are sweep seeds rather than hand-built draws on purpose. A grid of 1,512 deterministic
+ * first-round scenarios — 7 draw types x 2 sizes x 3 participant counts x every first-round
+ * position x two exit statuses x three action patterns — produced **zero** instances. The state
+ * needs the deeper randomized sequences the sweep reaches, so the seed IS the smallest
+ * reproduction available.
+ *
+ * Three seeds, not the five this change clears in a full run. `6161618` passes on master when this
+ * file runs alone — two of the 21 triaged seeds are sensitive to how much draw generation precedes
+ * them, which is recorded in the triage — and `6341977` still reports a DROPPED_PROGRESSION from a
+ * different cause. A test that is not red before the fix is not a regression test, so only the
+ * three that are red here are asserted.
+ */
+
+const EXIT_STATUSES = [WALKOVER, DEFAULTED, DOUBLE_WALKOVER, DOUBLE_DEFAULT];
+
+it.each([{ seed: 6041718 }, { seed: 6101993 }, { seed: 6161873 }])(
+  'sweep seed $seed no longer reports an orphaned exit or a dropped progression',
+  ({ seed }) => {
+    setSubscriptions({});
+    const config = randomConfig(seed);
+    const drawId = `sweep-${seed}`;
+    expect(prepareDraw(config, drawId)).toEqual(true);
+
+    const steps = generateSchedule(config, drawId, 30);
+    // the control: a schedule with no steps would satisfy everything below vacuously
+    expect(steps.length).toBeGreaterThan(0);
+
+    // the second control: the draw must actually contain exits, or this asserts nothing about them
+    const exits = getDrawMatchUps(drawId).filter((matchUp: any) => EXIT_STATUSES.includes(matchUp.matchUpStatus));
+    expect(exits.length).toBeGreaterThan(0);
+
+    // `replay` ends on the repo's own integrity checker — the oracle the sweep census counts.
+    expect(replay(config, steps, drawId)).toEqual(null);
+  },
+);

--- a/src/validators/isExit.ts
+++ b/src/validators/isExit.ts
@@ -1,5 +1,20 @@
-import { DEFAULTED, RETIRED, WALKOVER } from '@Constants/matchUpStatusConstants';
+import { DOUBLE_WALKOVER, DOUBLE_DEFAULT, DEFAULTED, RETIRED, WALKOVER } from '@Constants/matchUpStatusConstants';
 
+/**
+ * A SINGLE exit — one side is out and the other advances.
+ *
+ * **This deliberately EXCLUDES `DOUBLE_WALKOVER` / `DOUBLE_DEFAULT`**, which is correct for the
+ * advancement questions it was written for and a trap for every other one. It has cost three
+ * sessions in the exit-propagation workstream, because the double exits are exactly the statuses
+ * that stamp provenance — so a liveness or residue check built on this predicate silently filters
+ * out the thing it exists to find. When the question is "is this matchUp an exit at all", use
+ * {@link isAnyExit}.
+ */
 export function isExit(matchUpStatus: any): boolean {
   return [DEFAULTED, WALKOVER, RETIRED].includes(matchUpStatus);
+}
+
+/** Any exit, single or double — the predicate to use when asking whether a matchUp was played out. */
+export function isAnyExit(matchUpStatus: any): boolean {
+  return isExit(matchUpStatus) || [DOUBLE_WALKOVER, DOUBLE_DEFAULT].includes(matchUpStatus);
 }


### PR DESCRIPTION
Completes cluster **R1b** from the sweep triage, after [#4820](https://github.com/CourtHive/competition-factory/pull/4820) (carried-exit provenance) and [#4822](https://github.com/CourtHive/competition-factory/pull/4822) (pending-exit advancement).

## Two clears were taking provenance off a still-standing exit

The result in both cases is a matchUp that IS a `WALKOVER`/`DEFAULTED` but carries no marker at all. `exitProducedByPropagation` then reads false, and the two detectors that exclude a propagation-produced exit — `EXIT_WITHOUT_LOSER` and `DROPPED_PROGRESSION` — fire on legitimate ones.

### 1. The opportunistic clears

`attemptToModifyScore` coerces an absent `matchUpStatusCodes` to `[]`:

```ts
matchUpStatusCodes: (matchUpStatusIsValid && matchUpStatusCodes) ?? [],
```

so `[]` means both *"blank the codes"* and *"the caller supplied none"*, and three sites read the second as the first. Measured across the draws behind the 21 triaged sweep seeds:

| | count |
|---|---:|
| `clearSideExitProvenance` calls that removed something | 63 |
| ...leaving the matchUp **still an exit** | **51** |
| ...leaving it `COMPLETED` / `TO_BE_PLAYED` (correct) | 12 |

By site: `removeDirectedLoser` 38, `applyPositionToMatchUp` 9, `applyScoreAndStatus` 10. Those three now call `clearResolvedSideExitProvenance`, which clears only once the status has resolved. `positionClear` and `attemptToSetMatchUpStatusBYE` follow a real collapse of the status and stay unconditional.

### 2. The `toBePlayed` reset — and it is pre-existing

`applyScoreAndStatus` resets a matchUp through the **unwound-matchUp** fixture to clear the score a walkover cannot have. That fixture also carries `sideExitProvenance: undefined`, while the very next lines write an exit status onto the same matchUp. And the reset is gated on the walkover pair only:

```ts
const walkoverStatuses = new Set([WALKOVER, DOUBLE_WALKOVER]);
```

So a walkover lost its provenance and an otherwise identical **default kept it** — a fourth instance of the `=== DOUBLE_WALKOVER` vs `[DOUBLE_WALKOVER, DOUBLE_DEFAULT]` drift that `doubleExitStatusParity` was built to catch. Provenance now survives the reset when the same write is setting an exit.

**This asymmetry predates this PR.** Measured with the new guard on and off: in both configurations the DOUBLE_WALKOVER arm loses provenance during the forward phase and the DOUBLE_DEFAULT arm does not. Master's parity test is green only because a later unconditional clear removed it in the other arm too — the two arms agreed by both arriving at nothing, for different reasons. Fixing half of it is what made the disagreement visible.

## `isAnyExit`

Added alongside `isExit`, which deliberately excludes `DOUBLE_WALKOVER`/`DOUBLE_DEFAULT` — correct for the advancement questions it was written for, and a trap for every other one. It has now cost four sessions in this workstream, because the double exits are exactly the statuses that stamp provenance. Both predicates now carry the warning in their doc comments.

## Evidence

| | before | after |
|---|---:|---:|
| 600-seed window (`SEED_START=9000001`) — findings | 103 | **92** |
| ...seeds closed / **new** / changed issueType | — | 11 / **0** / **0** |
| `EXIT_WITHOUT_LOSER` | 9 | **1** |
| `DROPPED_PROGRESSION` | 7 | **4** |
| every other issueType | unchanged | unchanged |
| the 21 triaged sweep seeds with a finding | 12 | **8** |

- Properties matrix `transitionProperties.test.ts`: **144 / 0**.
- `pnpm verify` exit 0. Full suite **12,957 passed / 2 skipped**.
- **Each half falsified independently**: the three new seed tests are RED against master, and reverting *only* the `toBePlayed` hunk turns `doubleExitStatusParity` red again.
- The new tests use sweep seeds rather than hand-built draws because a grid of **1,512** deterministic first-round scenarios produced **zero** instances of the state — it needs the deeper randomized sequences.

## `PROVENANCE_OUTLIVES_CODES` is NOT changed

It was expected to need widening, since it asserts that provenance must not survive an emptied `matchUpStatusCodes` — the premise this PR disproves. Measured instead: **18,262 matchUps across 600 seeds, zero** cases where that actually happens. The invariant never fires, so it stays exactly as written and no existing test logic is touched.