### PR TITLE
fix(harness): narrow PROVENANCE_OUTLIVES_CODES, which contradicted #4823

### DIFF
--- a/src/tests/mutations/exitPropagation/provenanceOutlivesExitInvariant.test.ts
+++ b/src/tests/mutations/exitPropagation/provenanceOutlivesExitInvariant.test.ts
@@ -1,0 +1,52 @@
+import { getInvariantViolations } from '@Tests/testHarness/exitPropagation/invariants';
+import { DOUBLE_WALKOVER, TO_BE_PLAYED, WALKOVER } from '@Constants/matchUpStatusConstants';
+import { expect, it } from 'vitest';
+
+const rulesFor = (matchUp: any): string[] =>
+  getInvariantViolations({ matchUps: [matchUp], drawDefinition: { structures: [] } }).map((v: any) => v.rule);
+
+const provenance = { 1: { previousMatchUpStatus: DOUBLE_WALKOVER, sourceMatchUpId: 'source-1' } };
+
+/**
+ * `PROVENANCE_OUTLIVES_EXIT` replaces `PROVENANCE_OUTLIVES_CODES`, which was too strict.
+ *
+ * The old rule treated an emptied `matchUpStatusCodes` as proof the exit was gone. It is not:
+ * `attemptToModifyScore` coerces an absent array to `[]`, so `[]` means either "blank them" or "the
+ * caller supplied none" — and #4823 deliberately preserves provenance in the second case, on a
+ * matchUp that is still an exit. The old rule fired on exactly that state and was green only because
+ * no test happened to produce it.
+ */
+
+it('does NOT fire on a still-standing exit whose codes were emptied by the coercion', () => {
+  // the state #4823 deliberately preserves
+  expect(
+    rulesFor({
+      matchUpId: 'a',
+      matchUpStatus: WALKOVER,
+      winningSide: 1,
+      matchUpStatusCodes: [],
+      sideExitProvenance: provenance,
+    }),
+  ).not.toContain('PROVENANCE_OUTLIVES_EXIT');
+  // a double exit stamps provenance, so isAnyExit must cover it — isExit alone would not
+  expect(
+    rulesFor({
+      matchUpId: 'b',
+      matchUpStatus: DOUBLE_WALKOVER,
+      matchUpStatusCodes: [],
+      sideExitProvenance: provenance,
+    }),
+  ).not.toContain('PROVENANCE_OUTLIVES_EXIT');
+});
+
+it('fires when the matchUp is no longer an exit but still carries a reason for one', () => {
+  expect(
+    rulesFor({ matchUpId: 'c', matchUpStatus: TO_BE_PLAYED, matchUpStatusCodes: [], sideExitProvenance: provenance }),
+  ).toContain('PROVENANCE_OUTLIVES_EXIT');
+});
+
+it('stays silent when there is no provenance to outlive anything', () => {
+  expect(rulesFor({ matchUpId: 'd', matchUpStatus: TO_BE_PLAYED, matchUpStatusCodes: [] })).not.toContain(
+    'PROVENANCE_OUTLIVES_EXIT',
+  );
+});

--- a/src/tests/testHarness/exitPropagation/invariants.ts
+++ b/src/tests/testHarness/exitPropagation/invariants.ts
@@ -1,4 +1,5 @@
 import { DOUBLE_DEFAULT, DOUBLE_WALKOVER, COMPLETED, BYE } from '@Constants/matchUpStatusConstants';
+import { isAnyExit } from '@Validators/isExit';
 
 /**
  * Structural invariants over a draw, asserted after every mutation.
@@ -39,16 +40,26 @@ function matchUpInvariants(matchUp: any): InvariantViolation[] {
   const { matchUpStatus, matchUpId, winningSide, score } = matchUp;
   const record = (rule: string, detail: string) => violations.push({ rule, matchUpId, detail });
 
-  // Provenance and the legacy codes describe the SAME exit, so they must live and die together.
-  // Every site that blanks `matchUpStatusCodes` is unwinding the exit those codes described; if
-  // provenance survives that, the matchUp keeps a reason for an exit that no longer exists — a
-  // do/undo residue that the projection would otherwise only catch in the cells it happens to reach.
+  // Provenance must not outlive the exit it describes — but an emptied `matchUpStatusCodes` is NOT
+  // sufficient evidence that the exit is gone.
+  //
+  // This rule originally read "codes and provenance live and die together", which #4823 showed to be
+  // too strict: `attemptToModifyScore` coerces an absent `matchUpStatusCodes` to `[]`, so `[]` means
+  // either "blank them" or "the caller supplied none". A matchUp can therefore be an exit still, with
+  // provenance that legitimately stands, and an empty codes array. Measured there: 63 clears, 51 of
+  // them leaving the matchUp still an exit.
+  //
+  // The residue this exists to catch is the OTHER case — a matchUp that is no longer an exit at all,
+  // still carrying a reason for one. `isAnyExit`, not `isExit`, because the double exits are
+  // precisely the statuses that stamp provenance.
   const codes = matchUp.matchUpStatusCodes;
   const provenance = matchUp.sideExitProvenance;
-  if (provenance && Object.keys(provenance).length && Array.isArray(codes) && !codes.length) {
+  const stillAnExit = isAnyExit(matchUpStatus);
+  if (provenance && Object.keys(provenance).length && Array.isArray(codes) && !codes.length && !stillAnExit) {
     record(
-      'PROVENANCE_OUTLIVES_CODES',
-      `sideExitProvenance ${JSON.stringify(provenance)} survives an emptied matchUpStatusCodes`,
+      'PROVENANCE_OUTLIVES_EXIT',
+      `sideExitProvenance ${JSON.stringify(provenance)} survives on a matchUp that is no longer an exit ` +
+        `(matchUpStatus ${matchUpStatus}), with matchUpStatusCodes emptied`,
     );
   }
 


### PR DESCRIPTION
## An invariant I added is now wrong, and green only by coverage luck

I added `PROVENANCE_OUTLIVES_CODES` in #4816, asserting that provenance and `matchUpStatusCodes`
*"live and die together."* **#4823 disproved the premise** and did not touch the invariant.

`attemptToModifyScore` coerces an absent `matchUpStatusCodes` to `[]`, so `[]` means either *"blank
them"* or *"the caller supplied none."* A matchUp can therefore be an exit **still**, with provenance
that legitimately stands, and an empty codes array — and #4823 deliberately preserves exactly that
state, via `clearResolvedSideExitProvenance`.

My rule fires on it. Verified directly rather than reasoned about:

```
{ matchUpStatus: WALKOVER, matchUpStatusCodes: [], sideExitProvenance: {…} }
  → ['PROVENANCE_OUTLIVES_CODES']
```

It passes today only because no current test produces that state. The sweep would have found it as a
`STRUCTURAL_INVARIANT` finding, and worse, the comment would have taught the next reader a model
#4823 had already disproved.

## The fix

Renamed to **`PROVENANCE_OUTLIVES_EXIT`** and gated on `isAnyExit`, so it catches the residue it was
written for — *a matchUp that is no longer an exit, still carrying a reason for one* — and not the
legitimate case.

`isAnyExit` rather than `isExit`, because the double exits are precisely the statuses that stamp
provenance. (`isAnyExit` was added by #4823; using it here keeps the two definitions of "is this
still an exit" from drifting apart, which is how this predicate has cost sessions before.)

Three tests pin both directions:

| state | expected |
|---|---|
| `WALKOVER`, codes `[]`, provenance present | **silent** — the state #4823 preserves |
| `DOUBLE_WALKOVER`, codes `[]`, provenance present | **silent** — `isExit` alone would miss this |
| `TO_BE_PLAYED`, codes `[]`, provenance present | **fires** — the real residue |
| `TO_BE_PLAYED`, codes `[]`, no provenance | silent |

## Note for the session that owns this surface

This is a harness-only change — `invariants.ts` plus a new test. It touches nothing under
`src/mutate/matchUps/drawPositions/**` or `positionGovernor/**`, so it should not collide with the
refusal-cluster work in flight.

## Gate

Matrix **144/0**. `pnpm verify` exit 0 — **12,960 passed / 2 skipped**, coverage thresholds met,
build and published-`.d.ts` pack smoke OK.