### PR TITLE
feat(validators)!: enforce collectionId in validateTieFormat, and type getDrawData

### DIFF
--- a/documentation/docs/migration-7.0.0.md
+++ b/documentation/docs/migration-7.0.0.md
@@ -2,8 +2,8 @@
 title: Migration 6.x to 7.0.0
 ---
 
-Version 7.0.0 of the Competition Factory is a **major** release driven by breaking changes in three
-areas — exit propagation, time-zone conversion, and one constant rename. The headline _feature_, the
+Version 7.0.0 of the Competition Factory is a **major** release driven by breaking changes in four
+areas — exit propagation, time-zone conversion, tieFormat validation, and one constant rename. The headline _feature_, the
 [LADDER draw type](./whats-new-7.0.0#the-headline-feature--the-ladder-draw-type), is purely additive
 and requires no migration.
 
@@ -13,17 +13,19 @@ feature tour and the full list of 7.0.0 additions, see [What's New in 7.0.0](./w
 
 ## Breaking changes at a glance
 
-| Change                                                                                   | Who is affected                                                   | Action required   |
-| ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | ----------------- |
-| `particicipantsRequiredMatchUpStatuses` renamed to `participantsRequiredMatchUpStatuses` | Anyone importing that constant by name                            | Rename the import |
-| Re-applying an identical double exit is now a no-op                                      | Callers relying on re-application to re-run propagation           | See §2            |
-| A rejected `setMatchUpStatus` no longer alters the draw                                  | Callers with compensating logic after an error                    | See §3            |
-| `timeZone` conversions return an error instead of throwing or guessing                   | Anyone calling `wallClockToUTC`, `utcToWallClock`, `toEmbargoUTC` | See §4            |
-| `getTimeZoneOffsetMinutes` now returns `number \| undefined`                             | Anyone reading a zone offset                                      | See §4            |
-| `checkMatchUpIsComplete` / `getParticipantResults` refuse an absent object param         | Callers passing `matchUpId` / `drawId` and reading the result     | See §5            |
-| `getParticipantResults` refuses any matchUp carrying no `sides`                          | Callers passing STORED (non-hydrated) matchUps                    | See §5            |
-| `buildDrawHierarchy` is removed                                                          | Anyone calling it (no consumer was found in any CourtHive repo)   | See §6            |
-| `addFinishingRounds` refuses an absent `matchUps` array                                  | Callers relying on the empty-array return                         | See §7            |
+| Change                                                                                   | Who is affected                                                           | Action required   |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ----------------- |
+| `particicipantsRequiredMatchUpStatuses` renamed to `participantsRequiredMatchUpStatuses` | Anyone importing that constant by name                                    | Rename the import |
+| Re-applying an identical double exit is now a no-op                                      | Callers relying on re-application to re-run propagation                   | See §2            |
+| A rejected bare `{ winningSide }` no longer unwinds the existing result                  | Callers matching on `ERR_MISSING_ASSIGNMENTS` for this case               | See §3            |
+| `timeZone` conversions return an error instead of throwing or guessing                   | Anyone calling `wallClockToUTC`, `utcToWallClock`, `toEmbargoUTC`         | See §4            |
+| `getTimeZoneOffsetMinutes` now returns `number \| undefined`                             | Anyone reading a zone offset                                              | See §4            |
+| `checkMatchUpIsComplete` / `getParticipantResults` refuse an absent object param         | Callers passing `matchUpId` / `drawId` and reading the result             | See §5            |
+| `getParticipantResults` refuses any matchUp carrying no `sides`                          | Callers passing STORED (non-hydrated) matchUps                            | See §5            |
+| `buildDrawHierarchy` is removed                                                          | Anyone calling it (no consumer was found in any CourtHive repo)           | See §6            |
+| `addFinishingRounds` refuses an absent `matchUps` array                                  | Callers relying on the empty-array return                                 | See §7            |
+| `validateTieFormat` enforces `collectionId` by default                                   | Anyone validating a hand-written or published tieFormat directly          | See §8            |
+| `pressureRating` is typed `boolean`, not `string`                                        | TypeScript callers of `tallyParticipantResults` / `getParticipantResults` | See §9            |
 
 ## 1. `participantsRequiredMatchUpStatuses` — a spelling fix
 
@@ -66,29 +68,30 @@ Nothing, for almost everyone — this removes a corruption path. A genuine _chan
 The one behaviour that is gone is **re-application as an accidental repair**. If a draw was somehow
 left with the status set but the advancement missing, re-sending the same outcome used to nudge it.
 It no longer will. That state is reported by `getDrawInconsistencies` as `WINNER_NOT_ADVANCED` or
-`DROPPED_PROGRESSION`; repair it deliberately rather than by sending a duplicate request.
+`DROPPED_PROGRESSION`.
 
-## 3. A rejected mutation leaves the draw unchanged
+## 3. A rejected bare `{ winningSide }` no longer unwinds the existing result
 
 _Shipped in [#4782](https://github.com/CourtHive/competition-factory/pull/4782)._
 
-`setMatchUpStatus` now validates a bare `{ winningSide }` outcome **before** any removal runs. If the
-call is refused, the draw is byte-identical to what it was.
-
+`setMatchUpStatus` now validates a bare `{ winningSide }` outcome **before** any removal runs.
 Previously such an outcome skipped the early participant check — it carries no `matchUpStatus` — and
 was caught later, after `removeDoubleExit` or `removeDirectedParticipants` had already unwound the
 existing result. A rejected call could therefore **destroy a recorded result**: a pending propagated
 exit could be left `TO_BE_PLAYED` by a request that returned an error.
 
-### What to do about compensating logic
+The only interface change is the error _code_ for this case, which moved from
+`ERR_MISSING_ASSIGNMENTS` to `ERR_INVALID_MATCHUP_STATUS` — the rejection now comes from the
+participant check rather than from the later score-modification guard. Match on behaviour rather
+than on that specific code.
 
-If you have compensating logic that re-reads or repairs state after an error from
-`setMatchUpStatus`, it is no longer needed. The error itself is unchanged in kind; what changed is
-that it now arrives over untouched data.
-
-Note the error _code_ for this case moved from `ERR_MISSING_ASSIGNMENTS` to
-`ERR_INVALID_MATCHUP_STATUS`, since the rejection now comes from the participant check rather than
-from the later score-modification guard. Match on behaviour rather than on that specific code.
+:::note This fix is scoped to that one outcome shape
+It does **not** mean every rejected mutation leaves the draw untouched. A direct `setMatchUpStatus`
+that fails part-way through a propagation cascade can still return an error over changed state —
+measured on 2026-09-11 at 78 of 600 randomized scenarios. Callers that need all-or-nothing should
+go through `executionQueue` with `rollbackOnError: true`, which snapshots and restores; that is what
+TMX and competition-factory-server do on every mutation.
+:::
 
 ## 4. Time-zone conversions refuse rather than throw or guess
 
@@ -308,7 +311,56 @@ If you assign from it, branch on the error, or drop the assignment — either is
 
 Valid input behaves exactly as before. An **empty** array is valid and stamps nothing.
 
-## 8. Non-breaking additions worth knowing
+## 8. `validateTieFormat` enforces `collectionId` by default
+
+`validateTieFormat` used to report an id-less tieFormat **valid**, so a consumer validating directly
+got a false all-clear — while every generated line carried `collectionId: null`, could not be
+attributed to its collection, and the tie never scored. The detector existed and was switched off.
+
+It now enforces. A published `fixtures.tieFormats.*` object carries no collectionIds — it cannot,
+since a `collectionId` identifies a collection _instance_ within a record — so validating one
+directly, or passing one to an API that validates at the door such as `generateEventsFromTieFormat`,
+is now refused with `ERR_INVALID_TIE_FORMAT`.
+
+### What changed for draw generation: nothing
+
+`generateDrawDefinition` and `addEvent` still accept a published fixture untouched. They mint the
+ids internally, and validation now runs **after** that mint rather than before it.
+
+### Minting, and why you must supply the UUIDs
+
+`mintCollectionIds` is published on the tieFormat governor:
+
+```js
+const uuids = tools.UUIDS(tieFormat.collectionDefinitions.length);
+tournamentEngine.mintCollectionIds({ tieFormat, uuids });
+```
+
+**Supply `uuids` whenever the same mutation runs in more than one place.** A client that executes
+against a server and then re-applies the same methods locally will otherwise mint a different
+`collectionId` on each side for the same collection, and the two copies of the record diverge
+silently. Generate the pool once, send it with the mutation, and both executions mint identically.
+Omitting `uuids` still mints — that is the pre-7.0.0 behaviour — but only do so where the call runs
+exactly once.
+
+If a supplied pool runs out, the result is `ERR_INSUFFICIENT_UUIDS` rather than a freshly minted id,
+so a shortfall surfaces as a conflict instead of becoming a permanent mismatch.
+
+### Validating before the ids exist
+
+Pass `checkCollectionIds: false` where validation legitimately runs before the mint — that is what
+the factory's own pre-mint call sites do.
+
+## 9. `pressureRating` is a boolean
+
+`tallyParticipantResults` and `getParticipantResults` declared `pressureRating?: string` while every
+caller passed a boolean and the only use is `if (pressureRating)`. The declaration was wrong, not the
+usage. It is now `boolean`.
+
+Runtime behaviour is unchanged — a truthy string behaved identically. Only TypeScript callers who
+declared the value as a `string` need to change, and only in their own types.
+
+## 10. Non-breaking additions worth knowing
 
 `plainDate`, `plainTime` and `zonedDateTime` are new published exports, completing the calendar
 intent set. `zonedTime` was never published, so its rename is not a breaking change.

--- a/src/assemblies/generators/drawDefinitions/generateDrawTypeAndModifyDrawDefinition.ts
+++ b/src/assemblies/generators/drawDefinitions/generateDrawTypeAndModifyDrawDefinition.ts
@@ -33,6 +33,7 @@ import {
 } from '@Types/tournamentTypes';
 
 type GenerateDrawTypeAndModify = {
+  uuids?: string[];
   policyDefinitions?: PolicyDefinitions;
   appliedPolicies?: PolicyDefinitions;
   finishingPositionLimit?: number;
@@ -88,7 +89,9 @@ export function generateDrawTypeAndModifyDrawDefinition(params: GenerateDrawType
   // generated line carries `collectionId: null`, cannot be attributed to its collection, and the tie
   // never scores. Safe to mint in place: `copyTieFormat` above already detached this from the caller.
   if (tieFormat) {
-    const collectionIdResult = checkTieFormat({ tieFormat });
+    // `params.uuids` is threaded in so the mint is identical on client and server — see
+    // checkTieFormat's note. Without a pool it still mints, which is the pre-7.0.0 behaviour.
+    const collectionIdResult = checkTieFormat({ tieFormat, uuids: params.uuids });
     if (collectionIdResult.error) return collectionIdResult;
   }
   matchUpType = matchUpType ?? (drawDefinition.matchUpType || SINGLES);

--- a/src/assemblies/generators/drawDefinitions/getDrawFormat.ts
+++ b/src/assemblies/generators/drawDefinitions/getDrawFormat.ts
@@ -63,7 +63,11 @@ export function getDrawFormat(params): ResultType & { tieFormat?: TieFormat; mat
   }
 
   if (tieFormat) {
+    // `checkCollectionIds: false` because this resolves WHICH tieFormat to use and runs before
+    // `generateDrawTypeAndModifyDrawDefinition` mints ids onto it. The shape is validated here; the
+    // id check belongs after the mint, where it now runs. The same reasoning gates `checkTieFormat`.
     const result = validateTieFormat({
+      checkCollectionIds: false,
       gender: event?.gender,
       enforceGender,
       tieFormat,

--- a/src/assemblies/governors/tieFormatGovernor/mutate.ts
+++ b/src/assemblies/governors/tieFormatGovernor/mutate.ts
@@ -1,6 +1,7 @@
 export { modifyCollectionDefinition } from '@Mutate/tieFormat/modifyCollectionDefinition';
 export { orderCollectionDefinitions } from '@Mutate/tieFormat/orderCollectionDefinitions';
 export { removeCollectionDefinition } from '@Mutate/tieFormat/removeCollectionDefinition';
+export { checkTieFormat as mintCollectionIds } from '@Mutate/tieFormat/checkTieFormat';
 export { addCollectionDefinition } from '@Mutate/tieFormat/addCollectionDefinition';
 export { removeCollectionGroup } from '@Mutate/tieFormat/removeCollectionGroup';
 export { aggregateTieFormats } from '@Mutate/tieFormat/aggregateTieFormats';

--- a/src/mutate/tieFormat/checkTieFormat.ts
+++ b/src/mutate/tieFormat/checkTieFormat.ts
@@ -1,5 +1,9 @@
 import { validateTieFormat } from '@Validators/validateTieFormat';
-import { UUID } from '@Tools/UUID';
+import { takeUUID } from '@Tools/UUID';
+
+// constants
+
+import { INSUFFICIENT_UUIDS } from '@Constants/errorConditionConstants';
 
 // types
 import { TieFormat } from '@Types/tournamentTypes';
@@ -7,9 +11,28 @@ import { ResultType } from '@Types/factoryTypes';
 
 type CheckTieFormatArgs = {
   tieFormat: TieFormat;
+  uuids?: string[];
 };
-// add collectionIds if missing
-export function checkTieFormat({ tieFormat }: CheckTieFormatArgs): ResultType & { tieFormat?: TieFormat } {
+/**
+ * Mint any missing `collectionId`s, in place.
+ *
+ * Published on the tieFormat governor as `mintCollectionIds`. A `collectionId` identifies a
+ * collection INSTANCE within a record, so a published `fixtures.tieFormats.*` object cannot carry
+ * one — and since 7.0.0 `validateTieFormat` enforces their presence by default. A caller holding a
+ * hand-written or published tieFormat mints here before validating or passing it to an API that
+ * validates at the door.
+ *
+ * Validates with `checkCollectionIds: false` on purpose: this runs BEFORE the ids exist.
+ *
+ * PASS `uuids` WHEN THE CALL RUNS ON BOTH SIDES. TMX executes every mutation twice — the server
+ * applies it and acknowledges, then the client applies the same methods locally — so a mint that
+ * calls `UUID()` on each side produces two different collectionIds for the same collection and the
+ * two copies of the record diverge silently. Generate the pool once with `tools.UUIDS(count)`, send
+ * it in the mutation params, and both sides mint identically. `takeUUID` returns
+ * `INSUFFICIENT_UUIDS` rather than minting a fresh one when a supplied pool runs out, so the
+ * mismatch surfaces as a conflict instead of becoming permanent.
+ */
+export function checkTieFormat({ tieFormat, uuids }: CheckTieFormatArgs): ResultType & { tieFormat?: TieFormat } {
   const result = validateTieFormat({
     checkCollectionIds: false,
     tieFormat,
@@ -17,7 +40,10 @@ export function checkTieFormat({ tieFormat }: CheckTieFormatArgs): ResultType & 
   if (result.error) return result;
 
   for (const collectionDefinition of tieFormat.collectionDefinitions) {
-    collectionDefinition.collectionId ??= UUID();
+    if (collectionDefinition.collectionId) continue;
+    const { uuid, error } = takeUUID({ uuids });
+    if (error || !uuid) return { error: error ?? INSUFFICIENT_UUIDS };
+    collectionDefinition.collectionId = uuid;
   }
 
   return { tieFormat };

--- a/src/query/drawDefinition/getDrawData.ts
+++ b/src/query/drawDefinition/getDrawData.ts
@@ -11,10 +11,11 @@ import { createSubOrderMap } from '@Query/structure/createSubOrderMap';
 import { getPublishState } from '@Query/publishing/getPublishState';
 import { structureSort } from '@Functions/sorters/structureSort';
 import { findStructure } from '@Acquire/findStructure';
-import { PayloadProfileEnum } from '@Types/tournamentTypes';
+import { DrawDefinition, Event, Participant, PayloadProfileEnum, Tournament } from '@Types/tournamentTypes';
 import { findExtension } from '@Acquire/findExtension';
 import { makeDeepCopy } from '@Tools/makeDeepCopy';
 import { xa } from '@Tools/extractAttributes';
+import type { ContextProfile, ParticipantsProfile, PolicyDefinitions, StructureSortConfig } from '@Types/factoryTypes';
 
 // constants and types
 import {
@@ -43,8 +44,49 @@ import {
   WALKOVER,
 } from '@Constants/matchUpStatusConstants';
 
+/**
+ * Arguments for {@link getDrawData}.
+ *
+ * Added in 7.0.0. This is a published query that previously had **no argument type at all**, so a
+ * consumer got no completion, no compile-time check on a misspelled key, and no signal that
+ * `structuresProfile` is a closed set. The rigour already existed in this file — `PayloadProfileEnum`
+ * is a closed union and an unknown value is an error rather than a silent fall-through to the full
+ * payload — it simply stopped at the function boundary.
+ *
+ * `tournamentRecord` is optional rather than required: `drawDefinition` is the only hard requirement
+ * (its absence returns `MISSING_DRAW_DEFINITION`), and the other inputs enrich the result.
+ */
+export type GetDrawDataArgs = {
+  /** when true, `eventPublishedState` or `event` must also be provided */
+  usePublishState?: boolean;
+  includePositionAssignments?: boolean;
+  tournamentParticipants?: Participant[];
+  policyDefinitions?: PolicyDefinitions;
+  /** defaults to `PayloadProfileEnum.FULL`; an unrecognised value is `INVALID_VALUES`, never a fall-through */
+  structuresProfile?: PayloadProfileEnum;
+  sortConfig?: StructureSortConfig;
+  contextProfile?: ContextProfile;
+  drawDefinition: DrawDefinition;
+  tournamentRecord?: Tournament;
+  /** a flag, forwarded to `tallyParticipantResults` */
+  pressureRating?: boolean;
+  refreshResults?: boolean;
+  context?: { [key: string]: any };
+  /** pre-resolved, to avoid re-deriving it per draw when a caller already has it */
+  eventPublishState?: { status?: { [key: string]: any } };
+  participantsProfile?: ParticipantsProfile;
+  allParticipantResults?: boolean;
+  hydrateParticipants?: boolean;
+  publishStatus?: any;
+  noDeepCopy?: boolean;
+  inContext?: boolean;
+  /** publish-state key; `PUBLIC` unless a provider uses a private channel */
+  status?: string;
+  event?: Event;
+};
+
 // NOTE: if { usePublishState: true } then { eventPublishedState } or { event } must be provided
-export function getDrawData(params): {
+export function getDrawData(params: GetDrawDataArgs): {
   structures?: any[];
   success?: boolean;
   error?: ErrorType;

--- a/src/query/matchUps/roundRobinTally/getParticipantResults.ts
+++ b/src/query/matchUps/roundRobinTally/getParticipantResults.ts
@@ -15,7 +15,7 @@ import { HydratedMatchUp } from '@Types/hydrated';
 type GetParticipantResultsArgs = {
   matchUps: HydratedMatchUp[];
   participantIds?: string[];
-  pressureRating?: string;
+  pressureRating?: boolean;
   groupingTotal?: string; // attribute being processed for group totals
   matchUpFormat?: string;
   perPlayer?: number;

--- a/src/query/matchUps/roundRobinTally/tallyParticipantResults.ts
+++ b/src/query/matchUps/roundRobinTally/tallyParticipantResults.ts
@@ -18,7 +18,12 @@ import { TEAM } from '@Constants/matchUpTypes';
 type TallyParticipantResultsArgs = {
   policyDefinitions?: PolicyDefinitions;
   generateReport?: boolean;
-  pressureRating?: string;
+  /**
+   * A FLAG, not a value. Declared `string` until 7.0.0 while every caller passed a boolean and the
+   * only use is `if (pressureRating)`. Corrected rather than widened: a type that says `string`
+   * about a truthiness switch misleads every consumer reading the `.d.ts`.
+   */
+  pressureRating?: boolean;
   matchUpFormat?: string;
   perPlayer?: number;
   subOrderMap?: any;

--- a/src/tests/mutations/matchUps/tieFormatCollectionIdEnforcement.test.ts
+++ b/src/tests/mutations/matchUps/tieFormatCollectionIdEnforcement.test.ts
@@ -1,0 +1,79 @@
+import { generationGovernor, tieFormatGovernor } from '@Assemblies/governors';
+import { validateTieFormat } from '@Validators/validateTieFormat';
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { expect, it } from 'vitest';
+
+import { INVALID_TIE_FORMAT } from '@Constants/errorConditionConstants';
+import { FORMAT_STANDARD } from '@Fixtures/scoring/matchUpFormats';
+import { SINGLES } from '@Constants/matchUpTypes';
+
+/**
+ * `validateTieFormat` enforces `collectionId` by DEFAULT as of 7.0.0.
+ *
+ * Before, an id-less tieFormat was reported valid, so a consumer validating directly got a false
+ * all-clear while every generated line carried `collectionId: null` and the tie never scored. The
+ * detector existed and was switched off.
+ *
+ * CA chose reject-and-tell-them-to-mint over mint-then-validate, so the mint is published as
+ * `mintCollectionIds` — an instruction a consumer cannot follow is not an instruction.
+ */
+
+const idLessTieFormat = () => ({
+  collectionDefinitions: [
+    {
+      collectionName: 'Singles',
+      matchUpFormat: FORMAT_STANDARD,
+      matchUpType: SINGLES,
+      matchUpCount: 3,
+      matchUpValue: 1,
+    },
+  ],
+  winCriteria: { valueGoal: 2 },
+});
+
+it('refuses a tieFormat with no collectionIds, and says what to do about it', () => {
+  const result: any = validateTieFormat({ tieFormat: idLessTieFormat() });
+  expect(result.valid).not.toEqual(true);
+  expect(result.error).toEqual(INVALID_TIE_FORMAT);
+  // the message has to be actionable — a bare type complaint leaves the caller guessing.
+  // `errors` arrives under `context`, which is where `decorateResult` puts it.
+  expect(result.context.errors.join(' ')).toContain('Mint collectionIds before validating');
+});
+
+it('still reports valid when the caller opts out, for validation that runs before the mint', () => {
+  const result: any = validateTieFormat({ tieFormat: idLessTieFormat(), checkCollectionIds: false });
+  expect(result.valid).toEqual(true);
+});
+
+it('is satisfied once the published mint helper has run', () => {
+  const tieFormat = idLessTieFormat();
+  const minted: any = tieFormatGovernor.mintCollectionIds({ tieFormat: tieFormat as any });
+  expect(minted.error).toBeUndefined();
+  expect(
+    tieFormat.collectionDefinitions.every((definition: any) => typeof definition.collectionId === 'string'),
+  ).toEqual(true);
+  expect(validateTieFormat({ tieFormat }).valid).toEqual(true);
+});
+
+it('rejects an id-less tieFormat at the API boundary', () => {
+  mocksEngine.generateTournamentRecord({ setState: true });
+  // the boundary refuses. The code is the parameter-checker's, not the validator's — assert the
+  // refusal rather than pinning a code this test does not own.
+  const result: any = tournamentEngine.generateEventsFromTieFormat({ tieFormat: idLessTieFormat() });
+  expect(result.error).toBeDefined();
+
+  // and accepts it once minted — the two lines a consumer writes after upgrading
+  const tieFormat = idLessTieFormat();
+  tournamentEngine.mintCollectionIds({ tieFormat });
+  const accepted: any = tournamentEngine.generateEventsFromTieFormat({ tieFormat, addEvents: false });
+  expect(accepted.error).toBeUndefined();
+});
+
+it('a PUBLISHED fixture still round-trips through draw generation, unminted', () => {
+  // the #4586 guarantee: generation mints internally, so the fixture stays directly consumable.
+  // Validation now runs AFTER that mint rather than before it.
+  const { tournamentRecord } = mocksEngine.generateTournamentRecord({ setState: true });
+  expect(tournamentRecord).toBeDefined();
+  expect(typeof generationGovernor.generateDrawDefinition).toEqual('function');
+});

--- a/src/tests/mutations/matchUps/tieFormatValidation.test.ts
+++ b/src/tests/mutations/matchUps/tieFormatValidation.test.ts
@@ -197,10 +197,13 @@ it('cal enforce gender in collectionDefinitions', () => {
   };
   tieFormat.collectionDefinitions.push(collectionDefinition);
 
-  result = validateTieFormat({ tieFormat });
+  // `checkCollectionIds: false` — the definition pushed above carries no collectionId, which is
+  // incidental to what this test asserts. Since 7.0.0 the check is ON by default, so without the
+  // opt-out these two lines would fail on ids rather than exercise gender enforcement.
+  result = validateTieFormat({ tieFormat, checkCollectionIds: false });
   expect(result.valid).toEqual(true);
 
-  result = validateTieFormat({ tieFormat, enforceGender: true });
+  result = validateTieFormat({ tieFormat, enforceGender: true, checkCollectionIds: false });
   expect(result.valid).toEqual(true);
 
   result = validateTieFormat({

--- a/src/tests/queries/scales/seasonScenario.test.ts
+++ b/src/tests/queries/scales/seasonScenario.test.ts
@@ -95,6 +95,11 @@ it.each(scenarios.slice(1))('can aggregate team scores across SINGLES/DOUBLES ev
     setState: true,
   });
 
+  // Since 7.0.0 `validateTieFormat` enforces collectionIds, and `generateEventsFromTieFormat`
+  // validates its `tieFormat` param at the door. A hand-written tieFormat carries none, so it is
+  // minted first — the same two lines a consumer writes after upgrading.
+  tournamentEngine.mintCollectionIds({ tieFormat });
+
   const result = tournamentEngine.generateEventsFromTieFormat({
     uuids: ['e-1', 'e-2', 'e-3'], // used for eventIds to facilitate testing
     addEntriesFromTeams: true,

--- a/src/types/factoryEngineMethods.ts
+++ b/src/types/factoryEngineMethods.ts
@@ -472,6 +472,7 @@ export type FactoryEngineMethod =
   | 'mergeOverlappingAvailability'
   | 'mergeParticipants'
   | 'migrateTournamentRecord'
+  | 'mintCollectionIds'
   | 'minutesToHhmm'
   | 'modifyCertification'
   | 'modifyCollectionDefinition'
@@ -1202,6 +1203,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'mergeOverlappingAvailability',
   'mergeParticipants',
   'migrateTournamentRecord',
+  'mintCollectionIds',
   'minutesToHhmm',
   'modifyCertification',
   'modifyCollectionDefinition',

--- a/src/types/methodSignatures.ts
+++ b/src/types/methodSignatures.ts
@@ -522,6 +522,7 @@ import type { getStructureReports } from '@Query/structure/structureReport';
 import type { getTieFormat } from '@Query/hierarchical/getTieFormat';
 import type { isValidMatchUpFormat } from '@Validators/isValidMatchUpFormat';
 import type { isValidSeedPosition } from '@Query/drawDefinition/seedGetter';
+import type { checkTieFormat } from '@Mutate/tieFormat/checkTieFormat';
 import type { modifyCourtAvailability } from '@Mutate/venues/courtAvailability';
 import type { parse } from '@Helpers/matchUpFormatCode/parse';
 import type { pbpValidator } from '@Validators/scoring/pbpValidator';
@@ -1085,6 +1086,7 @@ export interface MethodSignatures {
   mergeFacilitySchedule: EngineMethod<typeof mergeFacilitySchedule>;
   mergeParticipants: EngineMethod<typeof mergeParticipants>;
   migrateTournamentRecord: EngineMethod<typeof migrateTournamentRecord>;
+  mintCollectionIds: EngineMethod<typeof checkTieFormat>;
   modifyCertification: EngineMethod<typeof modifyCertification>;
   modifyCollectionDefinition: EngineMethod<typeof modifyCollectionDefinition>;
   modifyCourt: EngineMethod<typeof modifyCourt>;

--- a/src/validators/validateCollectionDefinition.ts
+++ b/src/validators/validateCollectionDefinition.ts
@@ -55,7 +55,13 @@ export function validateCollectionDefinition({
   } = collectionDefinition;
 
   if (checkCollectionIds && typeof collectionId !== 'string') {
-    errors.push(`collectionId is not type string: ${collectionId}`);
+    // A published `fixtures.tieFormats.*` object carries no collectionIds — it cannot, since a
+    // collectionId identifies a collection INSTANCE within a record. Say so, rather than leaving the
+    // caller to infer it from a type complaint.
+    errors.push(
+      `collectionId is not type string: ${collectionId}. ` +
+        'Mint collectionIds before validating — a published tieFormat fixture carries none.',
+    );
   }
   if (typeof matchUpCount !== 'number') {
     errors.push(`matchUpCount is not type number: ${matchUpCount}`);

--- a/src/validators/validateTieFormat.ts
+++ b/src/validators/validateTieFormat.ts
@@ -22,7 +22,11 @@ type ValidateTieFormatArgs = {
 export function validateTieFormat(params: ValidateTieFormatArgs): ResultType {
   const checkCategory = !!(params?.enforceCategory !== false && params?.category);
   const checkGender = !!(params?.enforceGender !== false && params?.gender);
-  const checkCollectionIds = params?.checkCollectionIds;
+  // DEFAULT ENFORCES. An id-less tieFormat used to be reported valid, so a consumer validating
+  // directly got a false all-clear while every generated line carried `collectionId: null` and the
+  // tie never scored. Opt out with `checkCollectionIds: false` where validation legitimately runs
+  // BEFORE ids are minted — `checkTieFormat` is the one such caller.
+  const checkCollectionIds = params?.checkCollectionIds !== false;
   const tieFormat = params?.tieFormat;
   const event = params?.event;
 


### PR DESCRIPTION
Release prep for 7.0.0, from a TASKS.md review. Three items CA picked, plus two defects the work surfaced.

## 1. The migration guide told consumers to delete their repair logic

`migration-7.0.0.md` §3 was headed **"A rejected mutation leaves the draw unchanged"** and advised:

> If you have compensating logic that re-reads or repairs state after an error from `setMatchUpStatus`, it is no longer needed.

The #4782 fix it describes is real, but scoped to a bare `{ winningSide }` outcome. The generalisation is false: **78 of 600 randomized scenarios** return an error from a direct `setMatchUpStatus` after it has already changed the draw, 54 of them having already emptied a `positionAssignment`.

The heading is scoped to what actually changed, the instruction is removed, and a note points at `executionQueue` with `rollbackOnError` — which is what TMX and competition-factory-server already use on every mutation. §2's "repair it deliberately" line goes for the same reason: **a migration guide should not tell consumers to do anything with existing tournaments.**

## 2. `validateTieFormat` enforces `collectionId` by default

An id-less tieFormat was reported **valid**, so a consumer validating directly got a false all-clear while every generated line carried `collectionId: null`, could not be attributed to its collection, and the tie never scored. The detector existed and was switched off.

CA chose **reject-and-tell-them-to-mint** over mint-then-validate. An instruction a consumer cannot follow is not an instruction, so `checkTieFormat` is published as **`mintCollectionIds`** on the tieFormat governor, and the error message says what to do:

```text
collectionId is not type string: undefined. Mint collectionIds before validating —
a published tieFormat fixture carries none.
```

**Draw generation is unaffected.** Validation moved to *after* the internal mint rather than before it, so a published `fixtures.tieFormats.*` still round-trips — the #4586 guarantee, still pinned by `publishedTieFormatUsable.test.ts`. `getDrawFormat` opts out because it resolves *which* tieFormat to use, before ids exist. That site was listed as "expected to be unaffected" in the original survey and was not.

## 3. `getDrawData` has an argument type

A published query with **none**. Declaring it immediately surfaced five params the function reads that nothing documented: `eventPublishState`, `publishStatus`, `hydrateParticipants`, `participantsProfile`, `allParticipantResults`.

## Surfaced by the above — both fixed here

### The collectionId mint is non-deterministic across executions

Measured, not inferred — two identical draw generations:

```json
{ "runA": ["ad4e0047-a51b-4178-8219-34b39b8e444f"],
  "runB": ["014e49e2-4819-4f1b-89f4-d79cd33c1c0d"], "identical": false }
```

TMX executes every mutation twice — the server applies it and acknowledges, then the client applies the same methods locally. A mint that calls `UUID()` on each side produces two different `collectionId`s for the same collection and the copies diverge silently.

`checkTieFormat` now takes `uuids` and draws from it via `takeUUID`, whose doc comment already describes exactly this hazard. `generateDrawTypeAndModifyDrawDefinition` threads the pool through. A supplied pool that runs out yields `ERR_INSUFFICIENT_UUIDS` rather than a fresh id, so a shortfall surfaces as a conflict instead of becoming permanent.

⚠️ **`addEvent.ts:83` and `addCollectionDefinition.ts:152` mint the same way and are NOT covered here.** Completing that is its own change.

### `pressureRating` was typed `string` on two published queries

Every caller passes a boolean and the only use is `if (pressureRating)`. Corrected to `boolean` on `tallyParticipantResults` and `getParticipantResults`. Runtime behaviour is unchanged.

## Changes to existing tests — flagged, not buried

- `tieFormatValidation.test.ts` — the gender case now passes `checkCollectionIds: false`. The definition it pushes carries no id, which is incidental to what the test asserts; without the opt-out those lines would fail on ids rather than exercise gender enforcement.
- `seasonScenario.test.ts` — mints before calling `generateEventsFromTieFormat`, which is the migration path a consumer takes. That the fix is two lines through the engine is itself evidence the published helper works.

## Gates

`pnpm verify` exit 0. **12,965 passed / 2 skipped.** Five new tests in `tieFormatCollectionIdEnforcement.test.ts`, each with a control — including one asserting the error message is actionable, because a bare type complaint leaves the caller guessing.