### PR TITLE
fix(draws): the loser unwind must release the drawPosition it empties

### DIFF
--- a/src/mutate/matchUps/drawPositions/releaseAdvancedDrawPosition.ts
+++ b/src/mutate/matchUps/drawPositions/releaseAdvancedDrawPosition.ts
@@ -1,0 +1,84 @@
+import { modifyMatchUpNotice } from '@Mutate/notifications/drawNotifications';
+import { getInitialRoundNumber } from '@Query/matchUps/getInitialRoundNumber';
+import { getMatchUpsMap } from '@Query/matchUps/getMatchUpsMap';
+
+// constants and types
+import type { DrawDefinition, Event, Tournament } from '@Types/tournamentTypes';
+import { BYE, TO_BE_PLAYED } from '@Constants/matchUpStatusConstants';
+import { SUCCESS } from '@Constants/resultConstants';
+import type { MatchUpsMap } from '@Types/factoryTypes';
+
+const RELEASABLE_STATUSES: (string | undefined)[] = [undefined, TO_BE_PLAYED, BYE];
+
+type ReleaseAdvancedDrawPositionArgs = {
+  tournamentRecord?: Tournament;
+  drawDefinition: DrawDefinition;
+  matchUpsMap?: MatchUpsMap;
+  fromRoundNumber: number;
+  drawPosition: number;
+  structureId: string;
+  event?: Event;
+};
+
+/**
+ * Drop a drawPosition from the matchUps that hold it only by ADVANCEMENT.
+ *
+ * Emptying a `positionAssignment` is only half of a removal. The drawPosition is still carried by
+ * every matchUp the participant had advanced into, and `getUpdatedDrawPositions` can only claim a
+ * slot that is `undefined` in the array — so a position left behind blocks that slot permanently and
+ * the next arrival is refused with DRAW_POSITION_ASSIGNED for a matchUp that is, in substance, half
+ * empty. This makes `drawPositions` mean "positions this matchUp actually holds".
+ *
+ * Two scopes keep it from removing a position that is load-bearing, and both were measured rather
+ * than assumed:
+ *
+ *  1. **The round where the position FIRST appears is never touched.** That matchUp owns the slot
+ *     structurally — a feed round awaiting its arrival legitimately holds a position whose
+ *     assignment is still vacant, and releasing it would break the arrival path. Measured over the
+ *     600-seed sweep window: of the vacant slots seen at a refusal, 38 were exactly this case.
+ *
+ *  2. **Only an UNDECIDED matchUp releases a slot.** `drawPositions` is POSITIONAL — the index
+ *     carries the side — while `getUpdatedDrawPositions` sorts and compacts, so removing a position
+ *     and re-adding it inside the same mutation is not identity-preserving. A re-score directs a new
+ *     loser into the SAME seat, and on a matchUp that already records an outcome the round-trip
+ *     rewrote its `winningSide`. A matchUp with a recorded result therefore keeps its array; only
+ *     TO_BE_PLAYED and BYE, with no winningSide, release.
+ *
+ * The hole is preserved rather than compacted, for the same positional reason: closing it would
+ * shift the surviving position onto the other side.
+ */
+export function releaseAdvancedDrawPosition({
+  tournamentRecord,
+  fromRoundNumber,
+  drawDefinition,
+  drawPosition,
+  matchUpsMap,
+  structureId,
+  event,
+}: ReleaseAdvancedDrawPositionArgs) {
+  const resolvedMap = matchUpsMap ?? getMatchUpsMap({ drawDefinition });
+  const matchUps = resolvedMap?.mappedMatchUps?.[structureId]?.matchUps ?? [];
+  const { initialRoundNumber } = getInitialRoundNumber({ drawPosition, matchUps });
+
+  for (const matchUp of matchUps) {
+    if (matchUp.roundNumber === undefined || matchUp.roundNumber < fromRoundNumber) continue;
+    if (matchUp.roundNumber === initialRoundNumber) continue;
+    if (!matchUp.drawPositions?.includes(drawPosition)) continue;
+    if (matchUp.winningSide || !RELEASABLE_STATUSES.includes(matchUp.matchUpStatus)) continue;
+
+    matchUp.drawPositions = (matchUp.drawPositions ?? []).map((position) =>
+      position === drawPosition ? undefined : position,
+    ) as number[];
+
+    modifyMatchUpNotice({
+      tournamentId: tournamentRecord?.tournamentId,
+      context: 'releaseAdvancedDrawPosition',
+      eventId: event?.eventId,
+      drawDefinition,
+      matchUp,
+      event,
+    });
+  }
+
+  return { ...SUCCESS };
+}

--- a/src/mutate/matchUps/drawPositions/removeDirectedParticipants.ts
+++ b/src/mutate/matchUps/drawPositions/removeDirectedParticipants.ts
@@ -1,6 +1,7 @@
 import { includesMatchUpStatuses } from '@Mutate/drawDefinitions/matchUpGovernor/includesMatchUpStatuses';
 import { clearResolvedSideExitProvenance } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
 import { removeSubsequentRoundsParticipant } from './removeSubsequentRoundsParticipant';
+import { releaseAdvancedDrawPosition } from './releaseAdvancedDrawPosition';
 import { structureAssignedDrawPositions } from '@Query/drawDefinition/positionsGetter';
 import { updateTieMatchUpScore } from '@Mutate/matchUps/score/updateTieMatchUpScore';
 import { getAllStructureMatchUps } from '@Query/matchUps/getAllStructureMatchUps';
@@ -307,11 +308,42 @@ function removeDirectedLoser({
   const relevantDrawPosition = positionAssignments?.find(
     (assignment) => assignment.participantId === loserParticipantId,
   )?.drawPosition;
+  const clearedDrawPositions: number[] = [];
   positionAssignments?.forEach((assignment) => {
     if (assignment.participantId === loserParticipantId) {
       delete assignment.participantId;
+      clearedDrawPositions.push(assignment.drawPosition);
     }
   });
+
+  // Emptying the assignment above leaves the drawPosition behind in every target-structure matchUp
+  // the participant had ADVANCED into, which blocks that slot against the next arrival. Its twin
+  // `removeDirectedWinner` has always stripped — through `removeSubsequentRoundsParticipant`, which
+  // also collapses status and codes — and only the loser direction did not. That asymmetry was the
+  // largest single producer of the refusal cluster (72 of 87 stale slots measured over the 600-seed
+  // sweep window).
+  //
+  // The loser direction takes the NARROW form deliberately: reusing
+  // `removeSubsequentRoundsParticipant` here also rewrote matchUpStatus, winningSide and
+  // matchUpStatusCodes on the released matchUps, and that was measurably wider than the defect —
+  // it flipped a recorded winningSide on a re-score and broke a BYE unwind. Releasing the slot is
+  // the whole fix; see releaseAdvancedDrawPosition for the two scopes that keep it safe.
+  //
+  // Every position the loop above emptied is released, not just the first: the deletion is keyed on
+  // participantId, and a participant fed back into a draw holds more than one.
+  if (loserMatchUp?.roundNumber) {
+    for (const drawPosition of clearedDrawPositions) {
+      releaseAdvancedDrawPosition({
+        fromRoundNumber: loserMatchUp.roundNumber,
+        tournamentRecord,
+        drawDefinition,
+        drawPosition,
+        matchUpsMap,
+        structureId,
+        event,
+      });
+    }
+  }
 
   if (sourceMatchUpId && sourceMatchUpStatus) {
     //It could be that the loser match up was already a double walkover with one propagated

--- a/src/tests/mutations/exitPropagation/unwindRemovesDrawPosition.test.ts
+++ b/src/tests/mutations/exitPropagation/unwindRemovesDrawPosition.test.ts
@@ -1,0 +1,117 @@
+import { getDrawInconsistencies } from '@Query/drawDefinition/getDrawInconsistencies';
+import { setSubscriptions } from '@Global/state/globalState';
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { expect, it } from 'vitest';
+
+import { FIRST_MATCH_LOSER_CONSOLATION, MODIFIED_FEED_IN_CHAMPIONSHIP } from '@Constants/drawDefinitionConstants';
+import { DEFAULTED, DOUBLE_DEFAULT, DOUBLE_WALKOVER, WALKOVER } from '@Constants/matchUpStatusConstants';
+import { POLICY_TYPE_SCORING } from '@Constants/policyConstants';
+
+/**
+ * An unwind that empties a `positionAssignment` must also drop that drawPosition from the matchUps
+ * that only hold it by advancement.
+ *
+ * `removeDirectedLoser` deleted the loser's `participantId` from the target structure's
+ * positionAssignments but never removed the drawPosition from the consolation matchUps the
+ * participant had advanced into. `getUpdatedDrawPositions` can only claim a slot that is
+ * `undefined` in the array, so the stale entry blocked that slot permanently and the next arrival
+ * was refused with ERR_EXISTING_POSITION_ASSIGNMENT — for a matchUp that was, in substance, half
+ * empty. Its twin `removeDirectedWinner` had always stripped, via
+ * `removeSubsequentRoundsParticipant`; only the loser direction did not.
+ *
+ * Both cases below are shrunk reproductions from the 600-seed sweep window
+ * (`SEED_START=9000001`), which is why the seeds are the sweep's own and the step lists are three
+ * long. Each ends in a RE-SCORE of an already-decided round-1 matchUp to a double exit: that is
+ * what runs the removal path with a participant already advanced in the consolation.
+ */
+
+const DRAW_ID = 'unwind-removes-drawposition';
+
+function issues() {
+  const { drawDefinition } = tournamentEngine.getEvent({ drawId: DRAW_ID });
+  const result: any = getDrawInconsistencies({ drawDefinition, drawId: DRAW_ID });
+  return (result?.inconsistencies ?? []).map((issue: any) => issue.issueType);
+}
+
+function mainRoundOne(roundPosition: number) {
+  return tournamentEngine
+    .allDrawMatchUps({ inContext: true, drawId: DRAW_ID })
+    .matchUps.find(
+      (matchUp: any) =>
+        matchUp.stage === 'MAIN' && matchUp.roundNumber === 1 && matchUp.roundPosition === roundPosition,
+    );
+}
+
+it.each([
+  {
+    scenario: 'a DOUBLE_WALKOVER re-score of a DEFAULTED matchUp',
+    drawType: MODIFIED_FEED_IN_CHAMPIONSHIP,
+    participantsCount: 8,
+    drawSize: 8,
+    seed: 9000036,
+    steps: [
+      { roundPosition: 3, outcome: { matchUpStatus: DEFAULTED, winningSide: 1 } },
+      { roundPosition: 4, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
+      { roundPosition: 3, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
+    ],
+  },
+  {
+    scenario: 'a DOUBLE_DEFAULT re-score after a WALKOVER fed the consolation',
+    drawType: FIRST_MATCH_LOSER_CONSOLATION,
+    participantsCount: 16,
+    drawSize: 16,
+    seed: 9000035,
+    steps: [
+      { roundPosition: 8, outcome: { winningSide: 1 } },
+      { roundPosition: 7, outcome: { matchUpStatus: WALKOVER, winningSide: 2 } },
+      { roundPosition: 8, outcome: { matchUpStatus: DOUBLE_DEFAULT } },
+    ],
+  },
+  {
+    scenario: 'a DOUBLE_DEFAULT re-score in a FIRST_MATCH_LOSER_CONSOLATION',
+    drawType: FIRST_MATCH_LOSER_CONSOLATION,
+    participantsCount: 14,
+    drawSize: 16,
+    seed: 9000029,
+    steps: [
+      { roundPosition: 4, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
+      { roundPosition: 3, outcome: { winningSide: 1 } },
+      { roundPosition: 3, outcome: { matchUpStatus: DOUBLE_DEFAULT } },
+    ],
+  },
+])('$scenario is not refused by a drawPosition the unwind already emptied', (testCase) => {
+  const { participantsCount, drawType, drawSize, seed, steps } = testCase;
+
+  setSubscriptions({});
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ participantsCount, drawSize, drawType, drawId: DRAW_ID }],
+    nonRandom: seed,
+    setState: true,
+  });
+  tournamentEngine.attachPolicies({
+    policyDefinitions: { [POLICY_TYPE_SCORING]: { policyName: 'carry exits', propagateExitStatus: true } },
+  });
+
+  for (const [index, step] of steps.entries()) {
+    const matchUp = mainRoundOne(step.roundPosition);
+    expect(matchUp?.matchUpId).toBeDefined();
+    const result: any = tournamentEngine.setMatchUpStatus({
+      matchUpId: matchUp.matchUpId,
+      outcome: step.outcome,
+      drawId: DRAW_ID,
+    });
+    // the first two steps are the setup; the third is the one that used to be refused. Asserting
+    // every step keeps a future setup change from turning this into a vacuous pass.
+    expect(result.error, `step ${index + 1} (roundPosition ${step.roundPosition})`).toBeUndefined();
+  }
+
+  // CONTROL, not the regression assertion: the committed inconsistency oracle must stay clean, so
+  // the fix cannot buy the refusal back by leaving the draw in a worse shape. Its
+  // DRAW_POSITION_UNASSIGNED check is the scoped form of "a matchUp references a drawPosition whose
+  // assignment holds nobody" — scoped because it exempts exits, and a PENDING propagated exit
+  // legitimately advances a still-vacant drawPosition that is awaiting its arrival. These three
+  // scenarios are clean on this oracle before the fix too; the falsifying assertion is the loop
+  // above, which is RED on master at step 3 in all three cases.
+  expect(issues()).toEqual([]);
+});


### PR DESCRIPTION
Block **S1** of `Mentat/planning/EXIT_CASCADE_SESSION_PROMPTS.md`. Base `9173b9453`.

## Census — 600-seed window, `SEED_START=9000001`, `MAX_STEPS=30`

Seed-level, no fingerprint dedup, so "closed" and "new" mean what they say.

| | before | after |
|---|---:|---:|
| **failing seeds** | **92** | **58** |
| `ERROR_IMPLIES_NO_MUTATION` | 78 | 45 |
| `DRAW_INCONSISTENCY` | 13 | 12 |
| `MONOTONIC_DECISION` | 1 | 1 |

**34 seeds closed, ZERO new.** The baseline reproduced the discovery doc's 92 exactly, so
the window is comparable rather than merely similar. Matrix at 144/0. Full suite 12,963
passed / 2 skipped. `pnpm verify` exit 0.

## The defect

`removeDirectedLoser` deleted the loser's `participantId` from the target structure's
`positionAssignments` and stopped. The drawPosition stayed in every matchUp the participant
had advanced into, and `getUpdatedDrawPositions` can only claim a slot that is `undefined`
in the array — so the stale entry blocked that slot permanently and the next arrival was
refused `ERR_EXISTING_POSITION_ASSIGNMENT` for a matchUp that was, in substance, half empty.

`removeDirectedWinner` had always stripped. Only the loser direction did not.

## Attribution, measured before the fix was written

Instrumenting every `DRAW_POSITION_ASSIGNED` refusal over the window, recording each slot's
state **and** its `initialRoundNumber` in the target structure — 83 records, 43 distinct seeds:

| | count |
|---|---:|
| record has a **releasable** stale slot (`initialRound < targetRound`) | **78** |
| record has both slots genuinely held — a different defect, untouched here | 5 |

Of 87 releasable stale slots: **72 `removeDirectedLoser`**, 15 unattributed, **0**
`removeDirectedWinner`, **0** `drawPositionRemovals`.

The same probe answered the design question that had been blocking. A further 38 vacant slots
were the FED slot awaiting its arrival, whose initial round **is** the target's round. So
"`[4, 12]` receiving `11` could become `[4, 11]` or `[11, 12]`" is not ambiguous once
`initialRoundNumber` is consulted: 4 is structurally owned by that matchUp, 12 is an
advancement slot, and only the advancement slot is replaceable. In 83 of 87 cases the arriving
position's initial round equalled the stale slot's.

## Why this is a new helper and not the one the winner direction calls

The obvious fix is to reuse `removeSubsequentRoundsParticipant`. That is measurably wrong: it
also rewrites `matchUpStatus`, `winningSide` and `matchUpStatusCodes`, and `.filter(Boolean)`s
the array. From the loser direction it

- **flipped a recorded `winningSide`** — `drawPositions` is POSITIONAL (the index carries the
  side) while `getUpdatedDrawPositions` sorts numerically and compacts, so remove-then-re-add
  inside one mutation is not identity-preserving, and a re-score directs the new loser into the
  **same** seat. Master kept `[11, <hole>]`; the wide form produced `[11]` and the side inverted.
- **broke a BYE unwind two steps later** — `ERR_OCCUPIED_DRAW_POSITION`.

Wide form: 92 → 60 with **5 newly-failing seeds**. This form: 92 → 58 with **zero**.

`releaseAdvancedDrawPosition` does the release and nothing else, under two scopes that were
measured rather than reasoned:

1. never the round where the drawPosition first appears — that matchUp owns the slot
   structurally, and releasing it would break the arrival path;
2. only an **undecided** matchUp releases (`TO_BE_PLAYED`/`BYE`, no `winningSide`), for the
   positional reason above.

The hole is preserved rather than compacted, for the same reason.

## Tests

`unwindRemovesDrawPosition.test.ts` — three shrunk reproductions from the sweep window
(`MODIFIED_FEED_IN_CHAMPIONSHIP` at drawSize 8, `FIRST_MATCH_LOSER_CONSOLATION` at 16 ×2), each
three steps ending in a re-score of a decided round-1 matchUp to a double exit.

**All three proven RED against master first**, each failing at step 3 with exactly
`ERR_EXISTING_POSITION_ASSIGNMENT` — confirmed again against the final form of the test, not
just an earlier draft. The `getDrawInconsistencies` assertion is labelled in the file as a
control, not the regression assertion: these scenarios are clean on that oracle before the fix
too.

## Reported honestly

- **The other two refusal codes did not move.** `ERR_ACTIVE_DRAW_POSITION` and
  `ERR_OCCUPIED_DRAW_POSITION` are untouched, as is the 5-record cluster whose slots are
  genuinely occupied.
- **`conditionallyRemoveDrawPosition` does not exist** — it was named speculatively in the
  planning doc. The real function is `removeDrawPosition`, which exists twice as a private
  local (`positionClear.ts` and `removeSubsequentRoundsParticipant.ts`), and the two differ:
  the first preserves the array hole, the second compacts it.
- **"33 of 33" does not reproduce as an absolute** at this base — 5 of 83 records have both
  slots genuinely occupied. The dominant reading holds; the absolute claim does not.
- The 5 seeds that the wide form newly failed were each checked by replaying their **stored
  steps** on both commits, **10 repeats each**, because a seed is not a fixed scenario across
  commits and one replay is not a verdict. One (`9000559`) fails 10/10 on master and is
  pre-existing; one was an unstable seed identical on both; the rest are clean on this form.
