### PR TITLE
fix(publishing): honour discrete structure publishing, and pool the collectionId mint

### DIFF
--- a/documentation/docs/migration-7.0.0.md
+++ b/documentation/docs/migration-7.0.0.md
@@ -313,6 +313,8 @@ Valid input behaves exactly as before. An **empty** array is valid and stamps no
 
 ## 8. `validateTieFormat` enforces `collectionId` by default
 
+_Shipped in [#4825](https://github.com/CourtHive/competition-factory/pull/4825)._
+
 `validateTieFormat` used to report an id-less tieFormat **valid**, so a consumer validating directly
 got a false all-clear — while every generated line carried `collectionId: null`, could not be
 attributed to its collection, and the tie never scored. The detector existed and was switched off.
@@ -353,6 +355,8 @@ the factory's own pre-mint call sites do.
 
 ## 9. `pressureRating` is a boolean
 
+_Shipped in [#4825](https://github.com/CourtHive/competition-factory/pull/4825)._
+
 `tallyParticipantResults` and `getParticipantResults` declared `pressureRating?: string` while every
 caller passed a boolean and the only use is `if (pressureRating)`. The declaration was wrong, not the
 usage. It is now `boolean`.
@@ -360,7 +364,28 @@ usage. It is now `boolean`.
 Runtime behaviour is unchanged — a truthy string behaved identically. Only TypeScript callers who
 declared the value as a `string` need to change, and only in their own types.
 
-## 10. Non-breaking additions worth knowing
+## 10. `usePublishState` honours discrete structure publishing
+
+_Shipped in [#4827](https://github.com/CourtHive/competition-factory/pull/4827)._
+
+`getDrawData({ usePublishState: true })` now **omits** a structure whose publishing detail says it is
+not published, or that is embargoed. It previously returned every structure of a published draw
+regardless — the filter ended in `|| true`, so the `isVisiblyPublished` call it contained could never
+affect the result and discrete structure publishing was not honoured at all.
+
+A structure with **no** publishing detail is unaffected: it is still returned. That is the legacy
+shape — publish status predates discrete structure publishing — and it is now pinned by a test.
+
+### What to expect
+
+A consumer reading publish-state-filtered draw data may see **fewer** structures than before, for
+draws where a structure was explicitly unpublished or embargoed. That is the intended behaviour
+arriving for the first time, not a loss: those structures were being served despite being marked
+hidden.
+
+An unpublished **draw** is unchanged — it returned no structures before and returns none now.
+
+## 11. Non-breaking additions worth knowing
 
 `plainDate`, `plainTime` and `zonedDateTime` are new published exports, completing the calendar
 intent set. `zonedTime` was never published, so its rename is not a breaking change.

--- a/src/mutate/events/addEvent.ts
+++ b/src/mutate/events/addEvent.ts
@@ -21,12 +21,20 @@ import { ADD_MATCHUPS } from '@Constants/topicConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 
 type AddEventArgs = {
+  /**
+   * Pool for minting `collectionId`s onto an id-less `event.tieFormat`.
+   *
+   * Supply it whenever the same mutation runs in more than one place — a client that re-applies a
+   * mutation after the server acknowledges it otherwise mints a different id on each side for the
+   * same collection, and the two copies of the record diverge silently. See `checkTieFormat`.
+   */
+  uuids?: string[];
   suppressNotifications?: boolean;
   tournamentRecord: Tournament;
   internalUse?: boolean;
   event: any; // any because eventId need not be present
 };
-export function addEvent({ suppressNotifications, tournamentRecord, internalUse, event }: AddEventArgs): {
+export function addEvent({ suppressNotifications, tournamentRecord, internalUse, uuids, event }: AddEventArgs): {
   context?: { [key: string]: any };
   error?: ErrorType;
   event?: Event;
@@ -80,7 +88,7 @@ export function addEvent({ suppressNotifications, tournamentRecord, internalUse,
       // On a COPY: `eventRecord` is a shallow spread of `event`, so mutating `event.tieFormat` in place
       // would stamp ids onto the caller's object — and onto the shared fixture when that is what was
       // passed.
-      const result = checkTieFormat({ tieFormat: makeDeepCopy(event.tieFormat, false, true) });
+      const result = checkTieFormat({ tieFormat: makeDeepCopy(event.tieFormat, false, true), uuids });
       if (result.error) return result;
       eventRecord.tieFormat = result.tieFormat;
     } else if (event.tieFormatName) {

--- a/src/mutate/tieFormat/addCollectionDefinition.ts
+++ b/src/mutate/tieFormat/addCollectionDefinition.ts
@@ -12,10 +12,15 @@ import { validateTieFormat } from '@Validators/validateTieFormat';
 import { writeTieFormat } from '@Mutate/tieFormat/writeTieFormat';
 import { definedAttributes } from '@Tools/definedAttributes';
 import { validUpdate } from '@Validators/validUpdate';
-import { UUID } from '@Tools/UUID';
+import { takeUUID } from '@Tools/UUID';
 
 // constants and types
-import { CANNOT_MODIFY_TIEFORMAT, DUPLICATE_VALUE, MISSING_DRAW_DEFINITION } from '@Constants/errorConditionConstants';
+import {
+  CANNOT_MODIFY_TIEFORMAT,
+  DUPLICATE_VALUE,
+  INSUFFICIENT_UUIDS,
+  MISSING_DRAW_DEFINITION,
+} from '@Constants/errorConditionConstants';
 import { POLICY_TYPE_MATCHUP_ACTIONS } from '@Constants/policyConstants';
 import { PolicyDefinitions, ResultType } from '@Types/factoryTypes';
 import { SUCCESS } from '@Constants/resultConstants';
@@ -54,13 +59,16 @@ type AddCollectionDefinitionArgs = {
   eventId?: string;
   uuids?: string[];
   /**
-   * Pool for tieFormat copy-on-write forks in `writeTieFormat`, SEPARATE from
-   * `uuids` (which feeds matchUp id minting).
+   * Pool for tieFormat identities — copy-on-write forks in `writeTieFormat`, and the
+   * `collectionId` minted for a definition that arrives without one. SEPARATE from `uuids`, which
+   * feeds matchUp id minting.
    *
-   * Two pools rather than one so a shortfall is attributable: sharing a pool
-   * couples two unrelated id streams, and `INSUFFICIENT_UUIDS` could not say
-   * which one ran short. Strict when supplied — an exhausted pool signals that
-   * this replay needed a different number of ids than the origin did.
+   * Two pools rather than one so a shortfall is attributable: sharing a pool with the matchUp
+   * stream couples two unrelated id streams, and `INSUFFICIENT_UUIDS` could not say which ran
+   * short. A collectionId belongs on THIS side of that line — it identifies a collection within the
+   * tieFormat, the same container the forks describe — so it draws here rather than from a third
+   * pool. Strict when supplied: an exhausted pool signals that this replay needed a different
+   * number of ids than the origin did.
    */
   tieFormatUuids?: string[];
   event?: Event;
@@ -149,7 +157,13 @@ export function addCollectionDefinition({
         result: { error: DUPLICATE_VALUE },
       });
   } else {
-    collectionDefinition.collectionId = UUID();
+    // Drawn from `tieFormatUuids` so a mutation executed on both client and server mints the same
+    // id. Without a pool this called `UUID()` on each side and the two copies of the record
+    // diverged silently — see `checkTieFormat`. `takeUUID` returns INSUFFICIENT_UUIDS rather than a
+    // fresh id when a supplied pool runs out, so a shortfall surfaces as a conflict.
+    const { uuid, error: uuidError } = takeUUID({ uuids: tieFormatUuids });
+    if (uuidError || !uuid) return decorateResult({ result: { error: uuidError ?? INSUFFICIENT_UUIDS }, stack });
+    collectionDefinition.collectionId = uuid;
   }
 
   tieFormat.collectionDefinitions.push(collectionDefinition);

--- a/src/query/drawDefinition/getDrawData.ts
+++ b/src/query/drawDefinition/getDrawData.ts
@@ -57,7 +57,7 @@ import {
  * (its absence returns `MISSING_DRAW_DEFINITION`), and the other inputs enrich the result.
  */
 export type GetDrawDataArgs = {
-  /** when true, `eventPublishedState` or `event` must also be provided */
+  /** when true, `eventPublishState` or `event` must also be provided */
   usePublishState?: boolean;
   includePositionAssignments?: boolean;
   tournamentParticipants?: Participant[];
@@ -85,7 +85,7 @@ export type GetDrawDataArgs = {
   event?: Event;
 };
 
-// NOTE: if { usePublishState: true } then { eventPublishedState } or { event } must be provided
+// NOTE: if { usePublishState: true } then { eventPublishState } or { event } must be provided
 export function getDrawData(params: GetDrawDataArgs): {
   structures?: any[];
   success?: boolean;
@@ -343,11 +343,19 @@ export function getDrawData(params: GetDrawDataArgs): {
     return structures;
   });
 
-  // to support legacy publish status which did not support discrete structure publishing...
-  // ...default to true when no structureDetails are found
-  const structures = groupedStructures
-    .flat()
-    .filter((structure) => !usePublishState || isVisiblyPublished(structureDetails?.[structure?.structureId]) || true);
+  // Legacy publish status carried no discrete structure publishing, so a structure with NO
+  // structureDetail defaults to visible. One that HAS a detail is judged by it.
+  //
+  // This read `... || isVisiblyPublished(...) || true`, which is unconditionally true — the
+  // `isVisiblyPublished` call was dead and discrete structure publishing was not honoured at all.
+  // Measured before the fix on a published COMPASS 16 with one structure marked
+  // `{ published: false }`: all 8 structures were returned, while `isVisiblyPublished` correctly
+  // reported that structure invisible. The predicate had the right answer and discarded it.
+  const structures = groupedStructures.flat().filter((structure) => {
+    if (!usePublishState) return true;
+    const structureDetail = structureDetails?.[structure?.structureId];
+    return structureDetail ? isVisiblyPublished(structureDetail) : true;
+  });
 
   drawInfo.drawActive = drawActive;
   drawInfo.participantPlacements = participantPlacements;

--- a/src/tests/mutations/matchUps/collectionIdMintPool.test.ts
+++ b/src/tests/mutations/matchUps/collectionIdMintPool.test.ts
@@ -1,0 +1,79 @@
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { expect, it } from 'vitest';
+
+import { INSUFFICIENT_UUIDS } from '@Constants/errorConditionConstants';
+import { FORMAT_STANDARD } from '@Fixtures/scoring/matchUpFormats';
+import { TEAM as TEAM_EVENT } from '@Constants/eventConstants';
+import { SINGLES } from '@Constants/matchUpTypes';
+
+/**
+ * A `collectionId` minted from a caller-supplied pool, so client and server agree.
+ *
+ * TMX executes every mutation twice — the server applies it and acknowledges, then the client
+ * applies the same methods locally. A mint that calls `UUID()` on each side produces two different
+ * ids for the same collection and the copies of the record diverge silently. Measured on the
+ * pre-fix tree: two identical draw generations produced different collectionIds.
+ *
+ * `addCollectionDefinition` draws from `tieFormatUuids` rather than `uuids`: a collectionId
+ * identifies a collection within the tieFormat — the same container the copy-on-write forks
+ * describe — while `uuids` feeds matchUp id minting. Keeping the streams apart is what lets
+ * `INSUFFICIENT_UUIDS` say which one ran short.
+ */
+
+const collectionDefinition = (collectionName: string) => ({
+  matchUpFormat: FORMAT_STANDARD,
+  matchUpType: SINGLES,
+  matchUpCount: 1,
+  matchUpValue: 1,
+  collectionName,
+});
+
+function teamEvent() {
+  mocksEngine.generateTournamentRecord({ setState: true });
+  const tieFormat = {
+    collectionDefinitions: [{ ...collectionDefinition('Singles'), collectionId: 'fixed-1' }],
+    winCriteria: { valueGoal: 1 },
+  };
+  const result: any = tournamentEngine.addEvent({
+    event: { eventId: 'e1', eventName: 'Dual', eventType: TEAM_EVENT, tieFormat },
+  });
+  expect(result.success).toEqual(true);
+  return 'e1';
+}
+
+it('mints the collectionId from the supplied tieFormatUuids pool', () => {
+  const eventId = teamEvent();
+  const result: any = tournamentEngine.addCollectionDefinition({
+    collectionDefinition: collectionDefinition('Doubles'),
+    tieFormatUuids: ['pooled-collection-id'],
+    eventId,
+  });
+  expect(result.error).toBeUndefined();
+
+  const added = (result.tieFormat?.collectionDefinitions ?? []).find((d: any) => d.collectionName === 'Doubles');
+  expect(added).toBeDefined();
+  expect(added.collectionId).toEqual('pooled-collection-id');
+});
+
+it('refuses rather than minting a fresh id when a supplied pool is exhausted', () => {
+  const eventId = teamEvent();
+  const result: any = tournamentEngine.addCollectionDefinition({
+    collectionDefinition: collectionDefinition('Doubles'),
+    tieFormatUuids: [],
+    eventId,
+  });
+  // a silent fresh id here is the divergence this exists to prevent
+  expect(result.error).toEqual(INSUFFICIENT_UUIDS);
+});
+
+it('still mints when no pool is supplied — the single-execution case', () => {
+  const eventId = teamEvent();
+  const result: any = tournamentEngine.addCollectionDefinition({
+    collectionDefinition: collectionDefinition('Doubles'),
+    eventId,
+  });
+  expect(result.error).toBeUndefined();
+  const added = (result.tieFormat?.collectionDefinitions ?? []).find((d: any) => d.collectionName === 'Doubles');
+  expect(typeof added?.collectionId).toEqual('string');
+});

--- a/src/tests/mutations/publishing/structurePublishVisibility.test.ts
+++ b/src/tests/mutations/publishing/structurePublishVisibility.test.ts
@@ -1,0 +1,76 @@
+import { isVisiblyPublished } from '@Query/publishing/isEmbargoed';
+import { getDrawData } from '@Query/drawDefinition/getDrawData';
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { expect, it } from 'vitest';
+
+import { COMPASS } from '@Constants/drawDefinitionConstants';
+
+/**
+ * `usePublishState` must honour DISCRETE structure publishing.
+ *
+ * The filter read `!usePublishState || isVisiblyPublished(detail) || true`, which is unconditionally
+ * true — the `isVisiblyPublished` call was dead and a structure explicitly marked
+ * `{ published: false }` was returned anyway. Its comment said "default to true when no
+ * structureDetails are found"; the code defaulted to true always.
+ *
+ * The legacy behaviour the comment describes is preserved: a structure with NO detail is visible.
+ */
+
+function publishedDrawWithOneHiddenStructure() {
+  const { tournamentRecord, drawIds } = mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ drawSize: 16, drawType: COMPASS, participantsCount: 16 }],
+    setState: true,
+  });
+  const drawId = drawIds[0];
+  const { drawDefinition, event } = tournamentEngine.getEvent({ drawId });
+  const structureIds = (drawDefinition.structures ?? []).map((structure: any) => structure.structureId);
+  // the control: the scenario needs more than one structure for "one hidden" to mean anything
+  expect(structureIds.length).toBeGreaterThan(1);
+
+  return {
+    tournamentRecord,
+    drawDefinition,
+    structureIds,
+    event,
+    drawId,
+    publishStatus: { drawDetails: { [drawId]: { publishingDetail: { published: true } } } },
+  };
+}
+
+const read = (setup: any, structureDetails: any) =>
+  getDrawData({
+    eventPublishState: {
+      status: { published: true, drawDetails: { [setup.drawId]: { published: true, structureDetails } } },
+    },
+    drawDefinition: setup.drawDefinition,
+    tournamentRecord: setup.tournamentRecord,
+    publishStatus: setup.publishStatus,
+    usePublishState: true,
+    event: setup.event,
+  } as any);
+
+it('omits a structure explicitly marked not published', () => {
+  const setup = publishedDrawWithOneHiddenStructure();
+  const hidden = setup.structureIds[0];
+  // the control that matters: the predicate itself must consider this invisible, or the test is
+  // asserting nothing about the filter
+  expect(isVisiblyPublished({ published: false } as any)).toEqual(false);
+
+  const structureDetails = Object.fromEntries(
+    setup.structureIds.map((id: string) => [id, { published: id !== hidden }]),
+  );
+  const result: any = read(setup, structureDetails);
+  const returned = (result?.structures ?? []).map((structure: any) => structure.structureId);
+
+  expect(returned.length).toBeGreaterThan(0);
+  expect(returned).not.toContain(hidden);
+  expect(returned.length).toEqual(setup.structureIds.length - 1);
+});
+
+it('keeps a structure that has no publishing detail — the legacy shape', () => {
+  const setup = publishedDrawWithOneHiddenStructure();
+  const result: any = read(setup, undefined);
+  const returned = (result?.structures ?? []).map((structure: any) => structure.structureId);
+  expect(returned.length).toEqual(setup.structureIds.length);
+});

--- a/src/tests/query/finishingPositionsAndTally.test.ts
+++ b/src/tests/query/finishingPositionsAndTally.test.ts
@@ -206,7 +206,7 @@ test('calculatePressureRatings via tallyParticipantResults with ELO-rated partic
   // Call tallyParticipantResults with pressureRating to trigger calculatePressureRatings
   const result = tallyParticipantResults({
     matchUps: groupMatchUps,
-    pressureRating: 'true',
+    pressureRating: true,
   });
 
   expect(result.participantResults).toBeDefined();

--- a/src/tests/query/matchUps/roundRobinTally/roundRobinTally.extended.test.ts
+++ b/src/tests/query/matchUps/roundRobinTally/roundRobinTally.extended.test.ts
@@ -238,7 +238,7 @@ describe('Round Robin Tally - Extended Coverage', () => {
 
       const result = tallyParticipantResults({
         matchUps,
-        pressureRating: 'true',
+        pressureRating: true,
       });
 
       Object.values(result.participantResults).forEach((pr: any) => {


### PR DESCRIPTION
Follow-ups to [#4825](https://github.com/CourtHive/competition-factory/pull/4825), plus a defect found by pressing into `getDrawData`.

## Discrete structure publishing was never honoured

```ts
.filter((structure) => !usePublishState || isVisiblyPublished(structureDetails?.[id]) || true);
```

`A || B || true` is unconditionally true, so the `isVisiblyPublished` call was **dead**. The comment above it says *"default to true when no structureDetails are found"* — the code defaulted to true **always**.

Measured before the fix, on a published `COMPASS` 16 with one structure marked `{ published: false }`:

```json
{ "totalStructures": 8, "returnedCount": 8,
  "unpublishedStructureReturned": true,
  "isVisiblyPublishedSaysFalse": false }
```

The last line is the control: the predicate itself correctly reported that structure invisible, and the filter discarded the answer.

**Scope of the exposure.** A draw that is not published still returns no structures — the draw-level gate at the return is intact. What leaked is *structure* granularity within a published draw: a TD hiding one structure of a COMPASS or a playoff got no hiding. `getDrawData` feeds `getEventData`, which feeds the server's public endpoints.

A structure with **no** publishing detail is still visible — that is the legacy shape the comment describes, and it is now pinned by a test rather than implied by a dead expression.

## `addEvent` threads a uuid pool

#4825 established that the collectionId mint is non-deterministic across executions — a client re-applying a mutation after the server acknowledges it mints a different id for the same collection — and fixed the draw-generation site. `addEvent` is the second of three.

### The third, resolved by decision

`addCollectionDefinition.ts:152` already carried **two** pools, and a comment explaining why:

> Two pools rather than one so a shortfall is attributable: sharing a pool couples two unrelated id streams, and `INSUFFICIENT_UUIDS` could not say which one ran short.

My first attempt drew the collectionId from `uuids` — which violates exactly that. Reverted once I read the comment, then raised it as a design call rather than making it quietly.

**CA decided: merge it into `tieFormatUuids`**, since a `collectionId` and the copy-on-write forks both pertain to the same container. So the mint draws from `tieFormatUuids`, the matchUp stream stays separate, and the pool's doc comment now says why a collectionId belongs on that side of the line.

All three mint sites are now covered.

## `pressureRating` is not widened

Asked whether there was a use case for `boolean | string`. **There isn't** — every consumer passes `true`: TMX at 7 sites, competition-factory-server at 2. The only factory use is `if (pressureRating && matchUpType === SINGLES)`.

The two places passing the string `'true'` were the factory's **own tests**, written to satisfy the wrong declaration. Corrected here.

They were not type errors because **`tsconfig.json` excludes `src/**/*.test.ts`** — so `verify:types` says nothing about test files. Worth knowing separately from this PR: a green typecheck is not evidence about test code.

## Gates

`pnpm verify` exit 0. **12,967 passed / 2 skipped.** The publishing test is verified RED against the pre-fix tree, and carries two controls — that the scenario has more than one structure, and that `isVisiblyPublished` itself reports the hidden one invisible.

Note on CodeQL: this class of alert (`js/insecure-randomness` on a UUID call) is **not a finding in this codebase** — confirmed by CA and now written into `Mentat/standards/coding-standards.md`. 19 such alerts already sit open on master, including `src/tools/UUID.ts` itself; a `collectionId` is an identifier, not a secret. `verify` is the gate.

## A note on the migration-coverage gate

`verify:migration-coverage` extracts the PR number from the **commit subject**, so it cannot pass for an unmerged breaking commit — and because it sits 5th in the `verify` chain, everything after it is skipped when it fails. The subject here carries `(#4827)` so the full gate runs locally; GitHub's squash uses the PR title regardless.
