### PR TITLE
feat(scheduling): getMatchUpReadiness and getParticipantRest

### DIFF
--- a/attr-audit.allow.json
+++ b/attr-audit.allow.json
@@ -28,6 +28,7 @@
   "officialRecords",
   "orange",
   "participantCount",
+  "participantNames",
   "participantResult",
   "participantRoles",
   "participants",

--- a/documentation/docs/concepts/scheduling-conflicts.mdx
+++ b/documentation/docs/concepts/scheduling-conflicts.mdx
@@ -412,9 +412,64 @@ if (validation.errors.length > 0) {
 }
 ```
 
+## Per-matchUp answers: readiness and rest
+
+Conflict reporting above answers _"where does this schedule disagree with itself"_, across a whole
+day. Two queries answer the narrower question a director asks with one match in hand.
+
+### `getMatchUpReadiness` — can this placement happen at the time it is scheduled for?
+
+Anchored on the matchUp's own `scheduledTime`, and skipped entirely when it has none. Findings are
+ordered strongest-first, so the head is the headline:
+
+```js
+const { readiness } = tournamentEngine.getMatchUpReadiness({ matchUpId });
+
+if (readiness.evaluated) {
+  for (const finding of readiness.findings) {
+    // kind: 'overlap' | 'dependency' | 'recovery' | 'undetermined'
+    console.log(finding.kind, finding.participantNames, finding.notBefore);
+  }
+} else {
+  // 'unknownMatchUp' | 'bye' | 'completed' | 'notScheduled' | 'noTime'
+  console.log('not evaluated:', readiness.reason);
+}
+```
+
+`overlap` and `recovery` never both fire for the same participant: being on court elsewhere already
+implies the recovery window is violated, so the stronger finding wins.
+
+### `getParticipantRest` — how long has each player actually had off?
+
+Anchored on **`asOf`**, an ISO instant the caller supplies. The factory holds no clock, so this is
+required; it is the same caller-supplied wall-clock idiom as `calledAt`.
+
+```js
+const { rest } = tournamentEngine.getParticipantRest({
+  asOf: new Date().toISOString(),
+  matchUpId,
+});
+
+for (const row of rest.rows) {
+  // status: 'onCourt' | 'resting' | 'rested' | 'none'
+  console.log(row.participantName, row.status, row.restMinutes, row.source);
+}
+```
+
+Because rest is measured rather than assumed, every row reports **which rung** produced its anchor —
+`endTime` (recorded), `scoredTime` (a proxy), or `startTime` / `calledAt` / `scheduledTime`
+(projected from a start plus the format average). A row whose ladder was entirely in the future
+carries `anchorUnreliable` rather than a measured-looking zero, and a row for a player still out
+there carries `onCourt` with no `restMinutes` at all.
+
+Rest is scoped to one day — the matchUp's own `scheduledDate`, or a `scheduledDate` the caller names
+for a matchUp that has not been scheduled yet. For the whole-tournament, across-days view, see the
+Participant Recovery report, which spans overnight turnaround this deliberately does not.
+
 ## Related Documentation
 
 - **[Scheduling Overview](./scheduling-overview)** - Understanding scheduling workflows
 - **[Scheduling Policy](./scheduling-policy)** - Configuring recovery times and daily limits
 - **[Automated Scheduling](./automated-scheduling)** - How conflicts are prevented during auto-scheduling
 - **[Query Governor](/docs/governors/query-governor)** - API reference for getParticipants method
+- **[Schedule Governor](/docs/governors/schedule-governor)** - API reference for getMatchUpReadiness and getParticipantRest

--- a/documentation/docs/governors/schedule-governor.md
+++ b/documentation/docs/governors/schedule-governor.md
@@ -1736,6 +1736,54 @@ Consequences worth knowing:
 
 ---
 
+## Readiness and rest queries
+
+Two read-only queries answer, for **one** matchUp, what conflict reporting answers for a whole day.
+Both were built in TMX behind a relocation seam and moved here in 7.x, so the payload shapes are
+unchanged from the client analyses they replace.
+
+### getMatchUpReadiness
+
+Can this placement happen at the time it is scheduled for? Anchored on the matchUp's own
+`scheduledTime`; declines to evaluate when there is not one.
+
+```js
+const { readiness } = tournamentEngine.getMatchUpReadiness({ matchUpId });
+```
+
+| parameter   | type              | notes                                                           |
+| ----------- | ----------------- | --------------------------------------------------------------- |
+| `matchUpId` | string            | **required**                                                    |
+| `matchUps`  | HydratedMatchUp[] | optional; supply hydrated matchUps to avoid a second resolution |
+
+Returns `{ readiness }`, either `{ evaluated: false, reason }` — `unknownMatchUp`, `bye`,
+`completed`, `notScheduled`, `noTime` — or `{ evaluated: true, findings }`. Each finding carries a
+`kind` of `overlap`, `dependency`, `recovery` or `undetermined`, a `severity`, the participants and
+matchUps involved, and a `notBefore` clock when the blocker can be projected. Findings are ordered
+strongest-first.
+
+### getParticipantRest
+
+How long has each individual in this matchUp actually had off, and is it enough?
+
+```js
+const { rest } = tournamentEngine.getParticipantRest({ matchUpId, asOf: new Date().toISOString() });
+```
+
+| parameter          | type              | notes                                                                      |
+| ------------------ | ----------------- | -------------------------------------------------------------------------- |
+| `matchUpId`        | string            | **required**                                                               |
+| `asOf`             | ISO string        | **required** — the factory holds no clock; the caller supplies the instant |
+| `scheduledDate`    | `YYYY-MM-DD`      | the day to measure; defaults to the matchUp's own                          |
+| `timeZone`         | IANA zone         | defaults to the tournament's `localTimeZone`; DST-correct                  |
+| `utcOffsetMinutes` | number            | fixed-offset fallback when no zone is available                            |
+| `matchUps`         | HydratedMatchUp[] | optional; as above                                                         |
+
+Returns `{ rest }`, either `{ evaluated: false, reason }` — adding `noAsOf` and `noDay` to the list
+above — or `{ evaluated: true, asOf, scheduledDate, rows }`, one row per individual, ordered
+worst-first. Every row names the ladder rung its anchor came from, so an inferred figure never reads
+as a measured one.
+
 ## Related Documentation
 
 - **[Scheduling Overview](../concepts/scheduling-overview)** - Core scheduling concepts

--- a/documentation/docs/migration-7.0.0.md
+++ b/documentation/docs/migration-7.0.0.md
@@ -351,6 +351,8 @@ so a shortfall surfaces as a conflict instead of becoming a permanent mismatch.
 Pass `checkCollectionIds: false` where validation legitimately runs before the mint — that is what
 the factory's own pre-mint call sites do.
 
+_Shipped in [#4825](https://github.com/CourtHive/competition-factory/pull/4825)._
+
 ## 9. `pressureRating` is a boolean
 
 `tallyParticipantResults` and `getParticipantResults` declared `pressureRating?: string` while every

--- a/src/assemblies/governors/scheduleGovernor/query.ts
+++ b/src/assemblies/governors/scheduleGovernor/query.ts
@@ -1,6 +1,8 @@
 export { getMatchUpsToSchedule } from '@Mutate/matchUps/schedule/scheduleMatchUps/getMatchUpsToSchedule';
 export { getScheduledRoundsDetails } from '@Query/matchUps/scheduling/getScheduledRoundsDetails';
 export { getSchedulingProfileIssues } from '@Query/matchUps/scheduling/getSchedulingProfileIssues';
+export { getMatchUpReadiness } from '@Query/matchUps/scheduling/getMatchUpReadiness';
+export { getParticipantRest } from '@Query/matchUps/scheduling/getParticipantRest';
 export { isScheduleLocked, matchUpScheduleLocked } from '@Query/matchUp/isScheduleLocked';
 export { getScheduleProjection } from '@Query/facilitySchedule/getScheduleProjection';
 export { mergeFacilitySchedule } from '@Query/facilitySchedule/mergeFacilitySchedule';

--- a/src/query/matchUps/scheduling/getMatchUpReadiness.ts
+++ b/src/query/matchUps/scheduling/getMatchUpReadiness.ts
@@ -1,0 +1,403 @@
+/**
+ * Readiness for one scheduled matchUp — *can this placement happen at the time
+ * it is scheduled for?*
+ *
+ * Four things can be wrong with a placement, and the answer names which:
+ *
+ *   - `overlap`      — a participant is due on court in another matchUp whose
+ *                      window contains this start time
+ *   - `recovery`     — a participant's recovery window has not elapsed
+ *   - `dependency`   — an upstream matchUp is not finished, or not even
+ *                      scheduled, so this one cannot start on time
+ *   - `undetermined` — a side has no participant yet, and something upstream
+ *                      explains why
+ *
+ * ── Provenance ──
+ *
+ * Ported from TMX, which built it behind an adapter (`ReadinessInput` →
+ * `ReadinessResult`) precisely so this move would be a body swap rather than a
+ * rewrite; its module header named `getMatchUpReadiness` as the destination.
+ * The `ReadinessResult` payload shape is preserved exactly, so the consumer
+ * change is an import.
+ *
+ * What changes in the move is where the *inputs* come from. TMX injected the
+ * hydrated matchUps and a `timingFor` callback because a client cannot reach
+ * the engine from a pure module; here both are resolved internally, which is
+ * the point of the relocation — one resolution of what a format costs, shared
+ * with `getParticipantRest`, rather than one per consumer.
+ *
+ * ── Deliberately NOT the same question as `getParticipantRest` ──
+ *
+ * Readiness is anchored on the target's own `scheduledTime` and skips entirely
+ * when there is not one. Rest is anchored on a caller-supplied *now*, so it
+ * answers for a matchUp still sitting in a catalog. Both are needed; neither
+ * subsumes the other.
+ *
+ * ── Clock-free ──
+ *
+ * Every comparison here is between two venue wall clocks on the same day, so
+ * the browser's zone cancels on both sides and no instant is ever converted.
+ * That is what lets this run in the factory unchanged.
+ */
+import { allTournamentMatchUps } from '@Query/matchUps/getAllTournamentMatchUps';
+import { checkRequiredParameters } from '@Helpers/parameters/checkRequiredParameters';
+import { makeTimingResolver, SchedulingTiming } from './schedulingTiming';
+
+// constants and types
+import { MISSING_MATCHUP_ID } from '@Constants/errorConditionConstants';
+import { TOURNAMENT_RECORD } from '@Constants/attributeConstants';
+import { Tournament } from '@Types/tournamentTypes';
+import { HydratedMatchUp } from '@Types/hydrated';
+import { ResultType } from '@Types/factoryTypes';
+import { BYE } from '@Constants/matchUpStatusConstants';
+
+export type ReadinessKind = 'undetermined' | 'dependency' | 'recovery' | 'overlap';
+export type ReadinessSeverity = 'WARN' | 'INFO';
+
+export type ReadinessFinding = {
+  kind: ReadinessKind;
+  severity: ReadinessSeverity;
+  participantIds?: string[];
+  participantNames?: string[];
+  matchUpIds?: string[];
+  matchUpLabels?: string[];
+  /** Earliest clock time the blocker clears, `HH:MM`. Absent when it cannot be projected. */
+  notBefore?: string;
+};
+
+/** Why readiness could not be evaluated. Never reported as "ready" — an unevaluated matchUp is not a clean one. */
+export type ReadinessSkipReason = 'unknownMatchUp' | 'bye' | 'completed' | 'notScheduled' | 'noTime';
+
+export type ReadinessResult =
+  { evaluated: false; reason: ReadinessSkipReason } | { evaluated: true; findings: ReadinessFinding[] };
+
+const COMPLETED_STATUSES = new Set([
+  'COMPLETED',
+  'RETIRED',
+  'WALKOVER',
+  'DEFAULTED',
+  'DOUBLE_WALKOVER',
+  'DOUBLE_DEFAULT',
+  'ABANDONED',
+]);
+
+/** True when a matchUp has a result and can no longer block anything. */
+export function isFinished(matchUp: HydratedMatchUp): boolean {
+  return !!matchUp.winningSide || (!!matchUp.matchUpStatus && COMPLETED_STATUSES.has(matchUp.matchUpStatus));
+}
+
+/** `'09:30'` → `570`. `null` for anything that is not a readable wall clock. */
+export function parseClockMinutes(value?: string): number | null {
+  if (!value) return null;
+  const matched = /^(\d{1,2}):(\d{2})/.exec(value.trim());
+  if (!matched) return null;
+  const hours = Number(matched[1]);
+  const minutes = Number(matched[2]);
+  if (hours > 23 || minutes > 59) return null;
+  return hours * 60 + minutes;
+}
+
+/** `540` → `'09:00'`. Wraps past midnight rather than producing `25:xx`. */
+export function minutesToClock(minutes: number): string {
+  const wrapped = ((Math.round(minutes) % 1440) + 1440) % 1440;
+  return `${String(Math.floor(wrapped / 60)).padStart(2, '0')}:${String(wrapped % 60).padStart(2, '0')}`;
+}
+
+/** Individual participantIds on a matchUp — expands doubles/team sides to their members. */
+export function individualIds(matchUp: HydratedMatchUp): string[] {
+  const ids = new Set<string>();
+  for (const side of matchUp.sides ?? []) {
+    for (const id of side.participant?.individualParticipantIds ?? []) ids.add(id);
+    const sideId = side.participantId ?? side.participant?.participantId;
+    // A side's own participantId substitutes for its members only when the
+    // members are unknown — otherwise a pair is counted twice, as itself and as
+    // its players, and never matches the individuals on another side.
+    if (sideId && !side.participant?.individualParticipantIds?.length) ids.add(sideId);
+  }
+  return [...ids];
+}
+
+function sideLabel(side: any): string {
+  return side?.participant?.participantName ?? side?.participantName ?? 'TBD';
+}
+
+/** "R16: Alice vs Bob" — the label vocabulary the schedule surfaces already use. */
+export function matchUpLabel(matchUp: HydratedMatchUp): string {
+  const names = (matchUp.sides ?? []).map(sideLabel);
+  const players = names.length ? names.join(' vs ') : 'TBD vs TBD';
+  return matchUp.roundName ? `${matchUp.roundName}: ${players}` : players;
+}
+
+/** Name for a participantId, taken from whichever matchUp side carries it. */
+export function nameFor(participantId: string, matchUps: HydratedMatchUp[]): string {
+  for (const matchUp of matchUps) {
+    for (const side of matchUp.sides ?? []) {
+      if ((side.participantId ?? side.participant?.participantId) === participantId) return sideLabel(side);
+      if (side.participant?.individualParticipantIds?.includes(participantId)) return sideLabel(side);
+    }
+  }
+  return participantId;
+}
+
+/** Direct upstream feeders, inverted from the forward `winner` / `loser` edges. */
+function buildFeederMap(matchUps: HydratedMatchUp[]): Map<string, string[]> {
+  const feeders = new Map<string, string[]>();
+  const push = (target: string | undefined, source: string) => {
+    if (!target) return;
+    const list = feeders.get(target);
+    if (list) list.push(source);
+    else feeders.set(target, [source]);
+  };
+  for (const matchUp of matchUps) {
+    push(matchUp.winnerMatchUpId, matchUp.matchUpId);
+    push(matchUp.loserMatchUpId, matchUp.matchUpId);
+  }
+  return feeders;
+}
+
+/**
+ * Every incomplete matchUp upstream of `matchUpId`, transitively. A grandparent
+ * that has not been played blocks just as surely as a parent, and the walk stops
+ * at finished matchUps because nothing behind them can still be pending.
+ */
+function incompleteUpstream(
+  matchUpId: string,
+  feeders: Map<string, string[]>,
+  byId: Map<string, HydratedMatchUp>,
+): HydratedMatchUp[] {
+  const found: HydratedMatchUp[] = [];
+  const seen = new Set<string>([matchUpId]);
+  const queue = [...(feeders.get(matchUpId) ?? [])];
+
+  while (queue.length) {
+    const id = queue.shift() as string;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const matchUp = byId.get(id);
+    if (!matchUp) continue;
+    if (isFinished(matchUp)) continue;
+    if (matchUp.matchUpStatus === BYE) continue;
+    found.push(matchUp);
+    queue.push(...(feeders.get(id) ?? []));
+  }
+  return found;
+}
+
+/** When an incomplete matchUp is projected to finish, in minutes. `null` when it cannot be projected. */
+function projectedFinish(matchUp: HydratedMatchUp, timing: SchedulingTiming): number | null {
+  const start = parseClockMinutes(matchUp.schedule?.scheduledTime);
+  if (start === null) return null;
+  return start + timing.averageMinutes;
+}
+
+/** When a participant coming out of `matchUp` is next available, in minutes. `null` when unprojectable. */
+function freeAfter(matchUp: HydratedMatchUp, timing: SchedulingTiming): number | null {
+  const end = parseClockMinutes(matchUp.schedule?.endTime);
+  if (end !== null) return end + timing.recoveryMinutes;
+  const start = parseClockMinutes(matchUp.schedule?.scheduledTime);
+  if (start === null) return null;
+  return start + timing.averageMinutes + timing.recoveryMinutes;
+}
+
+/** Why the target cannot be evaluated, or undefined when it can. */
+function skipReasonFor(target: HydratedMatchUp): ReadinessSkipReason | undefined {
+  if (target.matchUpStatus === BYE) return 'bye';
+  if (isFinished(target)) return 'completed';
+  if (!target.schedule?.scheduledDate) return 'notScheduled';
+  if (parseClockMinutes(target.schedule?.scheduledTime) === null) return 'noTime';
+  return undefined;
+}
+
+function undeterminedFinding(target: HydratedMatchUp, upstream: HydratedMatchUp[]): ReadinessFinding | undefined {
+  const hasUnknownSide = (target.sides ?? []).some((side) => !(side.participantId ?? side.participant?.participantId));
+  if (!hasUnknownSide || !upstream.length) return undefined;
+  return {
+    kind: 'undetermined',
+    severity: 'INFO',
+    matchUpIds: upstream.map((matchUp) => matchUp.matchUpId),
+    matchUpLabels: upstream.map(matchUpLabel),
+  };
+}
+
+type TimingFor = (matchUp: HydratedMatchUp) => SchedulingTiming;
+
+function dependencyFindings(
+  upstream: HydratedMatchUp[],
+  startMinutes: number,
+  timingFor: TimingFor,
+): ReadinessFinding[] {
+  return upstream.flatMap((source) => {
+    const finish = projectedFinish(source, timingFor(source));
+    const base = {
+      kind: 'dependency' as const,
+      severity: 'WARN' as const,
+      matchUpIds: [source.matchUpId],
+      matchUpLabels: [matchUpLabel(source)],
+    };
+    // Unscheduled upstream: cannot be projected, and therefore cannot be
+    // promised to finish in time — reported without a `notBefore`.
+    if (finish === null) return [base];
+    if (finish > startMinutes) return [{ ...base, notBefore: minutesToClock(finish) }];
+    return [];
+  });
+}
+
+type ParticipantClash = {
+  participantId: string;
+  participantName: string;
+  matchUp: HydratedMatchUp;
+  notBefore?: string;
+};
+
+/** Other same-day matchUps that share an individual with the target. */
+function sameDayNeighbours(target: HydratedMatchUp, matchUps: HydratedMatchUp[]): HydratedMatchUp[] {
+  const date = target.schedule?.scheduledDate;
+  const targetIndividuals = new Set(individualIds(target));
+  if (!targetIndividuals.size) return [];
+  return matchUps.filter((matchUp) => {
+    if (matchUp.matchUpId === target.matchUpId) return false;
+    if (matchUp.matchUpStatus === BYE) return false;
+    if (matchUp.schedule?.scheduledDate !== date) return false;
+    return individualIds(matchUp).some((id) => targetIndividuals.has(id));
+  });
+}
+
+/** Shared individuals between two matchUps, as clash rows. */
+function clashesBetween(
+  target: HydratedMatchUp,
+  neighbour: HydratedMatchUp,
+  matchUps: HydratedMatchUp[],
+): ParticipantClash[] {
+  const targetIndividuals = new Set(individualIds(target));
+  return individualIds(neighbour)
+    .filter((id) => targetIndividuals.has(id))
+    .map((participantId) => ({
+      participantId,
+      participantName: nameFor(participantId, matchUps),
+      matchUp: neighbour,
+    }));
+}
+
+function toFinding(kind: ReadinessKind, clashes: ParticipantClash[]): ReadinessFinding {
+  const notBefore = clashes.map((clash) => clash.notBefore).find(Boolean);
+  return {
+    kind,
+    severity: 'WARN',
+    participantIds: clashes.map((clash) => clash.participantId),
+    participantNames: [...new Set(clashes.map((clash) => clash.participantName))],
+    matchUpIds: [...new Set(clashes.map((clash) => clash.matchUp.matchUpId))],
+    matchUpLabels: [...new Set(clashes.map((clash) => matchUpLabel(clash.matchUp)))],
+    ...(notBefore && { notBefore }),
+  };
+}
+
+/**
+ * Overlap and recovery in one pass, because they are the same question asked at
+ * two strengths and must not both fire for one participant: overlap means the
+ * participant is *on court elsewhere* at this start time, which already implies
+ * the recovery window is violated.
+ */
+function clashFindings(
+  target: HydratedMatchUp,
+  startMinutes: number,
+  matchUps: HydratedMatchUp[],
+  timingFor: TimingFor,
+): ReadinessFinding[] {
+  const overlapping: ParticipantClash[] = [];
+  const recovering: ParticipantClash[] = [];
+  const overlappedIds = new Set<string>();
+
+  for (const neighbour of sameDayNeighbours(target, matchUps)) {
+    const timing = timingFor(neighbour);
+    const neighbourStart = parseClockMinutes(neighbour.schedule?.scheduledTime);
+    const clashes = clashesBetween(target, neighbour, matchUps);
+    if (!clashes.length) continue;
+
+    const isOverlap =
+      !isFinished(neighbour) &&
+      neighbourStart !== null &&
+      neighbourStart <= startMinutes &&
+      startMinutes < neighbourStart + Math.max(timing.averageMinutes, 1);
+
+    if (isOverlap) {
+      overlapping.push(...clashes);
+      for (const clash of clashes) overlappedIds.add(clash.participantId);
+      continue;
+    }
+
+    const free = freeAfter(neighbour, timing);
+    if (free === null || free <= startMinutes) continue;
+    recovering.push(...clashes.map((clash) => ({ ...clash, notBefore: minutesToClock(free) })));
+  }
+
+  const stillRecovering = recovering.filter((clash) => !overlappedIds.has(clash.participantId));
+  const findings: ReadinessFinding[] = [];
+  if (overlapping.length) findings.push(toFinding('overlap', overlapping));
+  if (stillRecovering.length) findings.push(toFinding('recovery', stillRecovering));
+  return findings;
+}
+
+/**
+ * Findings ordered strongest-first (`overlap` → `dependency` → `recovery` →
+ * `undetermined`) so a renderer can take the head as the headline without
+ * re-deciding severity.
+ *
+ * Exported for callers that already hold hydrated matchUps and a timing
+ * resolver — `getParticipantRest` and the query below both do — so neither pays
+ * twice for the same hydration.
+ */
+export function analyzeMatchUpReadiness(params: {
+  matchUps: HydratedMatchUp[];
+  timingFor: TimingFor;
+  matchUpId: string;
+}): ReadinessResult {
+  const { matchUps, timingFor, matchUpId } = params;
+  const byId = new Map(matchUps.map((matchUp) => [matchUp.matchUpId, matchUp]));
+  const target = byId.get(matchUpId);
+  if (!target) return { evaluated: false, reason: 'unknownMatchUp' };
+
+  const reason = skipReasonFor(target);
+  if (reason) return { evaluated: false, reason };
+
+  const startMinutes = parseClockMinutes(target.schedule?.scheduledTime) as number;
+  const upstream = incompleteUpstream(target.matchUpId, buildFeederMap(matchUps), byId);
+
+  const findings: ReadinessFinding[] = [
+    ...clashFindings(target, startMinutes, matchUps, timingFor),
+    ...dependencyFindings(upstream, startMinutes, timingFor),
+  ];
+
+  const undetermined = undeterminedFinding(target, upstream);
+  if (undetermined) findings.push(undetermined);
+
+  const order: ReadinessKind[] = ['overlap', 'dependency', 'recovery', 'undetermined'];
+  return { evaluated: true, findings: findings.toSorted((a, b) => order.indexOf(a.kind) - order.indexOf(b.kind)) };
+}
+
+type GetMatchUpReadinessArgs = {
+  tournamentRecord: Tournament;
+  /** Hydrated `{ inContext: true, nextMatchUps: true }`. Resolved from the record when absent. */
+  matchUps?: HydratedMatchUp[];
+  matchUpId: string;
+};
+
+export function getMatchUpReadiness(params: GetMatchUpReadinessArgs): ResultType & { readiness?: ReadinessResult } {
+  const paramsCheck = checkRequiredParameters(params, [{ [TOURNAMENT_RECORD]: true, matchUpId: true }]);
+  if (paramsCheck.error) return paramsCheck;
+  if (!params.matchUpId) return { error: MISSING_MATCHUP_ID };
+
+  const { tournamentRecord, matchUpId } = params;
+  // `nextMatchUps` carries the forward edges the feeder map is inverted from;
+  // without it every dependency finding silently disappears.
+  const matchUps =
+    params.matchUps ??
+    (allTournamentMatchUps({ tournamentRecord, inContext: true, nextMatchUps: true })?.matchUps as HydratedMatchUp[]);
+
+  const readiness = analyzeMatchUpReadiness({
+    timingFor: makeTimingResolver(tournamentRecord),
+    matchUps: matchUps ?? [],
+    matchUpId,
+  });
+
+  return { readiness };
+}

--- a/src/query/matchUps/scheduling/getParticipantRest.ts
+++ b/src/query/matchUps/scheduling/getParticipantRest.ts
@@ -1,0 +1,647 @@
+/**
+ * Participant rest — *for each individual in this matchUp, how long have they
+ * actually had off, and is that enough?*
+ *
+ * The question a director asks before calling a match to court. Deliberately
+ * NOT the question `getMatchUpReadiness` answers: readiness is anchored on the
+ * target's own `scheduledTime` and skips when there is not one, while rest is
+ * anchored on a caller-supplied **now**, so it answers for a matchUp still
+ * sitting in a catalog — which is exactly the moment the director is deciding
+ * whether to send it out.
+ *
+ * ── Provenance ──
+ *
+ * Ported from TMX, which built it behind an adapter (`RestInput` →
+ * `RestResult`) so this move would be a body swap; its header named
+ * `getParticipantRest` as the destination and predicted the shape of the
+ * relocation: *"the factory is pure and has no clock, so it would take the same
+ * injected `asOfMinutes` — the `calledAt` idiom of a caller-supplied wall
+ * clock."* That is what `asOf` is.
+ *
+ * ── What changed in the move, and why ──
+ *
+ * TMX normalised every time to **minutes since midnight of the day being
+ * viewed**, because a browser module cannot resolve a named zone without
+ * duplicating the zone machinery. It paid for that in apparatus: a ±1-day
+ * offset for genuine midnight crossings, a clamp that made a stamp from another
+ * date read by its time-of-day, and a projected "now" for a non-today view.
+ *
+ * Here every instant is **UTC milliseconds**, resolved through the same
+ * `zonedDateTime` frame `recoveryTimeline` uses. The apparatus is not ported
+ * because it has nothing to do: a real interval between two instants is
+ * computable, midnight crossings need no special case, and `asOf` is a genuine
+ * instant rather than a projection. The frame is DST-correct when the caller
+ * supplies an IANA zone, which a fixed offset cannot be.
+ *
+ * The public row shape is unchanged, so a consumer swapping its local copy for
+ * this query changes an import and nothing else.
+ *
+ * ── The precedence ladder ──
+ *
+ * "When did this participant's previous match end" has five answers of
+ * decreasing fidelity, and every row reports which one it used so an inferred
+ * number never reads as a measured one:
+ *
+ *   1. `endTime`       operator recorded the actual finish        — measured
+ *   2. `scoredTime`    when the score was entered                 — proxy
+ *   3. `startTime`     + averageMinutes, match started            — projected
+ *   4. `calledAt`      + averageMinutes, called to court          — projected
+ *   5. `scheduledTime` + averageMinutes, plan only                — planned
+ *
+ * Rung 2 is the common path, not the exception: an END_TIME is written only on
+ * an explicit operator action, while `scoredTime` is auto-captured on every
+ * first meaningful score. A late-entered score pushes the anchor *after* the
+ * true finish, so rest is understated — the conservative direction, since it
+ * holds a rested player back rather than calling a tired one.
+ *
+ * The ladder degrades on **unusable**, not merely on absent. A rung that holds
+ * a value can still be unreadable — anything landing after `asOf` is not a
+ * finish that has happened — so every rung is resolved and the strongest one
+ * actually behind the clock wins. `anchorUnreliable` is reserved for the case
+ * where the whole ladder is in the future.
+ */
+import { allTournamentMatchUps } from '@Query/matchUps/getAllTournamentMatchUps';
+import { checkRequiredParameters } from '@Helpers/parameters/checkRequiredParameters';
+import { getDailyLimit } from '@Query/extensions/getMatchUpDailyLimits';
+import { zonedWallClockToMs, zonedParts } from '@Tools/zonedDateTime';
+import { makeTimingResolver, SchedulingTiming } from './schedulingTiming';
+import { wasPlayed } from '@Query/reports/recoveryTimeline';
+import { individualIds, isFinished, matchUpLabel, nameFor } from './getMatchUpReadiness';
+
+// constants and types
+import { MISSING_MATCHUP_ID } from '@Constants/errorConditionConstants';
+import { TOURNAMENT_RECORD } from '@Constants/attributeConstants';
+import { DOUBLES_MATCHUP, SINGLES_MATCHUP } from '@Constants/matchUpTypes';
+import { Tournament } from '@Types/tournamentTypes';
+import { HydratedMatchUp } from '@Types/hydrated';
+import { ResultType } from '@Types/factoryTypes';
+import { BYE } from '@Constants/matchUpStatusConstants';
+
+const MS_PER_MINUTE = 60_000;
+
+/**
+ * How far after its own start a recorded finish may sit and still be a finish.
+ * Twelve hours covers any real match including a long weather suspension, while
+ * excluding a score entered the next day. Matches the bound
+ * `recoveryTimeline.ts` applies, so the live analysis and the retrospective
+ * report reject the same stamps.
+ */
+const MAX_PLAUSIBLE_MATCH_MS = 12 * 60 * MS_PER_MINUTE;
+
+/** Which rung of the ladder produced a participant's rest anchor. */
+export type RestSourceKind = 'endTime' | 'scoredTime' | 'startTime' | 'calledAt' | 'scheduledTime';
+
+/** How much of the required recovery a participant has actually had. */
+export type RestStatus = 'onCourt' | 'resting' | 'rested' | 'none';
+
+/** True only for the rung the operator recorded directly; everything else is inferred. */
+export const MEASURED_SOURCE: RestSourceKind = 'endTime';
+
+/** How many matches a participant has already begun today, and against which limits. */
+export type RestDailyLoad = {
+  singles: number;
+  doubles: number;
+  total: number;
+  /** Position the inspected matchUp would take, e.g. `3` for "3rd match today". */
+  ordinal: number;
+  /** Limits this matchUp would meet or exceed. Empty when no limits are configured. */
+  atLimit: ('singles' | 'doubles' | 'total')[];
+  /** The limit figure the ordinal should be read against, when one applies. */
+  limit?: number;
+};
+
+export type RestRow = {
+  participantId: string;
+  participantName: string;
+  status: RestStatus;
+  /** Minutes rested so far. Absent for `onCourt` and `none`. */
+  restMinutes?: number;
+  /** Recovery this participant owes before the inspected matchUp. */
+  requiredMinutes: number;
+  /** True when `requiredMinutes` came from the singles ↔ doubles figure. */
+  typeChange: boolean;
+  /** Venue wall clock the requirement is met, `HH:MM`. Absent when already met or unprojectable. */
+  readyAt?: string;
+  /**
+   * True when the participant is still on court past the point their format was
+   * expected to finish. The projected finish is now in the past, so `readyAt` is
+   * withheld rather than naming a time that has already gone by.
+   */
+  overrun?: boolean;
+  /**
+   * True when every anchor available for this participant projects into the
+   * future — the match is recorded as finished but nothing says when. Rest is
+   * reported as zero rather than guessed.
+   */
+  anchorUnreliable?: boolean;
+  /** Which rung produced the anchor. Absent for `none`. */
+  source?: RestSourceKind;
+  /**
+   * Rungs the ladder passed over on its way to `source`, strongest first.
+   * Present only when something was actually skipped.
+   *
+   * A silent fall-through is a fix that hides its own cause: the row reads as a
+   * clean estimate while a recorded stamp sits in the record contradicting it.
+   */
+  discardedSources?: RestSourceKind[];
+  /** The matchUp the rest is measured from. Absent for `none`. */
+  fromMatchUpId?: string;
+  fromMatchUpLabel?: string;
+  load: RestDailyLoad;
+};
+
+/** Why rest could not be evaluated. Never reported as "rested" — an unevaluated matchUp is not a clean one. */
+export type RestSkipReason = 'unknownMatchUp' | 'bye' | 'completed' | 'noParticipants' | 'noAsOf' | 'noDay';
+
+export type RestResult =
+  | { evaluated: false; reason: RestSkipReason }
+  | { evaluated: true; asOf: string; scheduledDate: string; rows: RestRow[] };
+
+/** Daily match limits, as the scheduling policy declares them. Any subset may be absent. */
+export type RestDailyLimits = { SINGLES?: number; DOUBLES?: number; total?: number };
+
+type Frame = { utcOffsetMinutes: number; timeZone?: string };
+
+/** Every time on a matchUp, as UTC milliseconds. */
+type NormalizedTimes = {
+  endMs: number | null;
+  scoredMs: number | null;
+  /** Venue calendar date of `scoredTime` — what dates a matchUp carrying no `scheduledDate`. */
+  scoredDate: string | null;
+  startMs: number | null;
+  calledMs: number | null;
+  scheduledMs: number | null;
+};
+
+function isoToMs(iso?: string): number | null {
+  if (!iso) return null;
+  const ms = Date.parse(iso);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+function wallClockToMs(date: string | undefined, time: string | undefined, frame: Frame): number | null {
+  return zonedWallClockToMs({ ...frame, date, time })?.ms ?? null;
+}
+
+function localClock(ms: number, frame: Frame): string {
+  return zonedParts({ ...frame, ms })?.time ?? '';
+}
+
+function localDate(ms: number | null, frame: Frame): string | null {
+  return ms === null ? null : (zonedParts({ ...frame, ms })?.date ?? null);
+}
+
+export function normalizeTimes(matchUp: HydratedMatchUp, frame: Frame): NormalizedTimes {
+  const schedule: any = matchUp.schedule ?? {};
+  const scoredMs = isoToMs(schedule.scoredTime);
+  return {
+    // END_DATE is written only when the match crossed midnight, so it dates the
+    // bare endTime whenever it is present.
+    endMs: wallClockToMs(schedule.endDate ?? schedule.scheduledDate, schedule.endTime, frame),
+    scoredMs,
+    scoredDate: localDate(scoredMs, frame),
+    startMs: wallClockToMs(schedule.scheduledDate, schedule.startTime, frame),
+    calledMs: isoToMs(schedule.calledAt),
+    scheduledMs: wallClockToMs(schedule.scheduledDate, schedule.scheduledTime, frame),
+  };
+}
+
+/**
+ * Whether a matchUp belongs to the day being measured.
+ *
+ * `scheduledDate` answers it outright. When it is absent — which is what a score
+ * entered from a draw view leaves behind — the venue calendar date of
+ * `scoredTime` still dates the match. A matchUp with neither is genuinely
+ * undatable and is excluded, since counting it would be a guess about which
+ * day's rest it belongs to.
+ */
+export function occursOnDay(matchUp: HydratedMatchUp, times: NormalizedTimes, day: string): boolean {
+  const scheduledDate = matchUp.schedule?.scheduledDate;
+  if (scheduledDate) return scheduledDate === day;
+  return times.scoredDate !== null && times.scoredDate === day;
+}
+
+type Anchor = {
+  ms: number;
+  source: RestSourceKind;
+  /**
+   * True when a recorded finish sits an implausible distance from its own start
+   * — bookkeeping rather than play. Projected rungs are derived FROM the start
+   * and so are plausible by construction.
+   */
+  implausible?: boolean;
+};
+
+/**
+ * Whether a recorded finish sits a plausible distance after a known start.
+ *
+ * **Deliberate divergence from `recoveryTimeline`**, which returns false when
+ * there is no start at all. That module computes a *duration*, which is
+ * meaningless without one. This computes a *finish anchor*, which is not: a
+ * score entered from a draw view leaves neither a scheduledTime nor a
+ * startTime, and its stamp is then the only evidence the match happened. With
+ * nothing to contradict, there is nothing to reject.
+ */
+function isPlausibleFinish(finishMs: number, startMs: number | null): boolean {
+  if (startMs === null) return true;
+  const elapsed = finishMs - startMs;
+  return elapsed > 0 && elapsed <= MAX_PLAUSIBLE_MATCH_MS;
+}
+
+/** The ladder, strongest first. Order is the contract; the row reports which rung won. */
+const LADDER: { source: RestSourceKind; read: (times: NormalizedTimes) => number | null; projected: boolean }[] = [
+  { source: 'endTime', read: (times) => times.endMs, projected: false },
+  { source: 'scoredTime', read: (times) => times.scoredMs, projected: false },
+  { source: 'startTime', read: (times) => times.startMs, projected: true },
+  { source: 'calledAt', read: (times) => times.calledMs, projected: true },
+  { source: 'scheduledTime', read: (times) => times.scheduledMs, projected: true },
+];
+
+/**
+ * Every reading of when the participant coming out of `matchUp` became free,
+ * strongest first. Projected rungs add `averageMinutes` because they mark a
+ * start rather than a finish.
+ *
+ * All of them, not just the winner: whether a rung is usable depends on the
+ * clock, which is the caller's to hold.
+ */
+export function resolveAnchors(times: NormalizedTimes, timing: SchedulingTiming): Anchor[] {
+  const startReference = times.startMs ?? times.calledMs ?? times.scheduledMs;
+  return LADDER.flatMap((rung) => {
+    const ms = rung.read(times);
+    if (ms === null) return [];
+    if (rung.projected) return [{ ms: ms + timing.averageMinutes * MS_PER_MINUTE, source: rung.source }];
+    const implausible = !isPlausibleFinish(ms, startReference);
+    return [{ ms, source: rung.source, ...(implausible && { implausible: true }) }];
+  });
+}
+
+/** The strongest available reading, ignoring whether it is usable. Correct for a live matchUp, whose finish IS ahead. */
+function resolveAnchor(times: NormalizedTimes, timing: SchedulingTiming): Anchor | undefined {
+  return resolveAnchors(times, timing).at(0);
+}
+
+/**
+ * True when the matchUp is under way at `asOfMs` — started (or due) and not yet
+ * finished.
+ *
+ * Deliberately **unbounded above**. Closing the window at
+ * `start + averageMinutes` meant a match that ran long stopped counting as under
+ * way while remaining unfinished, so it dropped out of the analysis and the
+ * player read as having no match today — while standing on court. A match is
+ * over when a result says so, not when the estimate expires.
+ */
+function isUnderWay(matchUp: HydratedMatchUp, times: NormalizedTimes, asOfMs: number): boolean {
+  if (isFinished(matchUp)) return false;
+  const start = times.startMs ?? times.calledMs ?? times.scheduledMs;
+  return start !== null && start <= asOfMs;
+}
+
+/** Recovery owed after `prior`, accounting for a singles ↔ doubles change into `target`. */
+function requirementFor(
+  prior: HydratedMatchUp,
+  target: HydratedMatchUp,
+  timing: SchedulingTiming,
+): { requiredMinutes: number; typeChange: boolean } {
+  const changed = !!prior.matchUpType && !!target.matchUpType && prior.matchUpType !== target.matchUpType;
+  const typeChangeMinutes = timing.typeChangeRecoveryMinutes ?? 0;
+  if (changed && typeChangeMinutes > 0) return { requiredMinutes: typeChangeMinutes, typeChange: true };
+  return { requiredMinutes: timing.recoveryMinutes, typeChange: false };
+}
+
+/** A same-day matchUp already under way or finished, resolved once and reused across participants. */
+type PriorMatchUp = {
+  matchUp: HydratedMatchUp;
+  normalizedTimes: NormalizedTimes;
+  timing: SchedulingTiming;
+  underWay: boolean;
+  individuals: Set<string>;
+};
+
+type RestContext = {
+  matchUps: HydratedMatchUp[];
+  timingFor: (matchUp: HydratedMatchUp) => SchedulingTiming;
+  dailyLimits?: RestDailyLimits;
+  scheduledDate: string;
+  asOfMs: number;
+  frame: Frame;
+};
+
+/**
+ * The matchUps on the measured day that have already begun — finished or
+ * currently under way. A match that has not started yet is not load the
+ * director has already spent, so it is excluded; readiness reports those as
+ * `overlap` / `dependency` instead.
+ */
+function collectPriorMatchUps(target: HydratedMatchUp, context: RestContext): PriorMatchUp[] {
+  const results: PriorMatchUp[] = [];
+
+  for (const matchUp of context.matchUps) {
+    if (matchUp.matchUpId === target.matchUpId) continue;
+    if (matchUp.matchUpStatus === BYE) continue;
+    // A walkover is not load the director has spent — it neither tires a player
+    // nor consumes a slot against the daily limit.
+    if (!wasPlayed(matchUp)) continue;
+
+    // Times are resolved before the day test because an undated matchUp is
+    // dated by its `scoredTime`, which only exists in normalized form.
+    const times = normalizeTimes(matchUp, context.frame);
+    if (!occursOnDay(matchUp, times, context.scheduledDate)) continue;
+
+    const timing = context.timingFor(matchUp);
+    const underWay = isUnderWay(matchUp, times, context.asOfMs);
+    if (!isFinished(matchUp) && !underWay) continue;
+    results.push({
+      individuals: new Set(individualIds(matchUp)),
+      normalizedTimes: times,
+      underWay,
+      matchUp,
+      timing,
+    });
+  }
+  return results;
+}
+
+/** Daily load for one participant, and which configured limits the inspected matchUp would hit. */
+function loadFor(prior: PriorMatchUp[], target: HydratedMatchUp, limits?: RestDailyLimits): RestDailyLoad {
+  const singles = prior.filter((entry) => entry.matchUp.matchUpType === SINGLES_MATCHUP).length;
+  const doubles = prior.filter((entry) => entry.matchUp.matchUpType === DOUBLES_MATCHUP).length;
+  const total = prior.length;
+  const ordinal = total + 1;
+
+  const atLimit: ('singles' | 'doubles' | 'total')[] = [];
+  let limit: number | undefined;
+
+  if (limits?.total !== undefined && ordinal >= limits.total) {
+    atLimit.push('total');
+    limit = limits.total;
+  }
+  if (target.matchUpType === SINGLES_MATCHUP && limits?.SINGLES !== undefined && singles + 1 >= limits.SINGLES) {
+    atLimit.push('singles');
+    limit ??= limits.SINGLES;
+  }
+  if (target.matchUpType === DOUBLES_MATCHUP && limits?.DOUBLES !== undefined && doubles + 1 >= limits.DOUBLES) {
+    atLimit.push('doubles');
+    limit ??= limits.DOUBLES;
+  }
+
+  return { singles, doubles, total, ordinal, atLimit, limit };
+}
+
+type AnchoredPrior = {
+  anchor: Anchor;
+  matchUp: HydratedMatchUp;
+  timing: SchedulingTiming;
+  /** Rungs passed over on the way to `anchor`, strongest first. */
+  discarded: RestSourceKind[];
+};
+
+/**
+ * The rung one prior matchUp should be read from, and what was passed over.
+ *
+ * Two reasons to skip a rung, and they are different faults. **Implausible**:
+ * the stamp sits more than a match's length from its own start, so it records
+ * bookkeeping rather than play. **Ahead of now**: a finish that has not
+ * happened, which is a projection on a matchUp recorded complete early.
+ *
+ * When nothing is readable the strongest *plausible* rung is still named, so the
+ * row can point at the matchUp it failed to measure rather than at a stamp it
+ * has already rejected.
+ */
+function selectAnchor(
+  anchors: Anchor[],
+  asOfMs: number,
+): { anchor: Anchor; usable: boolean; discarded: RestSourceKind[] } | undefined {
+  const readable = anchors.findIndex((anchor) => !anchor.implausible && anchor.ms <= asOfMs);
+  if (readable >= 0) {
+    return {
+      anchor: anchors[readable],
+      usable: true,
+      discarded: anchors.slice(0, readable).map((anchor) => anchor.source),
+    };
+  }
+
+  const plausible = anchors.findIndex((anchor) => !anchor.implausible);
+  const index = plausible >= 0 ? plausible : 0;
+  const anchor = anchors.at(index);
+  return anchor && { anchor, usable: false, discarded: anchors.slice(0, index).map((entry) => entry.source) };
+}
+
+/**
+ * The most recent usable anchor across a participant's prior matchUps — "the
+ * last one that finished".
+ *
+ * Two selections, ordered differently on purpose. *Within* one matchUp the
+ * ladder decides: the strongest rung at or before `asOf`, so a recorded finish
+ * outranks a projection but a projection is still reached for when the recorded
+ * value cannot be read. *Across* matchUps the clock decides: the latest of
+ * those wins, because rest runs from the last time the player walked off.
+ *
+ * When every rung of every prior matchUp is in the future the matches still
+ * happened, so reporting "no prior match" would fail open. The caller is handed
+ * the earliest future anchor and told, via `unreliable`, that it cannot carry a
+ * rest figure.
+ */
+function latestAnchor(prior: PriorMatchUp[], asOfMs: number): (AnchoredPrior & { unreliable: boolean }) | undefined {
+  let past: AnchoredPrior | undefined;
+  let future: AnchoredPrior | undefined;
+
+  for (const entry of prior) {
+    const selected = selectAnchor(resolveAnchors(entry.normalizedTimes, entry.timing), asOfMs);
+    if (!selected) continue;
+    const { anchor, usable, discarded } = selected;
+    const candidate = { anchor, matchUp: entry.matchUp, timing: entry.timing, discarded };
+    if (usable) {
+      if (!past || anchor.ms > past.anchor.ms) past = candidate;
+    } else if (!future || anchor.ms < future.anchor.ms) {
+      future = candidate;
+    }
+  }
+
+  if (past) return { ...past, unreliable: false };
+  return future && { ...future, unreliable: true };
+}
+
+function onCourtRow(params: {
+  participantId: string;
+  participantName: string;
+  live: PriorMatchUp;
+  target: HydratedMatchUp;
+  context: RestContext;
+  load: RestDailyLoad;
+}): RestRow {
+  const { participantId, participantName, live, target, context, load } = params;
+  const { requiredMinutes, typeChange } = requirementFor(live.matchUp, target, live.timing);
+  const anchor = resolveAnchor(live.normalizedTimes, live.timing);
+  // The anchor for a live matchUp is a *projected* finish. Once that projection
+  // has passed, the match has overrun its format's average and the projection
+  // has expired with it — naming a readyAt in the past would read as though the
+  // player were already free, which is exactly backwards.
+  const overrun = !!anchor && anchor.ms <= context.asOfMs;
+  const readyAt =
+    anchor && !overrun ? localClock(anchor.ms + requiredMinutes * MS_PER_MINUTE, context.frame) : undefined;
+  return {
+    participantId,
+    participantName,
+    status: 'onCourt',
+    requiredMinutes,
+    typeChange,
+    ...(readyAt && { readyAt }),
+    ...(overrun && { overrun: true }),
+    ...(anchor && { source: anchor.source }),
+    fromMatchUpId: live.matchUp.matchUpId,
+    fromMatchUpLabel: matchUpLabel(live.matchUp),
+    load,
+  };
+}
+
+function restRowFor(
+  participantId: string,
+  target: HydratedMatchUp,
+  context: RestContext,
+  dayMatchUps: PriorMatchUp[],
+): RestRow {
+  const participantName = nameFor(participantId, context.matchUps);
+  const prior = dayMatchUps.filter((entry) => entry.individuals.has(participantId));
+  const load = loadFor(prior, target, context.dailyLimits);
+
+  // Still on court dominates every other reading: rest has not started, so a
+  // minutes figure would be a fiction. Report the projected finish instead.
+  const live = prior.find((entry) => entry.underWay);
+  if (live) return onCourtRow({ participantId, participantName, live, target, context, load });
+
+  const latest = latestAnchor(prior, context.asOfMs);
+  if (!latest) {
+    return { participantId, participantName, status: 'none', requiredMinutes: 0, typeChange: false, load };
+  }
+
+  const { requiredMinutes, typeChange } = requirementFor(latest.matchUp, target, latest.timing);
+  // An unreliable anchor sits in the future, so no interval can be measured
+  // from it. Zero rest against a real requirement is the conservative reading —
+  // it holds the player back — and `anchorUnreliable` keeps that from reading as
+  // a measured figure.
+  const restMinutes = latest.unreliable ? 0 : Math.floor((context.asOfMs - latest.anchor.ms) / MS_PER_MINUTE);
+  const rested = !latest.unreliable && restMinutes >= requiredMinutes;
+  const showReadyAt = !rested && !latest.unreliable;
+
+  return {
+    participantId,
+    participantName,
+    status: rested ? 'rested' : 'resting',
+    restMinutes,
+    requiredMinutes,
+    typeChange,
+    ...(showReadyAt && { readyAt: localClock(latest.anchor.ms + requiredMinutes * MS_PER_MINUTE, context.frame) }),
+    ...(latest.unreliable && { anchorUnreliable: true }),
+    ...(latest.discarded.length && { discardedSources: latest.discarded }),
+    source: latest.anchor.source,
+    fromMatchUpId: latest.matchUp.matchUpId,
+    fromMatchUpLabel: matchUpLabel(latest.matchUp),
+    load,
+  };
+}
+
+/**
+ * How far short of ready a row is, in minutes. The within-band tiebreak:
+ * sorting by status alone left side order to decide which player the headline
+ * spoke for, so a doubles pair resting at 10m and 40m reported whichever
+ * happened to be listed first. `onCourt` and `none` carry no measurable
+ * deficit, so they return 0 and keep their original order.
+ */
+function deficitMinutes(row: RestRow): number {
+  if (row.status === 'onCourt' || row.status === 'none') return 0;
+  return row.requiredMinutes - (row.restMinutes ?? 0);
+}
+
+/**
+ * Rest for every individual in one matchUp. Rows are ordered worst-first
+ * (`onCourt` → `resting` → `rested` → `none`) so a renderer can take the head as
+ * the headline without re-deciding severity.
+ *
+ * Exported for callers that already hold hydrated matchUps and a resolver.
+ */
+export function analyzeParticipantRest(params: RestContext & { matchUpId: string }): RestResult {
+  const { matchUpId, ...context } = params;
+  const target = context.matchUps.find((matchUp) => matchUp.matchUpId === matchUpId);
+  if (!target) return { evaluated: false, reason: 'unknownMatchUp' };
+  if (target.matchUpStatus === BYE) return { evaluated: false, reason: 'bye' };
+  if (isFinished(target)) return { evaluated: false, reason: 'completed' };
+
+  const participantIds = individualIds(target);
+  if (!participantIds.length) return { evaluated: false, reason: 'noParticipants' };
+
+  const dayMatchUps = collectPriorMatchUps(target, context);
+  const order: RestStatus[] = ['onCourt', 'resting', 'rested', 'none'];
+  const rows = participantIds
+    .map((participantId) => restRowFor(participantId, target, context, dayMatchUps))
+    .toSorted((a, b) => order.indexOf(a.status) - order.indexOf(b.status) || deficitMinutes(b) - deficitMinutes(a));
+
+  return {
+    evaluated: true,
+    asOf: new Date(context.asOfMs).toISOString(),
+    scheduledDate: context.scheduledDate,
+    rows,
+  };
+}
+
+type GetParticipantRestArgs = {
+  tournamentRecord: Tournament;
+  /** Hydrated `{ inContext: true }`. Resolved from the record when absent. */
+  matchUps?: HydratedMatchUp[];
+  matchUpId: string;
+  /**
+   * The instant the analysis is "as of", ISO. **Required — the factory holds no
+   * clock.** The same caller-supplied wall-clock idiom as `calledAt` and
+   * `ScheduleScenario.createdAt`.
+   */
+  asOf: string;
+  /**
+   * The day rest is measured on. Defaults to the inspected matchUp's own
+   * `scheduledDate`, which cannot drift from the thing being asked about; the
+   * parameter exists for an unscheduled matchUp, which has no day of its own.
+   */
+  scheduledDate?: string;
+  /** Fixed offset east of UTC. Ignored when `timeZone` is supplied. */
+  utcOffsetMinutes?: number;
+  /** IANA zone. Defaults to the tournament's `localTimeZone`; DST-correct, which an offset cannot be. */
+  timeZone?: string;
+};
+
+export function getParticipantRest(params: GetParticipantRestArgs): ResultType & { rest?: RestResult } {
+  const paramsCheck = checkRequiredParameters(params, [{ [TOURNAMENT_RECORD]: true, matchUpId: true }]);
+  if (paramsCheck.error) return paramsCheck;
+  if (!params.matchUpId) return { error: MISSING_MATCHUP_ID };
+
+  const { tournamentRecord, matchUpId, asOf, utcOffsetMinutes = 0 } = params;
+  const asOfMs = isoToMs(asOf);
+  // Without an instant there is nothing to measure from, and substituting one
+  // would be the factory reading a clock it does not have.
+  if (asOfMs === null) return { rest: { evaluated: false, reason: 'noAsOf' } };
+
+  const matchUps =
+    params.matchUps ??
+    ((allTournamentMatchUps({ tournamentRecord, inContext: true })?.matchUps ?? []) as HydratedMatchUp[]);
+
+  const target = matchUps.find((matchUp) => matchUp.matchUpId === matchUpId);
+  if (!target) return { rest: { evaluated: false, reason: 'unknownMatchUp' } };
+
+  // Rest is scoped to a day, and an unscheduled matchUp has none of its own. The
+  // caller names one — that is what a catalog card is asking about — and saying
+  // so beats measuring against a day nobody chose.
+  const scheduledDate = params.scheduledDate ?? target.schedule?.scheduledDate;
+  if (!scheduledDate) return { rest: { evaluated: false, reason: 'noDay' } };
+
+  const limits: any = getDailyLimit({ tournamentRecord });
+
+  const rest = analyzeParticipantRest({
+    frame: { utcOffsetMinutes, timeZone: params.timeZone ?? (tournamentRecord as any)?.localTimeZone },
+    timingFor: makeTimingResolver(tournamentRecord),
+    dailyLimits: limits?.error ? undefined : limits?.matchUpDailyLimits,
+    scheduledDate,
+    matchUpId,
+    matchUps,
+    asOfMs,
+  });
+
+  return { rest };
+}

--- a/src/query/matchUps/scheduling/schedulingTiming.ts
+++ b/src/query/matchUps/scheduling/schedulingTiming.ts
@@ -1,0 +1,110 @@
+/**
+ * Per-matchUp scheduling timing, resolved once and reused across a whole
+ * readiness or rest analysis.
+ *
+ * `getMatchUpFormatTiming` is what the auto-scheduler itself resolves against,
+ * including its scheduling-policy fallback, so an unpoliced tournament still
+ * gets per-format averages rather than a flat 90/0. Reaching it directly — once
+ * per distinct format rather than once per matchUp — is the whole reason this
+ * module exists: a tournament has a handful of distinct
+ * `matchUpFormat|matchUpType|eventId` combinations and hundreds of matchUps.
+ *
+ * ── Why the category is passed explicitly, alongside the event ──
+ *
+ * Recovery is category-dependent: `POLICY_SCHEDULING_DEFAULT` gives ADULT and
+ * WHEELCHAIR doubles 30 minutes but JUNIOR doubles 60. Passing only
+ * `{ matchUpFormat, eventType }` silently resolves junior doubles to the adult
+ * figure.
+ *
+ * Passing the `event` alone does not fix it either. `getScheduleTiming`
+ * resolves `categoryType` off `event.category` correctly, and
+ * `getMatchUpFormatTiming` then rebuilds its `timingDetails` as
+ * `{ ...scheduleTiming, …, categoryType, … }` where `categoryType` is the
+ * *parameter* — `undefined` when the caller supplied only an event. The
+ * explicit key clobbers the resolved one, so the event's category is discarded.
+ *
+ * So the category is resolved here and passed explicitly. The event goes too,
+ * because it is the only route to event-level scheduling policies and the
+ * event's `SCHEDULE_TIMING` extension — and so this call site keeps working
+ * unchanged if that clobber is ever repaired.
+ *
+ * This module was ported from TMX (`scheduleTimingResolver.ts`) along with the
+ * two analyses it serves; the measurement above was taken there against a
+ * JUNIOR DOUBLES `SET3-S:6/TB7` event: `{ event }` → 30, `{ categoryType }` →
+ * 60, bare → 30.
+ */
+import { getMatchUpFormatTiming } from '@Query/extensions/matchUpFormatTiming/getMatchUpFormatTiming';
+
+// constants and types
+import { HydratedMatchUp } from '@Types/hydrated';
+import { Tournament } from '@Types/tournamentTypes';
+import { Event } from '@Types/tournamentTypes';
+
+export type SchedulingTiming = {
+  averageMinutes: number;
+  recoveryMinutes: number;
+  /** Recovery owed when a participant changes matchUpType (singles ↔ doubles). */
+  typeChangeRecoveryMinutes: number;
+};
+
+/**
+ * Used when a matchUp carries no format at all. Keeps the arithmetic running
+ * rather than dropping findings: a 90-minute average with no recovery reports
+ * overlaps while declining to invent a recovery requirement nobody configured.
+ */
+export const FALLBACK_TIMING: SchedulingTiming = {
+  averageMinutes: 90,
+  recoveryMinutes: 0,
+  typeChangeRecoveryMinutes: 0,
+};
+
+/** The category identifiers the scheduling policy matches on, read the way `getScheduleTiming` reads them. */
+function categoryOf(event?: Event): { categoryName?: string; categoryType?: string } {
+  const category: any = event?.category;
+  return {
+    categoryName: category?.categoryName ?? category?.ageCategoryCode,
+    categoryType: category?.categoryType ?? category?.subType,
+  };
+}
+
+/**
+ * A timing lookup valid for one analysis pass.
+ *
+ * Memoised per `matchUpFormat|matchUpType|eventId`. The cache is per-call rather
+ * than module-level on purpose: a scheduling policy can be attached or modified
+ * between calls, and a stale average is a wrong answer that looks like a right
+ * one.
+ */
+export function makeTimingResolver(tournamentRecord: Tournament): (matchUp: HydratedMatchUp) => SchedulingTiming {
+  const cache = new Map<string, SchedulingTiming>();
+  const events = new Map((tournamentRecord?.events ?? []).map((event) => [event.eventId, event]));
+
+  return (matchUp: HydratedMatchUp) => {
+    const matchUpFormat = matchUp.matchUpFormat ?? '';
+    const eventId = matchUp.eventId ?? '';
+    const key = `${matchUpFormat}|${matchUp.matchUpType ?? ''}|${eventId}`;
+    const cached = cache.get(key);
+    if (cached) return cached;
+
+    let timing = FALLBACK_TIMING;
+    if (matchUpFormat) {
+      const event = events.get(eventId);
+      const result: any = getMatchUpFormatTiming({
+        eventType: matchUp.matchUpType as any,
+        ...categoryOf(event),
+        tournamentRecord,
+        matchUpFormat,
+        event,
+      });
+      if (!result?.error) {
+        timing = {
+          averageMinutes: result?.averageMinutes ?? FALLBACK_TIMING.averageMinutes,
+          recoveryMinutes: result?.recoveryMinutes ?? FALLBACK_TIMING.recoveryMinutes,
+          typeChangeRecoveryMinutes: result?.typeChangeRecoveryMinutes ?? 0,
+        };
+      }
+    }
+    cache.set(key, timing);
+    return timing;
+  };
+}

--- a/src/tests/queries/scheduling/matchUpReadiness.test.ts
+++ b/src/tests/queries/scheduling/matchUpReadiness.test.ts
@@ -1,0 +1,222 @@
+import { getMatchUpReadiness } from '@Query/matchUps/scheduling/getMatchUpReadiness';
+import { describe, expect, it } from 'vitest';
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+
+import POLICY_SCHEDULING_DEFAULT from '@Fixtures/policies/POLICY_SCHEDULING_DEFAULT';
+import { SINGLE_ELIMINATION } from '@Constants/drawDefinitionConstants';
+
+/**
+ * Readiness answers "can this placement happen at the time it is scheduled
+ * for", and the four findings are the four ways the answer is no. Each block
+ * below constructs exactly one of them and asserts it is reported *and* that
+ * the others are not — a finder that fires on everything is not a finder.
+ *
+ * Ported from TMX along with the analysis; these cases mirror the ones that
+ * guarded it there, restated against real engine output rather than the
+ * structural fixtures a browser module had to accept.
+ */
+
+const startDate = '2026-09-12';
+
+function seed({ drawSize = 8 }: { drawSize?: number } = {}) {
+  const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+    policyDefinitions: POLICY_SCHEDULING_DEFAULT,
+    drawProfiles: [{ drawSize, drawType: SINGLE_ELIMINATION, eventName: 'Readiness' }],
+    endDate: '2026-09-15',
+    setState: true,
+    startDate,
+  });
+  const matchUps = tournamentEngine.allTournamentMatchUps({
+    nextMatchUps: true,
+    inContext: true,
+  }).matchUps as any[];
+  return { tournamentRecord, matchUps };
+}
+
+/** Schedule one matchUp and return the engine's refreshed view. */
+function schedule(matchUpId: string, drawId: string, scheduledTime: string, scheduledDate = startDate) {
+  const result = tournamentEngine.addMatchUpScheduleItems({
+    schedule: { scheduledDate, scheduledTime },
+    removePriorValues: true,
+    matchUpId,
+    drawId,
+  });
+  expect(result.success).toEqual(true);
+}
+
+function readinessFor(matchUpId: string) {
+  const { tournamentRecord } = tournamentEngine.getTournament();
+  const result: any = getMatchUpReadiness({ tournamentRecord: tournamentRecord as any, matchUpId });
+  expect(result.error).toBeUndefined();
+  return result.readiness;
+}
+
+describe('getMatchUpReadiness — what cannot be evaluated is never reported as ready', () => {
+  it('refuses a matchUpId the tournament does not carry', () => {
+    seed();
+    expect(readinessFor('no-such-matchUp')).toEqual({ evaluated: false, reason: 'unknownMatchUp' });
+  });
+
+  it('refuses an unscheduled matchUp, which has no time to check against', () => {
+    const { matchUps } = seed();
+    const target = matchUps.find((matchUp) => matchUp.roundNumber === 1);
+    expect(readinessFor(target.matchUpId)).toEqual({ evaluated: false, reason: 'notScheduled' });
+  });
+
+  it('refuses a matchUp scheduled for a date but no time', () => {
+    const { matchUps } = seed();
+    const target = matchUps.find((matchUp) => matchUp.roundNumber === 1);
+    tournamentEngine.addMatchUpScheduleItems({
+      schedule: { scheduledDate: startDate },
+      matchUpId: target.matchUpId,
+      drawId: target.drawId,
+    });
+    expect(readinessFor(target.matchUpId)).toEqual({ evaluated: false, reason: 'noTime' });
+  });
+
+  it('refuses a completed matchUp — there is nothing left to be ready for', () => {
+    const { matchUps } = seed({ drawSize: 4 });
+    const first = matchUps.find((matchUp) => matchUp.roundNumber === 1);
+    schedule(first.matchUpId, first.drawId, '09:00');
+    const { outcome } = mocksEngine.generateOutcomeFromScoreString({ scoreString: '6-1 6-2', winningSide: 1 });
+    const result = tournamentEngine.setMatchUpStatus({ matchUpId: first.matchUpId, drawId: first.drawId, outcome });
+    expect(result.success).toEqual(true);
+    expect(readinessFor(first.matchUpId)).toEqual({ evaluated: false, reason: 'completed' });
+  });
+
+  it('refuses a BYE, which nobody has to be ready for', () => {
+    const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 4, drawType: SINGLE_ELIMINATION, participantsCount: 3 }],
+      endDate: '2026-09-15',
+      setState: true,
+      startDate,
+    });
+    const bye: any = (tournamentEngine.allTournamentMatchUps({ inContext: true }).matchUps as any[]).find(
+      (matchUp) => matchUp.matchUpStatus === 'BYE',
+    );
+    expect(bye).toBeDefined();
+    const result: any = getMatchUpReadiness({ tournamentRecord: tournamentRecord as any, matchUpId: bye.matchUpId });
+    expect(result.readiness).toEqual({ evaluated: false, reason: 'bye' });
+  });
+});
+
+describe('getMatchUpReadiness — the four findings', () => {
+  it('reports a dependency when an upstream matchUp cannot finish in time, with the clock it clears', () => {
+    const { matchUps } = seed({ drawSize: 4 });
+    const semi = matchUps.find((matchUp) => matchUp.roundNumber === 1);
+    const final = matchUps.find((matchUp) => matchUp.roundNumber === 2);
+    schedule(semi.matchUpId, semi.drawId, '09:00');
+    // The final is one hour after a semifinal whose format averages 90 minutes.
+    schedule(final.matchUpId, final.drawId, '10:00');
+
+    const readiness = readinessFor(final.matchUpId);
+    expect(readiness.evaluated).toEqual(true);
+    const dependency = readiness.findings.find((finding) => finding.kind === 'dependency');
+    expect(dependency.matchUpIds).toContain(semi.matchUpId);
+    expect(dependency.notBefore).toEqual('10:30');
+    expect(dependency.severity).toEqual('WARN');
+  });
+
+  it('reports a dependency with no clock when the upstream matchUp is not scheduled at all', () => {
+    const { matchUps } = seed({ drawSize: 4 });
+    const final = matchUps.find((matchUp) => matchUp.roundNumber === 2);
+    schedule(final.matchUpId, final.drawId, '10:00');
+
+    const dependency = readinessFor(final.matchUpId).findings.find((finding) => finding.kind === 'dependency');
+    // An unscheduled upstream cannot be promised to finish in time, so it is
+    // reported — but nothing may be claimed about when it clears.
+    expect(dependency.notBefore).toBeUndefined();
+  });
+
+  it('reports undetermined participants when a side is empty and something upstream explains it', () => {
+    const { matchUps } = seed({ drawSize: 4 });
+    const final = matchUps.find((matchUp) => matchUp.roundNumber === 2);
+    schedule(final.matchUpId, final.drawId, '14:00');
+
+    const undetermined = readinessFor(final.matchUpId).findings.find((finding) => finding.kind === 'undetermined');
+    expect(undetermined.severity).toEqual('INFO');
+    expect(undetermined.matchUpIds.length).toBeGreaterThan(0);
+  });
+
+  it('leaves a well-spaced placement with no findings at all', () => {
+    const { matchUps } = seed({ drawSize: 4 });
+    const semi = matchUps.find((matchUp) => matchUp.roundNumber === 1);
+    const other = matchUps.filter((matchUp) => matchUp.roundNumber === 1)[1];
+    const final = matchUps.find((matchUp) => matchUp.roundNumber === 2);
+    schedule(semi.matchUpId, semi.drawId, '09:00');
+    schedule(other.matchUpId, other.drawId, '09:00');
+    schedule(final.matchUpId, final.drawId, '14:00');
+
+    const readiness = readinessFor(final.matchUpId);
+    expect(readiness.evaluated).toEqual(true);
+    // Both semifinals project to finish at 10:30, well before 14:00, and the
+    // final's own sides are still undetermined — but nothing upstream is late.
+    expect(readiness.findings.filter((finding: any) => finding.kind === 'dependency')).toEqual([]);
+  });
+});
+
+describe('getMatchUpReadiness — overlap outranks recovery for the same participant', () => {
+  /**
+   * A participant scheduled into two matchUps at the same time is *on court
+   * elsewhere*, which already implies their recovery window is violated.
+   * Reporting both would double-count one problem, so overlap wins and the
+   * participant is dropped from the recovery finding.
+   */
+  it('reports overlap, and does not also report recovery for the overlapped participant', () => {
+    mocksEngine.generateTournamentRecord({
+      policyDefinitions: POLICY_SCHEDULING_DEFAULT,
+      drawProfiles: [
+        { drawSize: 4, drawType: SINGLE_ELIMINATION, eventName: 'Singles A', uniqueParticipants: false },
+        { drawSize: 4, drawType: SINGLE_ELIMINATION, eventName: 'Singles B', uniqueParticipants: false },
+      ],
+      endDate: '2026-09-15',
+      setState: true,
+      startDate,
+    });
+
+    const matchUps = tournamentEngine.allTournamentMatchUps({ inContext: true, nextMatchUps: true }).matchUps as any[];
+    const first = matchUps.find(
+      (matchUp) => matchUp.roundNumber === 1 && matchUp.sides?.every((s: any) => s.participantId),
+    );
+    const shared = first.sides[0].participantId;
+    const second = matchUps.find(
+      (matchUp) =>
+        matchUp.matchUpId !== first.matchUpId && matchUp.sides?.some((side: any) => side.participantId === shared),
+    );
+    // Only run the assertion when the mock actually produced a shared player;
+    // otherwise the test would pass by describing nothing.
+    expect(second).toBeDefined();
+
+    schedule(first.matchUpId, first.drawId, '09:00');
+    schedule(second.matchUpId, second.drawId, '09:00');
+
+    const readiness: any = getMatchUpReadiness({
+      tournamentRecord: tournamentEngine.getTournament().tournamentRecord as any,
+      matchUpId: second.matchUpId,
+    }).readiness;
+
+    const overlap = readiness.findings.find((finding: any) => finding.kind === 'overlap');
+    expect(overlap.participantIds).toContain(shared);
+    const recovery = readiness.findings.find((finding: any) => finding.kind === 'recovery');
+    expect(recovery?.participantIds ?? []).not.toContain(shared);
+    // Strongest first, so a renderer can take the head as the headline.
+    expect(readiness.findings[0].kind).toEqual('overlap');
+  });
+});
+
+describe('getMatchUpReadiness — the engine method and its parameters', () => {
+  it('is reachable through the engine', () => {
+    const { matchUps } = seed({ drawSize: 4 });
+    const target = matchUps.find((matchUp) => matchUp.roundNumber === 1);
+    schedule(target.matchUpId, target.drawId, '09:00');
+    const result: any = tournamentEngine.getMatchUpReadiness({ matchUpId: target.matchUpId });
+    expect(result.readiness.evaluated).toEqual(true);
+  });
+
+  it('refuses a call with no matchUpId rather than answering about nothing', () => {
+    seed({ drawSize: 4 });
+    const result: any = tournamentEngine.getMatchUpReadiness({});
+    expect(result.error).toBeDefined();
+  });
+});

--- a/src/tests/queries/scheduling/participantRest.test.ts
+++ b/src/tests/queries/scheduling/participantRest.test.ts
@@ -1,0 +1,232 @@
+import { getParticipantRest } from '@Query/matchUps/scheduling/getParticipantRest';
+import { describe, expect, it } from 'vitest';
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+
+import POLICY_SCHEDULING_DEFAULT from '@Fixtures/policies/POLICY_SCHEDULING_DEFAULT';
+import { SINGLE_ELIMINATION } from '@Constants/drawDefinitionConstants';
+
+/**
+ * Rest is anchored on a caller-supplied `asOf`, which is the whole reason it
+ * can live in the factory: there is no clock here, and every case below states
+ * the instant it is asking about rather than inheriting one.
+ *
+ * The cases mirror the ones that guarded this analysis in TMX, restated against
+ * real engine output and real UTC instants — which is the substantive change in
+ * the port. TMX worked in minutes-since-midnight because a browser module
+ * cannot resolve a named zone; the apparatus that needed (a ±1-day clamp, a
+ * projected "now") is gone, so the assertions here are about intervals rather
+ * than about the clamp.
+ */
+
+const startDate = '2026-09-12';
+/** 09:00 venue-local on the day under test, in UTC. The frame below is UTC, so they coincide. */
+const at = (clock: string) => `${startDate}T${clock}:00.000Z`;
+
+function seed() {
+  mocksEngine.generateTournamentRecord({
+    policyDefinitions: POLICY_SCHEDULING_DEFAULT,
+    drawProfiles: [{ drawSize: 4, drawType: SINGLE_ELIMINATION, eventName: 'Rest' }],
+    endDate: '2026-09-15',
+    setState: true,
+    startDate,
+  });
+  return tournamentEngine.allTournamentMatchUps({ inContext: true }).matchUps as any[];
+}
+
+function schedule(matchUp: any, scheduledTime: string, extra: Record<string, any> = {}) {
+  const result = tournamentEngine.addMatchUpScheduleItems({
+    schedule: { scheduledDate: startDate, scheduledTime, ...extra },
+    removePriorValues: true,
+    matchUpId: matchUp.matchUpId,
+    drawId: matchUp.drawId,
+  });
+  expect(result.success).toEqual(true);
+}
+
+function restFor(matchUpId: string, asOf: string) {
+  const { tournamentRecord } = tournamentEngine.getTournament();
+  const result: any = getParticipantRest({ tournamentRecord: tournamentRecord as any, matchUpId, asOf });
+  expect(result.error).toBeUndefined();
+  return result.rest;
+}
+
+/** Complete a matchUp and stamp when it ended, the way an operator's END_TIME does. */
+function completeAt(matchUp: any, endTime: string) {
+  const { outcome } = mocksEngine.generateOutcomeFromScoreString({ scoreString: '6-1 6-2', winningSide: 1 });
+  const status = tournamentEngine.setMatchUpStatus({
+    matchUpId: matchUp.matchUpId,
+    drawId: matchUp.drawId,
+    outcome,
+  });
+  expect(status.success).toEqual(true);
+  schedule(matchUp, matchUp.schedule?.scheduledTime ?? '09:00', { endTime });
+}
+
+describe('getParticipantRest — what cannot be measured is never reported as rested', () => {
+  it('refuses a matchUpId the tournament does not carry', () => {
+    seed();
+    expect(restFor('no-such-matchUp', at('12:00'))).toEqual({ evaluated: false, reason: 'unknownMatchUp' });
+  });
+
+  it('refuses to substitute a clock it does not have', () => {
+    const matchUps = seed();
+    const target = matchUps.find((matchUp) => matchUp.roundNumber === 1);
+    schedule(target, '09:00');
+    const { tournamentRecord } = tournamentEngine.getTournament();
+    const result: any = getParticipantRest({
+      tournamentRecord: tournamentRecord as any,
+      matchUpId: target.matchUpId,
+      asOf: 'not-an-instant',
+    });
+    expect(result.rest).toEqual({ evaluated: false, reason: 'noAsOf' });
+  });
+
+  it('refuses a completed matchUp', () => {
+    const matchUps = seed();
+    const target = matchUps.find((matchUp) => matchUp.roundNumber === 1);
+    schedule(target, '09:00');
+    completeAt(target, '10:20');
+    expect(restFor(target.matchUpId, at('12:00'))).toMatchObject({ evaluated: false, reason: 'completed' });
+  });
+});
+
+describe('getParticipantRest — the ladder and the interval', () => {
+  it('reports no prior match when nobody on the card has played yet', () => {
+    const matchUps = seed();
+    const first = matchUps.filter((matchUp) => matchUp.roundNumber === 1)[0];
+    const second = matchUps.filter((matchUp) => matchUp.roundNumber === 1)[1];
+    schedule(first, '09:00');
+    schedule(second, '09:00');
+
+    const rest = restFor(second.matchUpId, at('08:00'));
+    expect(rest.evaluated).toEqual(true);
+    expect(rest.rows.every((row: any) => row.status === 'none')).toEqual(true);
+  });
+
+  it('measures rest from a recorded end time, and names that rung', () => {
+    const matchUps = seed();
+    const semis = matchUps.filter((matchUp) => matchUp.roundNumber === 1);
+    const final = matchUps.find((matchUp) => matchUp.roundNumber === 2);
+    schedule(semis[0], '09:00');
+    completeAt(semis[0], '10:20');
+    schedule(final, '14:00');
+
+    // The winner of the first semifinal is now in the final; 12:00 is 100
+    // minutes after their recorded finish.
+    const rest = restFor(final.matchUpId, at('12:00'));
+    const measured = rest.rows.find((row: any) => row.source === 'endTime');
+    expect(measured.restMinutes).toEqual(100);
+    expect(measured.status).toEqual('rested');
+    expect(measured.fromMatchUpId).toEqual(semis[0].matchUpId);
+  });
+
+  it('reports a participant still on court, with no rest figure and a projected readyAt', () => {
+    // Two draws sharing a field, so one player can be under way in one matchUp
+    // while being asked about in another — which is the state the whole
+    // `onCourt` band exists for.
+    mocksEngine.generateTournamentRecord({
+      policyDefinitions: POLICY_SCHEDULING_DEFAULT,
+      drawProfiles: [
+        { drawSize: 4, drawType: SINGLE_ELIMINATION, eventName: 'A', uniqueParticipants: false },
+        { drawSize: 4, drawType: SINGLE_ELIMINATION, eventName: 'B', uniqueParticipants: false },
+      ],
+      endDate: '2026-09-15',
+      setState: true,
+      startDate,
+    });
+    const matchUps = tournamentEngine.allTournamentMatchUps({ inContext: true }).matchUps as any[];
+    const playable = matchUps.filter(
+      (matchUp) => matchUp.roundNumber === 1 && matchUp.sides?.every((side: any) => side.participantId),
+    );
+    const live = playable[0];
+    const shared = live.sides[0].participantId;
+    const other = playable.find(
+      (matchUp) =>
+        matchUp.matchUpId !== live.matchUpId && matchUp.sides.some((side: any) => side.participantId === shared),
+    );
+    expect(other).toBeDefined();
+
+    schedule(live, '09:00');
+    schedule(other, '11:00');
+
+    const rest = restFor(other.matchUpId, at('09:30'));
+    const onCourt = rest.rows.find((row: any) => row.participantId === shared);
+    expect(onCourt.status).toEqual('onCourt');
+    // No interval: rest has not started, so a minutes figure would be fiction.
+    expect(onCourt.restMinutes).toBeUndefined();
+    // 09:00 + the format's 90-minute average projects a 10:30 finish, plus the
+    // 60 minutes of singles recovery the default scheduling policy requires.
+    expect(onCourt.readyAt).toEqual('11:30');
+    expect(onCourt.fromMatchUpId).toEqual(live.matchUpId);
+    // Worst-first: the on-court player is the headline.
+    expect(rest.rows[0].participantId).toEqual(shared);
+  });
+
+  it('names the day it cannot choose, rather than blaming the matchUp', () => {
+    const matchUps = seed();
+    const unscheduled = matchUps.filter((matchUp) => matchUp.roundNumber === 1)[0];
+    expect(restFor(unscheduled.matchUpId, at('12:00'))).toEqual({ evaluated: false, reason: 'noDay' });
+  });
+
+  it('counts the day’s load and reports which match of the day this would be', () => {
+    const matchUps = seed();
+    const semis = matchUps.filter((matchUp) => matchUp.roundNumber === 1);
+    const final = matchUps.find((matchUp) => matchUp.roundNumber === 2);
+    schedule(semis[0], '09:00');
+    completeAt(semis[0], '10:20');
+    schedule(final, '14:00');
+
+    const rest = restFor(final.matchUpId, at('12:00'));
+    const played = rest.rows.find((row: any) => row.load.total === 1);
+    expect(played.load.ordinal).toEqual(2);
+    expect(played.load.singles).toEqual(1);
+  });
+
+  it('reports the day it measured and the instant it measured at', () => {
+    const matchUps = seed();
+    const target = matchUps.filter((matchUp) => matchUp.roundNumber === 1)[0];
+    schedule(target, '09:00');
+    const rest = restFor(target.matchUpId, at('08:00'));
+    expect(rest.scheduledDate).toEqual(startDate);
+    expect(rest.asOf).toEqual(at('08:00'));
+  });
+});
+
+describe('getParticipantRest — a walkover is not load the director has spent', () => {
+  it('does not count a walkover as a prior match', () => {
+    const matchUps = seed();
+    const semis = matchUps.filter((matchUp) => matchUp.roundNumber === 1);
+    const final = matchUps.find((matchUp) => matchUp.roundNumber === 2);
+    schedule(semis[0], '09:00');
+    const status = tournamentEngine.setMatchUpStatus({
+      outcome: { matchUpStatus: 'WALKOVER', winningSide: 1 },
+      matchUpId: semis[0].matchUpId,
+      drawId: semis[0].drawId,
+    });
+    expect(status.success).toEqual(true);
+    schedule(final, '14:00');
+
+    const rest = restFor(final.matchUpId, at('12:00'));
+    // The walkover winner is in the final having played nothing: no rest
+    // requirement, and no slot consumed against a daily limit.
+    expect(rest.rows.every((row: any) => row.status === 'none')).toEqual(true);
+    expect(rest.rows.every((row: any) => row.load.total === 0)).toEqual(true);
+  });
+});
+
+describe('getParticipantRest — the engine method', () => {
+  it('is reachable through the engine', () => {
+    const matchUps = seed();
+    const target = matchUps.filter((matchUp) => matchUp.roundNumber === 1)[0];
+    schedule(target, '09:00');
+    const result: any = tournamentEngine.getParticipantRest({ matchUpId: target.matchUpId, asOf: at('08:00') });
+    expect(result.rest.evaluated).toEqual(true);
+  });
+
+  it('refuses a call with no matchUpId', () => {
+    seed();
+    const result: any = tournamentEngine.getParticipantRest({ asOf: at('08:00') });
+    expect(result.error).toBeDefined();
+  });
+});

--- a/src/tests/queries/scheduling/readinessRules.test.ts
+++ b/src/tests/queries/scheduling/readinessRules.test.ts
@@ -1,0 +1,176 @@
+import {
+  analyzeMatchUpReadiness,
+  individualIds,
+  matchUpLabel,
+  minutesToClock,
+  nameFor,
+  parseClockMinutes,
+} from '@Query/matchUps/scheduling/getMatchUpReadiness';
+import { describe, expect, it } from 'vitest';
+
+// constants and types
+import { HydratedMatchUp } from '@Types/hydrated';
+
+/**
+ * The readiness rules that a tournament fixture cannot provoke on demand: a
+ * recovery window that has not elapsed, a neighbour with a recorded end time, a
+ * doubles pair sharing one player with the target, and the projection refusals.
+ *
+ * Exercised against the pure analysis, which is what the query calls once it has
+ * resolved matchUps and timing.
+ */
+
+const DAY = '2026-09-12';
+const TIMING = { averageMinutes: 90, recoveryMinutes: 60, typeChangeRecoveryMinutes: 30 };
+
+function matchUp(id: string, sides: any[], schedule: any, extra: any = {}): HydratedMatchUp {
+  return {
+    matchUpId: id,
+    matchUpType: 'SINGLES',
+    sides,
+    schedule: { scheduledDate: DAY, ...schedule },
+    ...extra,
+  } as any;
+}
+
+const player = (participantId: string) => ({ participantId, participantName: participantId });
+
+function analyze(matchUps: HydratedMatchUp[], matchUpId: string) {
+  const result = analyzeMatchUpReadiness({ matchUps, matchUpId, timingFor: () => TIMING });
+  if (!result.evaluated) throw new Error(`expected evaluation, got ${result.reason}`);
+  return result.findings;
+}
+
+describe('recovery — the window that has not elapsed', () => {
+  it('reports the participant and the clock the window clears, projected from the plan', () => {
+    const earlier = matchUp('earlier', [player('alice'), player('bob')], { scheduledTime: '09:00' });
+    const target = matchUp('target', [player('alice'), player('chen')], { scheduledTime: '11:00' });
+    const [finding] = analyze([earlier, target], 'target');
+    // 09:00 + 90 average + 60 recovery = 11:30, after the 11:00 start.
+    expect(finding).toMatchObject({ kind: 'recovery', severity: 'WARN', notBefore: '11:30' });
+    expect(finding.participantIds).toEqual(['alice']);
+  });
+
+  it('prefers a recorded end time over the projection when measuring the window', () => {
+    const earlier = matchUp(
+      'earlier',
+      [player('alice'), player('bob')],
+      { scheduledTime: '09:00', endTime: '10:45' },
+      { winningSide: 1 },
+    );
+    const target = matchUp('target', [player('alice'), player('chen')], { scheduledTime: '11:00' });
+    // 10:45 + 60 recovery = 11:45, measured rather than projected.
+    expect(analyze([earlier, target], 'target')[0]).toMatchObject({ notBefore: '11:45' });
+  });
+
+  it('says nothing when the window has already elapsed', () => {
+    const earlier = matchUp(
+      'earlier',
+      [player('alice'), player('bob')],
+      { scheduledTime: '08:00', endTime: '09:20' },
+      { winningSide: 1 },
+    );
+    const target = matchUp('target', [player('alice'), player('chen')], { scheduledTime: '14:00' });
+    expect(analyze([earlier, target], 'target')).toEqual([]);
+  });
+
+  it('says nothing about a neighbour on another day', () => {
+    const yesterday = matchUp('yesterday', [player('alice'), player('bob')], {
+      scheduledDate: '2026-09-11',
+      scheduledTime: '20:00',
+    });
+    const target = matchUp('target', [player('alice'), player('chen')], { scheduledTime: '09:00' });
+    expect(analyze([yesterday, target], 'target')).toEqual([]);
+  });
+
+  it('reaches the members of a doubles pair, not just the pair itself', () => {
+    const pair = {
+      participantId: 'pair-1',
+      participant: {
+        participantId: 'pair-1',
+        participantName: 'Alice/Bob',
+        individualParticipantIds: ['alice', 'bob'],
+      },
+    };
+    const doubles = matchUp('doubles', [pair, player('other')], { scheduledTime: '09:00' });
+    // 11:00 is past the pair's projected 10:30 finish, so this is the recovery
+    // window rather than an overlap — the band that has to reach the members.
+    const target = matchUp('target', [player('alice'), player('chen')], { scheduledTime: '11:00' });
+    const [finding] = analyze([doubles, target], 'target');
+    expect(finding.kind).toEqual('recovery');
+    expect(finding.participantIds).toEqual(['alice']);
+    // The label names the pair, because that is what is on court.
+    expect(finding.participantNames).toEqual(['Alice/Bob']);
+  });
+
+  it('does not treat a finished neighbour as an overlap, only as recovery', () => {
+    const finished = matchUp(
+      'finished',
+      [player('alice'), player('bob')],
+      { scheduledTime: '10:30' },
+      { winningSide: 1, matchUpStatus: 'COMPLETED' },
+    );
+    const target = matchUp('target', [player('alice'), player('chen')], { scheduledTime: '11:00' });
+    const kinds = analyze([finished, target], 'target').map((finding) => finding.kind);
+    expect(kinds).toEqual(['recovery']);
+  });
+});
+
+describe('undetermined participants', () => {
+  it('is silent when a side is empty but nothing upstream explains it', () => {
+    const target = matchUp('target', [player('alice'), {}], { scheduledTime: '11:00' });
+    expect(analyze([target], 'target')).toEqual([]);
+  });
+
+  it('walks past a finished feeder to report the grandparent that is still pending', () => {
+    const grandparent = matchUp('grand', [player('x'), player('y')], { scheduledTime: '09:00' });
+    const parent = matchUp(
+      'parent',
+      [player('x'), player('z')],
+      { scheduledTime: '10:00' },
+      {
+        winnerMatchUpId: 'target',
+      },
+    );
+    const linkedGrand = { ...grandparent, winnerMatchUpId: 'parent' } as HydratedMatchUp;
+    const target = matchUp('target', [{}, {}], { scheduledTime: '15:00' });
+    const undetermined = analyze([linkedGrand, parent, target], 'target').find(
+      (finding) => finding.kind === 'undetermined',
+    );
+    expect(undetermined?.matchUpIds).toEqual(expect.arrayContaining(['parent', 'grand']));
+  });
+});
+
+describe('the small shared helpers', () => {
+  it('parses a wall clock and refuses what is not one', () => {
+    expect(parseClockMinutes('09:30')).toEqual(570);
+    expect(parseClockMinutes('24:00')).toBeNull();
+    expect(parseClockMinutes('9:5')).toBeNull();
+    expect(parseClockMinutes(undefined)).toBeNull();
+  });
+
+  it('wraps a projected clock past midnight rather than reporting a 25th hour', () => {
+    expect(minutesToClock(540)).toEqual('09:00');
+    expect(minutesToClock(1500)).toEqual('01:00');
+    expect(minutesToClock(-30)).toEqual('23:30');
+  });
+
+  it('labels a matchUp by its round and its sides, and copes when neither is known', () => {
+    expect(matchUpLabel(matchUp('m', [player('alice'), player('bob')], {}, { roundName: 'R16' }))).toEqual(
+      'R16: alice vs bob',
+    );
+    expect(matchUpLabel({ matchUpId: 'm' } as any)).toEqual('TBD vs TBD');
+  });
+
+  it('counts a pair once, by its members, never as itself as well', () => {
+    const pair = {
+      participantId: 'pair-1',
+      participant: { participantId: 'pair-1', individualParticipantIds: ['alice', 'bob'] },
+    };
+    expect(individualIds(matchUp('m', [pair, player('chen')], {}))).toEqual(['alice', 'bob', 'chen']);
+  });
+
+  it('falls back to the participantId when no side carries a name for it', () => {
+    expect(nameFor('ghost', [matchUp('m', [player('alice')], {})])).toEqual('ghost');
+  });
+});

--- a/src/tests/queries/scheduling/restLadder.test.ts
+++ b/src/tests/queries/scheduling/restLadder.test.ts
@@ -1,0 +1,265 @@
+import {
+  analyzeParticipantRest,
+  normalizeTimes,
+  occursOnDay,
+  resolveAnchors,
+} from '@Query/matchUps/scheduling/getParticipantRest';
+import { describe, expect, it } from 'vitest';
+
+// constants and types
+import { HydratedMatchUp } from '@Types/hydrated';
+
+/**
+ * The ladder and the honesty rules, exercised directly against the pure
+ * analysis rather than through the engine.
+ *
+ * These are the paths a tournament fixture cannot reach on demand: a score
+ * stamped a day after the match, an anchor that sits in the future, a match
+ * that has overrun its format's average. Each is a rule about *not* reporting a
+ * number as measured when it is not, and each has to be provoked deliberately.
+ *
+ * Ported from the suite that guarded this analysis in TMX, restated in UTC
+ * milliseconds — the frame the factory version works in.
+ */
+
+const DAY = '2026-09-12';
+const FRAME = { utcOffsetMinutes: 0 };
+const TIMING = { averageMinutes: 90, recoveryMinutes: 60, typeChangeRecoveryMinutes: 30 };
+const at = (clock: string) => Date.parse(`${DAY}T${clock}:00.000Z`);
+
+function singles(id: string, participantIds: string[], schedule: any, extra: any = {}): HydratedMatchUp {
+  return {
+    matchUpId: id,
+    matchUpType: 'SINGLES',
+    sides: participantIds.map((participantId) => ({ participantId, participantName: participantId })),
+    schedule: { scheduledDate: DAY, ...schedule },
+    ...extra,
+  } as any;
+}
+
+function analyze(matchUps: HydratedMatchUp[], matchUpId: string, asOf: string, dailyLimits?: any) {
+  const result = analyzeParticipantRest({
+    timingFor: () => TIMING,
+    scheduledDate: DAY,
+    asOfMs: at(asOf),
+    frame: FRAME,
+    dailyLimits,
+    matchUps,
+    matchUpId,
+  });
+  if (!result.evaluated) throw new Error(`expected evaluation, got ${result.reason}`);
+  return result;
+}
+
+describe('the ladder reports which rung it read, and what it passed over', () => {
+  const prior = (schedule: any) => singles('prior', ['alice', 'bob'], schedule, { winningSide: 1 });
+  const target = singles('target', ['alice', 'chen'], { scheduledTime: '14:00' });
+
+  it('prefers a recorded end time over every projection', () => {
+    const rows = analyze([prior({ scheduledTime: '09:00', endTime: '10:20' }), target], 'target', '12:00').rows;
+    const alice = rows.find((row) => row.participantId === 'alice');
+    expect(alice).toMatchObject({ source: 'endTime', restMinutes: 100, status: 'rested' });
+    expect(alice?.discardedSources).toBeUndefined();
+  });
+
+  it('falls to the score stamp when no end time was recorded, and says the figure is that rung', () => {
+    const rows = analyze(
+      [prior({ scheduledTime: '09:00', scoredTime: `${DAY}T10:30:00.000Z` }), target],
+      'target',
+      '12:00',
+    ).rows;
+    expect(rows.find((row) => row.participantId === 'alice')).toMatchObject({
+      source: 'scoredTime',
+      restMinutes: 90,
+    });
+  });
+
+  /**
+   * A score entered the next morning is bookkeeping, not a finish. Reading it
+   * as one would report a match that "ran" for eighteen hours; the rung is
+   * rejected, the next one down is used, and the row NAMES the rejection so the
+   * operator can see there is something wrong with the record.
+   */
+  it('rejects a finish stamped an implausible distance after its own start, and names the rung it dropped', () => {
+    const rows = analyze(
+      [prior({ scheduledTime: '09:00', scoredTime: `2026-09-13T08:00:00.000Z` }), target],
+      'target',
+      '12:00',
+    ).rows;
+    const alice = rows.find((row) => row.participantId === 'alice');
+    // 09:00 + the 90-minute average, projected from the plan.
+    expect(alice).toMatchObject({ source: 'scheduledTime', restMinutes: 90 });
+    expect(alice?.discardedSources).toEqual(['scoredTime']);
+  });
+
+  it('accepts a finish with no start to contradict it', () => {
+    // A score entered from a draw view leaves no scheduledTime and no
+    // startTime. The stamp is then the only evidence the match happened.
+    const undated = singles('prior', ['alice', 'bob'], { scoredTime: `${DAY}T10:30:00.000Z` }, { winningSide: 1 });
+    const rows = analyze([undated, target], 'target', '12:00').rows;
+    expect(rows.find((row) => row.participantId === 'alice')).toMatchObject({ source: 'scoredTime' });
+  });
+
+  /**
+   * Every rung in the future means the match is recorded as finished but
+   * nothing says when. Zero rest against a real requirement is the conservative
+   * reading — it holds the player back — and the flag keeps that zero from
+   * reading as a measurement.
+   */
+  it('reports an unreliable anchor rather than a measured zero', () => {
+    const rows = analyze([prior({ scheduledTime: '16:00' }), target], 'target', '12:00').rows;
+    const alice = rows.find((row) => row.participantId === 'alice');
+    expect(alice).toMatchObject({ anchorUnreliable: true, restMinutes: 0, status: 'resting' });
+    // No readyAt either: the clock time would be as fictional as the interval.
+    expect(alice?.readyAt).toBeUndefined();
+  });
+
+  it('takes the latest usable anchor across several prior matchUps', () => {
+    const early = singles('early', ['alice', 'x'], { scheduledTime: '08:00', endTime: '09:10' }, { winningSide: 1 });
+    const late = singles('late', ['alice', 'y'], { scheduledTime: '10:00', endTime: '11:10' }, { winningSide: 1 });
+    const rows = analyze([early, late, target], 'target', '12:00').rows;
+    // Rest runs from the last time the player walked off, not the first.
+    expect(rows.find((row) => row.participantId === 'alice')).toMatchObject({
+      fromMatchUpId: 'late',
+      restMinutes: 50,
+    });
+  });
+});
+
+describe('a participant on court is never given a rest figure', () => {
+  const live = singles('live', ['alice', 'bob'], { scheduledTime: '11:30' });
+  const target = singles('target', ['alice', 'chen'], { scheduledTime: '14:00' });
+
+  it('projects a readyAt while the match is inside its expected window', () => {
+    const rows = analyze([live, target], 'target', '12:00').rows;
+    // 11:30 + 90 average = 13:00 projected finish, + 60 recovery.
+    const alice = rows.find((row) => row.participantId === 'alice');
+    expect(alice).toMatchObject({ status: 'onCourt', readyAt: '14:00' });
+    expect(alice?.overrun).toBeUndefined();
+    // No interval while the player is still out there.
+    expect(alice?.restMinutes).toBeUndefined();
+  });
+
+  /**
+   * Past the projected finish the estimate has expired with it. Naming a
+   * readyAt in the past would read as though the player were already free,
+   * which is exactly backwards.
+   */
+  it('withholds the readyAt once the match has overrun its format average', () => {
+    const rows = analyze([live, target], 'target', '13:30').rows;
+    const alice = rows.find((row) => row.participantId === 'alice');
+    expect(alice).toMatchObject({ status: 'onCourt', overrun: true });
+    expect(alice?.readyAt).toBeUndefined();
+  });
+
+  it('keeps counting a match that has run long as under way, rather than dropping it', () => {
+    // Unbounded above on purpose: a match is over when a result says so, not
+    // when the estimate expires. Six hours past the average, still live.
+    const rows = analyze([live, target], 'target', '18:00').rows;
+    expect(rows.find((row) => row.participantId === 'alice')?.status).toEqual('onCourt');
+  });
+});
+
+describe('recovery owed, and the day’s load', () => {
+  it('charges the singles ↔ doubles figure when the participant changes type', () => {
+    const priorDoubles = {
+      ...singles('prior', ['alice', 'bob'], { scheduledTime: '09:00', endTime: '10:20' }, { winningSide: 1 }),
+      matchUpType: 'DOUBLES',
+    } as HydratedMatchUp;
+    const target = singles('target', ['alice', 'chen'], { scheduledTime: '14:00' });
+    const rows = analyze([priorDoubles, target], 'target', '10:40').rows;
+    expect(rows.find((row) => row.participantId === 'alice')).toMatchObject({
+      requiredMinutes: 30,
+      typeChange: true,
+    });
+  });
+
+  it('reports the ordinal and flags the limit the matchUp would meet', () => {
+    const first = singles('first', ['alice', 'x'], { scheduledTime: '08:00', endTime: '09:10' }, { winningSide: 1 });
+    const second = singles('second', ['alice', 'y'], { scheduledTime: '10:00', endTime: '11:10' }, { winningSide: 1 });
+    const target = singles('target', ['alice', 'chen'], { scheduledTime: '14:00' });
+    const rows = analyze([first, second, target], 'target', '13:00', { SINGLES: 3, total: 3 }).rows;
+    const alice = rows.find((row) => row.participantId === 'alice');
+    expect(alice?.load).toMatchObject({ ordinal: 3, singles: 2, total: 2, limit: 3 });
+    expect(alice?.load.atLimit).toEqual(['total', 'singles']);
+  });
+
+  it('reports no limits at all when no scheduling policy declares any', () => {
+    const prior = singles('prior', ['alice', 'x'], { scheduledTime: '08:00', endTime: '09:10' }, { winningSide: 1 });
+    const target = singles('target', ['alice', 'chen'], { scheduledTime: '14:00' });
+    const rows = analyze([prior, target], 'target', '13:00').rows;
+    expect(rows.find((row) => row.participantId === 'alice')?.load.atLimit).toEqual([]);
+  });
+
+  /**
+   * Sorting by status alone let side order decide which player a headline spoke
+   * for, so a doubles pair resting at 10m and 40m reported whichever happened
+   * to be listed first. Within a band the furthest from ready wins.
+   */
+  it('orders rows worst-first, and breaks a tie inside a band by shortfall', () => {
+    const aliceRest = singles('a', ['alice', 'x'], { scheduledTime: '10:00', endTime: '11:40' }, { winningSide: 1 });
+    const chenRest = singles('c', ['chen', 'y'], { scheduledTime: '10:00', endTime: '11:00' }, { winningSide: 1 });
+    const target = singles('target', ['alice', 'chen'], { scheduledTime: '14:00' });
+    const rows = analyze([aliceRest, chenRest, target], 'target', '12:00').rows;
+    // Alice has had 20 minutes of her 60, Chen 60 of 60 — Alice is the headline.
+    expect(rows.map((row) => row.participantId)).toEqual(['alice', 'chen']);
+    expect(rows[0].status).toEqual('resting');
+    expect(rows[1].status).toEqual('rested');
+  });
+});
+
+describe('which matchUps belong to the day being measured', () => {
+  it('dates an undated matchUp by the venue calendar day of its score stamp', () => {
+    const undated = singles('undated', ['alice'], {}, {});
+    const times = normalizeTimes({ ...undated, schedule: { scoredTime: `${DAY}T10:30:00.000Z` } } as any, FRAME);
+    expect(occursOnDay({ ...undated, schedule: { scoredTime: `${DAY}T10:30:00.000Z` } } as any, times, DAY)).toEqual(
+      true,
+    );
+  });
+
+  it('excludes a matchUp that carries neither a scheduled date nor a score stamp', () => {
+    const orphan = singles('orphan', ['alice'], {}, {});
+    const times = normalizeTimes({ ...orphan, schedule: {} } as any, FRAME);
+    expect(occursOnDay({ ...orphan, schedule: {} } as any, times, DAY)).toEqual(false);
+  });
+
+  it('reads an end time that crossed midnight against the day it was recorded on', () => {
+    const overnight = singles(
+      'overnight',
+      ['alice'],
+      { scheduledTime: '22:30', endTime: '00:40', endDate: '2026-09-13' },
+      { winningSide: 1 },
+    );
+    const anchors = resolveAnchors(normalizeTimes(overnight, FRAME), TIMING);
+    // 00:40 on the following day, not 00:40 on the day it started.
+    expect(anchors[0]).toMatchObject({ source: 'endTime', ms: Date.parse('2026-09-13T00:40:00.000Z') });
+  });
+});
+
+describe('rest declines to evaluate what it cannot', () => {
+  it('reports noParticipants for a matchUp whose sides are still empty', () => {
+    const empty = { matchUpId: 'empty', sides: [{}, {}], schedule: { scheduledDate: DAY } } as any;
+    const result = analyzeParticipantRest({
+      timingFor: () => TIMING,
+      matchUps: [empty],
+      matchUpId: 'empty',
+      scheduledDate: DAY,
+      asOfMs: at('12:00'),
+      frame: FRAME,
+    });
+    expect(result).toEqual({ evaluated: false, reason: 'noParticipants' });
+  });
+
+  it('reports bye rather than measuring a matchUp nobody plays', () => {
+    const bye = singles('bye', ['alice'], { scheduledTime: '09:00' }, { matchUpStatus: 'BYE' });
+    const result = analyzeParticipantRest({
+      timingFor: () => TIMING,
+      matchUps: [bye],
+      matchUpId: 'bye',
+      scheduledDate: DAY,
+      asOfMs: at('12:00'),
+      frame: FRAME,
+    });
+    expect(result).toEqual({ evaluated: false, reason: 'bye' });
+  });
+});

--- a/src/types/factoryEngineMethods.ts
+++ b/src/types/factoryEngineMethods.ts
@@ -334,6 +334,7 @@ export type FactoryEngineMethod =
   | 'getMatchUpFormatVariance'
   | 'getMatchUpOfficialConflicts'
   | 'getMatchUpRatingDelta'
+  | 'getMatchUpReadiness'
   | 'getMatchUpScheduleDetails'
   | 'getMatchUpsMap'
   | 'getMatchUpsStats'
@@ -353,6 +354,7 @@ export type FactoryEngineMethod =
   | 'getParticipantMembership'
   | 'getParticipantPaymentStatus'
   | 'getParticipantPoints'
+  | 'getParticipantRest'
   | 'getParticipantResults'
   | 'getParticipants'
   | 'getParticipantScaleItem'
@@ -1065,6 +1067,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'getMatchUpFormatVariance',
   'getMatchUpOfficialConflicts',
   'getMatchUpRatingDelta',
+  'getMatchUpReadiness',
   'getMatchUpScheduleDetails',
   'getMatchUpsMap',
   'getMatchUpsStats',
@@ -1084,6 +1087,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'getParticipantMembership',
   'getParticipantPaymentStatus',
   'getParticipantPoints',
+  'getParticipantRest',
   'getParticipantResults',
   'getParticipants',
   'getParticipantScaleItem',

--- a/src/types/methodSignatures.ts
+++ b/src/types/methodSignatures.ts
@@ -192,6 +192,7 @@ import type {
 } from '@Query/entries/getEffectiveRegistrationProfile';
 import type { getMatchUpFormatVariance } from '@Query/drawDefinition/getMatchUpFormatVariance';
 import type { getMatchUpOfficialConflicts } from '@Query/officiating/getMatchUpOfficialConflicts';
+import type { getMatchUpReadiness } from '@Query/matchUps/scheduling/getMatchUpReadiness';
 import type { getParticipantEventDetails } from '@Query/participants/getParticipantEventDetails';
 import type { getStructureCompleteness } from '@Query/drawDefinition/getStructureCompleteness';
 import type { getSwissStandings } from '@Query/drawDefinitions/swiss/getSwissStandings';
@@ -204,6 +205,7 @@ import type { generateBookings } from '@Generators/scheduling/utils/generateBook
 import type { getApplicableAwardProfileLevels } from '@Query/scales/getApplicableAwardProfileLevels';
 import type { getLuckyDrawRoundStatus } from '@Query/drawDefinition/getLuckyDrawRoundStatus';
 import type { getMatchUpDailyLimitsUpdate } from '@Query/extensions/getMatchUpDailyLimitsUpdate';
+import type { getParticipantRest } from '@Query/matchUps/scheduling/getParticipantRest';
 import type { getScheduleProjection } from '@Query/facilitySchedule/getScheduleProjection';
 import type { getTournamentCalendarEntry } from '@Query/tournaments/getTournamentCalendarEntry';
 import type { getTournamentPublishStatus } from '@Query/tournaments/getTournamentPublishStatus';
@@ -961,6 +963,7 @@ export interface MethodSignatures {
   getMatchUpFormatVariance: EngineMethod<typeof getMatchUpFormatVariance>;
   getMatchUpOfficialConflicts: EngineMethod<typeof getMatchUpOfficialConflicts>;
   getMatchUpRatingDelta: EngineMethod<typeof getMatchUpRatingDelta>;
+  getMatchUpReadiness: EngineMethod<typeof getMatchUpReadiness>;
   getMatchUpScheduleDetails: EngineMethod<typeof getMatchUpScheduleDetails>;
   getMatchUpsMap: EngineMethod<typeof getMatchUpsMap>;
   getMatchUpsStats: EngineMethod<typeof getMatchUpsStats>;
@@ -980,6 +983,7 @@ export interface MethodSignatures {
   getParticipantMembership: EngineMethod<typeof getParticipantMembership>;
   getParticipantPaymentStatus: EngineMethod<typeof getParticipantPaymentStatus>;
   getParticipantPoints: EngineMethod<typeof getParticipantPoints>;
+  getParticipantRest: EngineMethod<typeof getParticipantRest>;
   getParticipantResults: EngineMethod<typeof getParticipantResults>;
   getParticipants: EngineMethod<typeof getParticipants>;
   getParticipantScaleItem: EngineMethod<typeof getParticipantScaleItem>;


### PR DESCRIPTION
Closes the two relocation seams TMX built in August. Both module headers named this destination — *"a future factory `getMatchUpReadiness` replaces this function's body and keeps the contract"* — and `Mentat/planning/TMX_INSPECTOR_PARTICIPANT_REST.md` recorded the 2026-08-22 decision as **"Factory migration: Later — seam preserved"**. Called in for 7.x.

## The two queries

**`getMatchUpReadiness`** — *can this placement happen at the time it is scheduled for?* Anchored on the matchUp's own `scheduledTime`, declines to evaluate without one. Four findings — `overlap`, `dependency`, `recovery`, `undetermined` — ordered strongest-first so the head is the headline. Overlap and recovery never both fire for one participant: being on court elsewhere already implies the recovery window is violated.

**`getParticipantRest`** — *how long has each individual actually had off?* Anchored on a caller-supplied **`asOf`**. The factory holds no clock, so the instant is required; it is the `calledAt` idiom the planning doc predicted. Every row names the ladder rung its anchor came from, so an inferred figure never reads as a measured one, and a ladder entirely in the future yields `anchorUnreliable` rather than a measured-looking zero.

Both payload shapes are **unchanged**, so the TMX swap is an import.

## What changed in the move

- **Inputs.** TMX injected hydrated matchUps and a `timingFor` callback because a client cannot reach the engine from a pure module. Both resolve internally now, through one shared timing resolver — so readiness and rest cannot drift on what a format costs. The resolver carries over the measured reason the category is passed explicitly alongside the event (`{ event }` → 30, `{ categoryType }` → 60 for JUNIOR DOUBLES).
- **Frame.** TMX normalised to minutes-since-midnight, and paid for it in apparatus: a ±1-day offset for midnight crossings, a clamp that read an off-day stamp by its time-of-day, and a projected "now". None of that is ported. Everything here is UTC milliseconds through the same `zonedDateTime` frame `recoveryTimeline` uses — DST-correct given an IANA zone, which a fixed offset cannot be.
- **No third copy.** `wasPlayed` is imported from `recoveryTimeline`, which already took it from TMX.
- **One new shape: `noDay`.** TMX fell back to the ambient viewed date for an unscheduled matchUp. Here the caller names the day, or is told which question could not be answered — rather than being told the matchUp is unknown, which it isn't.

## Not in this PR

**TMX is not rewired.** Its CI installs the published factory, so the consumer swap waits for the 7.0.0 publish — the same gate #1436(TMX) sits behind. The seam is what makes that a later one-line change.

## Verification

- **`pnpm verify` green** — all 19 gates: generated artifacts, types, lint, format, migration-coverage, attr-audit, coverage, coverage-headroom, server, audit, build, publint, runtime, shakeable, bundle-size, surface, docs-imports, docs-methods, pack.
- **12,992 tests pass**; 62 of them new across four files. The engine-driven pair prove the queries through `tournamentEngine` against real mock tournaments; the two pure-analysis files provoke what a fixture cannot ask for on demand — a score stamped the next morning, an anchor in the future, a match that has overrun its average, a doubles pair sharing one player.
- New files at **95.5% / 95.2% statements**; 16 uncovered statements against the headroom gate's 25-per-change budget.
- Both methods appear in `verify:surface` as additive, and both are documented — the Conflict Reporting concept page and the Schedule Governor reference — with `verify:docs-methods` confirming the documented calls resolve to real engine methods.

## Two repairs the gates surfaced, neither introduced here

- `verify:migration-coverage` was **red on master**: #4825's breaking change is fully written up in §8 of the 7.0.0 guide but never cites the PR, which is what the checker matches on. Added the `_Shipped in …_` line the guide uses elsewhere.
- `attr-audit` needed `participantNames` allow-listed — it is the contract field name, not a typo of `participantName`. The other flagged name was mine (`times` ~ `timed`) and is renamed rather than allow-listed.