### PR TITLE
fix(draws): a double exit with an unfilled side must not read as active

### DIFF
--- a/src/query/matchUp/activeMatchUp.ts
+++ b/src/query/matchUp/activeMatchUp.ts
@@ -2,7 +2,7 @@ import { checkScoreHasValue } from '@Query/matchUp/checkScoreHasValue';
 import { isActiveMatchUpStatus } from '@Query/matchUp/checkStatusType';
 
 // constants and types
-import { DEFAULTED, IN_PROGRESS, WALKOVER } from '@Constants/matchUpStatusConstants';
+import { DEFAULTED, DOUBLE_DEFAULT, DOUBLE_WALKOVER, IN_PROGRESS, WALKOVER } from '@Constants/matchUpStatusConstants';
 import { Score } from '@Types/tournamentTypes';
 
 // an active matchUp is one that has a winningSide, more than one set, or a single set with any score value greater than zero
@@ -11,12 +11,38 @@ import { Score } from '@Types/tournamentTypes';
 
 type IsActiveMatchUpArgs = {
   matchUpStatus?: string;
+  collectionId?: string;
   winningSide?: number;
   tieMatchUps?: any[];
   sides?: any[];
   score?: Score;
 };
-export function isActiveMatchUp({ matchUpStatus, winningSide, tieMatchUps, sides, score }: IsActiveMatchUpArgs) {
+export function isActiveMatchUp({
+  collectionId,
+  matchUpStatus,
+  winningSide,
+  tieMatchUps,
+  sides,
+  score,
+}: IsActiveMatchUpArgs) {
+  // A double exit is PENDING while either side is unfilled: nothing can have won it (a double exit
+  // carries no winningSide), so its drawPositions must not read as active. `activeMatchUpStatuses`
+  // contains DOUBLE_WALKOVER and DOUBLE_DEFAULT and the status exclusion list omits both, so such a
+  // matchUp otherwise reads ACTIVE purely from its status — marking its feeding drawPositions active
+  // and blocking the very arrival it waits for (ERR_ACTIVE_DRAW_POSITION) — the same failure the
+  // `winnerAssigned` guard below was written to prevent, which cannot cover this shape because a
+  // double exit has no `winningSide` for it to inspect.
+  //
+  // COLLECTION matchUps are excluded, and that exclusion is load-bearing rather than defensive: a
+  // rubber inside a TEAM tie carries its participants on `lineUp`, not on `sides[].participantId`,
+  // so every collection matchUp looks unpopulated by this test. Without the exclusion a
+  // DOUBLE_WALKOVER rubber stops making its tie IN_PROGRESS, which `teamAdvancement` asserts.
+  const isDoubleExit = [DOUBLE_WALKOVER, DOUBLE_DEFAULT].includes(matchUpStatus as any);
+  if (isDoubleExit && !collectionId && sides?.length) {
+    const populatedSides = sides.filter((side) => side?.participantId).length;
+    if (populatedSides < 2) return false;
+  }
+
   // A matchUp is active via winningSide only when the WINNING side actually holds a
   // participant. A "produced" WALKOVER (no participants) or a propagated exit whose
   // winning side is still an empty feed slot — e.g. a cascaded consolation WALKOVER

--- a/src/tests/mutations/exitPropagation/pendingDoubleExitNotActive.test.ts
+++ b/src/tests/mutations/exitPropagation/pendingDoubleExitNotActive.test.ts
@@ -1,0 +1,153 @@
+import { getDrawInconsistencies } from '@Query/drawDefinition/getDrawInconsistencies';
+import { setSubscriptions } from '@Global/state/globalState';
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { expect, it } from 'vitest';
+
+import { CURTIS_CONSOLATION, DOUBLE_ELIMINATION, OLYMPIC } from '@Constants/drawDefinitionConstants';
+import { DEFAULTED, DOUBLE_DEFAULT, DOUBLE_WALKOVER, WALKOVER } from '@Constants/matchUpStatusConstants';
+
+/**
+ * A double exit with an unfilled side must not mark its drawPositions ACTIVE.
+ *
+ * Nothing can have won a double exit — it carries no `winningSide` — so while either side is still
+ * empty the matchUp is PENDING and its feeding drawPositions must stay available for the arrival it
+ * is waiting for. `activeMatchUpStatuses` contains `DOUBLE_WALKOVER` and `DOUBLE_DEFAULT`, and
+ * `isActiveMatchUp`'s exclusion list omitted both, so such a matchUp read ACTIVE purely from its
+ * status. `getStructureDrawPositionProfiles` then marked its drawPositions active and the cascade
+ * refused the arrival with ERR_ACTIVE_DRAW_POSITION — after it had already mutated the draw.
+ *
+ * That is the failure `isActiveMatchUp`'s own comment was written to prevent; the existing
+ * `winnerAssigned` guard only covers the single-exit shape, where a `winningSide` points at an
+ * empty slot. A double exit has no `winningSide` for that guard to inspect.
+ *
+ * All three cases are shrunk reproductions from the 600-seed sweep window (`SEED_START=9000001`),
+ * which is why the seeds are the sweep's own. They span three draw types deliberately: the refusal
+ * reaches the same predicate through different link topologies.
+ *
+ * A fourth seed (9000315) that this change closes in the census is deliberately NOT here. Its
+ * SHRUNK reproduction exhibits a different defect — a mutual recursion between `removeDoubleExit`
+ * and `conditionallyRemoveDrawPosition` that throws, present on master before this change — so it
+ * would not be testing this fix. The shrinker preserves only the PROPERTY, not the mechanism.
+ */
+
+const DRAW_ID = 'pending-double-exit';
+
+function target({ structureName, roundNumber, roundPosition }: any) {
+  return tournamentEngine
+    .allDrawMatchUps({ inContext: true, drawId: DRAW_ID })
+    .matchUps.find(
+      (matchUp: any) =>
+        matchUp.structureName === structureName &&
+        matchUp.roundNumber === roundNumber &&
+        matchUp.roundPosition === roundPosition,
+    );
+}
+
+it.each([
+  {
+    scenario: 'a DOUBLE_DEFAULT re-score of a propagated WALKOVER in a DOUBLE_ELIMINATION',
+    drawType: DOUBLE_ELIMINATION,
+    participantsCount: 27,
+    drawSize: 32,
+    propagateExitStatus: true,
+    seed: 9000068,
+    steps: [
+      { structureName: 'Main', roundNumber: 1, roundPosition: 2, outcome: { winningSide: 1 } },
+      {
+        structureName: 'Main',
+        roundNumber: 2,
+        roundPosition: 1,
+        outcome: { matchUpStatus: WALKOVER, winningSide: 1 },
+      },
+      {
+        structureName: 'Main',
+        roundNumber: 1,
+        roundPosition: 15,
+        outcome: { matchUpStatus: WALKOVER, winningSide: 2 },
+      },
+      { structureName: 'Main', roundNumber: 2, roundPosition: 1, outcome: { matchUpStatus: DOUBLE_DEFAULT } },
+    ],
+  },
+  {
+    scenario: 'a DOUBLE_WALKOVER upstream of a consolation double exit in a CURTIS_CONSOLATION',
+    drawType: CURTIS_CONSOLATION,
+    participantsCount: 13,
+    drawSize: 16,
+    propagateExitStatus: false,
+    seed: 9000218,
+    steps: [
+      { structureName: 'Main', roundNumber: 1, roundPosition: 7, outcome: { winningSide: 1 } },
+      {
+        structureName: 'Main',
+        roundNumber: 1,
+        roundPosition: 2,
+        outcome: { matchUpStatus: WALKOVER, winningSide: 2 },
+      },
+      { structureName: 'Main', roundNumber: 2, roundPosition: 4, outcome: { winningSide: 2 } },
+      {
+        structureName: 'Consolation 1',
+        roundNumber: 2,
+        roundPosition: 1,
+        outcome: { matchUpStatus: DOUBLE_WALKOVER },
+      },
+      { structureName: 'Main', roundNumber: 2, roundPosition: 4, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
+    ],
+  },
+  {
+    scenario: 'a double exit re-scored to the other double exit in an OLYMPIC',
+    drawType: OLYMPIC,
+    participantsCount: 7,
+    drawSize: 8,
+    propagateExitStatus: false,
+    seed: 9000480,
+    steps: [
+      {
+        structureName: 'East',
+        roundNumber: 1,
+        roundPosition: 3,
+        outcome: { matchUpStatus: DEFAULTED, winningSide: 1 },
+      },
+      { structureName: 'East', roundNumber: 1, roundPosition: 4, outcome: { winningSide: 2 } },
+      { structureName: 'East', roundNumber: 2, roundPosition: 2, outcome: { matchUpStatus: DOUBLE_DEFAULT } },
+      { structureName: 'East', roundNumber: 2, roundPosition: 2, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
+      { structureName: 'East', roundNumber: 1, roundPosition: 2, outcome: { matchUpStatus: DOUBLE_DEFAULT } },
+    ],
+  },
+])('$scenario is not refused by a pending double exit reading as active', (testCase) => {
+  const { participantsCount, propagateExitStatus, drawType, drawSize, seed, steps } = testCase;
+
+  setSubscriptions({});
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ participantsCount, drawSize, drawType, drawId: DRAW_ID }],
+    nonRandom: seed,
+    setState: true,
+  });
+  // `propagateExitStatus` is passed PER CALL, exactly as the sweep's observeMutation does, and no
+  // scoring policy is attached. Attaching one changes behaviour: with a policy attached, seed
+  // 9000315 instead reaches a mutual recursion between removeDoubleExit and
+  // conditionallyRemoveDrawPosition that throws — a different defect, recorded separately.
+
+  for (const [index, step] of steps.entries()) {
+    const matchUp = target(step);
+    expect(matchUp?.matchUpId, `step ${index + 1} target missing`).toBeDefined();
+    const result: any = tournamentEngine.setMatchUpStatus({
+      matchUpId: matchUp.matchUpId,
+      outcome: step.outcome,
+      propagateExitStatus,
+      drawId: DRAW_ID,
+    });
+    // every step is asserted, so a future setup change cannot turn this into a vacuous pass
+    expect(
+      result.error,
+      `step ${index + 1} (${step.structureName} r${step.roundNumber}p${step.roundPosition})`,
+    ).toBeUndefined();
+  }
+
+  // CONTROL, not the regression assertion: the committed oracle must stay clean, so the fix cannot
+  // buy the refusal back by leaving the draw in a worse shape. These scenarios are clean on this
+  // oracle before the fix too — the falsifying assertion is the loop above.
+  const { drawDefinition } = tournamentEngine.getEvent({ drawId: DRAW_ID });
+  const inconsistencies: any = getDrawInconsistencies({ drawDefinition, drawId: DRAW_ID });
+  expect((inconsistencies?.inconsistencies ?? []).map((issue: any) => issue.issueType)).toEqual([]);
+});


### PR DESCRIPTION
Follows [#4826](https://github.com/CourtHive/competition-factory/pull/4826). Base `7f96bd8dd`.

## Census — 600-seed window, `SEED_START=9000001`, `MAX_STEPS=30`

Seed-level, no fingerprint dedup.

| | before | after |
|---|---:|---:|
| **failing seeds** | **58** | **54** |
| `ERROR_IMPLIES_NO_MUTATION` | 45 | 41 |
| `DRAW_INCONSISTENCY` | 12 | 12 |
| `MONOTONIC_DECISION` | 1 | 1 |

**4 closed, zero new.** Matrix 144/0. Full suite 12,973 passed / 2 skipped. `pnpm verify` exit 0.

## The defect

`activeMatchUpStatuses` (`matchUpStatusConstants.ts:108`) contains `DOUBLE_WALKOVER` and
`DOUBLE_DEFAULT`. `isActiveMatchUp`'s status exclusion list is `[DEFAULTED, WALKOVER, IN_PROGRESS]`
and omits both — so a double exit with fewer than two populated sides read ACTIVE purely from its
status. `getStructureDrawPositionProfiles` marked its feeding drawPositions active, and the cascade
then refused the arrival the matchUp was waiting for with `ERR_ACTIVE_DRAW_POSITION`, after having
already mutated the draw.

Nothing can have won a double exit — it carries no `winningSide` — so while either side is unfilled
it is **pending**, and its positions must stay available.

This is the same failure the existing `winnerAssigned` guard was written to prevent (its comment
names `ERR_ACTIVE_DRAW_POSITION` explicitly). That guard cannot cover this shape, because a double
exit has no `winningSide` for it to inspect. It is also the **fourth instance** of the
`=== DOUBLE_WALKOVER` vs `[DOUBLE_WALKOVER, DOUBLE_DEFAULT]` drift, here as an omission from an
exclusion list rather than an equality check.

## Three candidate forms, measured rather than argued

| form | seeds closed | new | gates |
|---|---:|---:|---|
| ungated (`populatedSides < 2`) | 4 | 0 | **breaks 2 asserted `teamAdvancement` tests** |
| gated on `sideExitProvenance` | 2 | 0 | green |
| **gated on `!collectionId`** | **4** | **0** | **green** |

The `!collectionId` exclusion is load-bearing, not defensive: a rubber inside a TEAM tie carries its
participants on `lineUp`, not on `sides[].participantId`, so every collection matchUp looks
unpopulated by this test. Without it, a `DOUBLE_WALKOVER` rubber stops making its tie `IN_PROGRESS`.

**Provenance is not the right gate here, and that is worth stating** since this block was entered
expecting it would be. The two seeds provenance-gating loses (9000218, 9000315) are blocked by a
double exit the *schedule entered* — verified by checking whether the step list targets those
coordinates — so their lack of provenance is correct rather than a writer gap. This fix therefore
stands on its own and does **not** advance the "make `sideExitProvenance` authoritative" goal.

## Tests

`pendingDoubleExitNotActive.test.ts` — three shrunk reproductions from the sweep window, spanning
`DOUBLE_ELIMINATION`, `CURTIS_CONSOLATION` and `OLYMPIC`, because the refusal reaches this predicate
through different link topologies. **All three proven RED against master first**, each failing with
exactly `ERR_ACTIVE_DRAW_POSITION`. `propagateExitStatus` is passed per call, as the sweep does; the
`getDrawInconsistencies` assertion is labelled in the file as a control, not the regression
assertion.

## Reported honestly

- A fourth seed this change closes in the census (9000315) is **deliberately excluded** from the
  test. Its *shrunk* reproduction exhibits a different defect — a mutual recursion between
  `removeDoubleExit` and `conditionallyRemoveDrawPosition` that throws, present on master before
  this change — so it would not be testing this fix. The shrinker preserves only the property, not
  the mechanism. That throw is logged for its own block rather than made to pass here.
- `updateTieMatchUpScore` calls `isActiveMatchUp` **without** `sides`; the first version of this
  guard read "none supplied" as "none populated" and killed `IN_PROGRESS`. Hence `sides?.length`.
- The other two refusal codes (`ERR_OCCUPIED_DRAW_POSITION`, `ERR_EXISTING_POSITION_ASSIGNMENT`) are
  untouched. 18 of the remaining 41 are `directLoser`'s terminal fall-through, which is a separate
  and separable piece of work.
