### PR TITLE
docs: cut factory branches from dev, not master

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Before doing anything else, read `../Mentat/CLAUDE.md`, `../Mentat/TASKS.md`, `../Mentat/standards/coding-standards.md`, and every file in `../Mentat/in-flight/`. Mentat is the orchestration layer for the entire CourtHive ecosystem; its standards override per-repo conventions when they conflict. If you are about to start **building** (not just planning), you must claim a surface in `../Mentat/in-flight/` and run the air-traffic-control conflict check first. See the parent `../CLAUDE.md` "Mentat Orchestration" section for the full protocol.
 
+## Branching — cut from `dev`, not `master` (CA, 2026-09-12)
+
+`dev` is this repo's integration branch. **Branch from `origin/dev` and open PRs against `dev`.**
+`master` advances only at checkpoints, by merging `dev` into it — which is also when release-please
+cuts a release, since it triggers on `push` to `master` alone.
+
+`verify.yml` uses a bare `pull_request:` trigger, so a PR into `dev` still runs the full verify
+gate. Land work by PR: a direct push to `dev` gets no push-triggered run.
+
+Full rationale and the CI/release compatibility table:
+`../Mentat/standards/coding-standards.md` § "Branch off `dev`, not `master`".
+
 ## Project Overview
 
 `tods-competition-factory` is the shared business-logic engine for the CourtHive ecosystem. It is published as an npm package with no runtime dependencies and is consumed by TMX (client PWA), competition-factory-server (NestJS backend), courthive-components, scoring-visualizations, and epixodic.


### PR DESCRIPTION
CA's direction 2026-09-12: work branches off `dev`, and `master` advances at checkpoints by merging `dev` into it.

**This PR is itself the first one opened against `dev`** — so it also exercises the claim that the gate still applies.

Verified rather than assumed:

| workflow | trigger | consequence |
|---|---|---|
| `verify.yml` | bare `pull_request:` (no branch filter) + `push: [master]` | PRs into `dev` get the full verify gate; a direct push to `dev` gets no push-triggered run, so land work by PR |
| `release-please.yml` | `push: [master]` only | releases cut at the checkpoint merge, not per PR — which is the point |
| `docs.yml` | `pull_request:` (path-filtered) | docs PRs into `dev` are checked |
| `npm-publish.yml` | `release: published` | unaffected |

`dev` was reconciled to `master` first (`ec43cafee`): it had been 10 commits behind with **0 unique non-merge commits**, and after the merge the two trees were byte-identical (0 files differing), so nothing was lost.

Full rationale and the scope note live in `Mentat/standards/coding-standards.md` § "Branch off `dev`, not `master`". Scope is **factory only** and deliberately unresolved elsewhere: only factory and courthive-public have a `dev` branch at all.