### PR TITLE
test(scheduling): seed the participantRest on-court case, which failed 3 runs in 12

### DIFF
--- a/src/tests/queries/scheduling/participantRest.test.ts
+++ b/src/tests/queries/scheduling/participantRest.test.ts
@@ -132,6 +132,14 @@ describe('getParticipantRest — the ladder and the interval', () => {
         { drawSize: 4, drawType: SINGLE_ELIMINATION, eventName: 'B', uniqueParticipants: false },
       ],
       endDate: '2026-09-15',
+      // `uniqueParticipants: false` shares a field across the two draws, which is the point of the
+      // scenario — but without a seed it also randomises WHICH participants are shared. The final
+      // assertion reads `rows[0]`, and two `onCourt` rows tie: `deficitMinutes` returns 0 for
+      // `onCourt` by design and `toSorted` is stable, so tied rows keep side order. Whether
+      // `live.sides[0]`'s participant lands on side 1 or side 2 of `other` was therefore decided by
+      // the random draw, and the assertion failed 3 runs in 12. The query is deterministic; it was
+      // the data that was under-specified.
+      nonRandom: 1,
       setState: true,
       startDate,
     });


### PR DESCRIPTION
Follows [#4828](https://github.com/CourtHive/competition-factory/pull/4828). One line of test setup; no source change.

## The flake

`src/tests/queries/scheduling/participantRest.test.ts`, the case *"reports a participant still on court…"*, final assertion:

```ts
expect(rest.rows[0].participantId).toEqual(shared);
```

Measured on `dev` at `b60e9afd3`, isolated runs: **3 failures in 12**, each comparing two different participant UUIDs. **With the seed: 0 failures in 20.**

It is on `dev` and `master`, so every `verify` run carried roughly a 1-in-4 chance of a red unrelated to the change under test. I hit exactly that: one red, then a pass, which is the signature that makes a flake expensive — my first hypothesis was that it was an interaction with my own change, and it wasn't.

## Cause

The call passed no `nonRandom` seed with `uniqueParticipants: false`. Sharing a field across the two draws is the *point* of the scenario, but without a seed it also randomises **which** participants are shared — so whether `live.sides[0]`'s participant lands on side 1 or side 2 of `other` was decided by the draw.

That matters because two `onCourt` rows **tie**: `deficitMinutes` returns 0 for `onCourt` by design, and `toSorted` is stable, so tied rows keep side order.

## Why this is a test fix and not a source fix

I checked the ordering first, in case a seed would only hide an ambiguous tiebreak behind one lucky dataset — which would have made the real fix a deterministic tiebreak in `getParticipantRest`. It would not:

```ts
.toSorted((a, b) => order.indexOf(a.status) - order.indexOf(b.status) || deficitMinutes(b) - deficitMinutes(a));
```

`deficitMinutes` documents the 0-for-`onCourt` behaviour explicitly (*"keep their original order"`), and `toSorted` is stable. **The query is deterministic given its data.** It was the data that was under-specified, so nothing in `src/query` is touched.

## Gates

Lint, `check-types`, and the full `src/tests/queries/scheduling/` suite (62) green. No assertions were changed — only the setup gained a seed, which is why this is its own PR rather than folded into unrelated work.