### PR TITLE
fix(draws): treat a DOUBLE_DEFAULT as a double exit wherever a DOUBLE_WALKOVER is

### DIFF
--- a/src/mutate/drawDefinitions/matchUpGovernor/noDownstreamDependencies.ts
+++ b/src/mutate/drawDefinitions/matchUpGovernor/noDownstreamDependencies.ts
@@ -11,7 +11,7 @@ import { attemptToModifyScore } from './attemptToModifyScore';
 import { pushGlobalLog } from '@Functions/global/globalLog';
 import { removeDoubleExit } from './removeDoubleExit';
 import { removeQualifier } from './removeQualifier';
-import { isExit } from '@Validators/isExit';
+import { isDoubleExit, isExit } from '@Validators/isExit';
 
 // constants
 import { POLICY_TYPE_PROGRESSION } from '@Constants/policyConstants';
@@ -39,12 +39,17 @@ export function noDownstreamDependencies(params) {
     if (result.error) return decorateResult({ result, stack });
   }
 
-  const doubleWalkover = matchUpStatus === DOUBLE_WALKOVER;
+  // `=== DOUBLE_WALKOVER` meant "is the incoming status a double exit", and the line directly above
+  // asks the same question correctly with `[DOUBLE_WALKOVER, DOUBLE_DEFAULT]` — the file
+  // contradicted itself. A DOUBLE_DEFAULT reached here 1303 times over the 600-seed sweep window
+  // against 3921 DOUBLE_WALKOVERs, and was treated as a score-without-winner where its sibling was
+  // not.
+  const doubleExit = isDoubleExit(matchUpStatus);
   // Non-directing statuses that should preserve their score (not treat as "remove winner")
   const preserveScoreStatuses = [IN_PROGRESS, SUSPENDED, CANCELLED, ABANDONED, INCOMPLETE];
   const scoreWithNoWinningSide =
     checkScoreHasValue({ score }) &&
-    !doubleWalkover &&
+    !doubleExit &&
     !preserveScoreStatuses.includes(matchUpStatus) &&
     ((params.isCollectionMatchUp && !params.projectedWinningSide) || !winningSide);
 

--- a/src/mutate/drawDefinitions/positionGovernor/doubleExitAdvancement.ts
+++ b/src/mutate/drawDefinitions/positionGovernor/doubleExitAdvancement.ts
@@ -11,7 +11,7 @@ import { buildSideExitProvenance, setSideExitProvenance } from '@Mutate/matchUps
 import { definedAttributes } from '@Tools/definedAttributes';
 import { pushGlobalLog } from '@Functions/global/globalLog';
 import { findStructure } from '@Acquire/findStructure';
-import { isExit } from '@Validators/isExit';
+import { isDoubleExit, isExit } from '@Validators/isExit';
 import { overlap } from '@Tools/arrays';
 
 // constants
@@ -39,7 +39,10 @@ export function doubleExitAdvancement(params) {
     isExit(loserMatchUp?.matchUpStatus) &&
     !loserMatchUp.sides?.map((side) => side.participantId ?? side.participant).filter(Boolean).length;
 
-  const loserMatchUpIsDoubleExit = loserMatchUp?.matchUpStatus === DOUBLE_WALKOVER;
+  // `=== DOUBLE_WALKOVER` here meant "is this a double exit" while naming itself so, and a
+  // DOUBLE_DEFAULT loserMatchUp took the false branch — measured 14 times over the 600-seed sweep
+  // window against 33 DOUBLE_WALKOVERs.
+  const loserMatchUpIsDoubleExit = isDoubleExit(loserMatchUp?.matchUpStatus);
 
   logAdvancement(stack, {
     newline: true,

--- a/src/query/drawDefinition/hasPropagatedExitDownstream.ts
+++ b/src/query/drawDefinition/hasPropagatedExitDownstream.ts
@@ -1,5 +1,4 @@
-import { DOUBLE_WALKOVER } from '@Constants/matchUpStatusConstants';
-import { isExit } from '@Validators/isExit';
+import { isDoubleExit, isExit } from '@Validators/isExit';
 
 export function hasPropagatedExitDownstream(params) {
   // relevantLink is passed in iterative calls (see below)
@@ -15,8 +14,10 @@ export function hasPropagatedExitDownstream(params) {
   );
 
   //if there is a downstream match with two propagated exits we mark it as active
+  // `=== DOUBLE_WALKOVER` meant "is this a double exit"; a DOUBLE_DEFAULT reached here and took the
+  // false branch 161 times over the 600-seed sweep window, against 526 DOUBLE_WALKOVERs.
   return (
-    (hasLoserMatchUpUpstreamWOMatches && loserMatchUp?.matchUpStatus === DOUBLE_WALKOVER) ||
+    (hasLoserMatchUpUpstreamWOMatches && isDoubleExit(loserMatchUp?.matchUpStatus)) ||
     //if there is a downstream propagated exit and we are trying to clear the score we stop the user
     //by marking the downstream as active
     (hasLoserMatchUpUpstreamWOMatches && isLoserMatchUpWO)

--- a/src/tests/mutations/exitPropagation/doubleExitPredicateParity.test.ts
+++ b/src/tests/mutations/exitPropagation/doubleExitPredicateParity.test.ts
@@ -1,0 +1,106 @@
+import { getDrawInconsistencies } from '@Query/drawDefinition/getDrawInconsistencies';
+import { setSubscriptions } from '@Global/state/globalState';
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { expect, it } from 'vitest';
+
+import { FEED_IN_CHAMPIONSHIP, FIRST_MATCH_LOSER_CONSOLATION } from '@Constants/drawDefinitionConstants';
+import { DOUBLE_DEFAULT, DOUBLE_WALKOVER } from '@Constants/matchUpStatusConstants';
+
+/**
+ * `DOUBLE_DEFAULT` must take the same propagation branches as `DOUBLE_WALKOVER`.
+ *
+ * Three sites asked "is this a double exit" by testing `=== DOUBLE_WALKOVER`, so a `DOUBLE_DEFAULT`
+ * took the false branch at each. Measured over the 600-seed sweep window before the fix:
+ * `noDownstreamDependencies` 1303 times, `hasPropagatedExitDownstream` 161,
+ * `doubleExitAdvancement` 14 — the last while assigning to a variable named
+ * `loserMatchUpIsDoubleExit`. `noDownstreamDependencies` contradicted itself outright: the line
+ * above the defect already asked the same question with `[DOUBLE_WALKOVER, DOUBLE_DEFAULT]`.
+ *
+ * Both cases below mix the two statuses and are shrunk reproductions from that window. Each ends by
+ * re-scoring to the OTHER double exit, which is what forces the two to be one class.
+ *
+ * NOTE: `doubleExitStatusParity` cannot police this. It renames `DOUBLE_DEFAULT` to
+ * `DOUBLE_WALKOVER` and `DEFAULTED` to `WALKOVER` before comparing its two runs, so a defect that
+ * forces exactly that convergence is invisible to it. A green parity suite is not evidence here,
+ * which is why these assertions are on the engine's own refusals.
+ */
+
+const DRAW_ID = 'double-exit-predicate-parity';
+
+function target({ structureName, roundNumber, roundPosition }: any) {
+  return tournamentEngine
+    .allDrawMatchUps({ inContext: true, drawId: DRAW_ID })
+    .matchUps.find(
+      (matchUp: any) =>
+        matchUp.structureName === structureName &&
+        matchUp.roundNumber === roundNumber &&
+        matchUp.roundPosition === roundPosition,
+    );
+}
+
+it.each([
+  {
+    scenario: 'a consolation DOUBLE_DEFAULT then main DOUBLE_WALKOVERs in a FEED_IN_CHAMPIONSHIP',
+    drawType: FEED_IN_CHAMPIONSHIP,
+    participantsCount: 8,
+    drawSize: 8,
+    propagateExitStatus: true,
+    seed: 9000464,
+    steps: [
+      { structureName: 'Main', roundNumber: 1, roundPosition: 1, outcome: { winningSide: 1 } },
+      { structureName: 'Main', roundNumber: 1, roundPosition: 2, outcome: { winningSide: 2 } },
+      {
+        structureName: 'Consolation',
+        roundNumber: 1,
+        roundPosition: 1,
+        outcome: { matchUpStatus: DOUBLE_DEFAULT },
+      },
+      { structureName: 'Main', roundNumber: 1, roundPosition: 2, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
+      { structureName: 'Main', roundNumber: 1, roundPosition: 3, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
+    ],
+  },
+  {
+    scenario: 'a DOUBLE_DEFAULT re-scored to DOUBLE_WALKOVER beside one in a FIRST_MATCH_LOSER_CONSOLATION',
+    drawType: FIRST_MATCH_LOSER_CONSOLATION,
+    participantsCount: 31,
+    drawSize: 32,
+    propagateExitStatus: false,
+    seed: 9000521,
+    steps: [
+      { structureName: 'Main', roundNumber: 1, roundPosition: 15, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
+      { structureName: 'Main', roundNumber: 1, roundPosition: 16, outcome: { matchUpStatus: DOUBLE_DEFAULT } },
+      { structureName: 'Main', roundNumber: 1, roundPosition: 16, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
+    ],
+  },
+])('$scenario propagates without refusing mid-cascade', (testCase) => {
+  const { participantsCount, propagateExitStatus, drawType, drawSize, seed, steps } = testCase;
+
+  setSubscriptions({});
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ participantsCount, drawSize, drawType, drawId: DRAW_ID }],
+    nonRandom: seed,
+    setState: true,
+  });
+
+  for (const [index, step] of steps.entries()) {
+    const matchUp = target(step);
+    expect(matchUp?.matchUpId, `step ${index + 1} target missing`).toBeDefined();
+    const result: any = tournamentEngine.setMatchUpStatus({
+      matchUpId: matchUp.matchUpId,
+      outcome: step.outcome,
+      propagateExitStatus,
+      drawId: DRAW_ID,
+    });
+    expect(
+      result.error,
+      `step ${index + 1} (${step.structureName} r${step.roundNumber}p${step.roundPosition})`,
+    ).toBeUndefined();
+  }
+
+  // CONTROL, not the regression assertion: the committed oracle must stay clean so the fix cannot
+  // buy the refusal back with a worse draw. Both scenarios are clean on it before the fix too.
+  const { drawDefinition } = tournamentEngine.getEvent({ drawId: DRAW_ID });
+  const inconsistencies: any = getDrawInconsistencies({ drawDefinition, drawId: DRAW_ID });
+  expect((inconsistencies?.inconsistencies ?? []).map((issue: any) => issue.issueType)).toEqual([]);
+});

--- a/src/validators/isExit.ts
+++ b/src/validators/isExit.ts
@@ -18,3 +18,16 @@ export function isExit(matchUpStatus: any): boolean {
 export function isAnyExit(matchUpStatus: any): boolean {
   return isExit(matchUpStatus) || [DOUBLE_WALKOVER, DOUBLE_DEFAULT].includes(matchUpStatus);
 }
+
+/**
+ * A DOUBLE exit — neither side advances, and the statuses that stamp exit provenance.
+ *
+ * The third member of this family, added because its absence was being filled by
+ * `=== DOUBLE_WALKOVER` at sites that meant "is this a double exit". Measured over the 600-seed
+ * sweep window, a `DOUBLE_DEFAULT` reaches three such sites and takes the wrong branch at each:
+ * `noDownstreamDependencies` 1303 times, `hasPropagatedExitDownstream` 161, `doubleExitAdvancement`
+ * 14. That asymmetry is the drift `doubleExitStatusParity` exists to police.
+ */
+export function isDoubleExit(matchUpStatus: any): boolean {
+  return [DOUBLE_WALKOVER, DOUBLE_DEFAULT].includes(matchUpStatus);
+}


### PR DESCRIPTION
S3 increment. Base `dev` at `f285ece34`.

## Census — 600-seed window, `SEED_START=9000001`, `MAX_STEPS=30`

| | before | after |
|---|---:|---:|
| **failing seeds** | **54** | **52** |
| `ERROR_IMPLIES_NO_MUTATION` | 41 | 39 |
| `DRAW_INCONSISTENCY` | 12 | 12 |
| `MONOTONIC_DECISION` | 1 | 1 |

2 closed, zero new. Full suite 13,033. `pnpm verify` green locally.

## The defect

Three sites asked *"is this a double exit"* by testing `=== DOUBLE_WALKOVER`, so a `DOUBLE_DEFAULT` took the false branch at each. Reachability was measured **before** any site was changed, and the census re-taken **after each one**, so the effect is attributable rather than lumped:

| site | `DOUBLE_DEFAULT` | `DOUBLE_WALKOVER` | census effect |
|---|---:|---:|---|
| `doubleExitAdvancement:42` | 14 | 33 | **2 seeds closed** |
| `hasPropagatedExitDownstream:19` | 161 | 526 | none on this window |
| `noDownstreamDependencies:42` | 1303 | 3921 | none on this window |
| `getEligibleVoluntaryConsolationParticipants:267,295` | **never fired** | — | unmeasured, **left alone** |

Two details worth noting:

- `doubleExitAdvancement:42` assigned the singleton test to a variable named **`loserMatchUpIsDoubleExit`**.
- `noDownstreamDependencies` contradicted itself: the line **directly above** the defect already asks the same question with `[DOUBLE_WALKOVER, DOUBLE_DEFAULT]`.

The absence being filled by `=== DOUBLE_WALKOVER` was a missing predicate, so this adds the third member of the family beside `isExit` (single) and `isAnyExit` (either): **`isDoubleExit`**.

The two sites that close nothing on this window are kept on correctness grounds, not census grounds — they are reachable 1303 and 161 times, and *"it never fires in 600 seeds"* is not *"it is still correct"*. The two that never fired are left untouched, because I have no measurement for them.

## Tests

`doubleExitPredicateParity.test.ts` — two shrunk reproductions (`FEED_IN_CHAMPIONSHIP` 8, `FIRST_MATCH_LOSER_CONSOLATION` 32), each mixing the two statuses and ending by re-scoring to the *other* double exit. **Both proven RED against `dev` first**, failing with exactly `ERR_EXISTING_POSITION_ASSIGNMENT`.

**`doubleExitStatusParity` cannot police this class**, which is why the new test asserts on the engine's own refusals. That oracle renames `DOUBLE_DEFAULT`→`DOUBLE_WALKOVER` and `DEFAULTED`→`WALKOVER` before comparing its two runs (lines 141-149), so a defect forcing exactly that convergence is invisible to it — even though its own comment names `progressExitStatus` RULE 4 as a suspect.

## Deliberately NOT in this PR

**`progressExitStatus` RULE 4 still hardcodes `DOUBLE_WALKOVER`.** I implemented the provenance-derived version and reverted it, because the measurement says the hardcode is load-bearing *because of this drift*: writing `DOUBLE_DEFAULT` there made the matchUp come out as a single `DEFAULTED` **with a `winningSide`**, since downstream sites testing `=== DOUBLE_WALKOVER` stopped matching. `productionStatusCodeSurvival` caught it — the consolation's codes changed *shape*, meaning a different producer took over.

So the consuming drift has to go first, which is what this PR does. RULE 4 is reached 323 times and splits 195 correct / 14 unambiguously relabelled / **114 mixed default-meets-walkover, which have no defined convention** and want a rules decision rather than a guess.

Also spotted, not fixed: `doubleExitAdvancement.ts:788` `producedMatchUpStatus` is a byte-identical duplicate of `producedExitStatus` in `sideExitProvenance.ts:31`.