### PR TITLE
fix(draws): derive which double exit a convergence becomes, and stop persisting a hole

### DIFF
--- a/src/mutate/drawDefinitions/positionGovernor/doubleExitAdvancement.ts
+++ b/src/mutate/drawDefinitions/positionGovernor/doubleExitAdvancement.ts
@@ -7,16 +7,16 @@ import { modifyMatchUpScore } from '@Mutate/matchUps/score/modifyMatchUpScore';
 import { directWinner } from '@Mutate/matchUps/drawPositions/directWinner';
 import { decorateResult } from '@Functions/global/decorateResult';
 import { positionTargets } from '@Query/matchUp/positionTargets';
-import {
-  buildSideExitProvenance,
-  setSideExitProvenance,
-  producedExitStatus,
-} from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
 import { definedAttributes } from '@Tools/definedAttributes';
 import { pushGlobalLog } from '@Functions/global/globalLog';
 import { findStructure } from '@Acquire/findStructure';
 import { isDoubleExit, isExit } from '@Validators/isExit';
 import { overlap } from '@Tools/arrays';
+import {
+  buildSideExitProvenance,
+  setSideExitProvenance,
+  producedExitStatus,
+} from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
 
 // constants
 import { DRAW_POSITION_ASSIGNED, MISSING_MATCHUP, MISSING_STRUCTURE } from '@Constants/errorConditionConstants';

--- a/src/mutate/drawDefinitions/positionGovernor/doubleExitAdvancement.ts
+++ b/src/mutate/drawDefinitions/positionGovernor/doubleExitAdvancement.ts
@@ -7,7 +7,11 @@ import { modifyMatchUpScore } from '@Mutate/matchUps/score/modifyMatchUpScore';
 import { directWinner } from '@Mutate/matchUps/drawPositions/directWinner';
 import { decorateResult } from '@Functions/global/decorateResult';
 import { positionTargets } from '@Query/matchUp/positionTargets';
-import { buildSideExitProvenance, setSideExitProvenance } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
+import {
+  buildSideExitProvenance,
+  setSideExitProvenance,
+  producedExitStatus,
+} from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
 import { definedAttributes } from '@Tools/definedAttributes';
 import { pushGlobalLog } from '@Functions/global/globalLog';
 import { findStructure } from '@Acquire/findStructure';
@@ -16,7 +20,7 @@ import { overlap } from '@Tools/arrays';
 
 // constants
 import { DRAW_POSITION_ASSIGNED, MISSING_MATCHUP, MISSING_STRUCTURE } from '@Constants/errorConditionConstants';
-import { BYE, DEFAULTED, DOUBLE_DEFAULT, DOUBLE_WALKOVER, WALKOVER } from '@Constants/matchUpStatusConstants';
+import { BYE, DOUBLE_DEFAULT, DOUBLE_WALKOVER } from '@Constants/matchUpStatusConstants';
 import { CONTAINER } from '@Constants/drawDefinitionConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 
@@ -173,7 +177,11 @@ function handleLoserMatchUp({
 
 function handleEmptyExitLoser({ loserMatchUp, matchUpsMap, params, stack }) {
   const DOUBLE_EXIT = params.matchUpStatus === DOUBLE_DEFAULT ? DOUBLE_DEFAULT : DOUBLE_WALKOVER;
-  const EXIT = params.matchUpStatus === DOUBLE_DEFAULT ? DEFAULTED : WALKOVER;
+  // What the double exit PRODUCES. CA ruling 2026-09-12: a double exit of either flavour produces a
+  // WALKOVER, unattributable to any upstream individual — so this is `producedExitStatus`, not a
+  // third inline copy of the mapping. It previously read `=== DOUBLE_DEFAULT ? DEFAULTED : WALKOVER`
+  // at both sites, which stamped a default on a matchUp nobody played.
+  const EXIT = producedExitStatus(params.matchUpStatus) as string;
 
   const noContextLoserMatchUp = matchUpsMap.drawMatchUps.find(
     (matchUp) => matchUp.matchUpId === loserMatchUp.matchUpId,
@@ -216,7 +224,11 @@ function conditionallyAdvanceDrawPosition(params) {
   const structure = drawDefinition.structures.find(({ structureId }) => structureId === targetMatchUp.structureId);
 
   const DOUBLE_EXIT = params.matchUpStatus === DOUBLE_DEFAULT ? DOUBLE_DEFAULT : DOUBLE_WALKOVER;
-  const EXIT = params.matchUpStatus === DOUBLE_DEFAULT ? DEFAULTED : WALKOVER;
+  // What the double exit PRODUCES. CA ruling 2026-09-12: a double exit of either flavour produces a
+  // WALKOVER, unattributable to any upstream individual — so this is `producedExitStatus`, not a
+  // third inline copy of the mapping. It previously read `=== DOUBLE_DEFAULT ? DEFAULTED : WALKOVER`
+  // at both sites, which stamped a default on a matchUp nobody played.
+  const EXIT = producedExitStatus(params.matchUpStatus) as string;
 
   const stack = 'conditionallyAdvanceDrawPosition';
 
@@ -462,12 +474,12 @@ function buildMatchUpStatusCodes({ sourceMatchUpStatus, pairedMatchUpStatus, sou
   if (sourceSideNumber === 1) {
     matchUpStatusCodes = [
       {
-        matchUpStatus: producedMatchUpStatus(sourceMatchUpStatus),
+        matchUpStatus: producedExitStatus(sourceMatchUpStatus),
         previousMatchUpStatus: sourceMatchUpStatus,
         sideNumber: 1,
       },
       {
-        matchUpStatus: producedMatchUpStatus(pairedMatchUpStatus),
+        matchUpStatus: producedExitStatus(pairedMatchUpStatus),
         previousMatchUpStatus: pairedMatchUpStatus,
         sideNumber: 2,
       },
@@ -475,12 +487,12 @@ function buildMatchUpStatusCodes({ sourceMatchUpStatus, pairedMatchUpStatus, sou
   } else if (sourceSideNumber === 2) {
     matchUpStatusCodes = [
       {
-        matchUpStatus: producedMatchUpStatus(pairedMatchUpStatus),
+        matchUpStatus: producedExitStatus(pairedMatchUpStatus),
         previousMatchUpStatus: pairedMatchUpStatus,
         sideNumber: 1,
       },
       {
-        matchUpStatus: producedMatchUpStatus(sourceMatchUpStatus),
+        matchUpStatus: producedExitStatus(sourceMatchUpStatus),
         previousMatchUpStatus: sourceMatchUpStatus,
         sideNumber: 2,
       },
@@ -785,10 +797,4 @@ function advanceByeToLoserMatchUp(params) {
     loserMatchUp,
     event,
   });
-}
-
-function producedMatchUpStatus(previousMatchUpStatus) {
-  if (previousMatchUpStatus === DOUBLE_WALKOVER) return WALKOVER;
-  if (previousMatchUpStatus === DOUBLE_DEFAULT) return DEFAULTED;
-  return previousMatchUpStatus;
 }

--- a/src/mutate/matchUps/drawPositions/progressExitStatus.ts
+++ b/src/mutate/matchUps/drawPositions/progressExitStatus.ts
@@ -6,12 +6,13 @@ import { pushGlobalLog } from '@Functions/global/globalLog';
 import { isExit } from '@Validators/isExit';
 import {
   buildCarriedExitProvenance,
+  collapseDoubleExitStatus,
   mergeSideExitProvenance,
   exitOutcomeCode,
 } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
 
 // constants
-import { DOUBLE_WALKOVER, RETIRED, WALKOVER } from '@Constants/matchUpStatusConstants';
+import { RETIRED, WALKOVER } from '@Constants/matchUpStatusConstants';
 import { MISSING_MATCHUP } from '@Constants/errorConditionConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 
@@ -140,11 +141,30 @@ export function progressExitStatus({
       winningSide = opponentSideNumber;
       placeCodeAtSide(statusCodes, loserParticipantSide.sideNumber, sourceCode);
     } else {
-      // RULE 4 — opponent has itself already walked over: DOUBLE_WALKOVER.
-      const currentStatusCode = statusCodes[0];
-      statusCodes[loserParticipantSide.sideNumber - 1] = sourceCode as string;
-      statusCodes[opponentSideNumber - 1] = currentStatusCode;
-      loserMatchUpStatus = DOUBLE_WALKOVER;
+      // RULE 4 — the opponent has itself already exited: the two exits MEET and this matchUp
+      // becomes a double exit. Nobody wins it.
+      //
+      // The carried code goes at the ARRIVING participant's side index, and the opponent's code is
+      // left where the earlier propagation already put it. The previous version did neither: it read
+      // `statusCodes[0]` unconditionally and re-assigned both slots by hand. That read was correct
+      // when RULE 2 always wrote index 0, but RULE 2 now uses `placeCodeAtSide` (see above), so when
+      // the FIRST exit landed on side 2 its code sits at index 1 and the index-0 read took an empty
+      // slot — silently discarding the earlier code. The masking case (first exit on side 1) is the
+      // one the existing tests cover.
+      //
+      // Removing the hand-assignment also removes the hole array. With `sourceCode` undefined — the
+      // normal case for a directly-recorded exit — the old code assigned `undefined` into both
+      // slots and PERSISTED `[undefined, undefined]`, which is not a `string[]`, serialises to
+      // `[null, null]`, and is load-bearing in this rule's own `opponentEmpty` gate because that
+      // tests `statusCodes.length === 0`. `placeCodeAtSide` returns early on an undefined code, so
+      // the array is simply left alone. CA ruled 2026-09-12: "we can't be persisting
+      // [undefined, undefined]".
+      placeCodeAtSide(statusCodes, loserParticipantSide.sideNumber, sourceCode);
+      // WHICH double exit is derived from what each side carried, not hardcoded. This always wrote
+      // DOUBLE_WALKOVER, which relabelled a default-on-default convergence as a walkover and so
+      // propagated a WALKOVER where a DEFAULTED belonged. A mixture still collapses to
+      // DOUBLE_WALKOVER — see collapseDoubleExitStatus for why the weaker claim wins there.
+      loserMatchUpStatus = collapseDoubleExitStatus([carryOverMatchUpStatus, updatedLoserMatchUp.matchUpStatus]);
       winningSide = undefined;
     }
   }

--- a/src/mutate/matchUps/matchUpStatus/setMatchUpState.ts
+++ b/src/mutate/matchUps/matchUpStatus/setMatchUpState.ts
@@ -804,7 +804,14 @@ function checkParticipants({
     matchUpStatus &&
     //we want to allow wo, default and double walkover inn the consolation draw
     //to have only one particpiant when they are caused by an exit propagation
-    [WALKOVER, DEFAULTED, DOUBLE_WALKOVER].includes(matchUpStatus) &&
+    //
+    // DOUBLE_DEFAULT was missing from this list while DOUBLE_WALKOVER was present, so a
+    // single-participant propagated DOUBLE_DEFAULT fell through to the participants-required
+    // validation and was refused. Measured: reachable, 1 occurrence over the 600-seed sweep window,
+    // and the probable mechanism behind an earlier experiment in which writing DOUBLE_DEFAULT at
+    // progressExitStatus RULE 4 produced a single DEFAULTED *with* a winningSide. This file already
+    // used the correct pair at line 454.
+    [WALKOVER, DEFAULTED, DOUBLE_WALKOVER, DOUBLE_DEFAULT].includes(matchUpStatus) &&
     participantsCount === 1 &&
     propagateExitStatus
   ) {

--- a/src/mutate/matchUps/matchUpStatus/sideExitProvenance.ts
+++ b/src/mutate/matchUps/matchUpStatus/sideExitProvenance.ts
@@ -27,11 +27,53 @@ import { DOUBLE_WALKOVER, DOUBLE_DEFAULT, DEFAULTED, RETIRED, WALKOVER } from '@
  * See Mentat/planning/MATCHUP_STATUS_CODES_PER_SIDE.md.
  */
 
-/** DOUBLE_WALKOVER produces WALKOVER downstream, DOUBLE_DEFAULT produces DEFAULTED. */
+/**
+ * What a matchUp PRODUCES downstream, given the status that produced it.
+ *
+ * A UNIFORM double exit produces its own flavour: `DOUBLE_WALKOVER` produces `WALKOVER`,
+ * `DOUBLE_DEFAULT` produces `DEFAULTED`. CA, 2026-09-12: *"a DOUBLE_DEFAULT producing a side record
+ * DEF sounds right, the same as a DOUBLE_WALKOVER producing a WO / WALKOVER sounds right."*
+ *
+ * The unattributed case is a MIXED convergence, and it is decided upstream of this function by
+ * `collapseDoubleExitStatus` — when two exits of differing origin meet, the converged matchUp is a
+ * `DOUBLE_WALKOVER`, so what it produces here is a `WALKOVER`. CA: *"a WALKOVER and a DEFAULT would
+ * produce a WALKOVER, not a DEF."* That is where the "not attributable to any upstream individual"
+ * rule lives; this mapping stays a faithful per-flavour projection.
+ */
 export function producedExitStatus(previousMatchUpStatus?: string): string | undefined {
   if (previousMatchUpStatus === DOUBLE_WALKOVER) return WALKOVER;
   if (previousMatchUpStatus === DOUBLE_DEFAULT) return DEFAULTED;
   return previousMatchUpStatus;
+}
+
+/**
+ * The status for a matchUp where two exits MEET, from the exits each side carried.
+ *
+ * CA, 2026-09-12: *"a WALKOVER and a DEFAULT would produce a WALKOVER, not a DEF… and a
+ * DOUBLE_WALKOVER and a DOUBLE_DEFAULT producing a WALKOVER and a DEFAULT would produce a
+ * WALKOVER."* So a convergence is `DOUBLE_DEFAULT` only when EVERY side's exit is default-flavoured;
+ * any mixture collapses to `DOUBLE_WALKOVER`.
+ *
+ * The asymmetry is deliberate and is about not attributing a ruling to someone it was not made
+ * about. `DOUBLE_DEFAULT` propagates `DEFAULTED` onward (see `producedExitStatus`), and a default is
+ * a referee's finding against a named player. In a mixed convergence one side merely failed to
+ * appear, so the weaker claim — "did not play" — is the only one true of both, and it is the one
+ * that must survive the collapse into a single field. Choosing the stronger claim would put a `DEF`
+ * badge beside an innocent participant's name: `courthive-components`
+ * `renderParticipant.ts:113`/`:48` render this matchUp-level status per PARTICIPANT via
+ * `renderStatusPill`.
+ *
+ * `RETIRED` is not default-flavoured, which matches `carryOverMatchUpStatus`'s existing decision to
+ * carry a retirement forward as a `WALKOVER`.
+ *
+ * Takes the statuses as ARGUMENTS rather than reading provenance: provenance writes are gated on
+ * `writeNativeEnabled()`, so under LEGACY mode there would be nothing to read.
+ */
+export function collapseDoubleExitStatus(sideStatuses: (string | undefined)[]): string {
+  const known = sideStatuses.filter(Boolean);
+  if (!known.length) return DOUBLE_WALKOVER;
+  const isDefaultFlavoured = (status?: string) => status === DEFAULTED || status === DOUBLE_DEFAULT;
+  return known.every(isDefaultFlavoured) ? DOUBLE_DEFAULT : DOUBLE_WALKOVER;
 }
 
 type BuildArgs = {

--- a/src/tests/mutations/drawDefinitions/setMatchUpStatus/propagateExitStatus.test.ts
+++ b/src/tests/mutations/drawDefinitions/setMatchUpStatus/propagateExitStatus.test.ts
@@ -234,7 +234,7 @@ test.for([
   },
 );
 
-test('can propagate a default to a consolation match with already the result of a double default, resulting in a DOUBLE_WALKOVER', () => {
+test('can propagate a default to a consolation match with already the result of a double default, resulting in a DOUBLE_DEFAULT', () => {
   const idPrefix = 'matchUp';
   const drawId = 'drawId';
   mocksEngine.generateTournamentRecord({
@@ -274,19 +274,23 @@ test('can propagate a default to a consolation match with already the result of 
   expect(matchUp?.matchUpStatus).toEqual(DEFAULTED);
   expect(matchUp?.readyToScore).toEqual(false);
   expect(matchUp?.winningSide).toEqual(2);
-  //consolation match should result in a DOUBLE_WALKOVER
+  // BOTH sides of this convergence originate in a default — the upstream DOUBLE_DEFAULT and the
+  // arriving DEFAULTED — so the consolation matchUp is a DOUBLE_DEFAULT.
+  //
+  // This is the STATUS half the comment below said was "a separate change". It was asserting
+  // DOUBLE_WALKOVER while asserting default-flavoured codes on the same matchUp, because RULE 4
+  // hardcoded the status. RULE 4 now derives it with `collapseDoubleExitStatus`, so the two halves
+  // of this record finally agree. A MIXED convergence still collapses to DOUBLE_WALKOVER.
   let loserMatchUp = matchUps?.find((mU) => mU.matchUpId === matchUp?.loserMatchUpId);
-  expect(loserMatchUp?.matchUpStatus).toEqual(DOUBLE_WALKOVER);
+  expect(loserMatchUp?.matchUpStatus).toEqual(DOUBLE_DEFAULT);
 
   // Was ['WO', 'DM'], which asserted that a DEFAULT is recorded as a WALKOVER. Index 0 carries the
   // code for the side that exited via matchUp-1-1's DOUBLE_DEFAULT, so 'DEF' is the truthful code;
   // the old value came from a coercion that mapped EVERY object-shaped element to OUTCOME_WALKOVER
   // (measured: of 50 provenance elements reaching it, 13 were BYE and 9 DEFAULTED).
   //
-  // NOTE the divergence this exposes rather than creates: matchUpStatus is still DOUBLE_WALKOVER
-  // because progressExitStatus RULE 4 hardcodes it, while doubleExitAdvancement preserves
-  // DOUBLE_DEFAULT. Two producers, two conventions — documented in doubleExitStatusParity.test.ts.
-  // Fixing the STATUS half is a separate change; this one makes the CODE stop lying.
+  // The divergence this NOTE used to describe — matchUpStatus saying DOUBLE_WALKOVER while the
+  // codes said default — is now closed: RULE 4 derives the flavour instead of hardcoding it.
   expect(loserMatchUp?.matchUpStatusCodes).toEqual(['DEF', 'DM']);
 });
 

--- a/src/tests/mutations/exitPropagation/convergingDoubleExitStatus.test.ts
+++ b/src/tests/mutations/exitPropagation/convergingDoubleExitStatus.test.ts
@@ -1,0 +1,92 @@
+import { generateSchedule, prepareDraw, randomConfig, replay } from '@Tests/testHarness/exitPropagation/sweep';
+import { collapseDoubleExitStatus } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
+import { getDrawDefinition } from '@Tests/testHarness/exitPropagation/transitions';
+import { setSubscriptions } from '@Global/state/globalState';
+import { expect, it } from 'vitest';
+
+import { DEFAULTED, DOUBLE_DEFAULT, DOUBLE_WALKOVER, RETIRED, WALKOVER } from '@Constants/matchUpStatusConstants';
+
+/**
+ * When two exits MEET, which double exit the matchUp becomes is derived from what each side carried.
+ *
+ * `progressExitStatus` RULE 4 hardcoded `DOUBLE_WALKOVER` for every convergence, so a
+ * default-on-default pair was relabelled a walkover — and since `producedExitStatus` maps
+ * `DOUBLE_DEFAULT` to `DEFAULTED`, the relabelling propagated a `WALKOVER` downstream where a
+ * `DEFAULTED` belonged.
+ *
+ * CA, 2026-09-12: *"a DOUBLE_DEFAULT producing a side record DEF sounds right, the same as a
+ * DOUBLE_WALKOVER producing a WO / WALKOVER sounds right; my assertion was a WALKOVER and a DEFAULT
+ * would produce a WALKOVER, not a DEF."* So a uniform pair keeps its flavour and any MIXTURE
+ * collapses to `DOUBLE_WALKOVER`, whose production is the unattributed walkover.
+ *
+ * The asymmetry is about attribution: a default is a referee's finding against a named player, and
+ * in a mixed convergence one side merely failed to appear. `courthive-components`
+ * `renderParticipant.ts:113`/`:48` render this matchUp-level status per PARTICIPANT, so the stronger
+ * claim would put a `DEF` badge beside an innocent name.
+ */
+
+it.each([
+  { label: 'both walkovers', sides: [WALKOVER, WALKOVER], expected: DOUBLE_WALKOVER },
+  { label: 'both defaults', sides: [DEFAULTED, DEFAULTED], expected: DOUBLE_DEFAULT },
+  { label: 'a default meeting a walkover', sides: [DEFAULTED, WALKOVER], expected: DOUBLE_WALKOVER },
+  { label: 'a walkover meeting a default (order reversed)', sides: [WALKOVER, DEFAULTED], expected: DOUBLE_WALKOVER },
+  { label: 'the double flavours, both default', sides: [DOUBLE_DEFAULT, DEFAULTED], expected: DOUBLE_DEFAULT },
+  { label: 'a retirement is not default-flavoured', sides: [RETIRED, DEFAULTED], expected: DOUBLE_WALKOVER },
+  { label: 'an unknown side does not force a default', sides: [DEFAULTED, undefined], expected: DOUBLE_DEFAULT },
+  { label: 'nothing known at all', sides: [undefined, undefined], expected: DOUBLE_WALKOVER },
+])('$label collapses to $expected', ({ sides, expected }) => {
+  expect(collapseDoubleExitStatus(sides)).toEqual(expected);
+});
+
+it('is order-invariant for every pair', () => {
+  const statuses = [WALKOVER, DEFAULTED, RETIRED, DOUBLE_WALKOVER, DOUBLE_DEFAULT, undefined];
+  for (const first of statuses) {
+    for (const second of statuses) {
+      expect(
+        collapseDoubleExitStatus([first, second]),
+        `[${first}, ${second}] must collapse the same way as its reverse`,
+      ).toEqual(collapseDoubleExitStatus([second, first]));
+    }
+  }
+});
+
+it('never persists a matchUpStatusCodes array containing a hole', () => {
+  // `progressExitStatus` RULE 4 assigned `sourceCode` — `undefined` for a directly-recorded exit —
+  // into BOTH slots by hand, and PERSISTED the result: `[undefined, undefined]`, which serialises to
+  // `[null, null]` and is not a `string[]`. It is also load-bearing in RULE 4's own `opponentEmpty`
+  // gate, which tests `statusCodes.length === 0`. CA: *"we can't be persisting
+  // [undefined, undefined]."*
+  //
+  // Driven through the sweep harness rather than by hand: a hand-built convergence did NOT reproduce
+  // it, so that version of this test passed against the unfixed tree and was vacuous. Measured on
+  // the unfixed tree across the first 120 seeds of the window: 14 persisted hole arrays, including
+  // the mixed shape `[null, ""]` which also evidences the index-0 read this replaced.
+  const seeds = [9000003, 9000056, 9000074];
+  let arraysSeen = 0;
+
+  for (const seed of seeds) {
+    setSubscriptions({});
+    const config = randomConfig(seed);
+    const drawId = `no-hole-${seed}`;
+    prepareDraw(config, drawId);
+    replay(config, generateSchedule(config, drawId, 30), drawId);
+
+    const drawDefinition = getDrawDefinition(drawId);
+    for (const structure of drawDefinition?.structures ?? []) {
+      for (const matchUp of structure.matchUps ?? []) {
+        const codes = matchUp.matchUpStatusCodes;
+        if (!Array.isArray(codes) || !codes.length) continue;
+        arraysSeen += 1;
+        for (const [index, code] of codes.entries()) {
+          expect(
+            code === undefined || code === null,
+            `seed ${seed} ${structure.structureName} r${matchUp.roundNumber}p${matchUp.roundPosition} codes[${index}] is a hole: ${JSON.stringify(codes)}`,
+          ).toEqual(false);
+        }
+      }
+    }
+  }
+
+  // the control: a run producing no codes at all would pass vacuously
+  expect(arraysSeen).toBeGreaterThan(0);
+});


### PR DESCRIPTION
Implements CA's ruling of 2026-09-12, informed by a three-advocate + auditor debate. Base `dev` at `9149f50f5`.

## Census — 600-seed window, `SEED_START=9000001`, `MAX_STEPS=30`

**52 -> 52 failing seeds. Zero closed, ZERO NEW.** `ERROR_IMPLIES_NO_MUTATION` stays at 39.

This is a **correctness change, not a census-moving one**, and that is stated plainly rather than dressed up: the sweep's properties do not observe which flavour of double exit a convergence becomes, nor whether a persisted codes array contains a hole. Full suite 13,043. `pnpm verify` exit 0.

## What changed

**1. RULE 4 derives the flavour instead of hardcoding it.** It wrote `DOUBLE_WALKOVER` for every convergence, so a default-on-default pair was relabelled a walkover — and since `producedExitStatus` maps `DOUBLE_DEFAULT` to `DEFAULTED`, that relabelling propagated a `WALKOVER` downstream where a `DEFAULTED` belonged.

`collapseDoubleExitStatus` returns `DOUBLE_DEFAULT` when **every** side's exit is default-flavoured, `DOUBLE_WALKOVER` for any mixture. A uniform pair keeps its flavour; a mixture takes the weaker claim.

That asymmetry is not aesthetic. A default is a referee's finding against a named player, and in a mixed convergence one side merely failed to appear — and the label is **rendered per participant**: `courthive-components/src/components/renderStructure/renderParticipant.ts:113` feeds it to `:48`'s `renderStatusPill`, which maps the default family to the literal `DEF` (`renderStatusPill.ts:28-31`). The stronger claim would print `DEF` beside an innocent participant's name in a published draw.

**2. RULE 4 no longer persists `[undefined, undefined]`.** It assigned `sourceCode` — `undefined` for a directly-recorded exit — into both slots by hand. The result persisted: not a `string[]`, serialising to `[null, null]`, and load-bearing in RULE 4's *own* `opponentEmpty` gate, which tests `statusCodes.length === 0`.

Measured on the unfixed tree across the first 120 seeds of the window: **14 persisted hole arrays → 0**. One of them was `[null, ""]`, the mixed shape that also evidences the hardcoded `statusCodes[0]` read this replaces — that read discarded the earlier side's code whenever the first exit landed on side 2, because RULE 2 writes with `placeCodeAtSide` (side-indexed) while RULE 4 read index 0.

**3. `setMatchUpState` omitted `DOUBLE_DEFAULT`** from the list permitting a single-participant propagated exit, while including `DOUBLE_WALKOVER`. Measured reachable — 1 occurrence over the window, refused today — and the same file already used the correct pair 350 lines above.

**4. The produced-status mapping had FOUR independent derivations**: `producedExitStatus`, the byte-identical `producedMatchUpStatus`, and two inline `=== DOUBLE_DEFAULT ? DEFAULTED : WALKOVER` ternaries. All now call the one implementation. The two inline copies were found only because a test failed — they were not in anyone's drift list.

## Tests

`convergingDoubleExitStatus.test.ts` — the collapse table, an **order-invariance property over all 36 status pairs**, and a no-hole-arrays assertion. All proven RED against `dev` first, the hole case failing with a named location (`seed 9000003 Backdraw r2p1 codes[0] is a hole: [null,null]`).

The hole test is driven through the sweep harness **because a hand-built convergence did not reproduce it** — that version passed against the unfixed tree, i.e. it was vacuous. Recorded in the test so nobody rebuilds it that way.

## Reported honestly

- `propagateExitStatus.test.ts` now expects `DOUBLE_DEFAULT` where it expected `DOUBLE_WALKOVER`. That is the change **its own comment called "a separate change"**: it asserted a walkover status alongside default-flavoured codes `['DEF','DM']` on the same matchUp. The two halves of that record now agree.
- **The stored status is still order-dependent** at `doubleExitAdvancement.ts:180`/`:223`, which derive `DOUBLE_EXIT` from the arriving source alone. This PR fixes RULE 4's producer only. An `ENTRY_ORDER_INVARIANCE` test fails today and is the gate for that follow-up.
- **`sideExitProvenance` is written for only ONE side on the FRLC convergence path**, which side depending on entry order, and `getSideExitProvenance` is all-or-nothing (`:196-197`) so a partial native write masks a complete legacy array. Found during the debate, not fixed here, and it weakens any plan that assumes per-side truth is already reliable.
- `doubleExitStatusParity` cannot police any of this: it renames `DEFAULTED`→`WALKOVER` before comparing (`:141-149`), and `driver.ts:102` applies a single `exitOutcome` per run so the in-suite matrix cannot build a mixed pair at all.