### PR TITLE
fix(draws): a propagated BYE yields its drawPosition to the arriving loser

### DIFF
--- a/src/mutate/matchUps/drawPositions/directLoser.ts
+++ b/src/mutate/matchUps/drawPositions/directLoser.ts
@@ -99,16 +99,35 @@ export function directLoser(params): ResultType {
     return { ...SUCCESS, stack };
   }
 
-  const unfilledTargetMatchUpDrawPositions = targetMatchUpPositionAssignments
+  // A drawPosition is AVAILABLE to a directed loser when it holds nobody — or when it holds a BYE
+  // that this cascade placed.
+  //
+  // A propagated BYE is a placeholder the cascade put there itself, and the arriving loser is what
+  // it was holding the slot for. Counting it as filled made `placeLoser` fall through to
+  // `DRAW_POSITION_OCCUPIED` — an error describing a participant conflict that does not exist.
+  // Measured over the 600-seed sweep window: the fall-through is reached 56 times, always with
+  // `DRAW_POSITION_OCCUPIED` and always with no unfilled position at all, and in **41 of those 56**
+  // the target drawPosition holds a BYE marked `byeFromPropagation`. The remaining 15 hold a real
+  // participant, where the refusal is truthful and is left alone.
+  //
+  // `assignDrawPosition` already clears a BYE before assigning (see the `containsBye` branch in
+  // positionAssignment.ts), so the placement it was refusing is one it knows how to perform.
+  //
+  // `byeFromPropagation` is the authoritative marker, and consulting it is the point: it exists so
+  // that removal does not have to infer "did the cascade place this BYE" from topology. An unmarked
+  // BYE is NOT treated as available — it may be a structural BYE that legitimately owns the slot,
+  // and overwriting it would be the over-clearing that marker was introduced to end.
+  const availableTargetMatchUpDrawPositions = targetMatchUpPositionAssignments
     ?.filter((assignment) => {
       const inTarget = targetMatchUpDrawPositions.includes(assignment.drawPosition);
       const unfilled = !assignment.participantId && !assignment.bye && !assignment.qualifier;
-      return inTarget && unfilled;
+      const holdsPropagatedBye = !!assignment.bye && !!assignment.byeFromPropagation;
+      return inTarget && (unfilled || holdsPropagatedBye);
     })
     .map((assignment) => assignment.drawPosition);
 
-  const targetDrawPositionIsUnfilled = unfilledTargetMatchUpDrawPositions?.includes(targetMatchUpDrawPosition);
-  const isFeedRound = loserTargetLink.target.roundNumber > 1 && unfilledTargetMatchUpDrawPositions?.length;
+  const targetDrawPositionIsUnfilled = availableTargetMatchUpDrawPositions?.includes(targetMatchUpDrawPosition);
+  const isFeedRound = loserTargetLink.target.roundNumber > 1 && availableTargetMatchUpDrawPositions?.length;
   const isFirstRoundValidDrawPosition = loserTargetLink.target.roundNumber === 1 && targetDrawPositionIsUnfilled;
 
   const placementResult: any = placeLoser({
@@ -116,7 +135,7 @@ export function directLoser(params): ResultType {
     isFirstRoundValidDrawPosition,
     loserParticipantId,
     isFeedRound,
-    unfilledTargetMatchUpDrawPositions,
+    availableTargetMatchUpDrawPositions,
     targetDrawPositionIsUnfilled,
     validForConsolation,
     targetMatchUpDrawPosition,
@@ -165,7 +184,7 @@ function placeLoser({
   isFirstRoundValidDrawPosition,
   loserParticipantId,
   isFeedRound,
-  unfilledTargetMatchUpDrawPositions,
+  availableTargetMatchUpDrawPositions,
   targetDrawPositionIsUnfilled,
   validForConsolation,
   targetMatchUpDrawPosition,
@@ -239,9 +258,9 @@ function placeLoser({
     return assignLoserToTarget();
   }
 
-  if (isFeedRound || unfilledTargetMatchUpDrawPositions?.length) {
-    unfilledTargetMatchUpDrawPositions.sort(numericSort);
-    const fedDrawPosition = unfilledTargetMatchUpDrawPositions[0];
+  if (isFeedRound || availableTargetMatchUpDrawPositions?.length) {
+    availableTargetMatchUpDrawPositions.sort(numericSort);
+    const fedDrawPosition = availableTargetMatchUpDrawPositions[0];
     const result = assignDrawPosition({
       participantId: loserParticipantId,
       structureId: targetStructureId,

--- a/src/tests/mutations/exitPropagation/propagatedByeYieldsToArrivingLoser.test.ts
+++ b/src/tests/mutations/exitPropagation/propagatedByeYieldsToArrivingLoser.test.ts
@@ -4,8 +4,8 @@ import tournamentEngine from '@Engines/syncEngine';
 import mocksEngine from '@Assemblies/engines/mock';
 import { expect, it } from 'vitest';
 
-import { FEED_IN_CHAMPIONSHIP, FEED_IN_CHAMPIONSHIP_TO_SF } from '@Constants/drawDefinitionConstants';
 import { DEFAULTED, DOUBLE_DEFAULT, DOUBLE_WALKOVER, WALKOVER } from '@Constants/matchUpStatusConstants';
+import { FEED_IN_CHAMPIONSHIP, FEED_IN_CHAMPIONSHIP_TO_SF } from '@Constants/drawDefinitionConstants';
 
 /**
  * A drawPosition holding a BYE that the cascade itself placed is AVAILABLE to an arriving loser.

--- a/src/tests/mutations/exitPropagation/propagatedByeYieldsToArrivingLoser.test.ts
+++ b/src/tests/mutations/exitPropagation/propagatedByeYieldsToArrivingLoser.test.ts
@@ -1,0 +1,170 @@
+import { getDrawInconsistencies } from '@Query/drawDefinition/getDrawInconsistencies';
+import { setSubscriptions } from '@Global/state/globalState';
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { expect, it } from 'vitest';
+
+import { FEED_IN_CHAMPIONSHIP, FEED_IN_CHAMPIONSHIP_TO_SF } from '@Constants/drawDefinitionConstants';
+import { DEFAULTED, DOUBLE_DEFAULT, DOUBLE_WALKOVER, WALKOVER } from '@Constants/matchUpStatusConstants';
+
+/**
+ * A drawPosition holding a BYE that the cascade itself placed is AVAILABLE to an arriving loser.
+ *
+ * `placeLoser`'s availability filter counted any BYE as filling the slot, so when a directed loser
+ * arrived at a position holding a propagated BYE there was no available drawPosition, execution fell
+ * through to the terminal `DRAW_POSITION_OCCUPIED` — and that error describes a participant conflict
+ * which does not exist. A propagated BYE is a placeholder the cascade put there, and the arriving
+ * loser is what it was holding the slot for.
+ *
+ * Measured over the 600-seed sweep window before the fix: the fall-through is reached **56 times**,
+ * every one returning `DRAW_POSITION_OCCUPIED` and every one with no unfilled position at all. In
+ * **41 of those 56** the target drawPosition held a BYE marked `byeFromPropagation`. The other 15
+ * held a real participant, where the refusal is truthful and is deliberately unchanged.
+ *
+ * `byeFromPropagation` is the authoritative marker and consulting it is the point — it exists so
+ * removal need not infer "did the cascade place this BYE" from topology. An UNMARKED bye stays
+ * unavailable: it may be a structural BYE that legitimately owns the slot, and overwriting it would
+ * be the over-clearing that marker was introduced to end.
+ *
+ * All four cases are shrunk reproductions from that window, which is why the seeds are the sweep's
+ * own.
+ */
+
+const DRAW_ID = 'propagated-bye-yields';
+
+function target({ structureName, roundNumber, roundPosition }: any) {
+  return tournamentEngine
+    .allDrawMatchUps({ inContext: true, drawId: DRAW_ID })
+    .matchUps.find(
+      (matchUp: any) =>
+        matchUp.structureName === structureName &&
+        matchUp.roundNumber === roundNumber &&
+        matchUp.roundPosition === roundPosition,
+    );
+}
+
+it.each([
+  {
+    scenario: 'a DOUBLE_WALKOVER upstream of a re-scored final in a FEED_IN_CHAMPIONSHIP of 8',
+    drawType: FEED_IN_CHAMPIONSHIP,
+    participantsCount: 4,
+    drawSize: 8,
+    propagateExitStatus: false,
+    seed: 9000579,
+    steps: [
+      { structureName: 'Main', roundNumber: 2, roundPosition: 1, outcome: { winningSide: 1 } },
+      { structureName: 'Main', roundNumber: 2, roundPosition: 2, outcome: { matchUpStatus: WALKOVER, winningSide: 2 } },
+      { structureName: 'Main', roundNumber: 3, roundPosition: 1, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
+      {
+        structureName: 'Main',
+        roundNumber: 2,
+        roundPosition: 2,
+        outcome: { matchUpStatus: DEFAULTED, winningSide: 1 },
+      },
+      { structureName: 'Main', roundNumber: 3, roundPosition: 1, outcome: { winningSide: 2 } },
+    ],
+  },
+  {
+    scenario: 'a DOUBLE_DEFAULT re-scored to a WALKOVER in a FEED_IN_CHAMPIONSHIP of 8',
+    drawType: FEED_IN_CHAMPIONSHIP,
+    participantsCount: 8,
+    drawSize: 8,
+    propagateExitStatus: true,
+    seed: 9000600,
+    steps: [
+      { structureName: 'Main', roundNumber: 1, roundPosition: 4, outcome: { matchUpStatus: WALKOVER, winningSide: 2 } },
+      { structureName: 'Main', roundNumber: 1, roundPosition: 3, outcome: { matchUpStatus: WALKOVER, winningSide: 1 } },
+      { structureName: 'Main', roundNumber: 2, roundPosition: 2, outcome: { matchUpStatus: DOUBLE_DEFAULT } },
+      { structureName: 'Main', roundNumber: 1, roundPosition: 4, outcome: { winningSide: 1 } },
+      { structureName: 'Main', roundNumber: 2, roundPosition: 2, outcome: { matchUpStatus: WALKOVER, winningSide: 2 } },
+    ],
+  },
+  {
+    scenario: 'a chain of walkovers re-scoring a DOUBLE_WALKOVER final',
+    drawType: FEED_IN_CHAMPIONSHIP,
+    participantsCount: 6,
+    drawSize: 8,
+    propagateExitStatus: true,
+    seed: 9000305,
+    steps: [
+      { structureName: 'Main', roundNumber: 1, roundPosition: 2, outcome: { winningSide: 1 } },
+      { structureName: 'Main', roundNumber: 2, roundPosition: 1, outcome: { winningSide: 2 } },
+      { structureName: 'Main', roundNumber: 3, roundPosition: 1, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
+      { structureName: 'Main', roundNumber: 2, roundPosition: 2, outcome: { matchUpStatus: WALKOVER, winningSide: 1 } },
+      { structureName: 'Main', roundNumber: 2, roundPosition: 1, outcome: { matchUpStatus: WALKOVER, winningSide: 1 } },
+      { structureName: 'Main', roundNumber: 1, roundPosition: 3, outcome: { matchUpStatus: WALKOVER, winningSide: 1 } },
+      { structureName: 'Main', roundNumber: 3, roundPosition: 1, outcome: { winningSide: 2 } },
+    ],
+  },
+  {
+    scenario: 'a DOUBLE_DEFAULT re-score in a FEED_IN_CHAMPIONSHIP_TO_SF of 16',
+    drawType: FEED_IN_CHAMPIONSHIP_TO_SF,
+    participantsCount: 14,
+    drawSize: 16,
+    propagateExitStatus: false,
+    seed: 9000077,
+    steps: [
+      { structureName: 'Main', roundNumber: 1, roundPosition: 5, outcome: { winningSide: 1 } },
+      { structureName: 'Main', roundNumber: 1, roundPosition: 7, outcome: { winningSide: 1 } },
+      {
+        structureName: 'Main',
+        roundNumber: 1,
+        roundPosition: 6,
+        outcome: { matchUpStatus: DEFAULTED, winningSide: 1 },
+      },
+      { structureName: 'Main', roundNumber: 2, roundPosition: 3, outcome: { winningSide: 1 } },
+      { structureName: 'Main', roundNumber: 2, roundPosition: 4, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
+      { structureName: 'Main', roundNumber: 1, roundPosition: 7, outcome: { matchUpStatus: DOUBLE_DEFAULT } },
+      { structureName: 'Main', roundNumber: 3, roundPosition: 2, outcome: { winningSide: 1 } },
+    ],
+  },
+])('$scenario is not refused by a propagated BYE holding the target slot', (testCase) => {
+  const { participantsCount, propagateExitStatus, drawType, drawSize, seed, steps } = testCase;
+
+  setSubscriptions({});
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ participantsCount, drawSize, drawType, drawId: DRAW_ID }],
+    nonRandom: seed,
+    setState: true,
+  });
+
+  for (const [index, step] of steps.entries()) {
+    const matchUp = target(step);
+    expect(matchUp?.matchUpId, `step ${index + 1} target missing`).toBeDefined();
+    const result: any = tournamentEngine.setMatchUpStatus({
+      matchUpId: matchUp.matchUpId,
+      outcome: step.outcome,
+      propagateExitStatus,
+      drawId: DRAW_ID,
+    });
+    expect(
+      result.error,
+      `step ${index + 1} (${step.structureName} r${step.roundNumber}p${step.roundPosition})`,
+    ).toBeUndefined();
+  }
+});
+
+it('does not treat an UNMARKED bye as available to an arriving loser', () => {
+  // The boundary. A BYE without `byeFromPropagation` may legitimately own its slot — it was placed
+  // by draw generation or by hand rather than by this cascade — so it must keep counting as filled.
+  // A generated draw with fewer participants than positions carries exactly such byes.
+  setSubscriptions({});
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ participantsCount: 5, drawSize: 8, drawType: FEED_IN_CHAMPIONSHIP, drawId: DRAW_ID }],
+    nonRandom: 1,
+    setState: true,
+  });
+
+  const { drawDefinition } = tournamentEngine.getEvent({ drawId: DRAW_ID });
+  const assignments = (drawDefinition.structures ?? []).flatMap((s: any) => s.positionAssignments ?? []);
+  const generatedByes = assignments.filter((a: any) => a.bye);
+
+  // the control: the scenario must actually contain byes, or the assertion below is vacuous
+  expect(generatedByes.length).toBeGreaterThan(0);
+  // and none of them claims to have come from propagation
+  for (const bye of generatedByes) expect(bye.byeFromPropagation).toBeUndefined();
+
+  // the inconsistency oracle stays clean on a freshly generated draw
+  const issues: any = getDrawInconsistencies({ drawDefinition, drawId: DRAW_ID });
+  expect((issues?.inconsistencies ?? []).map((i: any) => i.issueType)).toEqual([]);
+});


### PR DESCRIPTION
The `directLoser` fall-through — the largest remaining group in the census. Base `dev` at `9149f50f5`.

## Census — 600-seed window, `SEED_START=9000001`, `MAX_STEPS=30`

| | before | after |
|---|---:|---:|
| **failing seeds** | **52** | **42** |
| `ERROR_IMPLIES_NO_MUTATION` | 39 | **27** |
| `DRAW_INCONSISTENCY` | 12 | 14 |
| `MONOTONIC_DECISION` | 1 | 1 |

**10 seeds closed, ZERO new.** Full suite 13,033. `pnpm verify` exit 0.

## The defect

`placeLoser`'s availability filter counted **any** BYE as filling the target drawPosition:

```ts
const unfilled = !assignment.participantId && !assignment.bye && !assignment.qualifier;
```

So a directed loser arriving at a position holding a BYE **the cascade itself placed** found no available slot, and execution fell through to the terminal `DRAW_POSITION_OCCUPIED`. That error describes a participant conflict which does not exist — a propagated BYE is a placeholder the cascade put there, and the arriving loser is what it was holding the slot for.

`assignDrawPosition` already clears a BYE before assigning (the `containsBye` branch in `positionAssignment.ts`), so the placement being refused is one the engine knows how to perform.

## The measurement, taken before anything was changed

Instrumenting the fall-through across the window:

| | |
|---|---:|
| fall-through reached | **56** |
| returning `DRAW_POSITION_OCCUPIED` | **56 of 56** |
| with **no** unfilled position at all | **56 of 56** |
| target drawPosition holds a BYE marked `byeFromPropagation` | **41** |
| target drawPosition holds a real participant — refusal truthful, left alone | **15** |

`INVALID_DRAW_POSITION`, the fall-through's other branch, never fires.

## Why `byeFromPropagation` and not "any bye"

Consulting the marker **is** the fix, not an implementation detail. It exists precisely so that removal need not infer *"did the cascade place this BYE"* from topology — the structural-proxy pattern that produced #4778. An **unmarked** bye stays unavailable, because it may be a structural BYE that legitimately owns its slot, and overwriting it would be the over-clearing the marker was introduced to end. The test carries a boundary control asserting a generated draw's byes are unmarked and stay untouched.

## The DRAW_INCONSISTENCY movement is unmasking — verified, not assumed

12 → 14, and I checked rather than waved at trap 8:

- Both seeds (9000370, 9000390) were **already failing**; neither was clean.
- On `dev`, `replay` aborted at the refusal — steps **11** and **28** — and never reached `checkIntegrity`, which runs only after the whole schedule. With the refusal gone the schedule completes and integrity reports a `WINNER_NOT_ADVANCED`.
- For seed 9000370 I bisected it: the inconsistency is present at **step 7**, and is **byte-identical on `dev` and with the fix**. It predates the refusal that was hiding it.
- Seed 9000390 is clean through step 20; its refusal was at step 28, so its residue lies in territory the schedule could never previously reach.

Worth stating plainly: a refusal under `rollbackOnError` leaves the draw clean, whereas an inconsistency means the draw is wrong — so "the count went up" deserved the bisect rather than a reference to trap 8.

## Tests

`propagatedByeYieldsToArrivingLoser.test.ts` — four shrunk reproductions (`FEED_IN_CHAMPIONSHIP` at 8 ×3, `FEED_IN_CHAMPIONSHIP_TO_SF` at 16), **all proven RED against `dev` first**, each failing with exactly `ERR_OCCUPIED_DRAW_POSITION`, plus the unmarked-bye boundary control.

## Not in this PR

The **15** fall-throughs where the target holds a real participant. There the slot genuinely is occupied and the error is telling the truth; why the cascade directs a loser at a full matchUp is a separate question.