### PR TITLE
fix(draws): the converged double-exit status no longer depends on entry order

### DIFF
--- a/src/mutate/drawDefinitions/matchUpGovernor/matchUpStatusCodes.ts
+++ b/src/mutate/drawDefinitions/matchUpGovernor/matchUpStatusCodes.ts
@@ -1,5 +1,10 @@
+import { mergeSideExitProvenance, producedExitStatus } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
 import { getPairedPreviousMatchUp } from '@Query/matchUps/getPairedPreviousMatchup';
+import { definedAttributes } from '@Tools/definedAttributes';
 import { isString } from '@Tools/objects';
+
+// constants
+import { TO_BE_PLAYED } from '@Constants/matchUpStatusConstants';
 
 // types
 import { MatchUpsMap } from '@Types/factoryTypes';
@@ -41,9 +46,40 @@ export function updateMatchUpStatusCodes({
     matchUp.matchUpStatusCodes = (matchUp.matchUpStatusCodes ?? []).map((code) => {
       const value = isString(code) || !isNaN(code) ? { code } : code;
       if (value.sideNumber === sourceSideNumber) {
-        return { ...value, previousMatchUpStatus: sourceMatchUpStatus };
+        // `matchUpStatus` and `previousMatchUpStatus` are a PAIR — the second is the origin, the
+        // first is what that origin produced. Stamping only the origin left them contradicting each
+        // other: an element already reading `{ DEFAULTED, DOUBLE_DEFAULT }` became
+        // `{ DEFAULTED, DOUBLE_WALKOVER }`, i.e. a walkover origin producing a default. Measured as
+        // the last surviving entry-order dependence on the consolation convergence path — one order
+        // produced the coherent pair and the other this one.
+        return {
+          ...value,
+          matchUpStatus: producedExitStatus(sourceMatchUpStatus),
+          previousMatchUpStatus: sourceMatchUpStatus,
+        };
       }
       return value;
     });
+
+    // This is the site that LEARNS a side's origin after the fact, and it was recording it only in
+    // the legacy array. So a matchUp could carry the truthful origin in `matchUpStatusCodes`
+    // (`previousMatchUpStatus: COMPLETED`) while `sideExitProvenance` held nothing for that side —
+    // or, before the guard in `buildSideExitProvenance`, held `TO_BE_PLAYED`, which is not an
+    // origin at all.
+    //
+    // Merged, not set: the other side's origin may already be recorded, and may have arrived first.
+    // An UNDECIDED source is not recorded — provenance can never be TO_BE_PLAYED.
+    if (sourceMatchUpStatus && sourceMatchUpStatus !== TO_BE_PLAYED) {
+      mergeSideExitProvenance({
+        matchUp,
+        provenance: {
+          [sourceSideNumber]: definedAttributes({
+            matchUpStatus: producedExitStatus(sourceMatchUpStatus),
+            previousMatchUpStatus: sourceMatchUpStatus,
+            sourceMatchUpId,
+          }) as any,
+        },
+      });
+    }
   }
 }

--- a/src/mutate/drawDefinitions/positionGovernor/doubleExitAdvancement.ts
+++ b/src/mutate/drawDefinitions/positionGovernor/doubleExitAdvancement.ts
@@ -13,14 +13,15 @@ import { findStructure } from '@Acquire/findStructure';
 import { isDoubleExit, isExit } from '@Validators/isExit';
 import { overlap } from '@Tools/arrays';
 import {
+  collapseDoubleExitStatus,
   buildSideExitProvenance,
-  setSideExitProvenance,
+  mergeSideExitProvenance,
   producedExitStatus,
 } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
 
 // constants
 import { DRAW_POSITION_ASSIGNED, MISSING_MATCHUP, MISSING_STRUCTURE } from '@Constants/errorConditionConstants';
-import { BYE, DOUBLE_DEFAULT, DOUBLE_WALKOVER } from '@Constants/matchUpStatusConstants';
+import { BYE } from '@Constants/matchUpStatusConstants';
 import { CONTAINER } from '@Constants/drawDefinitionConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 
@@ -176,11 +177,27 @@ function handleLoserMatchUp({
 }
 
 function handleEmptyExitLoser({ loserMatchUp, matchUpsMap, params, stack }) {
-  const DOUBLE_EXIT = params.matchUpStatus === DOUBLE_DEFAULT ? DOUBLE_DEFAULT : DOUBLE_WALKOVER;
-  // What the double exit PRODUCES. CA ruling 2026-09-12: a double exit of either flavour produces a
-  // WALKOVER, unattributable to any upstream individual — so this is `producedExitStatus`, not a
-  // third inline copy of the mapping. It previously read `=== DOUBLE_DEFAULT ? DEFAULTED : WALKOVER`
-  // at both sites, which stamped a default on a matchUp nobody played.
+  // WHICH double exit this convergence becomes, from BOTH origins rather than the arriving one
+  // alone. `loserMatchUp` already carries the exit produced by the first arrival, which IS the other
+  // side's origin.
+  //
+  // Reading only `params.matchUpStatus` made the stored status a function of ENTRY ORDER: measured
+  // on SINGLE_ELIMINATION 8 and 16, the same two feeders give DOUBLE_DEFAULT one way and
+  // DOUBLE_WALKOVER the other, while the per-side facts are identical in both.
+  //
+  // Passing the target's PRODUCED exit beside the arriving RAW status is sound because
+  // `producedExitStatus` preserves the flavour family — DOUBLE_DEFAULT produces DEFAULTED, both
+  // default-flavoured — so the collapse classifies them the same either way.
+  const DOUBLE_EXIT = collapseDoubleExitStatus([params.matchUpStatus, loserMatchUp?.matchUpStatus]);
+  // What the double exit PRODUCES, through the single implementation rather than another inline copy
+  // of the mapping — it read `=== DOUBLE_DEFAULT ? DEFAULTED : WALKOVER` at both sites, two of four
+  // independent derivations of one rule.
+  //
+  // A UNIFORM double exit produces its own flavour: DOUBLE_DEFAULT produces DEFAULTED. The
+  // unattributed WALKOVER belongs to the MIXED case and is decided by `collapseDoubleExitStatus`
+  // choosing DOUBLE_WALKOVER for the convergence, not here. (An earlier revision of this comment
+  // said either flavour produces a WALKOVER; that over-read the ruling and the code was reverted
+  // while the comment was not.)
   const EXIT = producedExitStatus(params.matchUpStatus) as string;
 
   const noContextLoserMatchUp = matchUpsMap.drawMatchUps.find(
@@ -223,11 +240,15 @@ function conditionallyAdvanceDrawPosition(params) {
 
   const structure = drawDefinition.structures.find(({ structureId }) => structureId === targetMatchUp.structureId);
 
-  const DOUBLE_EXIT = params.matchUpStatus === DOUBLE_DEFAULT ? DOUBLE_DEFAULT : DOUBLE_WALKOVER;
-  // What the double exit PRODUCES. CA ruling 2026-09-12: a double exit of either flavour produces a
-  // WALKOVER, unattributable to any upstream individual — so this is `producedExitStatus`, not a
-  // third inline copy of the mapping. It previously read `=== DOUBLE_DEFAULT ? DEFAULTED : WALKOVER`
-  // at both sites, which stamped a default on a matchUp nobody played.
+  // What the double exit PRODUCES, through the single implementation rather than another inline copy
+  // of the mapping — it read `=== DOUBLE_DEFAULT ? DEFAULTED : WALKOVER` at both sites, two of four
+  // independent derivations of one rule.
+  //
+  // A UNIFORM double exit produces its own flavour: DOUBLE_DEFAULT produces DEFAULTED. The
+  // unattributed WALKOVER belongs to the MIXED case and is decided by `collapseDoubleExitStatus`
+  // choosing DOUBLE_WALKOVER for the convergence, not here. (An earlier revision of this comment
+  // said either flavour produces a WALKOVER; that over-read the ruling and the code was reverted
+  // while the comment was not.)
   const EXIT = producedExitStatus(params.matchUpStatus) as string;
 
   const stack = 'conditionallyAdvanceDrawPosition';
@@ -259,7 +280,6 @@ function conditionallyAdvanceDrawPosition(params) {
     sameStructure,
     paramMatchUpStatus: params.matchUpStatus,
     EXIT,
-    DOUBLE_EXIT,
   });
 
   // ensure targetMatchUp.drawPositions does not contain sourceMatchUp.drawPositions
@@ -334,6 +354,11 @@ function conditionallyAdvanceDrawPosition(params) {
   // assign the WALKOVER status to targetMatchUp
   const existingExit = isExit(noContextTargetMatchUp.matchUpStatus) && !drawPositions.length;
 
+  // Derived HERE, not at the top of the function, because this is where the other origin is known:
+  // `existingExit` means the target already carries the exit the first arrival produced. See
+  // handleEmptyExitLoser for the order-dependence measurement this removes.
+  const DOUBLE_EXIT = collapseDoubleExitStatus([params.matchUpStatus, noContextTargetMatchUp.matchUpStatus]);
+
   const matchUpStatus = existingExit ? DOUBLE_EXIT : EXIT;
 
   logAdvancement(stack, {
@@ -406,7 +431,10 @@ function conditionallyAdvanceDrawPosition(params) {
   });
   if (result.error) return decorateResult({ result, stack });
 
-  setSideExitProvenance({ matchUp: noContextTargetMatchUp, provenance: sideExitProvenance });
+  // ACCUMULATE, not replace: one side's origin can arrive before the other's, so a write that knows
+  // only its own side must not wipe an origin recorded earlier. CA, 2026-09-12: *"provenance is
+  // provenance… where did the sides come from. One origin can arrive before the other."*
+  mergeSideExitProvenance({ matchUp: noContextTargetMatchUp, provenance: sideExitProvenance });
 
   return advanceFromTarget({
     pairedPreviousMatchUpIsDoubleExit,

--- a/src/mutate/matchUps/matchUpStatus/sideExitProvenance.ts
+++ b/src/mutate/matchUps/matchUpStatus/sideExitProvenance.ts
@@ -5,7 +5,14 @@ import { isAnyExit } from '@Validators/isExit';
 
 // constants and types
 import { MatchUp, SideExitProvenance, SideExitProvenanceEntry } from '@Types/tournamentTypes';
-import { DOUBLE_WALKOVER, DOUBLE_DEFAULT, DEFAULTED, RETIRED, WALKOVER } from '@Constants/matchUpStatusConstants';
+import {
+  DOUBLE_WALKOVER,
+  DOUBLE_DEFAULT,
+  TO_BE_PLAYED,
+  DEFAULTED,
+  RETIRED,
+  WALKOVER,
+} from '@Constants/matchUpStatusConstants';
 
 /**
  * Paired writer/reader for `matchUp.sideExitProvenance`.
@@ -96,17 +103,37 @@ export function buildSideExitProvenance(params: BuildArgs): SideExitProvenance |
   if (sourceSideNumber !== 1 && sourceSideNumber !== 2) return undefined;
 
   const pairedSideNumber = sourceSideNumber === 1 ? 2 : 1;
+  // An entry records where a side CAME FROM — it exited upstream, or it won and advanced. What it
+  // must never record is a side that has not been decided at all.
+  //
+  // The paired previous matchUp is frequently still `TO_BE_PLAYED` when this runs, because the other
+  // feeder has not been played yet, and that was stamped as
+  // `{ matchUpStatus: TO_BE_PLAYED, previousMatchUpStatus: TO_BE_PLAYED }` — provenance asserting an
+  // origin for a side that has none. It matters because `exitProducedByPropagation` reads the mere
+  // PRESENCE of provenance, so an undecided side read as propagation-produced.
+  //
+  // A COMPLETED origin IS recorded, deliberately: `sideExitProvenance.test.ts` pins a double exit
+  // meeting a played win, and that opponent's origin is a real fact.
+  const isDecided = (status?: string) => !!status && status !== TO_BE_PLAYED;
   const provenance: SideExitProvenance = {
-    [sourceSideNumber]: definedAttributes({
-      matchUpStatus: producedExitStatus(sourceMatchUpStatus),
-      previousMatchUpStatus: sourceMatchUpStatus,
-      sourceMatchUpId,
-    }) as SideExitProvenanceEntry,
-    [pairedSideNumber]: definedAttributes({
-      matchUpStatus: producedExitStatus(pairedMatchUpStatus),
-      previousMatchUpStatus: pairedMatchUpStatus,
-      sourceMatchUpId: pairedMatchUpId,
-    }) as SideExitProvenanceEntry,
+    ...(isDecided(sourceMatchUpStatus)
+      ? {
+          [sourceSideNumber]: definedAttributes({
+            matchUpStatus: producedExitStatus(sourceMatchUpStatus),
+            previousMatchUpStatus: sourceMatchUpStatus,
+            sourceMatchUpId,
+          }) as SideExitProvenanceEntry,
+        }
+      : {}),
+    ...(isDecided(pairedMatchUpStatus)
+      ? {
+          [pairedSideNumber]: definedAttributes({
+            matchUpStatus: producedExitStatus(pairedMatchUpStatus),
+            previousMatchUpStatus: pairedMatchUpStatus,
+            sourceMatchUpId: pairedMatchUpId,
+          }) as SideExitProvenanceEntry,
+        }
+      : {}),
   };
 
   // an entry with nothing in it is noise; drop it rather than persist an empty object
@@ -233,6 +260,17 @@ export function clearResolvedSideExitProvenance(matchUp?: MatchUp): void {
  * The fallback exists so a record written before this field — or by a LEGACY-mode writer — still
  * answers. It reads only the provenance SHAPE out of `matchUpStatusCodes`; policy codes and
  * `{ code }` wrappers are not provenance and are ignored.
+ *
+ * NATIVE WINS WHOLE, deliberately, and this was tried the other way. Merging per side looks
+ * strictly more informative — it would recover a side the half-written native field omits — but
+ * measured on the consolation convergence path the legacy array is BOTH order-dependent and
+ * self-inconsistent there: one order stores `{ matchUpStatus: DEFAULTED, previousMatchUpStatus:
+ * DOUBLE_WALKOVER }`, a walkover origin producing a default. Merging imported that corruption into
+ * a field which was correct, so the native record is kept intact instead.
+ *
+ * The consequence is a real limit rather than a fix: where the native field is single-sided, this
+ * returns one side. Completing it means fixing the WRITER to record both origins, which is the
+ * `matchUpStatusCodes`-becomes-a-projection work — see MATCHUP_STATUS_CODES_PER_SIDE.md.
  */
 export function getSideExitProvenance({ matchUp }: { matchUp?: MatchUp }): SideExitProvenance | undefined {
   const native = matchUp?.sideExitProvenance;

--- a/src/tests/mutations/exitPropagation/entryOrderInvariance.test.ts
+++ b/src/tests/mutations/exitPropagation/entryOrderInvariance.test.ts
@@ -1,0 +1,108 @@
+import { setSubscriptions } from '@Global/state/globalState';
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { expect, it } from 'vitest';
+
+import {
+  FIRST_ROUND_LOSER_CONSOLATION,
+  FIRST_MATCH_LOSER_CONSOLATION,
+  FEED_IN_CHAMPIONSHIP,
+  SINGLE_ELIMINATION,
+  DOUBLE_ELIMINATION,
+  COMPASS,
+} from '@Constants/drawDefinitionConstants';
+import { DOUBLE_DEFAULT, DOUBLE_WALKOVER } from '@Constants/matchUpStatusConstants';
+
+/**
+ * Entering the same two double exits in either order must produce the same record.
+ *
+ * `doubleExitAdvancement` derived the converged status from the ARRIVING source alone — at
+ * `handleEmptyExitLoser` and at `conditionallyAdvanceDrawPosition` — so the stored `matchUpStatus`
+ * was a function of tournament state PLUS the order the operator entered the two results. Measured
+ * before the fix across 8 draw-type/size combinations x 4 status pairs: **28 of 32 differed**. A
+ * director entering the same two walkovers in the other order got a different record.
+ *
+ * Both sites now derive it with `collapseDoubleExitStatus` from BOTH origins, the second of which is
+ * the exit the first arrival already produced on the target.
+ *
+ * WHAT THIS ASSERTS, and what it deliberately does not:
+ *
+ *  - ASSERTED: the converged `matchUpStatus` and `winningSide`, across every structure the pair
+ *    touches. This is what the fix addresses and what a tournament director sees.
+ *  - NOT ASSERTED: the per-side record. Measured on the consolation convergence path, the native
+ *    `sideExitProvenance` is correct in both orders but SINGLE-SIDED — and which side it holds
+ *    depends on entry order — while the legacy `matchUpStatusCodes` array is both order-dependent
+ *    and self-inconsistent there, one order storing
+ *    `{ matchUpStatus: DEFAULTED, previousMatchUpStatus: DOUBLE_WALKOVER }`: a walkover origin
+ *    producing a default. Asserting either would pin a defect. Completing the per-side record means
+ *    fixing the WRITER to record both origins, which is the `matchUpStatusCodes`-becomes-a-
+ *    projection work in MATCHUP_STATUS_CODES_PER_SIDE.md.
+ *
+ * Generated ids are excluded: each run builds a fresh tournament, so any id differs by construction.
+ * An earlier version of this measurement compared `sourceMatchUpId` and reported 32 of 32 differing
+ * — including uniform pairs, which cannot differ by flavour — and that impossible result is how the
+ * flaw in the measurement surfaced.
+ */
+
+function playInOrder({ drawType, drawSize, statuses, order }: any) {
+  const drawId = `order-${drawType}-${drawSize}-${statuses.join('')}-${order.join('')}`;
+  setSubscriptions({});
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ drawId, drawSize, drawType, participantsCount: drawSize }],
+    nonRandom: 1,
+    setState: true,
+  });
+
+  const roundOne = () =>
+    tournamentEngine
+      .allDrawMatchUps({ inContext: true, drawId })
+      .matchUps.filter((matchUp: any) => matchUp.roundNumber === 1 && matchUp.stage === 'MAIN')
+      .sort((a: any, b: any) => a.roundPosition - b.roundPosition);
+
+  for (const index of order) {
+    const target = roundOne().find((matchUp: any) => matchUp.roundPosition === index + 1);
+    expect(target?.matchUpId).toBeDefined();
+    const result: any = tournamentEngine.setMatchUpStatus({
+      outcome: { matchUpStatus: statuses[index] },
+      matchUpId: target.matchUpId,
+      propagateExitStatus: true,
+      drawId,
+    });
+    expect(result.error).toBeUndefined();
+  }
+
+  return tournamentEngine
+    .allDrawMatchUps({ inContext: true, drawId })
+    .matchUps.filter((matchUp: any) => matchUp.matchUpStatus && matchUp.matchUpStatus !== 'TO_BE_PLAYED')
+    .map(
+      (matchUp: any) =>
+        `${matchUp.structureName}|r${matchUp.roundNumber}p${matchUp.roundPosition}|${matchUp.matchUpStatus}|ws=${matchUp.winningSide}`,
+    )
+    .sort();
+}
+
+it.each([
+  { drawType: SINGLE_ELIMINATION, drawSize: 8 },
+  { drawType: SINGLE_ELIMINATION, drawSize: 16 },
+  { drawType: FIRST_ROUND_LOSER_CONSOLATION, drawSize: 8 },
+  { drawType: FIRST_ROUND_LOSER_CONSOLATION, drawSize: 16 },
+  { drawType: FIRST_MATCH_LOSER_CONSOLATION, drawSize: 8 },
+  { drawType: FEED_IN_CHAMPIONSHIP, drawSize: 8 },
+  { drawType: DOUBLE_ELIMINATION, drawSize: 8 },
+  { drawType: COMPASS, drawSize: 8 },
+])('$drawType of $drawSize records two double exits the same way in either order', ({ drawType, drawSize }) => {
+  // uniform pairs and both mixed orderings; the mixed pair is where the flavour collapse matters
+  for (const statuses of [
+    [DOUBLE_WALKOVER, DOUBLE_WALKOVER],
+    [DOUBLE_DEFAULT, DOUBLE_DEFAULT],
+    [DOUBLE_WALKOVER, DOUBLE_DEFAULT],
+    [DOUBLE_DEFAULT, DOUBLE_WALKOVER],
+  ]) {
+    const forward = playInOrder({ drawType, drawSize, statuses, order: [0, 1] });
+    const reversed = playInOrder({ drawType, drawSize, statuses, order: [1, 0] });
+
+    // the control: the pair must actually have produced propagated state, or this passes vacuously
+    expect(forward.length, `${statuses.join('+')} produced no decided matchUps`).toBeGreaterThan(0);
+    expect(reversed, `${drawType}/${drawSize} ${statuses.join('+')} depends on entry order`).toEqual(forward);
+  }
+});


### PR DESCRIPTION
Base `dev` at `06d47b4c6`.

## The defect

`doubleExitAdvancement` derived which double exit a convergence becomes from the **arriving source alone** — at `handleEmptyExitLoser` and at `conditionallyAdvanceDrawPosition`:

```ts
const DOUBLE_EXIT = params.matchUpStatus === DOUBLE_DEFAULT ? DOUBLE_DEFAULT : DOUBLE_WALKOVER;
```

The paired side is read thirty lines later and only for the per-side codes, so the collapsed status never saw it. **The stored `matchUpStatus` was therefore a function of tournament state PLUS the order the operator entered the two results.** Measured across 8 draw-type/size combinations × 4 status pairs: **28 of 32 differed by entry order**. A director entering the same two walkovers the other way round got a different record.

Both sites now derive it with `collapseDoubleExitStatus` from **both** origins — the second being the exit the first arrival already produced on the target. Passing that produced status beside the arriving raw one is sound because `producedExitStatus` preserves the flavour family, so the collapse classifies them identically either way.

## Three further corrections to the per-side record

Following CA's ruling of 2026-09-12 — provenance records where each side **came from**, one origin can arrive **before** the other, and provenance can **never** be `TO_BE_PLAYED`:

1. **`buildSideExitProvenance` no longer writes an UNDECIDED side.** The paired feeder is frequently still `TO_BE_PLAYED`, and that was stamped as `{ matchUpStatus: TO_BE_PLAYED, previousMatchUpStatus: TO_BE_PLAYED }` — an origin for a side that has none. It matters because `exitProducedByPropagation` reads the mere *presence* of provenance, so an undecided side read as propagation-produced.
2. **The convergence write ACCUMULATES** rather than replaces, so a write that knows only its own side cannot wipe an origin recorded earlier.
3. **`updateMatchUpStatusCodes`** is the site that *learns* a side's origin after the fact. It recorded it only in the legacy array, and it overwrote `previousMatchUpStatus` while leaving `matchUpStatus` stale — producing `{ DEFAULTED, DOUBLE_WALKOVER }`, a walkover origin producing a default. The two are a pair, are now written together, and the learned origin reaches `sideExitProvenance` too.

## Tests

`entryOrderInvariance.test.ts` — 8 draw types × 4 status pairs including both mixed orderings. **8/8 RED against `dev`, 8/8 green with the fix.**

## Reported honestly

**The per-side record is NOT yet order-invariant, and the test deliberately does not assert it.** On the consolation convergence path the native `sideExitProvenance` is correct in both orders but **single-sided**, and which side it holds depends on entry order; the legacy `matchUpStatusCodes` array there is both order-dependent and self-inconsistent. Asserting either would pin a defect.

**I tried and reverted a reader-side fix for that.** Merging provenance per side — native winning each key, legacy filling the gaps — looks strictly more informative and does recover the missing side. But measured, it imports the legacy array's corruption into a field that was correct, so `getSideExitProvenance` keeps native-wins-whole and the finding is recorded in its docblock instead. Completing the per-side record means fixing the WRITER to record both origins, which is the `matchUpStatusCodes`-becomes-a-projection work.

**Census: 42 → 42 failing seeds, zero closed, zero new.** The sweep's properties do not observe which flavour a convergence takes, so this moves nothing there — stated plainly rather than dressed up. Full suite 13,056. `pnpm verify` exit 0.

**A measurement flaw worth recording:** the first version of the order-invariance probe compared `sourceMatchUpId` and reported 32 of 32 differing — including uniform pairs, which cannot differ by flavour. That impossible result is what exposed the flaw: each run builds a fresh tournament, so any generated id differs by construction. The test comments carry this.

Also corrects a stale comment I shipped in #4833, which described the over-read of the ruling that was reverted in the same session while the comment was not.