### PR TITLE
fix(participants): collapse whitespace in person names on write

### DIFF
--- a/src/helpers/normalizedPersonName.ts
+++ b/src/helpers/normalizedPersonName.ts
@@ -1,0 +1,32 @@
+import { collapseWhitespace } from '@Tools/strings';
+
+type PersonNames = {
+  standardFamilyName?: any;
+  standardGivenName?: any;
+};
+
+// The name fields whitespace is normalized on. Deliberately the two the factory
+// composes `participantName` from — widening this to every name-ish field on a
+// person would start rewriting values no comparison depends on.
+const NAME_KEYS = ['standardGivenName', 'standardFamilyName'] as const;
+
+// Mutate a person in place, collapsing whitespace runs in its standard names.
+// No-op when the person is absent or a name is not a string.
+//
+// Person names reach the factory from forms and spreadsheets that trim
+// inconsistently or not at all, and a trailing space in a given-name field
+// composes a participantName with a double space in the middle of it. HTML
+// collapses that run when it renders, so nothing looks wrong until something
+// compares the string — a schedule search for 'Michael Livson' skipping past the
+// cell that plainly reads "Michael Livson" is how this surfaces.
+//
+// Normalizing here rather than at each caller is what makes the guarantee hold
+// for every consumer: the client's edit form, the server's import paths, and
+// anything else that reaches addParticipant/modifyParticipant.
+export function normalizePersonNames(person?: PersonNames): void {
+  if (!person) return;
+  for (const key of NAME_KEYS) {
+    const normalized = collapseWhitespace(person[key]);
+    if (normalized !== person[key]) person[key] = normalized;
+  }
+}

--- a/src/mutate/participants/addParticipant.ts
+++ b/src/mutate/participants/addParticipant.ts
@@ -1,9 +1,11 @@
 import { generatePairParticipantName } from '@Functions/participants/generatePairParticipantName';
+import { normalizePersonNames } from '@Helpers/normalizedPersonName';
 import { decorateResult } from '@Functions/global/decorateResult';
 import { definedAttributes } from '@Tools/definedAttributes';
 import { normalizeGender } from '@Helpers/coercedGender';
 import { coercePersonSex } from '@Helpers/coercedSex';
 import { addNotice } from '@Global/state/globalState';
+import { collapseWhitespace } from '@Tools/strings';
 import { makeDeepCopy } from '@Tools/makeDeepCopy';
 import { intersection } from '@Tools/arrays';
 import { UUID } from '@Tools/UUID';
@@ -184,6 +186,11 @@ export function addParticipant(params: AddParticipantType) {
   const baseError = validateBaseParticipant(participant, tournamentRecord);
   if (baseError) return decorateResult({ result: baseError, stack });
 
+  // A caller-supplied name gets the same whitespace guarantee as a composed one.
+  // Same reason, one layer up: whatever is stored here is what a search compares
+  // against later, and an interior double space makes that comparison lie.
+  if (participant.participantName) participant.participantName = collapseWhitespace(participant.participantName);
+
   const { participantType } = participant;
   const tournamentParticipants = tournamentRecord.participants ?? [];
   const tournamentIndividualParticipantIds = tournamentParticipants
@@ -206,6 +213,9 @@ export function addParticipant(params: AddParticipantType) {
   } else if (participantType === INDIVIDUAL) {
     // normalize accepted sex short codes (F/M/O) to the canonical extended form at rest
     coercePersonSex(participant.person);
+    // and collapse whitespace runs in the names participantName is composed from,
+    // so a trailing space in a given name cannot produce 'Michael  Livson'
+    normalizePersonNames(participant.person);
     const hasPersonName = participant.person?.standardFamilyName && participant.person?.standardGivenName;
     const hasAlternateName = participant.participantOtherName || participant.participantName;
     if (!hasPersonName && !hasAlternateName) return { error: MISSING_PERSON_DETAILS };

--- a/src/mutate/participants/modifyParticipant.ts
+++ b/src/mutate/participants/modifyParticipant.ts
@@ -8,6 +8,7 @@ import { participantRoles } from '@Constants/participantRoles';
 import { definedAttributes } from '@Tools/definedAttributes';
 import { modifyParticipantsNotice } from '@Mutate/notifications/participantNotifications';
 import { isValidDateString } from '@Tools/dateTime';
+import { collapseWhitespace } from '@Tools/strings';
 import { makeDeepCopy } from '@Tools/makeDeepCopy';
 import { countries } from '@Fixtures/countryData';
 import { addParticipant } from './addParticipant';
@@ -70,7 +71,8 @@ export function modifyParticipant(params) {
   if (onlineResources) newValues.onlineResources = onlineResources;
 
   if (participantOtherName !== undefined) newValues.participantOtherName = participantOtherName || undefined;
-  const suppliedParticipantName = participantName && isString(participantName) ? participantName : undefined;
+  const suppliedParticipantName =
+    participantName && isString(participantName) ? collapseWhitespace(participantName) : undefined;
   if (suppliedParticipantName) newValues.participantName = suppliedParticipantName;
 
   if (Array.isArray(individualParticipantIds)) {
@@ -191,8 +193,16 @@ function isClearRequest(value) {
 function updatePerson({ updateParticipantName, existingParticipant, newValues, person }) {
   const newPersonValues: any = {};
   const clearedKeys: string[] = [];
-  const { standardFamilyName, standardGivenName, nationalityCode, personId, birthDate, tennisId, sex, contacts } =
-    person;
+  const { nationalityCode, personId, birthDate, tennisId, sex, contacts } = person;
+
+  // Names are whitespace-normalized before they are measured or stored. Before, a
+  // trailing space in a given-name field survived to compose 'Michael  Livson' —
+  // a participantName that renders correctly (HTML collapses the run) and fails
+  // every string comparison made against it afterwards, which is how it hid.
+  // Normalizing ahead of the length check also stops ' A ' from passing a test
+  // that the value actually persisted ('A') would fail.
+  const standardFamilyName = collapseWhitespace(person.standardFamilyName);
+  const standardGivenName = collapseWhitespace(person.standardGivenName);
 
   // `person.contacts` had no write path anywhere in the factory — declared on the type, readable, and
   // impossible to persist. That made `Contact.isPublic` inert by construction: nothing could set it, so
@@ -215,19 +225,26 @@ function updatePerson({ updateParticipantName, existingParticipant, newValues, p
     newPersonValues.nationalityCode = nationalityCode;
   }
 
-  if (standardFamilyName && typeof isString(standardFamilyName) && standardFamilyName.length > 1) {
+  if (standardFamilyName && isString(standardFamilyName) && standardFamilyName.length > 1) {
     newPersonValues.standardFamilyName = standardFamilyName;
     personNameModified = true;
   }
 
-  if (standardGivenName && typeof isString(standardGivenName) && standardGivenName.length > 1) {
+  if (standardGivenName && isString(standardGivenName) && standardGivenName.length > 1) {
     newPersonValues.standardGivenName = standardGivenName;
     personNameModified = true;
   }
 
   if (personNameModified && updateParticipantName) {
-    const givenName = newPersonValues.standardGivenName || existingParticipant.person?.standardGivenName;
-    const familyName = newPersonValues.standardFamilyName || existingParticipant.person?.standardFamilyName;
+    // Collapsed on the existing values too, not only the incoming ones: a record
+    // that already carries 'Michael ' would otherwise re-compose the double space
+    // whenever the OTHER name is the one being edited.
+    const givenName = collapseWhitespace(
+      newPersonValues.standardGivenName || existingParticipant.person?.standardGivenName,
+    );
+    const familyName = collapseWhitespace(
+      newPersonValues.standardFamilyName || existingParticipant.person?.standardFamilyName,
+    );
     if (givenName && familyName) {
       newValues.participantName = `${givenName} ${familyName}`;
     } else {

--- a/src/tests/mutations/participants/personNameWhitespace.test.ts
+++ b/src/tests/mutations/participants/personNameWhitespace.test.ts
@@ -1,0 +1,103 @@
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { expect, it } from 'vitest';
+
+// constants and types
+import { INDIVIDUAL } from '@Constants/participantConstants';
+import { COMPETITOR } from '@Constants/participantRoles';
+
+/**
+ * Whitespace in a person name is invisible until something compares the string.
+ *
+ * A trailing space left in a first-name field composes `'Michael  Livson'`, which
+ * renders correctly everywhere — HTML collapses the run — and then fails to match
+ * a search for `'Michael Livson'`. These cover the write boundaries so no consumer
+ * can compose one.
+ */
+
+it('collapses whitespace in the person names addParticipant composes from', () => {
+  const { tournamentRecord } = mocksEngine.generateTournamentRecord();
+  tournamentEngine.setState(tournamentRecord);
+
+  const result: any = tournamentEngine.addParticipant({
+    participant: {
+      participantType: INDIVIDUAL,
+      participantRole: COMPETITOR,
+      person: {
+        standardGivenName: 'Michael ',
+        standardFamilyName: ' Livson',
+      },
+    },
+    returnParticipant: true,
+  });
+
+  expect(result.success).toEqual(true);
+  expect(result.participant.person.standardGivenName).toEqual('Michael');
+  expect(result.participant.person.standardFamilyName).toEqual('Livson');
+  expect(result.participant.participantName).toEqual('Michael Livson');
+});
+
+it('collapses whitespace in a participantName supplied to addParticipant', () => {
+  const { tournamentRecord } = mocksEngine.generateTournamentRecord();
+  tournamentEngine.setState(tournamentRecord);
+
+  const result: any = tournamentEngine.addParticipant({
+    participant: {
+      participantType: INDIVIDUAL,
+      participantRole: COMPETITOR,
+      participantName: '  Michael   Livson  ',
+      person: { standardGivenName: 'Michael', standardFamilyName: 'Livson' },
+    },
+    returnParticipant: true,
+  });
+
+  expect(result.success).toEqual(true);
+  expect(result.participant.participantName).toEqual('Michael Livson');
+});
+
+it('collapses whitespace in the person names modifyParticipant composes from', () => {
+  const { tournamentRecord } = mocksEngine.generateTournamentRecord();
+  tournamentEngine.setState(tournamentRecord);
+
+  const { participants } = tournamentEngine.getParticipants();
+  const { participantId } = participants[0];
+
+  const result: any = tournamentEngine.modifyParticipant({
+    participant: {
+      participantId,
+      participantType: INDIVIDUAL,
+      person: { standardGivenName: 'Michael ', standardFamilyName: 'Livson' },
+    },
+  });
+  expect(result.success).toEqual(true);
+
+  const { participants: modified } = tournamentEngine.getParticipants();
+  const participant: any = modified.find((p: any) => p.participantId === participantId);
+  expect(participant.person.standardGivenName).toEqual('Michael');
+  expect(participant.participantName).toEqual('Michael Livson');
+});
+
+it('repairs a stored double space when the OTHER name is the one being edited', () => {
+  // The regression this guards: normalizing only the INCOMING values leaves a
+  // record that already carries 'Michael ' re-composing the double space every
+  // time its family name is edited.
+  const { tournamentRecord } = mocksEngine.generateTournamentRecord();
+  const individual: any = tournamentRecord.participants?.find((p: any) => p.participantType === INDIVIDUAL);
+  individual.person.standardGivenName = 'Michael ';
+  individual.person.standardFamilyName = 'Livsen';
+  individual.participantName = 'Michael  Livsen';
+  tournamentEngine.setState(tournamentRecord);
+
+  const result: any = tournamentEngine.modifyParticipant({
+    participant: {
+      participantId: individual.participantId,
+      participantType: INDIVIDUAL,
+      person: { standardFamilyName: 'Livson' },
+    },
+  });
+  expect(result.success).toEqual(true);
+
+  const { participants } = tournamentEngine.getParticipants();
+  const participant: any = participants.find((p: any) => p.participantId === individual.participantId);
+  expect(participant.participantName).toEqual('Michael Livson');
+});

--- a/src/tools/strings.ts
+++ b/src/tools/strings.ts
@@ -17,3 +17,19 @@ export function capitalizeFirst(str) {
 export function constantToString(str) {
   return !isString(str) ? '' : capitalizeFirst(str.replace(/_/g, ' '));
 }
+
+/**
+ * Collapse every run of whitespace to a single space and trim the ends.
+ *
+ * Names arrive from forms and spreadsheets carrying whitespace nobody typed on
+ * purpose — a trailing space left in a first-name field, a double space pasted
+ * out of a roster. HTML collapses the run when it renders, so the artifact is
+ * invisible on screen and surfaces only where a string is compared: a search for
+ * `'Michael Livson'` misses the stored `'Michael  Livson'`. Trimming alone never
+ * reaches an interior run, which is why this collapses rather than trims.
+ *
+ * Non-strings pass through untouched, matching `capitalizeFirst`.
+ */
+export function collapseWhitespace(str) {
+  return !isString(str) ? str : str.replace(/\s+/g, ' ').trim();
+}


### PR DESCRIPTION
## The defect

A participant is stored as `'Michael  Livson'` — an interior double space. HTML collapses the run when it paints, so the name reads correctly in every view and the artifact is invisible until something **compares** the string. It surfaced in TMX's schedule search: `'Michael'` highlighted the cell, `'Michael Livson'` highlighted nothing.

## Where it comes from

The factory did **no** whitespace normalization on person names anywhere — verified by grep, not memory. Both write paths composed the name verbatim:

- `addParticipant.ts` — `` `${person.standardGivenName} ${person.standardFamilyName}` ``
- `modifyParticipant.ts` — the same, in `updatePerson`

So a trailing space typed into a first-name field on any consumer (the TMX edit form, an import path on the server) became a double space in `participantName`, and no caller could produce a clean one from dirty input.

## The fix

- **`collapseWhitespace`** (`@Tools/strings`) — collapse every whitespace run to one space, trim the ends. Collapsing rather than trimming is the point: `trim()` never reaches an interior run pasted out of a roster.
- **`normalizePersonNames`** (`@Helpers/normalizedPersonName`) — mutates a person in place, mirroring the existing `coercePersonSex` shape and called right beside it.
- Applied at three points: the composed name, a **caller-supplied** `participantName`, and the **existing stored** values when only one of the two names is being edited. That last one matters — a record already holding `'Michael '` would otherwise re-compose the double space every time its family name changed. As a side effect, editing either half of such a name now repairs the stored `participantName`.

Normalizing ahead of the `length > 1` gate also stops `' A '` from passing a check that the value actually persisted (`'A'`) would fail.

### One adjacent correction

The two lines this touches read `typeof isString(name)` where they meant `isString(name)`. `typeof x` is always a non-empty string, so the guard was inert and a non-string carrying a `.length` could reach the store. Corrected rather than left in place, since the condition is being edited anyway.

## Not done, deliberately

Records already carrying a double space are **not** repaired. They stay findable because TMX normalizes on read ([#1444(TMX)](https://github.com/CourtHive/TMX/pull/1444)). A repair sweep remains available if the stored values themselves ever need to be clean.

## Verification

- Full suite **13052 passed / 2 skipped**; `check-types`, `lint`, `verify:format`, `verify:generated`, `verify:attr-audit`, `verify:migration-coverage` all clean.
- **Falsified, not assumed**: neutralizing `collapseWhitespace` to the identity turns all four new tests red (4 failed / 4). The fourth — "repairs a stored double space when the OTHER name is the one being edited" — is the one that catches normalizing only the incoming values.
- `verify:build` / `verify:coverage` were not run locally: `verify:build` opens with `rimraf dist`, and the linked `factory/dist` was being served to a live Playwright run at the time. CI's verify gate covers both.