### PR TITLE
fix(draws): generate matchUpStatusCodes from sideExitProvenance in the double-exit cascade

### DIFF
--- a/src/mutate/drawDefinitions/positionGovernor/doubleExitAdvancement.ts
+++ b/src/mutate/drawDefinitions/positionGovernor/doubleExitAdvancement.ts
@@ -7,15 +7,17 @@ import { modifyMatchUpScore } from '@Mutate/matchUps/score/modifyMatchUpScore';
 import { directWinner } from '@Mutate/matchUps/drawPositions/directWinner';
 import { decorateResult } from '@Functions/global/decorateResult';
 import { positionTargets } from '@Query/matchUp/positionTargets';
-import { definedAttributes } from '@Tools/definedAttributes';
 import { pushGlobalLog } from '@Functions/global/globalLog';
 import { findStructure } from '@Acquire/findStructure';
 import { isDoubleExit, isExit } from '@Validators/isExit';
 import { overlap } from '@Tools/arrays';
 import {
+  buildCarriedExitProvenance,
   collapseDoubleExitStatus,
+  projectExitStatusCodes,
   buildSideExitProvenance,
   mergeSideExitProvenance,
+  getSideExitProvenance,
   producedExitStatus,
 } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
 
@@ -145,7 +147,7 @@ function handleLoserMatchUp({
   }
 
   if (loserMatchUpIsEmptyExit) {
-    return handleEmptyExitLoser({ loserMatchUp, matchUpsMap, params, stack });
+    return handleEmptyExitLoser({ loserTargetDrawPosition, sourceMatchUp, loserMatchUp, matchUpsMap, params, stack });
   }
 
   if (loserMatchUpIsDoubleExit) {
@@ -176,7 +178,7 @@ function handleLoserMatchUp({
   });
 }
 
-function handleEmptyExitLoser({ loserMatchUp, matchUpsMap, params, stack }) {
+function handleEmptyExitLoser({ loserTargetDrawPosition, sourceMatchUp, loserMatchUp, matchUpsMap, params, stack }) {
   // WHICH double exit this convergence becomes, from BOTH origins rather than the arriving one
   // alone. `loserMatchUp` already carries the exit produced by the first arrival, which IS the other
   // side's origin.
@@ -189,16 +191,6 @@ function handleEmptyExitLoser({ loserMatchUp, matchUpsMap, params, stack }) {
   // `producedExitStatus` preserves the flavour family — DOUBLE_DEFAULT produces DEFAULTED, both
   // default-flavoured — so the collapse classifies them the same either way.
   const DOUBLE_EXIT = collapseDoubleExitStatus([params.matchUpStatus, loserMatchUp?.matchUpStatus]);
-  // What the double exit PRODUCES, through the single implementation rather than another inline copy
-  // of the mapping — it read `=== DOUBLE_DEFAULT ? DEFAULTED : WALKOVER` at both sites, two of four
-  // independent derivations of one rule.
-  //
-  // A UNIFORM double exit produces its own flavour: DOUBLE_DEFAULT produces DEFAULTED. The
-  // unattributed WALKOVER belongs to the MIXED case and is decided by `collapseDoubleExitStatus`
-  // choosing DOUBLE_WALKOVER for the convergence, not here. (An earlier revision of this comment
-  // said either flavour produces a WALKOVER; that over-read the ruling and the code was reverted
-  // while the comment was not.)
-  const EXIT = producedExitStatus(params.matchUpStatus) as string;
 
   const noContextLoserMatchUp = matchUpsMap.drawMatchUps.find(
     (matchUp) => matchUp.matchUpId === loserMatchUp.matchUpId,
@@ -213,12 +205,40 @@ function handleEmptyExitLoser({ loserMatchUp, matchUpsMap, params, stack }) {
   });
 
   if (noContextLoserMatchUp) {
-    const matchUpStatusCodes = [
-      { matchUpStatus: EXIT, previousMatchUpStatus: DOUBLE_EXIT, sideNumber: 1 },
-      { matchUpStatus: EXIT, previousMatchUpStatus: params.matchUpStatus, sideNumber: 2 },
-    ].map((code) => definedAttributes(code));
+    // This is the SECOND arrival at a convergence: the target already carries the exit the first
+    // arrival produced, and — measured over the exit-propagation suite, 222 of 223 firings — already
+    // carries that side's provenance. Recording the arriving side and projecting the codes from the
+    // union is what makes the pair order-invariant.
+    //
+    // The arriving side is where the cascade is directing this loser. `loserTargetDrawPosition` names
+    // that drawPosition and the target's `drawPositions` are in side order, which is the same
+    // derivation the sibling non-empty branch uses for `walkoverWinningSide`. Measured across those
+    // 223 firings it resolves to a valid side every time, and to the side the existing provenance
+    // does NOT hold in every case but one — a re-score of the same side, where replacing is right.
+    const exitingSideNumber = (loserMatchUp.drawPositions ?? []).indexOf(loserTargetDrawPosition) + 1;
+    const arrivingProvenance = buildCarriedExitProvenance({
+      previousMatchUpStatus: params.matchUpStatus,
+      sourceMatchUpId: sourceMatchUp?.matchUpId,
+      matchUpStatus: params.matchUpStatus,
+      exitingSideNumber,
+    });
+    // `getSideExitProvenance` rather than the raw field so the union still finds the first arrival's
+    // origin under LEGACY write mode, where nothing writes the native field.
+    const provenance = {
+      ...(getSideExitProvenance({ matchUp: noContextLoserMatchUp }) ?? {}),
+      ...(arrivingProvenance ?? {}),
+    };
 
-    return modifyMatchUpScore({
+    // GENERATED, not hand-built. The previous pair was `[{ matchUpStatus: EXIT, previousMatchUpStatus:
+    // DOUBLE_EXIT, sideNumber: 1 }, { matchUpStatus: EXIT, previousMatchUpStatus: params.matchUpStatus,
+    // sideNumber: 2 }]`, which was wrong in three ways at once: side 1's `previousMatchUpStatus` was
+    // the target's own COLLAPSED status rather than an origin, both sides took the ARRIVING exit's
+    // produced status, and the write replaced an array whose other entry was still true. In the mixed
+    // case that stored `{ matchUpStatus: DEFAULTED, previousMatchUpStatus: DOUBLE_WALKOVER }` — a
+    // walkover origin producing a default — and it stored the opposite in the opposite entry order.
+    const matchUpStatusCodes = projectExitStatusCodes(provenance);
+
+    const result = modifyMatchUpScore({
       ...params,
       matchUp: noContextLoserMatchUp,
       matchUpId: loserMatchUp.matchUpId,
@@ -228,6 +248,10 @@ function handleEmptyExitLoser({ loserMatchUp, matchUpsMap, params, stack }) {
       removeScore: true,
       context: stack,
     });
+    if (result.error) return result;
+
+    mergeSideExitProvenance({ matchUp: noContextLoserMatchUp, provenance });
+    return result;
   }
 
   return { ...SUCCESS };
@@ -392,22 +416,29 @@ function conditionallyAdvanceDrawPosition(params) {
   const sourceMatchUpStatus = params.matchUpStatus;
   const pairedMatchUpStatus = pairedPreviousMatchUp?.matchUpStatus;
 
-  const matchUpStatusCodes = buildMatchUpStatusCodes({
-    sourceMatchUpStatus,
-    pairedMatchUpStatus,
-    sourceSideNumber,
-  });
-
-  // CODES first-class: the same facts, keyed by sideNumber and attributed to their source.
-  // Written alongside the legacy array, not instead of it — see sideExitProvenance.ts on why the
-  // legacy write is not yet gated on writeLegacyEnabled().
-  const sideExitProvenance = buildSideExitProvenance({
+  // CODES first-class: the facts, keyed by sideNumber and attributed to their source.
+  const newProvenance = buildSideExitProvenance({
     pairedMatchUpId: pairedPreviousMatchUp?.matchUpId,
     sourceMatchUpId: sourceMatchUp?.matchUpId,
     pairedMatchUpStatus,
     sourceMatchUpStatus,
     sourceSideNumber,
   });
+
+  // Provenance ACCUMULATES — one side's origin can arrive before the other's — so the union of what
+  // the target already holds and what this write establishes is the record, and the legacy array is
+  // its projection. `getSideExitProvenance` rather than the raw field so the union still finds an
+  // earlier origin under LEGACY write mode, where nothing writes the native field.
+  const provenance = {
+    ...(getSideExitProvenance({ matchUp: noContextTargetMatchUp }) ?? {}),
+    ...(newProvenance ?? {}),
+  };
+
+  // A PROJECTION of provenance, replacing a second, independent derivation of the same facts. Where
+  // this write establishes no provenance at all — `sourceSideNumber` unknown, so neither structure
+  // can attribute anything — the array is blanked exactly as the previous builder blanked it, rather
+  // than re-projecting state this write knows nothing about.
+  const matchUpStatusCodes = newProvenance ? projectExitStatusCodes(provenance) : [];
 
   logAdvancement(stack, {
     color: 'brightgreen',
@@ -434,7 +465,7 @@ function conditionallyAdvanceDrawPosition(params) {
   // ACCUMULATE, not replace: one side's origin can arrive before the other's, so a write that knows
   // only its own side must not wipe an origin recorded earlier. CA, 2026-09-12: *"provenance is
   // provenance… where did the sides come from. One origin can arrive before the other."*
-  mergeSideExitProvenance({ matchUp: noContextTargetMatchUp, provenance: sideExitProvenance });
+  mergeSideExitProvenance({ matchUp: noContextTargetMatchUp, provenance: newProvenance });
 
   return advanceFromTarget({
     pairedPreviousMatchUpIsDoubleExit,
@@ -494,42 +525,6 @@ function inferSourceSideNumber({
   });
 
   return sourceSideNumber;
-}
-
-function buildMatchUpStatusCodes({ sourceMatchUpStatus, pairedMatchUpStatus, sourceSideNumber }) {
-  let matchUpStatusCodes: any[] = [];
-
-  if (sourceSideNumber === 1) {
-    matchUpStatusCodes = [
-      {
-        matchUpStatus: producedExitStatus(sourceMatchUpStatus),
-        previousMatchUpStatus: sourceMatchUpStatus,
-        sideNumber: 1,
-      },
-      {
-        matchUpStatus: producedExitStatus(pairedMatchUpStatus),
-        previousMatchUpStatus: pairedMatchUpStatus,
-        sideNumber: 2,
-      },
-    ];
-  } else if (sourceSideNumber === 2) {
-    matchUpStatusCodes = [
-      {
-        matchUpStatus: producedExitStatus(pairedMatchUpStatus),
-        previousMatchUpStatus: pairedMatchUpStatus,
-        sideNumber: 1,
-      },
-      {
-        matchUpStatus: producedExitStatus(sourceMatchUpStatus),
-        previousMatchUpStatus: sourceMatchUpStatus,
-        sideNumber: 2,
-      },
-    ];
-  }
-
-  if (matchUpStatusCodes.length) matchUpStatusCodes = matchUpStatusCodes.map((code) => definedAttributes(code));
-
-  return matchUpStatusCodes;
 }
 
 function advanceFromTarget({

--- a/src/mutate/matchUps/drawPositions/assignMatchUpDrawPosition.ts
+++ b/src/mutate/matchUps/drawPositions/assignMatchUpDrawPosition.ts
@@ -252,8 +252,8 @@ function resolveMatchUpStatus({ isByeMatchUp, matchUpStatus, isDoubleExitExit, m
  * The array holds THREE shapes, which is the root problem:
  *   1. policy codes      `{ matchUpStatusCode, label, matchUpStatusCodeDisplay }` — the scoring
  *                        policy's vocabulary (see POLICY_SCORING_USTA)
- *   2. exit provenance   `{ matchUpStatus, previousMatchUpStatus, sideNumber }` — written by
- *                        doubleExitAdvancement.buildMatchUpStatusCodes
+ *   2. exit provenance   `{ matchUpStatus, previousMatchUpStatus, sideNumber }` — projected from
+ *                        `sideExitProvenance` by `projectExitStatusCodes`
  *   3. wrapped codes     `{ code }` — written by updateMatchUpStatusCodes, which wraps any string
  *                        element before stamping `previousMatchUpStatus` onto it
  *

--- a/src/mutate/matchUps/matchUpStatus/sideExitProvenance.ts
+++ b/src/mutate/matchUps/matchUpStatus/sideExitProvenance.ts
@@ -262,15 +262,16 @@ export function clearResolvedSideExitProvenance(matchUp?: MatchUp): void {
  * `{ code }` wrappers are not provenance and are ignored.
  *
  * NATIVE WINS WHOLE, deliberately, and this was tried the other way. Merging per side looks
- * strictly more informative — it would recover a side the half-written native field omits — but
- * measured on the consolation convergence path the legacy array is BOTH order-dependent and
- * self-inconsistent there: one order stores `{ matchUpStatus: DEFAULTED, previousMatchUpStatus:
- * DOUBLE_WALKOVER }`, a walkover origin producing a default. Merging imported that corruption into
- * a field which was correct, so the native record is kept intact instead.
+ * strictly more informative — it would recover a side the half-written native field omits — but at
+ * the time it was measured the legacy array was BOTH order-dependent and self-inconsistent on the
+ * consolation convergence path: one entry order stored `{ matchUpStatus: DEFAULTED,
+ * previousMatchUpStatus: DOUBLE_WALKOVER }`, a walkover origin producing a default. Merging imported
+ * that corruption into a field which was correct.
  *
- * The consequence is a real limit rather than a fix: where the native field is single-sided, this
- * returns one side. Completing it means fixing the WRITER to record both origins, which is the
- * `matchUpStatusCodes`-becomes-a-projection work — see MATCHUP_STATUS_CODES_PER_SIDE.md.
+ * That corruption is gone at the source — `doubleExitAdvancement` now GENERATES the array from
+ * provenance rather than hand-building it, so the two cannot disagree — but native-wins-whole
+ * remains the right rule: a record written before the projection landed still carries the old shape,
+ * and native is the only structure with an authoritative side key.
  */
 export function getSideExitProvenance({ matchUp }: { matchUp?: MatchUp }): SideExitProvenance | undefined {
   const native = matchUp?.sideExitProvenance;

--- a/src/mutate/matchUps/matchUpStatus/sideExitProvenance.ts
+++ b/src/mutate/matchUps/matchUpStatus/sideExitProvenance.ts
@@ -295,6 +295,51 @@ export function getSideExitProvenance({ matchUp }: { matchUp?: MatchUp }): SideE
   return Object.keys(derived).length ? derived : undefined;
 }
 
+/**
+ * The legacy `matchUpStatusCodes` array, GENERATED from provenance.
+ *
+ * CA, 2026-09-11: *"I don't think we can reasonably build our propagation logic on LEGACY
+ * matchUpStatusCodes… we shouldn't try."* The destination that follows from it is that propagation
+ * reads and writes `sideExitProvenance` and the legacy array becomes a PROJECTION of it — not a
+ * structure anyone parses to decide behaviour.
+ *
+ * Why a projection removes a whole class of defect rather than one instance of it. The propagation
+ * writers used to build the two structures INDEPENDENTLY from whatever each site happened to have in
+ * scope, so they could disagree, and did:
+ *
+ *  - `handleEmptyExitLoser` wrote `{ matchUpStatus: <the arriving exit>, previousMatchUpStatus: <the
+ *    CONVERGED status of the target> }` at side 1 — a walkover origin recorded as producing a
+ *    default in the mixed case, which is not a fact about either side.
+ *  - the same site replaced the array wholesale while provenance ACCUMULATED, so the earlier
+ *    arrival's entry survived in one structure and was overwritten in the other.
+ *
+ * Both are impossible once one structure is a function of the other. Order-invariance and internal
+ * consistency are inherited rather than separately maintained.
+ *
+ * SHAPE. Positional, index 0 = side 1, and BOTH slots are always emitted once there is any
+ * provenance at all — which is what the previous builder did and is not cosmetic. A side with no
+ * origin yet gets a bare `{ sideNumber }`, and that stub is a RESERVED SLOT, not noise:
+ * `updateMatchUpStatusCodes` is the site that learns a side's origin late, and it stamps by mapping
+ * over the elements that already exist. Drop the stub and the origin it learns has nowhere to land —
+ * measured, as two suite failures, when this projection first padded with `''` instead.
+ *
+ * `sourceMatchUpId` is deliberately NOT projected. CA decided 2026-09-09 not to add source identity
+ * to `matchUpStatusCodes`, which ships on every matchUp; the identity lives in `sideExitProvenance`,
+ * whose contents were ours to define from the start.
+ */
+export function projectExitStatusCodes(provenance?: SideExitProvenance): any[] {
+  const hasProvenance = [1, 2].some((sideNumber) => provenance?.[sideNumber]);
+  if (!hasProvenance) return [];
+
+  return [1, 2].map((sideNumber) =>
+    definedAttributes({
+      previousMatchUpStatus: provenance?.[sideNumber]?.previousMatchUpStatus,
+      matchUpStatus: provenance?.[sideNumber]?.matchUpStatus,
+      sideNumber,
+    }),
+  );
+}
+
 /** Whether this matchUp's exit was PRODUCED by upstream propagation rather than played. */
 export function exitProducedByPropagation({ matchUp }: { matchUp?: MatchUp }): boolean {
   return !!getSideExitProvenance({ matchUp });

--- a/src/query/drawDefinition/getStructureInconsistencies.ts
+++ b/src/query/drawDefinition/getStructureInconsistencies.ts
@@ -102,8 +102,9 @@ type GetStructureInconsistenciesArgs = {
  *
  * EXIT_CODE_ON_WINNER_SIDE means "an exit code sits on the winner's side rather than the loser's".
  * That is a rule about POLICY codes, which belong to the match and land on the exiting side.
- * Provenance is written to BOTH sides by `buildMatchUpStatusCodes`, so index `winningSide - 1` is
- * always occupied for a propagation-produced matchUp and the rule cannot hold for it. Measured
+ * Provenance describes BOTH sides, and `projectExitStatusCodes` emits both slots, so index
+ * `winningSide - 1` is always occupied for a propagation-produced matchUp and the rule cannot hold
+ * for it. Measured
  * 2026-09-10: teaching this function to read object elements produced 717 findings, all false
  * positives, and broke two named negative-control tests.
  *

--- a/src/tests/mutations/exitPropagation/entryOrderInvariance.test.ts
+++ b/src/tests/mutations/exitPropagation/entryOrderInvariance.test.ts
@@ -1,3 +1,4 @@
+import { producedExitStatus } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
 import { setSubscriptions } from '@Global/state/globalState';
 import tournamentEngine from '@Engines/syncEngine';
 import mocksEngine from '@Assemblies/engines/mock';
@@ -25,24 +26,70 @@ import { DOUBLE_DEFAULT, DOUBLE_WALKOVER } from '@Constants/matchUpStatusConstan
  * Both sites now derive it with `collapseDoubleExitStatus` from BOTH origins, the second of which is
  * the exit the first arrival already produced on the target.
  *
- * WHAT THIS ASSERTS, and what it deliberately does not:
+ * WHAT THIS ASSERTS. Three properties, each on its own assertion so a failure says which:
  *
- *  - ASSERTED: the converged `matchUpStatus` and `winningSide`, across every structure the pair
- *    touches. This is what the fix addresses and what a tournament director sees.
- *  - NOT ASSERTED: the per-side record. Measured on the consolation convergence path, the native
- *    `sideExitProvenance` is correct in both orders but SINGLE-SIDED — and which side it holds
- *    depends on entry order — while the legacy `matchUpStatusCodes` array is both order-dependent
- *    and self-inconsistent there, one order storing
- *    `{ matchUpStatus: DEFAULTED, previousMatchUpStatus: DOUBLE_WALKOVER }`: a walkover origin
- *    producing a default. Asserting either would pin a defect. Completing the per-side record means
- *    fixing the WRITER to record both origins, which is the `matchUpStatusCodes`-becomes-a-
- *    projection work in MATCHUP_STATUS_CODES_PER_SIDE.md.
+ *  1. STATUS — the converged `matchUpStatus` and `winningSide`, across every structure the pair
+ *     touches. This is what a tournament director sees.
+ *  2. PER-SIDE RECORD — `sideExitProvenance` and its projection `matchUpStatusCodes`, per side.
+ *     Measured before the projection landed: **24 of these same 32 cells differed** on this
+ *     property while passing property 1. On the consolation convergence path the native provenance
+ *     was correct but SINGLE-SIDED, holding only the FIRST arrival's origin, because the second
+ *     arrival (`handleEmptyExitLoser`) wrote the legacy array and no provenance at all. Which side
+ *     survived was therefore a function of entry order.
+ *  3. SELF-CONSISTENCY — within any one record, `matchUpStatus` must be what `previousMatchUpStatus`
+ *     produces. The same site hand-built `{ matchUpStatus: <the arriving exit>,
+ *     previousMatchUpStatus: <the target's CONVERGED status> }`, which in the mixed pair stored a
+ *     walkover origin producing a default. That is not a fact about either side, and it is
+ *     order-dependent in its own right: the other entry order stored the opposite.
+ *
+ * Properties 2 and 3 are gated here rather than in `doubleExitStatusParity`, which cannot see this
+ * class twice over: `asWalkoverVocabulary` renames DOUBLE_DEFAULT to DOUBLE_WALKOVER and DEFAULTED
+ * to WALKOVER before comparing, and its driver applies a single `exitOutcome` per run, so the
+ * in-suite matrix cannot construct a mixed pair at all.
  *
  * Generated ids are excluded: each run builds a fresh tournament, so any id differs by construction.
  * An earlier version of this measurement compared `sourceMatchUpId` and reported 32 of 32 differing
  * — including uniform pairs, which cannot differ by flavour — and that impossible result is how the
  * flaw in the measurement surfaced.
  */
+
+// provenance is keyed by sideNumber; the legacy codes array is positional. Both are rendered per
+// side so a difference names the side rather than an index.
+function sideRecord(matchUp: any): string {
+  const codes = matchUp.matchUpStatusCodes ?? [];
+  return [1, 2]
+    .map((sideNumber) => {
+      const entry = matchUp.sideExitProvenance?.[sideNumber];
+      const code = codes[sideNumber - 1];
+      const provenance = entry ? `${entry.previousMatchUpStatus}>${entry.matchUpStatus}` : '-';
+      const projected =
+        code && typeof code === 'object' ? `${code.previousMatchUpStatus ?? '-'}>${code.matchUpStatus ?? '-'}` : '-';
+      return `s${sideNumber}(${provenance}|${projected})`;
+    })
+    .join(' ');
+}
+
+// an origin and what it produced are a PAIR; a record where they disagree describes no side
+function inconsistentPairs(matchUp: any): string[] {
+  const entries = [1, 2].flatMap((sideNumber) => {
+    const provenance = matchUp.sideExitProvenance?.[sideNumber];
+    const code = matchUp.matchUpStatusCodes?.[sideNumber - 1];
+    return [
+      ...(provenance ? [{ label: `provenance s${sideNumber}`, ...provenance }] : []),
+      ...(code && typeof code === 'object' && code.previousMatchUpStatus
+        ? [{ label: `code s${sideNumber}`, ...code }]
+        : []),
+    ];
+  });
+
+  return entries
+    .filter((entry: any) => entry.matchUpStatus !== producedExitStatus(entry.previousMatchUpStatus))
+    .map(
+      (entry: any) =>
+        `${matchUp.structureName}|r${matchUp.roundNumber}p${matchUp.roundPosition}|${entry.label}|` +
+        `${entry.previousMatchUpStatus} produced ${entry.matchUpStatus}`,
+    );
+}
 
 function playInOrder({ drawType, drawSize, statuses, order }: any) {
   const drawId = `order-${drawType}-${drawSize}-${statuses.join('')}-${order.join('')}`;
@@ -71,14 +118,25 @@ function playInOrder({ drawType, drawSize, statuses, order }: any) {
     expect(result.error).toBeUndefined();
   }
 
-  return tournamentEngine
-    .allDrawMatchUps({ inContext: true, drawId })
-    .matchUps.filter((matchUp: any) => matchUp.matchUpStatus && matchUp.matchUpStatus !== 'TO_BE_PLAYED')
-    .map(
-      (matchUp: any) =>
-        `${matchUp.structureName}|r${matchUp.roundNumber}p${matchUp.roundPosition}|${matchUp.matchUpStatus}|ws=${matchUp.winningSide}`,
-    )
-    .sort();
+  const matchUps = tournamentEngine.allDrawMatchUps({ inContext: true, drawId }).matchUps;
+
+  return {
+    status: matchUps
+      .filter((matchUp: any) => matchUp.matchUpStatus && matchUp.matchUpStatus !== 'TO_BE_PLAYED')
+      .map(
+        (matchUp: any) =>
+          `${matchUp.structureName}|r${matchUp.roundNumber}p${matchUp.roundPosition}|${matchUp.matchUpStatus}|ws=${matchUp.winningSide}`,
+      )
+      .sort((a: string, b: string) => a.localeCompare(b)),
+    perSide: matchUps
+      .filter((matchUp: any) => matchUp.sideExitProvenance || matchUp.matchUpStatusCodes?.length)
+      .map(
+        (matchUp: any) =>
+          `${matchUp.structureName}|r${matchUp.roundNumber}p${matchUp.roundPosition}|${sideRecord(matchUp)}`,
+      )
+      .sort((a: string, b: string) => a.localeCompare(b)),
+    inconsistent: matchUps.flatMap(inconsistentPairs).sort((a: string, b: string) => a.localeCompare(b)),
+  };
 }
 
 it.each([
@@ -100,9 +158,13 @@ it.each([
   ]) {
     const forward = playInOrder({ drawType, drawSize, statuses, order: [0, 1] });
     const reversed = playInOrder({ drawType, drawSize, statuses, order: [1, 0] });
+    const cell = `${drawType}/${drawSize} ${statuses.join('+')}`;
 
     // the control: the pair must actually have produced propagated state, or this passes vacuously
-    expect(forward.length, `${statuses.join('+')} produced no decided matchUps`).toBeGreaterThan(0);
-    expect(reversed, `${drawType}/${drawSize} ${statuses.join('+')} depends on entry order`).toEqual(forward);
+    expect(forward.status.length, `${statuses.join('+')} produced no decided matchUps`).toBeGreaterThan(0);
+    expect(reversed.status, `${cell} status depends on entry order`).toEqual(forward.status);
+    expect(reversed.perSide, `${cell} per-side record depends on entry order`).toEqual(forward.perSide);
+    expect(forward.inconsistent, `${cell} forward: an origin producing a status it does not`).toEqual([]);
+    expect(reversed.inconsistent, `${cell} reversed: an origin producing a status it does not`).toEqual([]);
   }
 });


### PR DESCRIPTION
## The defect

`doubleExitAdvancement` built the per-side record **twice, independently** — once as
`sideExitProvenance`, once as the legacy `matchUpStatusCodes` array. Two derivations of one fact can
disagree, and did.

`handleEmptyExitLoser` is the SECOND arrival at a convergence. It wrote **no provenance at all** and
hand-built the codes:

```ts
[{ matchUpStatus: EXIT, previousMatchUpStatus: DOUBLE_EXIT, sideNumber: 1 },
 { matchUpStatus: EXIT, previousMatchUpStatus: params.matchUpStatus, sideNumber: 2 }]
```

Three defects in one literal:

- side 1's `previousMatchUpStatus` is the target's own **collapsed** status, not an origin;
- both sides take the **arriving** exit's produced status;
- the write **replaces** an array whose other entry was still true.

## Measured, before

8 draw types × 4 status pairs, both entry orders, comparing the whole per-side record:

| | |
|---|---:|
| cells whose per-side record differs by entry order | **24 of 32** |
| cells where status + winningSide differ | 0 (closed by #4834/#4836) |

Every difference is on the one convergence matchUp. Two distinct faults:

- **provenance is single-sided.** It holds only the FIRST arrival's origin, because the second
  arrival wrote none. Which side survives is therefore a function of entry order:
  `prov=1:DOUBLE_WALKOVER>WALKOVER 2:-` forward, `1:- 2:…` reversed.
- **the codes are self-inconsistent.** In the mixed pair, forward stores
  `{ matchUpStatus: DEFAULTED, previousMatchUpStatus: DOUBLE_WALKOVER }` — a walkover origin
  producing a default — and reversed stores the opposite.

## The change

Both writers now record the arriving side's provenance, union it with what the target already holds,
and **generate** `matchUpStatusCodes` from that union through a new `projectExitStatusCodes`.
`buildMatchUpStatusCodes` — the second, independent derivation — is deleted.

Per CA 2026-09-11: *"I don't think we can reasonably build our propagation logic on LEGACY
`matchUpStatusCodes`… we shouldn't try."* Once the array is a projection, order-dependence and
self-inconsistency cannot exist in it separately from provenance.

**Deriving the arriving side.** `loserTargetDrawPosition` against the target's `drawPositions` — the
same derivation the sibling non-empty branch already uses for `walkoverWinningSide`. Instrumented
across the whole exit-propagation suite before relying on it:

| | |
|---|---:|
| `handleEmptyExitLoser` firings | **223** |
| resolving to a valid side (0/1 index, 2 drawPositions) | **223** |
| resolving to the complement of the already-recorded side | **222** |

The one exception is an OLYMPIC re-score of the same side (`pendingDoubleExitNotActive`), where
replacing that side's entry is the correct outcome.

**Reading, not just writing.** The union reads through `getSideExitProvenance` rather than the raw
field, so it still finds the first arrival's origin under LEGACY write mode, where nothing writes
the native field.

**Projection shape.** Both slots are always emitted, with a bare `{ sideNumber }` where a side has no
origin yet. That stub is a **reserved slot, not noise**: `updateMatchUpStatusCodes` is the site that
learns a side's origin late, and it stamps by mapping over the elements that already exist. Padding
with `''` instead was tried first and cost two suite failures (`sourceMatchUpStatus`,
`doubleExitConsolation`) — the late-learned `COMPLETED` origin had nowhere to land. `sourceMatchUpId`
is deliberately not projected: CA decided 2026-09-09 not to add source identity to a field that ships
on every matchUp.

## After

Same 32 cells: **0 differ**. The converged record now reads, in both orders:

```text
DOUBLE_WALKOVER+DOUBLE_DEFAULT | DOUBLE_WALKOVER | ws=undefined
  prov:  {1: DOUBLE_WALKOVER>WALKOVER, 2: DOUBLE_DEFAULT>DEFAULTED}
  codes: [{DOUBLE_WALKOVER>WALKOVER, side 1}, {DOUBLE_DEFAULT>DEFAULTED, side 2}]
```

Both sides present, each entry's `matchUpStatus` is what its `previousMatchUpStatus` produces, and
the codes are an exact projection of provenance.

## The gate

`entryOrderInvariance.test.ts` deliberately asserted only status and `winningSide`; its docblock said
the per-side record was left out because asserting it would pin a defect. It now asserts three
properties, each separately so a failure names which:

1. status + `winningSide` (unchanged, #4836's gate);
2. the per-side record — provenance and its projection, per side;
3. self-consistency — `matchUpStatus === producedExitStatus(previousMatchUpStatus)` for every
   provenance entry and every object-shaped code element.

**Proven RED against `dev` first**, in a separate worktree at `e0c8a8a96`:

| property | result on dev |
|---|---|
| 2 — per-side order invariance | **6 of 8 rows fail** (both FRLC sizes, FMLC, FIC, DOUBLE_ELIMINATION, COMPASS) |
| 3 — self-consistency | **the same 6 rows fail**, verified by disabling property 2 so it is reached |

The two passing rows are `SINGLE_ELIMINATION` 8 and 16, which have no convergence structure — the
property is vacuous there, which is why the existing "produced no decided matchUps" control stays.

`doubleExitStatusParity` cannot police this class, twice over: `asWalkoverVocabulary` renames
`DOUBLE_DEFAULT`→`DOUBLE_WALKOVER` and `DEFAULTED`→`WALKOVER` before comparing, and its driver
applies a single `exitOutcome` per run so the in-suite matrix cannot construct a mixed pair at all.

## Deliberately not in scope

`progressExitStatus` still maintains a local `string[]` and is **not** converted. Re-siding a
provenance object in place there would put object elements into a locally-`string[]` array and flip
`exitProducedByPropagation` from false to true at a site nothing has measured. That is the next
increment, not this one.

## Gates

| | |
|---|---|
| `transitionProperties.test.ts` | **144 passed / 0 failed** |
| full suite | **13060 passed / 2 skipped** |
| `pnpm lint` | exit 0, zero warnings |
| `npx tsc --noEmit` | clean |
| `pnpm verify` | **exit 0** |
