### PR TITLE
docs(migration): stop quoting a seed-sweep count, and correct the ladder query count

### DIFF
--- a/documentation/docs/migration-7.0.0.md
+++ b/documentation/docs/migration-7.0.0.md
@@ -89,10 +89,9 @@ than on that specific code.
 
 :::note This fix is scoped to that one outcome shape
 It does **not** mean every rejected mutation leaves the draw untouched. A direct `setMatchUpStatus`
-that fails part-way through a propagation cascade can still return an error over changed state —
-measured on 2026-09-11 at 78 of 600 randomized scenarios. Callers that need all-or-nothing should
-go through `executionQueue` with `rollbackOnError: true`, which snapshots and restores; that is what
-TMX and competition-factory-server do on every mutation.
+that fails part-way through a propagation cascade can still return an error over changed state.
+Callers that need all-or-nothing should go through `executionQueue` with `rollbackOnError: true`,
+which snapshots and restores; that is what TMX and competition-factory-server do on every mutation.
 :::
 
 ## 4. Time-zone conversions refuse rather than throw or guess
@@ -533,7 +532,8 @@ intent set. `zonedTime` was never published, so its rename is not a breaking cha
 The `LADDER` drawType is generatable and its lifecycle is on the engine as eighteen new methods —
 `issueChallenge`, `acceptChallenge`, `declineChallenge`, `submitResult`, `confirmResult`,
 `disputeResult`, `applyLadderMovement`, `addLadderParticipant`, `removeLadderParticipant`,
-`refreshLadderRatings`, and eight `get*` queries. All are additive; see
+`refreshLadderRatings`, seven `get*` queries and the `isChallengeInRange` predicate. All are
+additive; see
 [What's New in 7.0.0](./whats-new-7.0.0#driving-a-ladder).
 
 `PositionAssignment.byeFromPropagation` is a new optional boolean recording that a BYE was placed by


### PR DESCRIPTION
Two consumer-facing corrections to `migration-7.0.0.md`, both pre-publish items on `Mentat/TASKS.md` § *Factory 7.0.0*.

## §3 — drop the seed-sweep count rather than reset it

The note claimed a direct `setMatchUpStatus` can return an error over changed state *"measured on 2026-09-11 at **78 of 600** randomized scenarios"*.

**That was stale within a day.** S1 ([#4826](https://github.com/CourtHive/competition-factory/pull/4826)) took `ERROR_IMPLIES_NO_MUTATION` from 78 → 45 on the same window, and the census has moved twice since (136 → 92 → 58 → 45 → 42).

The first instinct was to reset it to 45. CA overruled that, and correctly — the count does not belong in a consumer document at all:

- a consumer has no harness, no seed window (`SEED_START=9000001`, `MAX_STEPS=30`), and no definition of "scenario". It reads as precision while conveying nothing they can act on.
- it decays on **every** cascade block, and blocks are still queued. Resetting it just schedules the next staleness.
- the caveat is complete without it. What a caller must know is the *behaviour* — a direct call can fail over changed state, so use `executionQueue` with `rollbackOnError: true` — and that sentence stands on its own.

```diff
- that fails part-way through a propagation cascade can still return an error over changed state —
- measured on 2026-09-11 at 78 of 600 randomized scenarios. Callers that need all-or-nothing should
- go through `executionQueue` with `rollbackOnError: true`, which snapshots and restores; …
+ that fails part-way through a propagation cascade can still return an error over changed state.
+ Callers that need all-or-nothing should go through `executionQueue` with `rollbackOnError: true`,
+ which snapshots and restores; …
```

The residue stays tracked where restaling it is free — the cascade rows in `Mentat/TASKS.md` and the harness write-up.

## §10 — the ladder query count was wrong

*"eighteen new methods … and eight `get*` queries."* **Eighteen is right.** The queries are **seven** `get*` plus `isChallengeInRange`, which is a predicate, not a getter.

Verified against the governor barrel rather than recounted from the prose:

| file | exports |
|---|---|
| `ladderGovernor/mutate.ts` | 10 |
| `ladderGovernor/query.ts` | 8 — of which 7 match `get*`, plus `isChallengeInRange` |

Found by the 2026-09-12 Mentat corpus audit (findings F4 and F7).