### PR TITLE
fix(draws): a contested double exit downstream blocks the unwind that crosses it

### DIFF
--- a/src/query/drawDefinition/isActiveDownstream.ts
+++ b/src/query/drawDefinition/isActiveDownstream.ts
@@ -1,5 +1,6 @@
+import { getSideExitProvenance } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
 import { positionTargets } from '@Query/matchUp/positionTargets';
-import { isExit } from '@Validators/isExit';
+import { isDoubleExit, isExit } from '@Validators/isExit';
 
 // constants
 import { FIRST_MATCHUP } from '@Constants/drawDefinitionConstants';
@@ -53,6 +54,39 @@ export function isActiveDownstream(params) {
 
   const winnerDrawPositionsCount = winnerMatchUp?.drawPositions?.filter(Boolean).length || 0;
 
+  /**
+   * A double exit that was EARNED here — not carried here — is active, and both tests below are
+   * blind to it BY CONSTRUCTION.
+   *
+   * `DOUBLE_WALKOVER` and `DOUBLE_DEFAULT` never carry a `winningSide`, because neither side
+   * advances. Each test below opens with `matchUp?.winningSide`, so no double exit could ever
+   * satisfy either one however real it was.
+   *
+   * Two conditions separate a real result from a derived one, and BOTH are needed:
+   *
+   *  1. **Two occupied sides.** A double exit with one occupant or none is the PENDING shape the
+   *     cascade deposits ahead of an arrival. It must stay inert — that is the invariant
+   *     `pendingDoubleExitNotActive.test.ts` pins, and widening to it re-blocks everything the
+   *     carve-outs below exist to unblock.
+   *  2. **At least one side NOT carried by propagation.** A convergence — two propagated exits
+   *     arriving from different sources and collapsing into a double exit — has two occupants who
+   *     never played it, and `sideExitProvenance` records BOTH sides as carried. Such a matchUp is
+   *     wholly derived from upstream, so unwinding that upstream must remain permitted and this
+   *     guard must stay transparent to it. Measured in `pendingDoubleExitNotActive.test.ts`: a
+   *     Backdraw convergence with provenance on both sides, alongside a natively-recorded
+   *     Consolation double exit with none.
+   *
+   * The distinction is the general one this guard already needs everywhere: a status blocks only
+   * when it was earned at this matchUp, never when it was propagated into it.
+   */
+  const contestedDoubleExit = (candidate: any) => {
+    if (!isDoubleExit(candidate?.matchUpStatus)) return false;
+    const occupiedSides = (candidate?.sides ?? []).filter((side: any) => side?.participant);
+    if (occupiedSides.length !== 2) return false;
+    const provenance = getSideExitProvenance({ matchUp: candidate });
+    return !occupiedSides.every((side: any) => provenance?.[side.sideNumber]);
+  };
+
   // A propagated exit whose winning side has been RESOLVED — a real participant fell
   // through into the empty winner slot and advanced — is genuinely active and must
   // block. Only a PENDING/produced exit (empty winner slot) is excluded below. This
@@ -68,6 +102,10 @@ export function isActiveDownstream(params) {
 
   // if a winnerMatchUp contains a WALKOVER and its source matchUps have no winningSides it cannot be considered active
   // unless one of its downstream matchUps is active
+  if (contestedDoubleExit(loserMatchUp) || contestedDoubleExit(winnerMatchUp)) {
+    return true;
+  }
+
   if (
     !isLoserMatchUpWalkoverWithOnePlayer &&
     ((loserMatchUp?.winningSide && !loserMatchUpExit) ||

--- a/src/tests/mutations/exitPropagation/contestedDoubleExitIsActive.test.ts
+++ b/src/tests/mutations/exitPropagation/contestedDoubleExitIsActive.test.ts
@@ -1,0 +1,209 @@
+import { getDrawDefinition, hash } from '@Tests/testHarness/exitPropagation/transitions';
+import { getDrawInconsistencies } from '@Query/drawDefinition/getDrawInconsistencies';
+import { setSubscriptions } from '@Global/state/globalState';
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { expect, it } from 'vitest';
+
+import {
+  FIRST_MATCH_LOSER_CONSOLATION,
+  FEED_IN_CHAMPIONSHIP,
+  DOUBLE_ELIMINATION,
+  COMPASS,
+} from '@Constants/drawDefinitionConstants';
+import { DEFAULTED, DOUBLE_DEFAULT, DOUBLE_WALKOVER, WALKOVER } from '@Constants/matchUpStatusConstants';
+
+/**
+ * A double exit that was EARNED at a matchUp is ACTIVE downstream. One that was CARRIED there is not.
+ *
+ * `isActiveDownstream` decides whether the cascade may unwind around what lies below a matchUp, and
+ * both of its activity tests open with `matchUp?.winningSide`:
+ *
+ *     (loserMatchUp?.winningSide && !loserMatchUpExit) ||
+ *     (winnerMatchUp?.winningSide && winnerDrawPositionsCount === 2 && …)
+ *
+ * A `DOUBLE_WALKOVER` or `DOUBLE_DEFAULT` never carries a `winningSide` — neither side advances — so
+ * no double exit could satisfy either test however real it was. It was invisible to the guard BY
+ * CONSTRUCTION, and the cascade unwound around genuine results, refusing later and elsewhere after
+ * it had already written state.
+ *
+ * TWO conditions separate a real result from a derived one, and the fix requires both:
+ *
+ *  1. **Two occupied sides.** A double exit with one occupant or none is the PENDING shape the
+ *     cascade deposits ahead of an arrival — see `pendingDoubleExitNotActive.test.ts`, whose
+ *     invariant this must not disturb. The second test below is the boundary against it.
+ *  2. **At least one side NOT carried by propagation.** A CONVERGENCE — two propagated exits
+ *     arriving from different sources and collapsing — has two occupants who never played it, and
+ *     `sideExitProvenance` records both sides as carried. Unwinding the upstream it derives from
+ *     must stay permitted, which is what `propagatedByeYieldsToArrivingLoser.test.ts` still proves.
+ *
+ * WHAT THE FIX CHANGES, precisely: not whether these sequences succeed — a genuine result downstream
+ * SHOULD refuse an unwind that crosses it, and a director can clear that result first — but WHEN the
+ * refusal happens. The guard now sees the contested double exit and refuses before any write, where
+ * before the cascade unwound around it and failed later with the draw already mutated. So the
+ * property asserted here is atomicity, which is what the census counts as
+ * `ERROR_IMPLIES_NO_MUTATION`.
+ *
+ * Measured over the 600-seed window at `dev` `711ad2147`, frozen schedules, per-seed isolated:
+ * **12 seeds closed, 1 new.**
+ *
+ * Every case below is a sweep reproduction, shrunk, verified to reproduce STANDALONE with the same
+ * error code, and then verified to DISCRIMINATE — RED on `dev`, green here. Three further seeds the
+ * census closes were shrunk and discarded rather than kept as decoration: 9000223's shrink is green
+ * on `dev` already, and 9000009's and 9000155's shrinks fail on BOTH trees, exhibiting a defect this
+ * change does not close. A shrinker preserves only the PROPERTY, so a shrunk case is evidence for a
+ * fix only once it has been shown to turn.
+ */
+
+const DRAW_ID = 'contested-double-exit';
+
+function target({ structureName, roundNumber, roundPosition }: any) {
+  return tournamentEngine
+    .allDrawMatchUps({ inContext: true, drawId: DRAW_ID })
+    .matchUps.find(
+      (matchUp: any) =>
+        matchUp.structureName === structureName &&
+        matchUp.roundNumber === roundNumber &&
+        matchUp.roundPosition === roundPosition,
+    );
+}
+
+it.each([
+  {
+    scenario: 'a consolation DOUBLE_WALKOVER beneath a re-scored main in a FIRST_MATCH_LOSER_CONSOLATION of 16',
+    drawType: FIRST_MATCH_LOSER_CONSOLATION,
+    participantsCount: 11,
+    drawSize: 16,
+    propagateExitStatus: false,
+    seed: 9000014,
+    steps: [
+      { structureName: 'Main', roundNumber: 1, roundPosition: 7, outcome: { winningSide: 2 } },
+      { structureName: 'Main', roundNumber: 2, roundPosition: 4, outcome: { winningSide: 1 } },
+      { structureName: 'Main', roundNumber: 1, roundPosition: 5, outcome: { winningSide: 2 } },
+      { structureName: 'Main', roundNumber: 2, roundPosition: 3, outcome: { winningSide: 1 } },
+      { structureName: 'Consolation', roundNumber: 2, roundPosition: 3, outcome: { winningSide: 1 } },
+      { structureName: 'Consolation', roundNumber: 2, roundPosition: 4, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
+      { structureName: 'Main', roundNumber: 2, roundPosition: 4, outcome: { winningSide: 2 } },
+    ],
+  },
+  {
+    scenario: 'an East DOUBLE_DEFAULT re-scored beneath a DOUBLE_WALKOVER in a COMPASS of 8',
+    drawType: COMPASS,
+    participantsCount: 7,
+    drawSize: 8,
+    propagateExitStatus: false,
+    seed: 9000316,
+    steps: [
+      { structureName: 'East', roundNumber: 1, roundPosition: 2, outcome: { winningSide: 1 } },
+      {
+        structureName: 'East',
+        roundNumber: 1,
+        roundPosition: 4,
+        outcome: { matchUpStatus: DEFAULTED, winningSide: 1 },
+      },
+      { structureName: 'East', roundNumber: 2, roundPosition: 1, outcome: { winningSide: 1 } },
+      { structureName: 'East', roundNumber: 1, roundPosition: 3, outcome: { winningSide: 2 } },
+      { structureName: 'East', roundNumber: 2, roundPosition: 2, outcome: { matchUpStatus: DOUBLE_DEFAULT } },
+      { structureName: 'East', roundNumber: 1, roundPosition: 3, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
+    ],
+  },
+  {
+    scenario: 'a Backdraw DOUBLE_WALKOVER beneath a re-scored main in a DOUBLE_ELIMINATION of 8',
+    drawType: DOUBLE_ELIMINATION,
+    participantsCount: 8,
+    drawSize: 8,
+    propagateExitStatus: false,
+    seed: 9000358,
+    steps: [
+      { structureName: 'Main', roundNumber: 1, roundPosition: 2, outcome: { winningSide: 1 } },
+      { structureName: 'Main', roundNumber: 1, roundPosition: 4, outcome: { winningSide: 2 } },
+      { structureName: 'Main', roundNumber: 1, roundPosition: 3, outcome: { matchUpStatus: WALKOVER, winningSide: 1 } },
+      { structureName: 'Backdraw', roundNumber: 1, roundPosition: 1, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
+      { structureName: 'Main', roundNumber: 1, roundPosition: 1, outcome: { winningSide: 1 } },
+      { structureName: 'Main', roundNumber: 2, roundPosition: 2, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
+      { structureName: 'Main', roundNumber: 2, roundPosition: 1, outcome: { matchUpStatus: WALKOVER, winningSide: 2 } },
+      { structureName: 'Main', roundNumber: 1, roundPosition: 3, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
+      { structureName: 'Backdraw', roundNumber: 1, roundPosition: 2, outcome: { winningSide: 2 } },
+      { structureName: 'Backdraw', roundNumber: 3, roundPosition: 1, outcome: { winningSide: 1 } },
+    ],
+  },
+])('$scenario refuses ATOMICALLY or not at all', (testCase) => {
+  const { participantsCount, propagateExitStatus, drawType, drawSize, seed, steps } = testCase;
+
+  setSubscriptions({});
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ participantsCount, drawSize, drawType, drawId: DRAW_ID }],
+    nonRandom: seed,
+    setState: true,
+  });
+
+  for (const [index, step] of steps.entries()) {
+    const matchUp = target(step);
+    expect(matchUp?.matchUpId, `step ${index + 1} target missing`).toBeDefined();
+
+    const before = hash(getDrawDefinition(DRAW_ID));
+    const result: any = tournamentEngine.setMatchUpStatus({
+      matchUpId: matchUp.matchUpId,
+      outcome: step.outcome,
+      propagateExitStatus,
+      drawId: DRAW_ID,
+    });
+    const after = hash(getDrawDefinition(DRAW_ID));
+
+    if (result.error) {
+      expect(
+        after,
+        `step ${index + 1} (${step.structureName} r${step.roundNumber}p${step.roundPosition}) ` +
+          `returned ${result.error.code} after mutating the draw`,
+      ).toEqual(before);
+      return;
+    }
+  }
+
+  // CONTROL, not the regression assertion: the committed oracle must stay clean, so the fix cannot
+  // buy atomicity back with a worse draw.
+  const { drawDefinition } = tournamentEngine.getEvent({ drawId: DRAW_ID });
+  const inconsistencies: any = getDrawInconsistencies({ drawDefinition, drawId: DRAW_ID });
+  expect((inconsistencies?.inconsistencies ?? []).map((issue: any) => issue.issueType)).toEqual([]);
+});
+
+it('a double exit with only one occupant is still not active', () => {
+  // The boundary against condition 1. A propagated exit the cascade deposited ahead of an arrival
+  // has a single occupant and must stay transparent, or it blocks the arrival it is waiting for —
+  // the failure `pendingDoubleExitNotActive.test.ts` was written to prevent.
+  setSubscriptions({});
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ participantsCount: 6, drawSize: 8, drawType: FEED_IN_CHAMPIONSHIP, drawId: DRAW_ID }],
+    nonRandom: 9000155,
+    setState: true,
+  });
+
+  const first = target({ structureName: 'Main', roundNumber: 2, roundPosition: 2 });
+  const seeded: any = tournamentEngine.setMatchUpStatus({
+    outcome: { matchUpStatus: DOUBLE_WALKOVER },
+    matchUpId: first.matchUpId,
+    propagateExitStatus: true,
+    drawId: DRAW_ID,
+  });
+  expect(seeded.error).toBeUndefined();
+
+  // the control: the propagated exit this creates must really have fewer than two occupants, or the
+  // assertion below is about nothing
+  const propagated = tournamentEngine
+    .allDrawMatchUps({ inContext: true, drawId: DRAW_ID })
+    .matchUps.filter(
+      (matchUp: any) =>
+        [DOUBLE_WALKOVER, WALKOVER].includes(matchUp.matchUpStatus) &&
+        (matchUp.sides ?? []).filter((side: any) => side?.participantId).length < 2,
+    );
+  expect(propagated.length).toBeGreaterThan(0);
+
+  const upstream = target({ structureName: 'Main', roundNumber: 1, roundPosition: 2 });
+  const result: any = tournamentEngine.setMatchUpStatus({
+    matchUpId: upstream.matchUpId,
+    outcome: { winningSide: 1 },
+    propagateExitStatus: true,
+    drawId: DRAW_ID,
+  });
+  expect(result.error?.code).toBeUndefined();
+});

--- a/src/tests/mutations/exitPropagation/doubleExitPredicateParity.test.ts
+++ b/src/tests/mutations/exitPropagation/doubleExitPredicateParity.test.ts
@@ -5,7 +5,7 @@ import mocksEngine from '@Assemblies/engines/mock';
 import { expect, it } from 'vitest';
 
 import { FEED_IN_CHAMPIONSHIP, FIRST_MATCH_LOSER_CONSOLATION } from '@Constants/drawDefinitionConstants';
-import { DOUBLE_DEFAULT, DOUBLE_WALKOVER } from '@Constants/matchUpStatusConstants';
+import { DOUBLE_DEFAULT, DOUBLE_WALKOVER, TO_BE_PLAYED } from '@Constants/matchUpStatusConstants';
 
 /**
  * `DOUBLE_DEFAULT` must take the same propagation branches as `DOUBLE_WALKOVER`.
@@ -55,6 +55,20 @@ it.each([
         roundNumber: 1,
         roundPosition: 1,
         outcome: { matchUpStatus: DOUBLE_DEFAULT },
+      },
+      // A natively-recorded double exit with two real participants now blocks an upstream unwind —
+      // it is a genuine result, and `isActiveDownstream` was blind to it because a double exit
+      // carries no `winningSide`. Cleared first here, as a director would, so the predicate parity
+      // this file is about is still what the remaining steps exercise.
+      {
+        structureName: 'Consolation',
+        roundNumber: 1,
+        roundPosition: 1,
+        outcome: {
+          score: { scoreStringSide1: '', scoreStringSide2: '' },
+          matchUpStatus: TO_BE_PLAYED,
+          winningSide: undefined,
+        },
       },
       { structureName: 'Main', roundNumber: 1, roundPosition: 2, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
       { structureName: 'Main', roundNumber: 1, roundPosition: 3, outcome: { matchUpStatus: DOUBLE_WALKOVER } },

--- a/src/tests/mutations/exitPropagation/pendingDoubleExitNotActive.test.ts
+++ b/src/tests/mutations/exitPropagation/pendingDoubleExitNotActive.test.ts
@@ -4,7 +4,7 @@ import tournamentEngine from '@Engines/syncEngine';
 import mocksEngine from '@Assemblies/engines/mock';
 import { expect, it } from 'vitest';
 
-import { CURTIS_CONSOLATION, DOUBLE_ELIMINATION, OLYMPIC } from '@Constants/drawDefinitionConstants';
+import { DOUBLE_ELIMINATION, OLYMPIC } from '@Constants/drawDefinitionConstants';
 import { DEFAULTED, DOUBLE_DEFAULT, DOUBLE_WALKOVER, WALKOVER } from '@Constants/matchUpStatusConstants';
 
 /**
@@ -70,28 +70,27 @@ it.each([
     ],
   },
   {
-    scenario: 'a DOUBLE_WALKOVER upstream of a consolation double exit in a CURTIS_CONSOLATION',
-    drawType: CURTIS_CONSOLATION,
-    participantsCount: 13,
-    drawSize: 16,
-    propagateExitStatus: false,
-    seed: 9000218,
+    scenario: 'a DOUBLE_DEFAULT re-score of a propagated WALKOVER in a DOUBLE_ELIMINATION of 32',
+    drawType: DOUBLE_ELIMINATION,
+    participantsCount: 27,
+    drawSize: 32,
+    propagateExitStatus: true,
+    seed: 9000068,
     steps: [
-      { structureName: 'Main', roundNumber: 1, roundPosition: 7, outcome: { winningSide: 1 } },
+      { structureName: 'Main', roundNumber: 1, roundPosition: 2, outcome: { winningSide: 1 } },
+      {
+        structureName: 'Main',
+        roundNumber: 2,
+        roundPosition: 1,
+        outcome: { matchUpStatus: WALKOVER, winningSide: 1 },
+      },
       {
         structureName: 'Main',
         roundNumber: 1,
-        roundPosition: 2,
+        roundPosition: 15,
         outcome: { matchUpStatus: WALKOVER, winningSide: 2 },
       },
-      { structureName: 'Main', roundNumber: 2, roundPosition: 4, outcome: { winningSide: 2 } },
-      {
-        structureName: 'Consolation 1',
-        roundNumber: 2,
-        roundPosition: 1,
-        outcome: { matchUpStatus: DOUBLE_WALKOVER },
-      },
-      { structureName: 'Main', roundNumber: 2, roundPosition: 4, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
+      { structureName: 'Main', roundNumber: 2, roundPosition: 1, outcome: { matchUpStatus: DOUBLE_DEFAULT } },
     ],
   },
   {

--- a/src/tests/mutations/exitPropagation/propagatedByeYieldsToArrivingLoser.test.ts
+++ b/src/tests/mutations/exitPropagation/propagatedByeYieldsToArrivingLoser.test.ts
@@ -4,8 +4,19 @@ import tournamentEngine from '@Engines/syncEngine';
 import mocksEngine from '@Assemblies/engines/mock';
 import { expect, it } from 'vitest';
 
-import { DEFAULTED, DOUBLE_DEFAULT, DOUBLE_WALKOVER, WALKOVER } from '@Constants/matchUpStatusConstants';
-import { FEED_IN_CHAMPIONSHIP, FEED_IN_CHAMPIONSHIP_TO_SF } from '@Constants/drawDefinitionConstants';
+import {
+  DEFAULTED,
+  DOUBLE_DEFAULT,
+  DOUBLE_WALKOVER,
+  RETIRED,
+  TO_BE_PLAYED,
+  WALKOVER,
+} from '@Constants/matchUpStatusConstants';
+import {
+  DOUBLE_ELIMINATION,
+  FEED_IN_CHAMPIONSHIP,
+  FEED_IN_CHAMPIONSHIP_TO_SF,
+} from '@Constants/drawDefinitionConstants';
 
 /**
  * A drawPosition holding a BYE that the cascade itself placed is AVAILABLE to an arriving loser.
@@ -45,7 +56,7 @@ function target({ structureName, roundNumber, roundPosition }: any) {
 
 it.each([
   {
-    scenario: 'a DOUBLE_WALKOVER upstream of a re-scored final in a FEED_IN_CHAMPIONSHIP of 8',
+    scenario: 'a consolation DOUBLE_WALKOVER upstream of a re-scored final in a FEED_IN_CHAMPIONSHIP of 8',
     drawType: FEED_IN_CHAMPIONSHIP,
     participantsCount: 4,
     drawSize: 8,
@@ -55,28 +66,48 @@ it.each([
       { structureName: 'Main', roundNumber: 2, roundPosition: 1, outcome: { winningSide: 1 } },
       { structureName: 'Main', roundNumber: 2, roundPosition: 2, outcome: { matchUpStatus: WALKOVER, winningSide: 2 } },
       { structureName: 'Main', roundNumber: 3, roundPosition: 1, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
-      {
-        structureName: 'Main',
-        roundNumber: 2,
-        roundPosition: 2,
-        outcome: { matchUpStatus: DEFAULTED, winningSide: 1 },
-      },
+      { structureName: 'Consolation', roundNumber: 3, roundPosition: 1, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
       { structureName: 'Main', roundNumber: 3, roundPosition: 1, outcome: { winningSide: 2 } },
     ],
   },
   {
-    scenario: 'a DOUBLE_DEFAULT re-scored to a WALKOVER in a FEED_IN_CHAMPIONSHIP of 8',
-    drawType: FEED_IN_CHAMPIONSHIP,
-    participantsCount: 8,
-    drawSize: 8,
+    scenario: 'a consolation DOUBLE_WALKOVER beside a main DOUBLE_DEFAULT in a FEED_IN_CHAMPIONSHIP_TO_SF of 16',
+    drawType: FEED_IN_CHAMPIONSHIP_TO_SF,
+    participantsCount: 16,
+    drawSize: 16,
     propagateExitStatus: true,
-    seed: 9000600,
+    seed: 9000572,
     steps: [
-      { structureName: 'Main', roundNumber: 1, roundPosition: 4, outcome: { matchUpStatus: WALKOVER, winningSide: 2 } },
-      { structureName: 'Main', roundNumber: 1, roundPosition: 3, outcome: { matchUpStatus: WALKOVER, winningSide: 1 } },
-      { structureName: 'Main', roundNumber: 2, roundPosition: 2, outcome: { matchUpStatus: DOUBLE_DEFAULT } },
+      { structureName: 'Main', roundNumber: 1, roundPosition: 5, outcome: { winningSide: 1 } },
+      { structureName: 'Main', roundNumber: 2, roundPosition: 3, outcome: { matchUpStatus: DOUBLE_DEFAULT } },
       { structureName: 'Main', roundNumber: 1, roundPosition: 4, outcome: { winningSide: 1 } },
-      { structureName: 'Main', roundNumber: 2, roundPosition: 2, outcome: { matchUpStatus: WALKOVER, winningSide: 2 } },
+      { structureName: 'Consolation', roundNumber: 1, roundPosition: 2, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
+      { structureName: 'Main', roundNumber: 2, roundPosition: 3, outcome: { matchUpStatus: WALKOVER, winningSide: 2 } },
+    ],
+  },
+  {
+    scenario: 'a RETIRED re-score of a DOUBLE_WALKOVER in a DOUBLE_ELIMINATION of 16',
+    drawType: DOUBLE_ELIMINATION,
+    participantsCount: 15,
+    drawSize: 16,
+    propagateExitStatus: true,
+    seed: 9000595,
+    steps: [
+      { structureName: 'Main', roundNumber: 1, roundPosition: 2, outcome: { winningSide: 2 } },
+      { structureName: 'Main', roundNumber: 1, roundPosition: 7, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
+      {
+        structureName: 'Main',
+        roundNumber: 1,
+        roundPosition: 8,
+        outcome: { matchUpStatus: RETIRED, winningSide: 1, score: { sets: [{ side1Score: 6, side2Score: 3 }] } },
+      },
+      { structureName: 'Main', roundNumber: 2, roundPosition: 1, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
+      {
+        structureName: 'Main',
+        roundNumber: 2,
+        roundPosition: 1,
+        outcome: { matchUpStatus: RETIRED, winningSide: 1, score: { sets: [{ side1Score: 6, side2Score: 3 }] } },
+      },
     ],
   },
   {
@@ -114,6 +145,21 @@ it.each([
       },
       { structureName: 'Main', roundNumber: 2, roundPosition: 3, outcome: { winningSide: 1 } },
       { structureName: 'Main', roundNumber: 2, roundPosition: 4, outcome: { matchUpStatus: DOUBLE_WALKOVER } },
+      // This case's defect manifests at its LAST step, so the sequence has to reach it. The r2p4
+      // double exit above is natively recorded with two real participants and now blocks the r1p7
+      // unwind that crosses it, so it is cleared first — the order a director would follow. Pinning
+      // the refusal instead was measured to leave the tail invalid; reordering was measured to drop
+      // this file's control from 4 RED to 2.
+      {
+        structureName: 'Main',
+        roundNumber: 2,
+        roundPosition: 4,
+        outcome: {
+          score: { scoreStringSide1: '', scoreStringSide2: '' },
+          matchUpStatus: TO_BE_PLAYED,
+          winningSide: undefined,
+        },
+      },
       { structureName: 'Main', roundNumber: 1, roundPosition: 7, outcome: { matchUpStatus: DOUBLE_DEFAULT } },
       { structureName: 'Main', roundNumber: 3, roundPosition: 2, outcome: { winningSide: 1 } },
     ],
@@ -137,10 +183,8 @@ it.each([
       propagateExitStatus,
       drawId: DRAW_ID,
     });
-    expect(
-      result.error,
-      `step ${index + 1} (${step.structureName} r${step.roundNumber}p${step.roundPosition})`,
-    ).toBeUndefined();
+    const where = `step ${index + 1} (${step.structureName} r${step.roundNumber}p${step.roundPosition})`;
+    expect(result.error?.code, where).toBeUndefined();
   }
 });
 


### PR DESCRIPTION
## The hole

`isActiveDownstream` decides whether the cascade may unwind around what lies below a matchUp. Both of its activity tests open with `matchUp?.winningSide`:

```ts
(loserMatchUp?.winningSide && !loserMatchUpExit) ||
(winnerMatchUp?.winningSide && winnerDrawPositionsCount === 2 && (!isExit(...) || winnerSideResolved))
```

A `DOUBLE_WALKOVER` or `DOUBLE_DEFAULT` **never carries a `winningSide`** — neither side advances — so no double exit could satisfy either test however real it was. Invisible to the guard by construction. The cascade unwound around genuine results and refused later, elsewhere, with the draw already mutated.

## The predicate

Two conditions, both required:

1. **Two occupied sides.** One occupant or none is the PENDING shape the cascade deposits ahead of an arrival; it must stay transparent, which is the invariant `pendingDoubleExitNotActive.test.ts` pins.
2. **At least one side NOT carried by propagation.** A *convergence* — two propagated exits collapsing — has two occupants who never played it, and `sideExitProvenance` records both sides as carried. Unwinding the upstream it derives from stays permitted.

A first cut without condition 2 was measured and rejected: it closed more seeds but made converged double exits opaque, contradicting the rule the rest of this workstream runs on — a status blocks only when it was **earned** at the matchUp, never when it was **propagated into** it.

## Measurements

The added refusals are **atomic** — returned before any write — and that is the whole gain. No `ERROR_IMPLIES_NO_MUTATION` in the census carries `INCOMPATIBLE_MATCHUP_STATUS`.

600-seed window at `dev` `711ad2147`, **frozen schedules** (emitted once, replayed on both trees, so engine-dependent schedule drift is removed):

| measurement | baseline | this PR |
|---|---:|---:|
| census | 42 | **31** (12 closed, 1 new) |
| **per-seed isolated** | 38 | **27** (11 closed) |
| integrity over frozen schedules, atomicity ignored | 23 | **18** (6 closed, 1 new) |

Per-seed isolation matters here: a sibling investigation established that this census is **not** attributable seed-by-seed inside one long run, so every closure above was re-checked by replaying each seed in its own process.

## Re-authored tests, not weakened ones

Three committed tests asserted that a natively-recorded two-participant double exit downstream must **not** block an upstream re-score. CA authorised re-authoring. What was done, and the control at each step:

- **`propagatedByeYieldsToArrivingLoser`** — two cases whose sequences the new guard makes unreachable (they never reach the propagated-BYE path at all) are **replaced** with freshly mined sweep reproductions, each shrunk and verified to reproduce standalone. A third keeps its sequence and clears the blocker first, the order a director follows. Anti-vacuity control with #4834 neutralised: original 4/5 RED → **4/6 RED**, now spanning three draw types instead of two.
- **`pendingDoubleExitNotActive`** — the CURTIS case is replaced with a mined DOUBLE_ELIMINATION reproduction. Control with #4829 neutralised: original 3/3 RED → **3/3 RED**.
- **`doubleExitPredicateParity`** — one clear step inserted; the sequence and its all-steps-succeed assertion are otherwise untouched.

## New test

`contestedDoubleExitIsActive.test.ts` asserts the real property — **an error implies no mutation** — across FIRST_MATCH_LOSER_CONSOLATION, COMPASS and DOUBLE_ELIMINATION, plus a boundary case pinning that a single-occupant double exit is still inert.

Three further closed seeds were shrunk and **discarded rather than kept as decoration**: one shrink is already green on `dev`, and two fail on *both* trees, exhibiting a defect this change does not close. A shrinker preserves only the property, so a shrunk case is evidence only once it has been shown to turn.

## Gates

`transitionProperties` **144/0** · full suite **13065 passed / 2 skipped** · `pnpm lint` 0 · `tsc --noEmit` clean · **`pnpm verify` exit 0**