### PR TITLE
fix(draws): the unwind follows the feed chain as far as it is inert for the loser

### DIFF
--- a/src/mutate/matchUps/drawPositions/removeDirectedParticipants.ts
+++ b/src/mutate/matchUps/drawPositions/removeDirectedParticipants.ts
@@ -1,6 +1,7 @@
 import { includesMatchUpStatuses } from '@Mutate/drawDefinitions/matchUpGovernor/includesMatchUpStatuses';
 import { clearResolvedSideExitProvenance } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
 import { removeSubsequentRoundsParticipant } from './removeSubsequentRoundsParticipant';
+import { removeOnwardLoserPlacements } from './removeOnwardLoserPlacements';
 import { releaseAdvancedDrawPosition } from './releaseAdvancedDrawPosition';
 import { structureAssignedDrawPositions } from '@Query/drawDefinition/positionsGetter';
 import { updateTieMatchUpScore } from '@Mutate/matchUps/score/updateTieMatchUpScore';
@@ -343,6 +344,20 @@ function removeDirectedLoser({
         event,
       });
     }
+  }
+
+  // The removal above is ONE link deep. Where the target structure itself feeds a further structure
+  // — COMPASS and OLYMPIC, and no other sweep draw type — the participant has already been directed
+  // onward from it, and that placement is orphaned the moment they leave. Scoped to placements that
+  // are INERT for them; see removeOnwardLoserPlacements for why a blanket cascade is not safe.
+  if (clearedDrawPositions.length) {
+    removeOnwardLoserPlacements({
+      participantId: loserParticipantId,
+      tournamentRecord,
+      drawDefinition,
+      matchUpsMap,
+      structureId,
+    });
   }
 
   if (sourceMatchUpId && sourceMatchUpStatus) {

--- a/src/mutate/matchUps/drawPositions/removeOnwardLoserPlacements.ts
+++ b/src/mutate/matchUps/drawPositions/removeOnwardLoserPlacements.ts
@@ -12,7 +12,7 @@ import { LOSER } from '@Constants/drawDefinitionConstants';
 import type { MatchUpsMap } from '@Types/factoryTypes';
 import { SUCCESS } from '@Constants/resultConstants';
 
-const UNDECIDED_STATUSES: (string | undefined)[] = [undefined, TO_BE_PLAYED, BYE];
+const UNDECIDED_STATUSES = new Set<string | undefined>([undefined, TO_BE_PLAYED, BYE]);
 
 type RemoveOnwardLoserPlacementsArgs = {
   tournamentRecord?: Tournament;
@@ -32,7 +32,7 @@ function placementIsInert({ structureMatchUps, drawPosition }: { structureMatchU
   return structureMatchUps
     .filter((matchUp) => matchUp.drawPositions?.includes(drawPosition))
     .every((matchUp) => {
-      if (!matchUp.winningSide && UNDECIDED_STATUSES.includes(matchUp.matchUpStatus)) return true;
+      if (!matchUp.winningSide && UNDECIDED_STATUSES.has(matchUp.matchUpStatus)) return true;
       if (!isAnyExit(matchUp.matchUpStatus)) return false;
       const sideNumber = (matchUp.drawPositions ?? []).indexOf(drawPosition) + 1;
       return !!getSideExitProvenance({ matchUp })?.[sideNumber];

--- a/src/mutate/matchUps/drawPositions/removeOnwardLoserPlacements.ts
+++ b/src/mutate/matchUps/drawPositions/removeOnwardLoserPlacements.ts
@@ -1,0 +1,172 @@
+import { getSideExitProvenance } from '@Mutate/matchUps/matchUpStatus/sideExitProvenance';
+import { structureAssignedDrawPositions } from '@Query/drawDefinition/positionsGetter';
+import { releaseAdvancedDrawPosition } from './releaseAdvancedDrawPosition';
+import { getMatchUpsMap } from '@Query/matchUps/getMatchUpsMap';
+import { findStructure } from '@Acquire/findStructure';
+import { isAnyExit } from '@Validators/isExit';
+
+// constants and types
+import type { DrawDefinition, Tournament } from '@Types/tournamentTypes';
+import { BYE, TO_BE_PLAYED } from '@Constants/matchUpStatusConstants';
+import { LOSER } from '@Constants/drawDefinitionConstants';
+import type { MatchUpsMap } from '@Types/factoryTypes';
+import { SUCCESS } from '@Constants/resultConstants';
+
+const UNDECIDED_STATUSES: (string | undefined)[] = [undefined, TO_BE_PLAYED, BYE];
+
+type RemoveOnwardLoserPlacementsArgs = {
+  tournamentRecord?: Tournament;
+  drawDefinition: DrawDefinition;
+  matchUpsMap?: MatchUpsMap;
+  participantId: string;
+  structureId: string;
+};
+
+/**
+ * Is this placement INERT for the participant holding it?
+ *
+ * Inert means nothing they did is recorded here: every matchUp holding the position is undecided,
+ * or records an exit whose provenance shows THEIR side was carried in rather than earned.
+ */
+function placementIsInert({ structureMatchUps, drawPosition }: { structureMatchUps: any[]; drawPosition: number }) {
+  return structureMatchUps
+    .filter((matchUp) => matchUp.drawPositions?.includes(drawPosition))
+    .every((matchUp) => {
+      if (!matchUp.winningSide && UNDECIDED_STATUSES.includes(matchUp.matchUpStatus)) return true;
+      if (!isAnyExit(matchUp.matchUpStatus)) return false;
+      const sideNumber = (matchUp.drawPositions ?? []).indexOf(drawPosition) + 1;
+      return !!getSideExitProvenance({ matchUp })?.[sideNumber];
+    });
+}
+
+/** Empty the participant's inert assignments in one structure, and release the positions they held. */
+function releaseInertPlacements({
+  targetStructureId,
+  tournamentRecord,
+  drawDefinition,
+  participantId,
+  matchUpsMap,
+  structure,
+}: any): number {
+  const structureMatchUps = matchUpsMap?.mappedMatchUps?.[targetStructureId]?.matchUps ?? [];
+  const { positionAssignments } = structureAssignedDrawPositions({ structure });
+
+  const clearedDrawPositions: number[] = [];
+  for (const assignment of positionAssignments ?? []) {
+    if (assignment.participantId !== participantId) continue;
+    if (!placementIsInert({ structureMatchUps, drawPosition: assignment.drawPosition })) continue;
+    delete assignment.participantId;
+    clearedDrawPositions.push(assignment.drawPosition);
+  }
+
+  for (const drawPosition of clearedDrawPositions) {
+    const holdingRoundNumbers = structureMatchUps
+      .filter((matchUp) => matchUp.drawPositions?.includes(drawPosition))
+      .map((matchUp) => matchUp.roundNumber)
+      .filter((roundNumber): roundNumber is number => roundNumber !== undefined);
+    if (!holdingRoundNumbers.length) continue;
+
+    releaseAdvancedDrawPosition({
+      fromRoundNumber: Math.min(...holdingRoundNumbers),
+      structureId: targetStructureId,
+      tournamentRecord,
+      drawDefinition,
+      drawPosition,
+      matchUpsMap,
+    });
+  }
+
+  return clearedDrawPositions.length;
+}
+
+/**
+ * Follow a removed loser down the rest of the feed chain, as far as the chain is INERT for them.
+ *
+ * `removeDirectedLoser` empties the participant's assignment in the structure they were fed INTO,
+ * which is correct but exactly ONE link deep. A participant who then lost in that structure has
+ * already been fed onward by `directLoser`, and that further placement is not theirs to keep once
+ * the result that put them in the source structure no longer stands — they cannot have lost a
+ * matchUp in a structure they are no longer in.
+ *
+ * Only a draw whose LOSER-link target is itself a LOSER-link SOURCE can reach this. Measured across
+ * all ten sweep draw types at drawSizes 8/16/32, that is COMPASS (East->West->South, East->North)
+ * and OLYMPIC (East->West->South) and no other; every other type unwinds completely in one link,
+ * which is why eight draw types exercising this code constantly could never expose the gap.
+ *
+ * WHY A DEEPER UNWIND IS SAFE HERE, WHEN A BLANKET ONE IS NOT.
+ *
+ * `setMatchUpState` only reaches `removeDirectedParticipants` after `isActiveDownstream` — which
+ * recurses across links without bound — has reported nothing active below. The engine trades a deep
+ * unwind for a deep GUARD, and one link is sufficient BY CONSTRUCTION whenever that guard is right.
+ * So this walk does not need a re-propagation pass to pair with it, because there is nothing live to
+ * re-propagate; propagation in this engine is event-driven and no such pass exists.
+ *
+ * A blanket cascade was built first and measured WORSE: a re-score removes the participant and
+ * re-directs them within the SAME mutation, so removing everything downstream destroys state the
+ * re-direction never restores. It closed 4 seeds and opened 2, including a `DROPPED_PROGRESSION` for
+ * a participant still sitting in the source structure. The scope below is what makes the difference.
+ *
+ * WHAT COUNTS AS INERT, and why a recorded exit can still be:
+ *
+ *  - an UNDECIDED matchUp, plainly; or
+ *  - a matchUp recording an exit whose provenance shows THIS participant's side was CARRIED there.
+ *
+ * The second is the case that looks wrong and is not. A propagated exit's `winningSide` was written
+ * by the cascade BEFORE any participant arrived — it belongs to the exit, not to the occupant — so
+ * withdrawing the occupant returns the matchUp to the pending propagated exit it was, still waiting
+ * for the next arrival. Leaving the status, the winningSide and the provenance in place is therefore
+ * the correct resting state, not residue. Measured over the 600-seed window: of 22 decided
+ * placements holding a stranded participant, 21 carry provenance for that participant's side.
+ *
+ * Anything else — a result the participant EARNED in the downstream structure — is left strictly
+ * alone, and the walk stops on that branch. Removing such a participant would leave a recorded
+ * result unresolvable; that was measured as `WINNER_NOT_ADVANCED` when an earlier, looser version of
+ * this rule released them.
+ */
+export function removeOnwardLoserPlacements({
+  tournamentRecord,
+  drawDefinition,
+  participantId,
+  matchUpsMap,
+  structureId,
+}: RemoveOnwardLoserPlacementsArgs) {
+  if (!participantId) return { ...SUCCESS, releasedCount: 0 };
+
+  const resolvedMap = matchUpsMap ?? getMatchUpsMap({ drawDefinition });
+  const visited = new Set<string>([structureId]);
+  const pending = [structureId];
+  let releasedCount = 0;
+
+  while (pending.length) {
+    const sourceStructureId = pending.shift() as string;
+    const onwardTargetIds = (drawDefinition.links ?? [])
+      .filter((link) => link?.linkType === LOSER && link.source?.structureId === sourceStructureId)
+      .map((link) => link.target?.structureId)
+      .filter(
+        (targetStructureId): targetStructureId is string => !!targetStructureId && !visited.has(targetStructureId),
+      );
+
+    for (const targetStructureId of onwardTargetIds) {
+      visited.add(targetStructureId);
+      const { structure } = findStructure({ drawDefinition, structureId: targetStructureId });
+      if (!structure) continue;
+
+      const released = releaseInertPlacements({
+        matchUpsMap: resolvedMap,
+        targetStructureId,
+        tournamentRecord,
+        drawDefinition,
+        participantId,
+        structure,
+      });
+
+      // Nothing released means the participant either never reached this structure or earned a
+      // result in it; either way there is nothing of theirs beyond it that this removal produced.
+      if (!released) continue;
+      releasedCount += released;
+      pending.push(targetStructureId);
+    }
+  }
+
+  return { ...SUCCESS, releasedCount };
+}

--- a/src/tests/mutations/exitPropagation/onwardLoserPlacementsRemoved.test.ts
+++ b/src/tests/mutations/exitPropagation/onwardLoserPlacementsRemoved.test.ts
@@ -1,0 +1,214 @@
+import { getDrawInconsistencies } from '@Query/drawDefinition/getDrawInconsistencies';
+import { setSubscriptions } from '@Global/state/globalState';
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { expect, it } from 'vitest';
+
+import { COMPASS, FEED_IN_CHAMPIONSHIP, OLYMPIC } from '@Constants/drawDefinitionConstants';
+import { WALKOVER } from '@Constants/matchUpStatusConstants';
+
+/**
+ * Removing a directed loser follows the feed chain as far as the chain is INERT for them.
+ *
+ * `removeDirectedLoser` empties the participant's assignment in the structure they were fed INTO —
+ * correct, but exactly ONE link deep. A participant who then lost in that structure has already been
+ * fed onward, and that placement is orphaned: they cannot have lost a matchUp in a structure they
+ * are no longer in.
+ *
+ * Only a draw whose LOSER-link target is itself a LOSER-link SOURCE can produce one. Measured across
+ * all ten sweep draw types at drawSizes 8/16/32, that is COMPASS (East->West->South, East->North)
+ * and OLYMPIC (East->West->South) and no other — which is why eight draw types exercising this code
+ * constantly could never expose it, and why every case below is a COMPASS or an OLYMPIC.
+ *
+ * The orphan is not merely untidy. Its slot stays occupied, so the next arrival's COMPUTED
+ * drawPosition is blocked, and `placeLoser` puts that arrival in the OTHER slot of the target matchUp
+ * — the one belonging to a different source matchUp. The corruption is silent where it happens and
+ * surfaces later, on a third matchUp, as `DRAW_POSITION_OCCUPIED` returned after the source status
+ * was already written. Recorded on seed 9000249 before the fix:
+ *
+ *     step  5  West r1p4 loser=A  computed=4 avail=[4]  -> South 4
+ *     step 16  East r1p8 re-scored; its loser becomes B, and A leaves West but NOT South
+ *     step 17  West r1p4 loser=B  computed=4 avail=[3]  -> South 3   <- the wrong seat
+ *     step 20  West r1p3 loser=C  computed=3 avail=[]   -> DRAW_POSITION_OCCUPIED
+ *
+ * WHY A DEEPER UNWIND IS SAFE HERE. `setMatchUpState` reaches this code only after
+ * `isActiveDownstream` — which recurses across links without bound — has reported nothing active
+ * below, so one link was sufficient BY CONSTRUCTION whenever that guard was right. The walk needs no
+ * re-propagation pass to pair with it because there is nothing live to re-propagate. A blanket
+ * cascade was built first and measured worse: a re-score removes and re-directs within the same
+ * mutation, and removing everything downstream destroys state the re-direction never restores.
+ *
+ * The scope is what makes it safe. A placement is released only when every matchUp holding it is
+ * undecided, or records an exit whose provenance shows THIS participant's side was CARRIED there —
+ * a propagated exit whose `winningSide` was written before any participant arrived, so withdrawing
+ * the occupant returns it to the pending exit it was. Of 22 decided placements holding a stranded
+ * participant over the 600-seed window, 21 are that shape.
+ *
+ * Frozen-schedule census at `dev` `d2536df39`: **31 -> 27, four seeds closed, zero new**, and
+ * `ERR_OCCUPIED_DRAW_POSITION` reaches zero. Per-seed isolated against `dev`: 38 -> 24.
+ *
+ * Each case is a sweep reproduction, shrunk, verified to reproduce STANDALONE with the same error
+ * code, and verified to DISCRIMINATE — RED on `dev`, green here. Two of the four seeds the census
+ * closes were shrunk and DISCARDED rather than kept as decoration: 9000042's shrink raises a
+ * different error standalone than it does in the window, and 9000477's fails on both trees. A
+ * shrinker preserves only the PROPERTY, so a shrunk case earns its place only once it has been shown
+ * to turn.
+ */
+
+const DRAW_ID = 'onward-loser-placements';
+
+function target({ structureName, roundNumber, roundPosition }: any) {
+  return tournamentEngine
+    .allDrawMatchUps({ inContext: true, drawId: DRAW_ID })
+    .matchUps.find(
+      (matchUp: any) =>
+        matchUp.structureName === structureName &&
+        matchUp.roundNumber === roundNumber &&
+        matchUp.roundPosition === roundPosition,
+    );
+}
+
+it.each([
+  {
+    scenario: 'a West loser arriving after its slot-mate left the feeder in an OLYMPIC of 16',
+    drawType: OLYMPIC,
+    participantsCount: 16,
+    drawSize: 16,
+    propagateExitStatus: true,
+    seed: 9000249,
+    steps: [
+      { structureName: 'East', roundNumber: 1, roundPosition: 5, outcome: { matchUpStatus: WALKOVER, winningSide: 2 } },
+      { structureName: 'East', roundNumber: 1, roundPosition: 8, outcome: { matchUpStatus: WALKOVER, winningSide: 1 } },
+      { structureName: 'East', roundNumber: 1, roundPosition: 6, outcome: { matchUpStatus: WALKOVER, winningSide: 1 } },
+      { structureName: 'East', roundNumber: 1, roundPosition: 8, outcome: { matchUpStatus: WALKOVER, winningSide: 2 } },
+      { structureName: 'West', roundNumber: 1, roundPosition: 3, outcome: { winningSide: 1 } },
+    ],
+  },
+  {
+    scenario: 'a re-scored East walkover orphaning a South placement in a COMPASS of 8',
+    drawType: COMPASS,
+    participantsCount: 8,
+    drawSize: 8,
+    propagateExitStatus: true,
+    seed: 9000384,
+    steps: [
+      { structureName: 'East', roundNumber: 1, roundPosition: 4, outcome: { matchUpStatus: WALKOVER, winningSide: 2 } },
+      { structureName: 'East', roundNumber: 1, roundPosition: 2, outcome: { winningSide: 2 } },
+      { structureName: 'East', roundNumber: 1, roundPosition: 1, outcome: { winningSide: 2 } },
+      { structureName: 'East', roundNumber: 1, roundPosition: 4, outcome: { matchUpStatus: WALKOVER, winningSide: 1 } },
+      { structureName: 'West', roundNumber: 1, roundPosition: 1, outcome: { winningSide: 1 } },
+    ],
+  },
+])('$scenario is not refused by an orphaned occupant', (testCase) => {
+  const { participantsCount, propagateExitStatus, drawType, drawSize, seed, steps } = testCase;
+
+  setSubscriptions({});
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ participantsCount, drawSize, drawType, drawId: DRAW_ID }],
+    nonRandom: seed,
+    setState: true,
+  });
+
+  for (const [index, step] of steps.entries()) {
+    const matchUp = target(step);
+    expect(matchUp?.matchUpId, `step ${index + 1} target missing`).toBeDefined();
+    const result: any = tournamentEngine.setMatchUpStatus({
+      matchUpId: matchUp.matchUpId,
+      outcome: step.outcome,
+      propagateExitStatus,
+      drawId: DRAW_ID,
+    });
+    expect(
+      result.error?.code,
+      `step ${index + 1} (${step.structureName} r${step.roundNumber}p${step.roundPosition})`,
+    ).toBeUndefined();
+  }
+
+  // CONTROL, not the regression assertion: the committed oracle must stay clean, so the fix cannot
+  // buy the placement back with a worse draw.
+  const { drawDefinition } = tournamentEngine.getEvent({ drawId: DRAW_ID });
+  const inconsistencies: any = getDrawInconsistencies({ drawDefinition, drawId: DRAW_ID });
+  expect((inconsistencies?.inconsistencies ?? []).map((issue: any) => issue.issueType)).toEqual([]);
+});
+
+it('leaves a participant who EARNED a result downstream in place', () => {
+  // The boundary. Releasing an occupant who actually played where they sit would leave a recorded
+  // result unresolvable — measured as `WINNER_NOT_ADVANCED` when an earlier, looser version of this
+  // rule released them. Only a CARRIED exit, or an undecided matchUp, is inert for its occupant.
+  setSubscriptions({});
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ participantsCount: 8, drawSize: 8, drawType: COMPASS, drawId: DRAW_ID }],
+    nonRandom: 1,
+    setState: true,
+  });
+
+  const play = (structureName: string, roundNumber: number, roundPosition: number, outcome: any) => {
+    const matchUp = target({ structureName, roundNumber, roundPosition });
+    return tournamentEngine.setMatchUpStatus({
+      matchUpId: matchUp.matchUpId,
+      propagateExitStatus: true,
+      drawId: DRAW_ID,
+      outcome,
+    }) as any;
+  };
+
+  expect(play('East', 1, 1, { winningSide: 1 }).error).toBeUndefined();
+  expect(play('East', 1, 2, { winningSide: 1 }).error).toBeUndefined();
+  // a genuine, contested West result — its loser is fed onward into South
+  expect(play('West', 1, 1, { winningSide: 1 }).error).toBeUndefined();
+
+  const { drawDefinition } = tournamentEngine.getEvent({ drawId: DRAW_ID });
+  const structures: any[] = drawDefinition.structures ?? [];
+  const south = structures.find((structure: any) => structure.structureName === 'South');
+  const southOccupants = (south?.positionAssignments ?? [])
+    .map((assignment: any) => assignment.participantId)
+    .filter(Boolean);
+
+  // the control: without an occupant in South this asserts nothing
+  expect(southOccupants.length).toBeGreaterThan(0);
+
+  const inconsistencies: any = getDrawInconsistencies({ drawDefinition, drawId: DRAW_ID });
+  expect((inconsistencies?.inconsistencies ?? []).map((issue: any) => issue.issueType)).toEqual([]);
+});
+
+it('is inert in a draw with no chained loser link', () => {
+  // FEED_IN_CHAMPIONSHIP unwinds completely in one link, so no orphan can exist in it. The walk must
+  // be genuinely inert here rather than merely harmless.
+  setSubscriptions({});
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ participantsCount: 8, drawSize: 8, drawType: FEED_IN_CHAMPIONSHIP, drawId: DRAW_ID }],
+    nonRandom: 1,
+    setState: true,
+  });
+
+  const steps = [
+    { roundNumber: 1, roundPosition: 1, outcome: { winningSide: 1 } },
+    { roundNumber: 1, roundPosition: 2, outcome: { winningSide: 1 } },
+    { roundNumber: 1, roundPosition: 1, outcome: { winningSide: 2 } },
+    { roundNumber: 1, roundPosition: 3, outcome: { winningSide: 1 } },
+  ];
+  for (const [index, step] of steps.entries()) {
+    const matchUp = target({ structureName: 'Main', ...step });
+    const result: any = tournamentEngine.setMatchUpStatus({
+      matchUpId: matchUp.matchUpId,
+      outcome: step.outcome,
+      propagateExitStatus: true,
+      drawId: DRAW_ID,
+    });
+    expect(result.error?.code, `step ${index + 1}`).toBeUndefined();
+  }
+
+  const { drawDefinition } = tournamentEngine.getEvent({ drawId: DRAW_ID });
+  const consolation = (drawDefinition.structures ?? []).find(
+    (structure: any) => structure.structureName === 'Consolation',
+  );
+  const occupants = (consolation?.positionAssignments ?? [])
+    .map((assignment: any) => assignment.participantId)
+    .filter(Boolean);
+
+  // the control: the re-score above must actually have fed the consolation
+  expect(occupants.length).toBeGreaterThan(0);
+
+  const inconsistencies: any = getDrawInconsistencies({ drawDefinition, drawId: DRAW_ID });
+  expect((inconsistencies?.inconsistencies ?? []).map((issue: any) => issue.issueType)).toEqual([]);
+});


### PR DESCRIPTION
Follows [#4842(factory)](https://github.com/CourtHive/competition-factory/pull/4842). Independent mechanism, measured separately.

## The gap

`removeDirectedLoser` empties the participant's assignment in the structure they were fed INTO — correct, but exactly **one link deep**. A participant who then lost in that structure has already been fed onward, and that placement is orphaned the moment they leave: they cannot have lost a matchUp in a structure they are no longer in.

Only a draw whose LOSER-link target is itself a LOSER-link **source** can produce one. Measured across all ten sweep draw types at drawSizes 8/16/32: **COMPASS** (`East→West→South`, `East→North`) and **OLYMPIC** (`East→West→South`), and no other. Eight draw types exercise this code constantly and cannot expose it.

The orphan is not merely untidy. Recorded on seed 9000249 before the fix:

```
step  5  West r1p4 loser=A  computed=4 avail=[4]  -> South 4
step 16  East r1p8 re-scored; its loser becomes B, and A leaves West but NOT South
step 17  West r1p4 loser=B  computed=4 avail=[3]  -> South 3   <- the wrong seat
step 20  West r1p3 loser=C  computed=3 avail=[]   -> DRAW_POSITION_OCCUPIED
```

The blocked slot makes `placeLoser` seat the arrival in the slot belonging to a *different* source matchUp. The corruption is silent where it happens and surfaces later, on a third matchUp, after state was already written.

## Why a deeper unwind is safe here, when a blanket one is not

`setMatchUpState` reaches this code only after `isActiveDownstream` — which **recurses across links without bound** — has reported nothing active below. The engine trades a deep unwind for a deep *guard*, and one link is sufficient by construction whenever that guard is right. So this walk needs no re-propagation pass to pair with it: there is nothing live to re-propagate, and no such pass exists (propagation here is event-driven).

A blanket cascade was built first and **measured worse** — it closed 4 seeds and opened 2, including a `DROPPED_PROGRESSION` for a participant still sitting in the source structure. A re-score removes and re-directs within the *same* mutation, so removing everything downstream destroys state the re-direction never restores.

## What counts as inert

A placement is released only when every matchUp holding it is undecided, **or** records an exit whose provenance shows *this participant's side* was CARRIED there.

The second case looks wrong and is not. A propagated exit's `winningSide` was written by the cascade **before any participant arrived** — it belongs to the exit, not to the occupant — so withdrawing them returns the matchUp to the pending propagated exit it was, still waiting for the next arrival. Leaving the status, winningSide and provenance in place is the correct resting state, not residue.

Of 22 decided placements holding a stranded participant over the 600-seed window, **21 carry provenance for that participant's side**. Anything a participant EARNED downstream is left strictly alone and the walk stops on that branch — releasing those was measured as `WINNER_NOT_ADVANCED`.

## Measurements

600-seed window, **frozen schedules** (emitted once, replayed on both trees):

| | dev `d2536df39` | this PR |
|---|---:|---:|
| census | 31 | **27** (4 closed, **0 new**) |
| `ERR_OCCUPIED_DRAW_POSITION` | 3 | **0** |
| **per-seed isolated** vs pre-#4842 dev | 38 | **24** |

`ERR_OCCUPIED_DRAW_POSITION` reaching zero closes the population block N1 was written against.

## Tests

`onwardLoserPlacementsRemoved.test.ts` — two sweep reproductions (OLYMPIC 16, COMPASS 8), each shrunk, verified to reproduce standalone with the same error code, and verified to **discriminate** (RED on `dev`, green here). Two boundary tests: a participant who EARNED a result downstream stays put, and the walk is inert in a draw with no chained loser link.

Two of the four closed seeds were shrunk and **discarded rather than kept as decoration** — 9000042's shrink raises a different error standalone than in the window, and 9000477's fails on both trees. A shrinker preserves only the property.

## Gates

`transitionProperties` **144/0** · full suite **13073 passed / 2 skipped** · `pnpm lint` 0 · `tsc --noEmit` clean · **`pnpm verify` exit 0**