### PR TITLE
fix(mocks): nonRandom no longer stops determining the tournament after nine calls

### DIFF
--- a/src/assemblies/generators/mocks/generateTournamentRecord.ts
+++ b/src/assemblies/generators/mocks/generateTournamentRecord.ts
@@ -14,7 +14,7 @@ import { processLeagueProfiles } from './processLeagueProfiles';
 import { definedAttributes } from '@Tools/definedAttributes';
 import { Extension, Participant } from '@Types/tournamentTypes';
 import { addEvent } from '@Mutate/events/addEvent';
-import { randomPop } from '@Tools/arrays';
+import { randomMember } from '@Tools/arrays';
 
 // constants and fixtures
 import { INVALID_DATE, INVALID_VALUES } from '@Constants/errorConditionConstants';
@@ -22,6 +22,20 @@ import { ParticipantsProfile, PolicyDefinitions } from '@Types/factoryTypes';
 import defaultRatingsParameters from '@Fixtures/ratings/ratingsParameters';
 import { SUCCESS } from '@Constants/resultConstants';
 
+// SELECTED WITH `randomMember`, NEVER `randomPop`. `randomPop` SPLICES, and this array is a
+// module-level constant — so popping from it permanently consumed one name per call and, after the
+// ninth `generateTournamentRecord` in a process, left it empty.
+//
+// An empty array makes `randomPop` return `undefined` WITHOUT drawing, so from the tenth call the
+// shared seeded RNG was one draw out of step for the rest of the process. `nonRandom` then no longer
+// determined the result: the same seed produced different participants, different BYE placement and
+// a different draw depending only on how many tournaments had been generated before it.
+//
+// Measured before the fix: draws consumed per call 8970, 8970, … (nine times), then 8969 forever;
+// the first participant changed from "Ursula Escher" to "Ursula Yates" and a BYE moved from
+// drawPosition 23 to 10. In the exit-propagation sweep this made three of thirty-one failing seeds
+// unreproducible in isolation, which is why per-seed attribution in that census could not be
+// trusted. See `mockTournamentNameReuse.test.ts`.
 const mockTournamentNames = [
   'Generated Tournament',
   'CourtHive Challenge',
@@ -65,7 +79,7 @@ type GenerateTournamentRecordArgs = {
 export function generateTournamentRecord(params: GenerateTournamentRecordArgs) {
   let { startDate, endDate } = params ?? {};
   const {
-    tournamentName = randomPop(mockTournamentNames, params?.random),
+    tournamentName = randomMember(mockTournamentNames, params?.random),
     ratingsParameters = defaultRatingsParameters,
     tournamentExtensions,
     policyDefinitions,

--- a/src/tests/mocks/mockTournamentNameReuse.test.ts
+++ b/src/tests/mocks/mockTournamentNameReuse.test.ts
@@ -1,0 +1,75 @@
+import mocksEngine from '@Assemblies/engines/mock';
+import { expect, it } from 'vitest';
+
+import { COMPASS } from '@Constants/drawDefinitionConstants';
+
+/**
+ * `nonRandom` must fully determine a generated tournament, however many were generated before it.
+ *
+ * `generateTournamentRecord` selected its default `tournamentName` with `randomPop`, which SPLICES.
+ * The array it popped from is a module-level constant of nine names, so each call permanently
+ * consumed one and the tenth call in a process found it empty.
+ *
+ * That is not merely a naming quirk. `randomPop` on an empty array returns `undefined` WITHOUT
+ * drawing, so from the tenth call onward the shared seeded RNG was one draw out of step for the rest
+ * of the process — and every later consumer read a shifted stream. Measured before the fix, same
+ * seed throughout:
+ *
+ *   - draws consumed per call: 8970 nine times, then **8969** forever;
+ *   - first participant changed from "Ursula Escher" to "Ursula Yates";
+ *   - a BYE moved from drawPosition 23 to 10.
+ *
+ * The consequence that cost real time: in the exit-propagation sweep, three of thirty-one failing
+ * seeds could not be reproduced in isolation, because their outcome depended on how many tournaments
+ * the process had generated first. Per-seed attribution in that census was therefore unsound, and a
+ * reproduction lifted out of a long run might not reproduce alone. This test exists so that class
+ * cannot come back.
+ *
+ * The generator is the RIGHT place to fix it: a test-local workaround would leave every other
+ * consumer of `mocksEngine` — and every future sweep — exposed.
+ */
+
+it('generates identical tournaments for one seed however many precede it', () => {
+  const generate = (call: number) => {
+    const { tournamentRecord }: any = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ participantsCount: 29, drawSize: 32, drawType: COMPASS, drawId: `reuse-${call}` }],
+      nonRandom: 9000158,
+    });
+    const structures: any[] = tournamentRecord?.events?.[0]?.drawDefinitions?.[0]?.structures ?? [];
+    return JSON.stringify({
+      participantNames: (tournamentRecord?.participants ?? []).map((participant: any) => participant.participantName),
+      byePositions: structures.map((structure: any) => [
+        structure.structureName,
+        (structure.positionAssignments ?? [])
+          .filter((assignment: any) => assignment.bye)
+          .map((assignment: any) => assignment.drawPosition),
+      ]),
+    });
+  };
+
+  // Twelve is deliberate: the pool held NINE names, so the divergence began at the tenth call.
+  const fingerprints = Array.from({ length: 12 }, (_, call) => generate(call));
+
+  const distinct = [...new Set(fingerprints)];
+  expect(
+    distinct.length,
+    `the same seed produced ${distinct.length} distinct tournaments across 12 calls; ` +
+      `first divergence at call ${fingerprints.findIndex((entry) => entry !== fingerprints[0])}`,
+  ).toEqual(1);
+});
+
+it('does not consume the shared name pool', () => {
+  // The mechanism, asserted directly rather than only through its effect. A default name must remain
+  // available no matter how many tournaments have been generated — `undefined` here is the tell that
+  // the pool was spliced empty.
+  const names = Array.from({ length: 12 }, (_, call) => {
+    const { tournamentRecord }: any = mocksEngine.generateTournamentRecord({ nonRandom: 500 + call });
+    return tournamentRecord?.tournamentName;
+  });
+
+  // the control: these are DEFAULT names, so every one must be a non-empty string
+  for (const [call, name] of names.entries()) {
+    expect(typeof name, `call ${call + 1} produced ${JSON.stringify(name)}`).toEqual('string');
+    expect(name.length, `call ${call + 1} produced an empty name`).toBeGreaterThan(0);
+  }
+});


### PR DESCRIPTION
This is the **harness contamination** block, diagnosed to a one-line root cause.

## The bug

`generateTournamentRecord` picked its default `tournamentName` with `randomPop`, which **splices**:

```ts
tournamentName = randomPop(mockTournamentNames, params?.random),
```

`mockTournamentNames` is a **module-level constant of nine names**. Every call permanently consumed one, and the tenth call in a process found it empty.

That is not a naming quirk. `randomPop` on an empty array returns `undefined` **without drawing**, so from the tenth call the shared seeded RNG was one draw out of step for the rest of the process, and every later consumer read a shifted stream.

Measured, same seed throughout:

| | |
|---|---|
| draws consumed per call | 8970 ×9, then **8969 forever** |
| first participant | "Ursula Escher" → **"Ursula Yates"** |
| a BYE | drawPosition 23 → **10** |

So **`nonRandom` did not determine the result.** The same seed produced a different tournament depending only on how many had been generated before it in the process.

## How it was found

The symptom was in the exit-propagation sweep: three of thirty-one failing seeds could not be reproduced in isolation. Narrowing, in order — each step ruled out a hypothesis rather than confirming a guess:

1. **Not `setState`** — it replaces records rather than accumulating, and the divergence occurs with `setState: false` too.
2. **Not which seeds preceded** — repeating one fixed seed diverges identically; delta-debugging the 15 preceding seeds found no single culprit.
3. **Not schedule generation** — `prepareDraw` alone diverges.
4. **Purely the call count**, with a sharp step at the 10th call.
5. **Not `Math.random` leakage** — runs are deterministic run-to-run (verified 3×), and `createSeededRandom` is pure and per-call.
6. Counting RNG draws per call gave **8970 → 8969**; a per-call-site histogram put the missing draw at `randomPop`, and its caller at `generateTournamentRecord.ts:68`.

Nine names, threshold at the tenth call.

## Why it matters beyond the sweep

Any process generating more than nine mock tournaments got irreproducible data despite passing `nonRandom` — sweeps, long test files, seeded fixtures. It also silently produced `tournamentName: undefined`.

## The fix

`randomMember` — the non-mutating equivalent, drawing exactly once, so the stream is the same length on every call. Default names may repeat across tournaments, which is correct for mocks and was already true in effect once the pool ran dry.

Every other `randomPop` call site in the repo passes a freshly built array; this was the only one splicing a module-level constant.

## Verification

**Before:** 3 of 31 failing sweep seeds were CLEAN when replayed alone.
**After:** all 31 reproduce standalone — **zero divergent seeds.**

Both regression tests proven RED first, with precise messages:
`the same seed produced 2 distinct tournaments across 12 calls; first divergence at call 9` and `call 1 produced undefined`.

The second test asserts the mechanism directly rather than only its effect, so the class cannot return through a different consumer.

## Gates

`transitionProperties` **144/0** · full suite **13075 passed / 2 skipped** (no existing test disturbed) · `pnpm lint` 0 · `tsc --noEmit` clean · **`pnpm verify` exit 0**